### PR TITLE
Fixed stack-use-after-scope error in tests of kvstore

### DIFF
--- a/src/kvstore/test/KVStoreTest.cpp
+++ b/src/kvstore/test/KVStoreTest.cpp
@@ -90,8 +90,10 @@ TEST(KVStoreTest, SimpleTest) {
     int32_t start = 0, end = 100;
     std::string s(reinterpret_cast<const char*>(&start), sizeof(int32_t));
     std::string e(reinterpret_cast<const char*>(&end), sizeof(int32_t));
+    s = prefix + s;
+    e = prefix + e;
     std::unique_ptr<KVIterator> iter;
-    EXPECT_EQ(ResultCode::SUCCEEDED, kv->range(1, 1, prefix + s, prefix + e, &iter));
+    EXPECT_EQ(ResultCode::SUCCEEDED, kv->range(1, 1, s, e, &iter));
     int num = 0;
     while (iter->valid()) {
         auto key = *reinterpret_cast<const int32_t*>(iter->key().data() + prefix.size());

--- a/src/kvstore/test/RocksdbEngineTest.cpp
+++ b/src/kvstore/test/RocksdbEngineTest.cpp
@@ -134,10 +134,9 @@ TEST(RocksdbEngineTest, RemoveRangeTest) {
     {
         int32_t s = 0, e = 100;
         std::unique_ptr<KVIterator> iter;
-        EXPECT_EQ(ResultCode::SUCCEEDED, engine->range(
-                                std::string(reinterpret_cast<const char*>(&s), sizeof(int32_t)),
-                                std::string(reinterpret_cast<const char*>(&e), sizeof(int32_t)),
-                                &iter));
+        std::string start(reinterpret_cast<const char*>(&s), sizeof(int32_t));
+        std::string end(reinterpret_cast<const char*>(&e), sizeof(int32_t));
+        EXPECT_EQ(ResultCode::SUCCEEDED, engine->range(start, end, &iter));
         int num = 0;
         int expectedFrom = 50;
         while (iter->valid()) {


### PR DESCRIPTION
A temporary object will be destructed instantly after the involved statement finishes. `RocksdbRangeIter` holds a reference to such temporary object. I leave it to @dangleptr to deicide whether this behavour is appropriate.