### PR TITLE
Fix bug in QueryBoundProcessor

### DIFF
--- a/src/storage/AddEdgesProcessor.cpp
+++ b/src/storage/AddEdgesProcessor.cpp
@@ -5,7 +5,7 @@
  */
 #include "storage/AddEdgesProcessor.h"
 #include <algorithm>
-#include <climits>
+#include <limits>
 #include "time/TimeUtils.h"
 #include "storage/KeyUtils.h"
 
@@ -14,7 +14,7 @@ namespace storage {
 
 void AddEdgesProcessor::process(const cpp2::AddEdgesRequest& req) {
     auto spaceId = req.get_space_id();
-    auto version = LLONG_MAX - time::TimeUtils::nowInMSeconds();
+    auto version = std::numeric_limits<int64_t>::max() - time::TimeUtils::nowInMSeconds();
     callingNum_ = req.parts.size();
     CHECK_NOTNULL(kvstore_);
     std::for_each(req.parts.begin(), req.parts.end(), [&](auto& partEdges){

--- a/src/storage/QueryBaseProcessor.h
+++ b/src/storage/QueryBaseProcessor.h
@@ -22,6 +22,10 @@ const std::unordered_map<std::string, PropContext::PropInKeyType> kPropsInKey_ =
     {"_rank", PropContext::PropInKeyType::RANK}
 };
 
+enum class BoundType {
+    IN_BOUND,
+    OUT_BOUND,
+};
 
 template<typename REQ, typename RESP>
 class QueryBaseProcessor : public BaseProcessor<RESP> {
@@ -31,8 +35,9 @@ public:
     void process(const cpp2::GetNeighborsRequest& req);
 
 protected:
-    explicit QueryBaseProcessor(kvstore::KVStore* kvstore)
-        : BaseProcessor<RESP>(kvstore) {}
+    explicit QueryBaseProcessor(kvstore::KVStore* kvstore, BoundType type = BoundType::OUT_BOUND)
+        : BaseProcessor<RESP>(kvstore)
+        , type_(type) {}
     /**
      * Check whether current operatin on the data is valid or not.
      * */
@@ -62,6 +67,7 @@ protected:
 
 protected:
     GraphSpaceID  spaceId_;
+    BoundType     type_;
 };
 
 }  // namespace storage

--- a/src/storage/QueryBaseProcessor.inl
+++ b/src/storage/QueryBaseProcessor.inl
@@ -152,7 +152,7 @@ cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::checkAndBuildContexts(
                 if (it != kPropsInKey_.end()) {
                     prop.pikType_ = it->second;
                     prop.type_.type = nebula::cpp2::SupportedType::INT;
-                } else if (edgeContext.edgeType_ > 0) {
+                } else if (type_ == BoundType::OUT_BOUND) {
                     // Only outBound have properties on edge.
                     auto schema = meta::SchemaManager::getEdgeSchema(spaceId_,
                                                                      edgeContext.edgeType_);

--- a/src/storage/QueryBoundProcessor.cpp
+++ b/src/storage/QueryBoundProcessor.cpp
@@ -61,12 +61,12 @@ kvstore::ResultCode QueryBoundProcessor::collectEdgeProps(
             continue;
         }
         lastRank = rank;
-        RowWriter writer(rsWriter.schema());
-        PropsCollector collector(&writer);
         std::unique_ptr<RowReader> reader;
-        if (edgeType > 0 && !val.empty()) {
+        if (type_ == BoundType::OUT_BOUND && !val.empty()) {
             reader = RowReader::getEdgePropReader(val, spaceId_, edgeType);
         }
+        RowWriter writer(rsWriter.schema());
+        PropsCollector collector(&writer);
         this->collectProps(reader.get(), key, props, &collector);
         rsWriter.addRow(writer);
     }

--- a/src/storage/QueryBoundProcessor.h
+++ b/src/storage/QueryBoundProcessor.h
@@ -17,14 +17,15 @@ namespace storage {
 class QueryBoundProcessor
     : public QueryBaseProcessor<cpp2::GetNeighborsRequest, cpp2::QueryResponse> {
 public:
-    static QueryBoundProcessor* instance(kvstore::KVStore* kvstore) {
-        return new QueryBoundProcessor(kvstore);
+    static QueryBoundProcessor* instance(kvstore::KVStore* kvstore,
+                                         BoundType type = BoundType::OUT_BOUND) {
+        return new QueryBoundProcessor(kvstore, type);
     }
 
 protected:
-    explicit QueryBoundProcessor(kvstore::KVStore* kvstore)
+    explicit QueryBoundProcessor(kvstore::KVStore* kvstore, BoundType type)
         : QueryBaseProcessor<cpp2::GetNeighborsRequest,
-                             cpp2::QueryResponse>(kvstore) {}
+                             cpp2::QueryResponse>(kvstore, type) {}
 
     kvstore::ResultCode processVertex(PartitionID partID,
                                       VertexID vId,

--- a/src/storage/QueryStatsProcessor.cpp
+++ b/src/storage/QueryStatsProcessor.cpp
@@ -33,7 +33,6 @@ QueryStatsProcessor::collectVertexStats(PartitionID partId,
     return ret;
 }
 
-
 kvstore::ResultCode
 QueryStatsProcessor::collectEdgesStats(PartitionID partId,
                                        VertexID vId,
@@ -55,13 +54,14 @@ QueryStatsProcessor::collectEdgesStats(PartitionID partId,
             continue;
         }
         lastRank = rank;
-        CHECK_GT(edgeType, 0) << "Only outBound support stats on edge props.";
-        auto reader = RowReader::getEdgePropReader(val, spaceId_, edgeType);
+        std::unique_ptr<RowReader> reader;
+        if (type_ == BoundType::OUT_BOUND && !val.empty()) {
+            reader = RowReader::getEdgePropReader(val, spaceId_, edgeType);
+        }
         collectProps(reader.get(), key, props, &collector_);
     }
     return ret;
 }
-
 
 void QueryStatsProcessor::calcResult(std::vector<PropContext>&& props) {
     RowWriter writer;

--- a/src/storage/QueryStatsProcessor.h
+++ b/src/storage/QueryStatsProcessor.h
@@ -16,14 +16,15 @@ namespace storage {
 class QueryStatsProcessor
     : public QueryBaseProcessor<cpp2::GetNeighborsRequest, cpp2::QueryStatsResponse> {
 public:
-    static QueryStatsProcessor* instance(kvstore::KVStore* kvstore) {
-        return new QueryStatsProcessor(kvstore);
+    static QueryStatsProcessor* instance(kvstore::KVStore* kvstore,
+                                         BoundType type = BoundType::OUT_BOUND) {
+        return new QueryStatsProcessor(kvstore, type);
     }
 
 private:
-    explicit QueryStatsProcessor(kvstore::KVStore* kvstore)
+    explicit QueryStatsProcessor(kvstore::KVStore* kvstore, BoundType type)
         : QueryBaseProcessor<cpp2::GetNeighborsRequest,
-                             cpp2::QueryStatsResponse>(kvstore) {}
+                             cpp2::QueryStatsResponse>(kvstore, type) {}
 
     kvstore::ResultCode processVertex(PartitionID partID,
                                       VertexID vId,
@@ -38,7 +39,6 @@ private:
                                            VertexID vId,
                                            TagID tagId,
                                            std::vector<PropContext>& props);
-
 
     kvstore::ResultCode collectEdgesStats(PartitionID partId,
                                           VertexID vId,

--- a/src/storage/QueryVertexPropsProcessor.h
+++ b/src/storage/QueryVertexPropsProcessor.h
@@ -23,7 +23,7 @@ public:
 
 private:
     explicit QueryVertexPropsProcessor(kvstore::KVStore* kvstore)
-        : QueryBoundProcessor(kvstore) {}
+        : QueryBoundProcessor(kvstore, BoundType::OUT_BOUND) {}
 };
 
 }  // namespace storage

--- a/src/storage/StorageServiceHandler.cpp
+++ b/src/storage/StorageServiceHandler.cpp
@@ -29,7 +29,7 @@ StorageServiceHandler::future_getOutBound(const cpp2::GetNeighborsRequest& req) 
 
 folly::Future<cpp2::QueryResponse>
 StorageServiceHandler::future_getInBound(const cpp2::GetNeighborsRequest& req) {
-    auto* processor = QueryBoundProcessor::instance(kvstore_);
+    auto* processor = QueryBoundProcessor::instance(kvstore_, BoundType::IN_BOUND);
     RETURN_FUTURE(processor);
 }
 
@@ -41,7 +41,7 @@ StorageServiceHandler::future_outBoundStats(const cpp2::GetNeighborsRequest& req
 
 folly::Future<cpp2::QueryStatsResponse>
 StorageServiceHandler::future_inBoundStats(const cpp2::GetNeighborsRequest& req) {
-    auto* processor = QueryStatsProcessor::instance(kvstore_);
+    auto* processor = QueryStatsProcessor::instance(kvstore_, BoundType::IN_BOUND);
     RETURN_FUTURE(processor);
 }
 


### PR DESCRIPTION
1.  Fix bug in QueryInBound,  skip the properties requested on edge.
2.  Only return the latest version when query out bounds.