### PR TITLE
Avoid code checking errors

### DIFF
--- a/src/dataman/RowSetReader.cpp
+++ b/src/dataman/RowSetReader.cpp
@@ -11,7 +11,7 @@
 
 namespace nebula {
 
-using namespace nebula::meta;
+using nebula::meta::SchemaProviderIf;
 
 /***********************************
  *

--- a/src/meta/test/FileBasedPartManagerTest.cpp
+++ b/src/meta/test/FileBasedPartManagerTest.cpp
@@ -19,7 +19,7 @@ DECLARE_string(schema_file);
 namespace nebula {
 namespace meta {
 
-using namespace nebula::network;
+using nebula::network::NetworkUtils;
 
 void prepareConfFile() {
     static fs::TempFile confFile("/tmp/file_based_part_manager.XXXXXX");


### PR DESCRIPTION
**fixed cpplint errors:**
 ./cpplint/bin/pre-commit.sh src/
Performing C++ linters...
src/meta/test/FileBasedPartManagerTest.cpp:22:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/meta/test/FileBasedPartManagerTest.cpp
src/dataman/RowSetReader.cpp:14:  Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces] [5]
Done processing src/dataman/RowSetReader.cpp
Total errors found: 2