### PR TITLE
fixed parallel compilation error

### DIFF
--- a/src/interface/CMakeLists.txt
+++ b/src/interface/CMakeLists.txt
@@ -98,6 +98,7 @@ add_library(
     gen-cpp2/common_data.cpp
     gen-cpp2/common_types.cpp
 )
+add_dependencies(common_thrift_obj tgt_fbthrift)
 
 add_library(
     storage_thrift_obj OBJECT


### PR DESCRIPTION
Below error occur when compiling in parallel:
```
[  0%] Generating gen-cpp2/common_constants.cpp, gen-cpp2/common_data.cpp, gen-cpp2/common_types.cpp
cd /source_code/tag_remove/src/interface && ../../third-party/fbthrift/_install/bin/thrift1 --allow-neg-enum-vals --templates /source_code/tag_remove/third-party/fbthrift/_install/include/thrift/templates --gen mstch_cpp2:include_prefix="interface",process_in_event_base,stack_arguments --gen java:hashcode --gen go -o . ./common.thrift
/bin/sh: ../../third-party/fbthrift/_install/bin/thrift1: No such file or directory
make[2]: *** [src/interface/CMakeFiles/common_thrift_obj.dir/build.make:65: src/interface/gen-cpp2/common_constants.cpp] Error 127
make[2]: Leaving directory '/source_code/tag_remove'
make[1]: *** [CMakeFiles/Makefile2:3580: src/interface/CMakeFiles/common_thrift_obj.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....

```