### PR TITLE
Fix bugs in storage

### DIFF
--- a/src/storage/AddVerticesProcessor.cpp
+++ b/src/storage/AddVerticesProcessor.cpp
@@ -6,6 +6,7 @@
 
 #include "storage/AddVerticesProcessor.h"
 #include <algorithm>
+#include <limits>
 #include "time/TimeUtils.h"
 #include "storage/KeyUtils.h"
 
@@ -14,7 +15,7 @@ namespace storage {
 
 void AddVerticesProcessor::process(const cpp2::AddVerticesRequest& req) {
     VLOG(3) << "Receive AddVerticesRequest...";
-    auto now = time::TimeUtils::nowInMSeconds();
+    auto now = std::numeric_limits<int64_t>::max() - time::TimeUtils::nowInMSeconds();
     const auto& partVertices = req.get_parts();
     auto spaceId = req.get_space_id();
     callingNum_ = partVertices.size();

--- a/src/storage/test/QueryBoundTest.cpp
+++ b/src/storage/test/QueryBoundTest.cpp
@@ -40,7 +40,7 @@ void mockData(kvstore::KVStore* kv) {
                 // Write multi versions,  we should get the latest version.
                 for (auto version = 0; version < 3; version++) {
                     auto key = KeyUtils::edgeKey(partId, vertexId, 101,
-                                                 dstId - 10001, dstId,
+                                                 0, dstId,
                                                  std::numeric_limits<int>::max() - version);
                     RowWriter writer(nullptr);
                     for (uint64_t numInt = 0; numInt < 10; numInt++) {
@@ -58,7 +58,7 @@ void mockData(kvstore::KVStore* kv) {
                 VLOG(3) << "Write part " << partId << ", vertex " << vertexId << ", src " << srcId;
                 for (auto version = 0; version < 3; version++) {
                     auto key = KeyUtils::edgeKey(partId, vertexId, -101,
-                                                 srcId - 20001, srcId,
+                                                 0, srcId,
                                                  std::numeric_limits<int>::max() - version);
                     data.emplace_back(std::move(key), "");
                 }
@@ -147,7 +147,7 @@ void checkResponse(cpp2::QueryResponse& resp, bool outBound = true) {
                 // _rank
                 int64_t v;
                 EXPECT_EQ(ResultType::SUCCEEDED, it->getInt<int64_t>(1, v));
-                CHECK_EQ(rowNum, v);
+                CHECK_EQ(0, v);
             }
             if (outBound) {
                 // col_0, col_2 ... col_8


### PR DESCRIPTION
Two bugs:
1.  Use rank and dstId to identify last edge during collectEdgeProps
2.  Use Max - now for version in vertex key.