### PR TITLE
Remove NamedThread::tid()

### DIFF
--- a/src/common/thread/NamedThread.h
+++ b/src/common/thread/NamedThread.h
@@ -30,19 +30,6 @@ public:
     NamedThread(const NamedThread&) = delete;
     NamedThread& operator=(const NamedThread&) = delete;
 
-    pid_t tid() const {
-        while (tid_ == 0) {
-            // `tid_' is unavailable until the thread function is called.
-        }
-        return tid_;
-    }
-
-    // Busy waiting for the thread to enter the thread function
-    void waitForRunning() const {
-        // Use `tid()' for our purpose
-        tid();
-    }
-
 public:
     class Nominator {
     public:
@@ -70,24 +57,18 @@ public:
     };
 
 private:
-    static void hook(NamedThread *thread,
-                     const std::string &name,
+    static void hook(const std::string &name,
                      const std::function<void()> &f) {
-        thread->tid_ = nebula::thread::gettid();
         if (!name.empty()) {
             Nominator::set(name);
         }
         f();
     }
-
-private:
-    // `volatile' to make the change visible in `tid()'
-    volatile pid_t                      tid_{0};
 };
 
 template <typename F, typename...Args>
 NamedThread::NamedThread(const std::string &name, F &&f, Args&&...args)
-    : std::thread(hook, this, name,
+    : std::thread(hook, name,
                   std::bind(std::forward<F>(f), std::forward<Args>(args)...)) {
 }
 

--- a/src/common/thread/test/ThreadTest.cpp
+++ b/src/common/thread/test/ThreadTest.cpp
@@ -23,14 +23,7 @@ TEST(NamedThread, ThreadName) {
 }
 
 TEST(NamedThread, ThreadID) {
-    pid_t tid;
-    auto getter = [&] () {
-        tid = ::syscall(SYS_gettid);
-    };
-
-    NamedThread thread("", getter);
-    thread.join();
-    ASSERT_EQ(tid, thread.tid());
+    ASSERT_EQ(::getpid(), nebula::thread::gettid());
 }
 
 }   // namespace thread

--- a/src/common/time/Duration.cpp
+++ b/src/common/time/Duration.cpp
@@ -59,13 +59,6 @@ void launchTickTockThread() {
             }  // while
         });
 
-    // Since `t' would be destructed instantly when this function returns.
-    // We have to make sure that the thread function has been invoked.
-    // Otherwise, accessing `NamedThread::tid_' in the the `NamedThread::hook' might
-    // cause a `stack-buffer-overflow' error under ASAN.
-    // See `src/common/thread/NamedThread.h' for details.
-    t.waitForRunning();
-
     t.detach();
 }
 


### PR DESCRIPTION
It's impossible to implement this interface reliably, because:
  * `NamedThread` is derived from `std::thread`
  * Execution of the constructor of `std::thread` comes before `NamedThread`'s
  * New thread is launched from inside the constructor of `std::thread`
  * `NamedThread::tid_`'s initialization(to zero) is performed concurrently with the thread function's execution, i.e. `NamedThread::hook`.

So the order of the initialization and assignment of `NamedThread::tid_` is undetermined.