### PR TITLE
Adjust meta client ctor  && implement heartbeat logic inside.

### DIFF
--- a/src/daemons/GraphDaemon.cpp
+++ b/src/daemons/GraphDaemon.cpp
@@ -111,7 +111,12 @@ int main(int argc, char *argv[]) {
         localIP = std::move(result).value();
     }
 
+    if (FLAGS_num_netio_threads <= 0) {
+        LOG(WARNING) << "Number netio threads should be greater than zero";
+        return EXIT_FAILURE;
+    }
     gServer = std::make_unique<apache::thrift::ThriftServer>();
+    gServer->getIOThreadPool()->setNumThreads(FLAGS_num_netio_threads);
     auto interface = std::make_shared<GraphService>(gServer->getIOThreadPool());
 
     gServer->setInterface(std::move(interface));
@@ -126,12 +131,6 @@ int main(int argc, char *argv[]) {
     gServer->setNumAcceptThreads(FLAGS_num_accept_threads);
     gServer->setListenBacklog(FLAGS_listen_backlog);
     gServer->setThreadStackSizeMB(5);
-    if (FLAGS_num_netio_threads > 0) {
-        gServer->setNumIOWorkerThreads(FLAGS_num_netio_threads);
-    } else {
-        LOG(WARNING) << "Number netio threads should be greater than zero";
-        return EXIT_FAILURE;
-    }
 
     // Setup the signal handlers
     status = setupSignalHandler();

--- a/src/graph/GraphFlags.cpp
+++ b/src/graph/GraphFlags.cpp
@@ -25,3 +25,5 @@ DEFINE_bool(redirect_stdout, true, "Whether to redirect stdout and stderr to sep
 DEFINE_string(stdout_log_file, "graphd-stdout.log", "Destination filename of stdout");
 DEFINE_string(stderr_log_file, "graphd-stderr.log", "Destination filename of stderr");
 DEFINE_bool(daemonize, true, "Whether run as a daemon process");
+DEFINE_string(meta_server_addrs, "", "list of meta server addresses,"
+                                     "the format looks like ip1:port1, ip2:port2, ip3:port3");

--- a/src/graph/GraphFlags.h
+++ b/src/graph/GraphFlags.h
@@ -24,6 +24,7 @@ DECLARE_bool(redirect_stdout);
 DECLARE_string(stdout_log_file);
 DECLARE_string(stderr_log_file);
 DECLARE_bool(daemonize);
+DECLARE_string(meta_server_addrs);
 
 
 #endif  // GRAPH_GRAPHFLAGS_H_

--- a/src/graph/test/TestEnv.cpp
+++ b/src/graph/test/TestEnv.cpp
@@ -27,10 +27,10 @@ void TestEnv::SetUp() {
     FLAGS_load_data_interval_second = 1;
     using ThriftServer = apache::thrift::ThriftServer;
     server_ = std::make_unique<ThriftServer>();
+    server_->getIOThreadPool()->setNumThreads(1);
     auto interface = std::make_shared<GraphService>(server_->getIOThreadPool());
     server_->setInterface(std::move(interface));
     server_->setPort(0);    // Let the system choose an available port for us
-
     auto serve = [this] {
         server_->serve();
     };

--- a/src/kvstore/PartManager.cpp
+++ b/src/kvstore/PartManager.cpp
@@ -35,17 +35,8 @@ bool MemPartManager::partExist(const HostAddr& host, GraphSpaceID spaceId, Parti
 
 MetaServerBasedPartManager::MetaServerBasedPartManager(HostAddr host, meta::MetaClient *client)
     : localHost_(std::move(host)) {
-    if (nullptr == client) {
-        LOG(INFO) << "MetaClient is nullptr, create new one";
-        // multi instances use one metaclient
-        static auto clientPtr = std::make_unique<meta::MetaClient>();
-        static std::once_flag flag;
-        std::call_once(flag, std::bind(&meta::MetaClient::init, clientPtr.get()));
-        client_ = clientPtr.get();
-    } else {
-        client_ = client;
-    }
-
+    client_ = client;
+    CHECK_NOTNULL(client_);
     client_->registerListener(this);
 }
 

--- a/src/meta/SchemaManager.cpp
+++ b/src/meta/SchemaManager.cpp
@@ -6,26 +6,14 @@
 
 #include "base/Base.h"
 #include "meta/SchemaManager.h"
-#include "meta/FileBasedSchemaManager.h"
 #include "meta/ServerBasedSchemaManager.h"
-
-DECLARE_string(schema_file);
-DECLARE_string(meta_server_addrs);
 
 namespace nebula {
 namespace meta {
 
 std::unique_ptr<SchemaManager> SchemaManager::create() {
-    if (!FLAGS_schema_file.empty()) {
-        std::unique_ptr<SchemaManager> sm(new FileBasedSchemaManager());
-        return sm;
-    } else if (!FLAGS_meta_server_addrs.empty()) {
-        std::unique_ptr<SchemaManager> sm(new ServerBasedSchemaManager());
-        return sm;
-    } else {
-        std::unique_ptr<SchemaManager> sm(new AdHocSchemaManager());
-        return sm;
-    }
+    auto sm = std::unique_ptr<SchemaManager>(new ServerBasedSchemaManager());
+    return sm;
 }
 
 void AdHocSchemaManager::addTagSchema(GraphSpaceID space,

--- a/src/meta/ServerBasedSchemaManager.cpp
+++ b/src/meta/ServerBasedSchemaManager.cpp
@@ -17,15 +17,8 @@ ServerBasedSchemaManager::~ServerBasedSchemaManager() {
 }
 
 void ServerBasedSchemaManager::init(MetaClient *client) {
-    if (nullptr == client) {
-        LOG(INFO) << "MetaClient is nullptr, create new one";
-        static auto clientPtr = std::make_unique<meta::MetaClient>();
-        static std::once_flag flag;
-        std::call_once(flag, std::bind(&meta::MetaClient::init, clientPtr.get()));
-        metaClient_ = clientPtr.get();
-    } else {
-        metaClient_ = client;
-    }
+    metaClient_ = client;
+    CHECK_NOTNULL(metaClient_);
 }
 
 std::shared_ptr<const SchemaProviderIf>

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -10,25 +10,18 @@
 #include "meta/NebulaSchemaProvider.h"
 
 DEFINE_int32(load_data_interval_second, 2 * 60, "Load data interval, unit: second");
-DEFINE_string(meta_server_addrs, "", "list of meta server addresses,"
-                                     "the format looks like ip1:port1, ip2:port2, ip3:port3");
-DEFINE_int32(meta_client_io_threads, 3, "meta client io threads");
+DEFINE_int32(heartbeat_interval_sec, 10, "Heartbeat interval, unit: second");
 
 namespace nebula {
 namespace meta {
 
 MetaClient::MetaClient(std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool,
-                       std::vector<HostAddr> addrs)
+                       std::vector<HostAddr> addrs,
+                       bool sendHeartBeat)
     : ioThreadPool_(ioThreadPool)
-    , addrs_(std::move(addrs)) {
-    if (ioThreadPool_ == nullptr) {
-        ioThreadPool_
-            = std::make_shared<folly::IOThreadPoolExecutor>(FLAGS_meta_client_io_threads);
-    }
-    if (addrs_.empty() && !FLAGS_meta_server_addrs.empty()) {
-        addrs_ = network::NetworkUtils::toHosts(FLAGS_meta_server_addrs);
-    }
-    CHECK(!addrs_.empty());
+    , addrs_(std::move(addrs))
+    , sendHeartBeat_(sendHeartBeat) {
+    CHECK(ioThreadPool_ != nullptr && !addrs_.empty());
     clientsMan_ = std::make_shared<thrift::ThriftClientManager<
                                     meta::cpp2::MetaServiceAsyncClient>>();
     updateHost();
@@ -44,13 +37,39 @@ MetaClient::~MetaClient() {
 void MetaClient::init() {
     loadDataThreadFunc();
     CHECK(loadDataThread_.start());
-    size_t delayMS = FLAGS_load_data_interval_second * 1000 + folly::Random::rand32(900);
-    loadDataThread_.addTimerTask(delayMS,
-                                 FLAGS_load_data_interval_second * 1000,
-                                 &MetaClient::loadDataThreadFunc, this);
+    {
+        size_t delayMS = FLAGS_load_data_interval_second * 1000 + folly::Random::rand32(900);
+        LOG(INFO) << "Register timer task for load data!";
+        loadDataThread_.addTimerTask(delayMS,
+                                     FLAGS_load_data_interval_second * 1000,
+                                     &MetaClient::loadDataThreadFunc, this);
+    }
+    if (sendHeartBeat_) {
+        LOG(INFO) << "Register time task for heartbeat!";
+        size_t delayMS = FLAGS_heartbeat_interval_sec * 1000 + folly::Random::rand32(900);
+        loadDataThread_.addTimerTask(delayMS,
+                                     FLAGS_heartbeat_interval_sec * 1000,
+                                     &MetaClient::heartBeatThreadFunc, this);
+    }
+}
+
+void MetaClient::heartBeatThreadFunc() {
+    if (listener_ == nullptr) {
+        VLOG(1) << "Can't send heartbeat due to listener_ is nullptr!";
+        return;
+    }
+    auto ret = heartbeat().get();
+    if (!ret.ok()) {
+        LOG(ERROR) << "Heartbeat failed, status:" << ret.status();
+        return;
+    }
 }
 
 void MetaClient::loadDataThreadFunc() {
+    if (ioThreadPool_->numThreads() <= 0) {
+        LOG(ERROR) << "The threads number in ioThreadPool should be greater than 0";
+        return;
+    }
     auto ret = listSpaces().get();
     if (!ret.ok()) {
         LOG(ERROR) << "List space failed, status:" << ret.status();
@@ -822,6 +841,21 @@ SchemaVer MetaClient::getNewestEdgeVerFromCache(const GraphSpaceID& space,
         return -1;
     }
     return it->second;
+}
+
+folly::Future<StatusOr<bool>> MetaClient::heartbeat() {
+    CHECK_NOTNULL(listener_);
+    auto localHost = listener_->getLocalHost();
+    cpp2::HBReq req;
+    nebula::cpp2::HostAddr thriftHost;
+    thriftHost.set_ip(localHost.first);
+    thriftHost.set_port(localHost.second);
+    req.set_host(std::move(thriftHost));
+    return getResponse(std::move(req), [] (auto client, auto request) {
+        return client->future_heartBeat(request);
+    }, [] (cpp2::HBResp&& resp) -> decltype(auto) {
+        return resp.code == cpp2::ErrorCode::SUCCEEDED;
+    }, true);
 }
 
 }  // namespace meta

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -59,8 +59,9 @@ public:
 
 class MetaClient {
 public:
-    explicit MetaClient(std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool = nullptr,
-                        std::vector<HostAddr> addrs = {});
+    explicit MetaClient(std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool,
+                        std::vector<HostAddr> addrs,
+                        bool sendHeartBeat = false);
 
     virtual ~MetaClient();
 
@@ -182,12 +183,16 @@ public:
 protected:
     void loadDataThreadFunc();
 
+    void heartBeatThreadFunc();
+
     bool loadSchemas(GraphSpaceID spaceId,
                      std::shared_ptr<SpaceInfoCache> spaceInfoCache,
                      SpaceTagNameIdMap &tagNameIdMap,
                      SpaceEdgeNameTypeMap &edgeNameTypeMap,
                      SpaceNewestTagVerMap &newestTagVerMap,
                      SpaceNewestEdgeVerMap &newestEdgeVerMap);
+
+    folly::Future<StatusOr<bool>> heartbeat();
 
     std::unordered_map<HostAddr, std::vector<PartitionID>> reverse(const PartsAlloc& parts);
 
@@ -228,20 +233,21 @@ protected:
 private:
     std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool_;
     std::shared_ptr<thrift::ThriftClientManager<meta::cpp2::MetaServiceAsyncClient>> clientsMan_;
+    std::unordered_map<GraphSpaceID, std::shared_ptr<SpaceInfoCache>> localCache_;
     std::vector<HostAddr> addrs_;
     // The lock used to protect active_ and leader_.
     folly::RWSpinLock hostLock_;
     HostAddr active_;
     HostAddr leader_;
     thread::GenericWorker loadDataThread_;
-    std::unordered_map<GraphSpaceID, std::shared_ptr<SpaceInfoCache>> localCache_;
     SpaceNameIdMap        spaceIndexByName_;
     SpaceTagNameIdMap     spaceTagIndexByName_;
     SpaceEdgeNameTypeMap  spaceEdgeIndexByName_;
     SpaceNewestTagVerMap  spaceNewestTagVerMap_;
     SpaceNewestEdgeVerMap spaceNewestEdgeVerMap_;
-    folly::RWSpinLock localCacheLock_;
-    MetaChangedListener* listener_{nullptr};
+    folly::RWSpinLock     localCacheLock_;
+    MetaChangedListener*  listener_{nullptr};
+    bool                  sendHeartBeat_ = false;
 };
 }  // namespace meta
 }  // namespace nebula

--- a/src/meta/processors/HBProcessor.h
+++ b/src/meta/processors/HBProcessor.h
@@ -20,6 +20,7 @@ namespace meta {
 
 class HBProcessor : public BaseProcessor<cpp2::HBResp> {
     FRIEND_TEST(HBProcessorTest, HBTest);
+    FRIEND_TEST(MetaClientTest, HeartbeatTest);
 
 public:
     static HBProcessor* instance(kvstore::KVStore* kvstore) {

--- a/src/storage/client/StorageClient.cpp
+++ b/src/storage/client/StorageClient.cpp
@@ -15,16 +15,9 @@ namespace storage {
 
 StorageClient::StorageClient(std::shared_ptr<folly::IOThreadPoolExecutor> threadPool,
                              meta::MetaClient *client)
-        : ioThreadPool_(threadPool) {
-    if (nullptr == client) {
-        LOG(INFO) << "MetaClient is nullptr, create new one";
-        static auto clientPtr = std::make_unique<meta::MetaClient>();
-        static std::once_flag flag;
-        std::call_once(flag, std::bind(&meta::MetaClient::init, clientPtr.get()));
-        client_ = clientPtr.get();
-    } else {
-        client_ = client;
-    }
+        : ioThreadPool_(threadPool)
+        , client_(client) {
+    CHECK_NOTNULL(client_);
     clientsMan_
         = std::make_unique<thrift::ThriftClientManager<storage::cpp2::StorageServiceAsyncClient>>();
 }

--- a/src/storage/test/StorageClientTest.cpp
+++ b/src/storage/test/StorageClientTest.cpp
@@ -28,26 +28,29 @@ TEST(StorageClientTest, VerticesInterfacesTest) {
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     uint32_t localMetaPort = 10001;
     uint32_t localDataPort = 20002;
-    FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", localMetaPort);
 
     LOG(INFO) << "Start meta server....";
     std::string metaPath = folly::stringPrintf("%s/meta", rootPath.path());
     auto metaServerContext = meta::TestUtils::mockServer(10001, metaPath.c_str());
 
+    LOG(INFO) << "Create meta client...";
+    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
+    auto addrs = network::NetworkUtils::toHosts(folly::stringPrintf("127.0.0.1:%d", localMetaPort));
+    auto mClient = std::make_unique<meta::MetaClient>(threadPool, std::move(addrs), true);
+    mClient->init();
+
     LOG(INFO) << "Start data server....";
     std::string dataPath = folly::stringPrintf("%s/data", rootPath.path());
-    auto sc = TestUtils::mockServer(dataPath.c_str(), localIp, localDataPort);
+    auto sc = TestUtils::mockServer(mClient.get(), dataPath.c_str(), localIp, localDataPort);
 
     LOG(INFO) << "Add hosts and create space....";
-    auto mClient = std::make_unique<meta::MetaClient>();
-    mClient->init();
-    auto r = mClient->addHosts({HostAddr(localIp, localDataPort)}).get();
+
+        auto r = mClient->addHosts({HostAddr(localIp, localDataPort)}).get();
     ASSERT_TRUE(r.ok());
     auto ret = mClient->createSpace("default", 10, 1).get();
     spaceId = ret.value();
     sleep(2 * FLAGS_load_data_interval_second + 1);
 
-    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     auto client = std::make_unique<StorageClient>(threadPool, mClient.get());
     // VerticesInterfacesTest(addVertices and getVertexProps)
     {

--- a/src/storage/test/TestUtils.h
+++ b/src/storage/test/TestUtils.h
@@ -165,7 +165,8 @@ public:
          uint32_t port_;
      };
 
-     static std::unique_ptr<ServerContext> mockServer(const char* dataPath,
+     static std::unique_ptr<ServerContext> mockServer(meta::MetaClient* mClient,
+                                                      const char* dataPath,
                                                       uint32_t ip,
                                                       uint32_t port = 0) {
          auto sc = std::make_unique<ServerContext>();
@@ -178,7 +179,7 @@ public:
             options.local_ = HostAddr(ip, port);
             options.dataPaths_ = std::move(paths);
             options.partMan_
-                = std::make_unique<kvstore::MetaServerBasedPartManager>(options.local_);
+                = std::make_unique<kvstore::MetaServerBasedPartManager>(options.local_, mClient);
             kvstore::NebulaStore* kvPtr = static_cast<kvstore::NebulaStore*>(
                                         kvstore::KVStore::instance(std::move(options)));
              std::unique_ptr<kvstore::KVStore> kv(kvPtr);


### PR DESCRIPTION
1. Force meta client to reuse IOThreadPool outside.
2. Move meta_server_addrs flag outside, so we don't check the flag in MetaClient ctor any more.
3. Implement heartbeat logic.  


Subtask of #283