### PR TITLE
Use ephemeral port to bind on in tests

### DIFF
--- a/src/common/network/NetworkUtils.cpp
+++ b/src/common/network/NetworkUtils.cpp
@@ -109,6 +109,7 @@ std::unordered_set<uint16_t> NetworkUtils::getPortsInUse() {
     while (iter.valid()) {
         auto &sm = iter.matched();
         inUse.emplace(std::stoul(sm[1].str(), NULL, 16));
+        ++iter;
     }
     return std::move(inUse);
 }

--- a/src/common/network/test/NetworkUtilsTest.cpp
+++ b/src/common/network/test/NetworkUtilsTest.cpp
@@ -61,6 +61,7 @@ TEST(NetworkUtils, listDeviceAndIPv4s) {
     ASSERT_NE(result.value().end(), result.value().find("lo"));
 }
 
+
 TEST(NetworkUtils, intIPv4Conversion) {
     uint32_t ip;
     ASSERT_TRUE(NetworkUtils::ipv4ToInt("127.0.0.1", ip));
@@ -70,6 +71,19 @@ TEST(NetworkUtils, intIPv4Conversion) {
     uint32_t converted;
     ASSERT_TRUE(NetworkUtils::ipv4ToInt(NetworkUtils::intToIPv4(ip), converted));
     EXPECT_EQ(converted, ip);
+}
+
+
+TEST(NetworkUtils, getDynamicPortRange) {
+    uint16_t low, high;
+    ASSERT_TRUE(NetworkUtils::getDynamicPortRange(low, high));
+    ASSERT_NE(low, high);
+}
+
+
+TEST(NetworkUtils, getAvailablePort) {
+    auto port = NetworkUtils::getAvailablePort();
+    ASSERT_GT(port, 0);
 }
 
 }   // namespace network

--- a/src/daemons/MetaDaemon.cpp
+++ b/src/daemons/MetaDaemon.cpp
@@ -17,6 +17,7 @@ using nebula::ProcessUtils;
 using nebula::Status;
 
 DEFINE_int32(port, 45500, "Meta daemon listening port");
+DEFINE_bool(reuse_port, true, "Whether to turn on the SO_REUSEPORT option");
 DEFINE_string(data_path, "", "Root data path");
 DEFINE_string(peers, "", "It is a list of IPs split by comma,"
                          "the ips number equals replica number."
@@ -120,6 +121,7 @@ int main(int argc, char *argv[]) {
         gServer = std::make_unique<apache::thrift::ThriftServer>();
         gServer->setInterface(std::move(handler));
         gServer->setPort(FLAGS_port);
+        gServer->setReusePort(FLAGS_reuse_port);
         gServer->setIdleTimeout(std::chrono::seconds(0));  // No idle timeout on client connection
         gServer->serve();  // Will wait until the server shuts down
     } catch (const std::exception &e) {

--- a/src/daemons/StorageDaemon.cpp
+++ b/src/daemons/StorageDaemon.cpp
@@ -18,6 +18,7 @@
 #include "meta/client/MetaClient.h"
 
 DEFINE_int32(port, 44500, "Storage daemon listening port");
+DEFINE_bool(reuse_port, true, "Whether to turn on the SO_REUSEPORT option");
 DEFINE_string(data_path, "", "Root data path, multi paths should be split by comma."
                              "For rocksdb engine, one path one instance.");
 DEFINE_string(local_ip, "", "Local ip speicified for NetworkUtils::getLocalIP");
@@ -147,6 +148,7 @@ int main(int argc, char *argv[]) {
         gServer = std::make_unique<apache::thrift::ThriftServer>();
         gServer->setInterface(std::move(handler));
         gServer->setPort(FLAGS_port);
+        gServer->setReusePort(FLAGS_reuse_port);
         gServer->setIdleTimeout(std::chrono::seconds(0));  // No idle timeout on client connection
         gServer->setIOThreadPool(ioThreadPool);
         gServer->serve();  // Will wait until the server shuts down

--- a/src/graph/test/TestMain.cpp
+++ b/src/graph/test/TestMain.cpp
@@ -9,25 +9,26 @@
 #include "graph/test/TestEnv.h"
 #include "fs/TempDir.h"
 #include "meta/test/TestUtils.h"
+#include "network/NetworkUtils.h"
 
 using nebula::graph::TestEnv;
 using nebula::graph::gEnv;
 using nebula::meta::TestUtils;
 using nebula::fs::TempDir;
+using nebula::network::NetworkUtils;
 
 DECLARE_string(meta_server_addrs);
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);
     folly::init(&argc, &argv, true);
-    FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:44503");
     google::SetStderrLogging(google::INFO);
 
     gEnv = new TestEnv();   // gtest will delete this env object for us
     ::testing::AddGlobalTestEnvironment(gEnv);
 
-    // TODO(YT) use an ephemeral port
-    int32_t localMetaPort = 10001;
+    // use an ephemeral port
+    int32_t localMetaPort = NetworkUtils::getAvailablePort();
     FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", localMetaPort);
 
     // need to start meta server

--- a/src/graph/test/TestMain.cpp
+++ b/src/graph/test/TestMain.cpp
@@ -9,13 +9,11 @@
 #include "graph/test/TestEnv.h"
 #include "fs/TempDir.h"
 #include "meta/test/TestUtils.h"
-#include "network/NetworkUtils.h"
 
 using nebula::graph::TestEnv;
 using nebula::graph::gEnv;
 using nebula::meta::TestUtils;
 using nebula::fs::TempDir;
-using nebula::network::NetworkUtils;
 
 DECLARE_string(meta_server_addrs);
 
@@ -27,13 +25,12 @@ int main(int argc, char **argv) {
     gEnv = new TestEnv();   // gtest will delete this env object for us
     ::testing::AddGlobalTestEnvironment(gEnv);
 
-    // use an ephemeral port
-    int32_t localMetaPort = NetworkUtils::getAvailablePort();
-    FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", localMetaPort);
-
+    // Let the system choose an available port for us
+    int32_t localMetaPort = 0;
     // need to start meta server
     TempDir rootPath("/tmp/MetaClientTest.XXXXXX");
     auto metaServer = TestUtils::mockServer(localMetaPort, rootPath.path());
 
+    FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", metaServer->port_);
     return RUN_ALL_TESTS();
 }

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -148,7 +148,7 @@ struct AddVerticesRequest {
     1: common.GraphSpaceID space_id,
     // partId => vertices
     2: map<common.PartitionID, list<Vertex>>(cpp.template = "std::unordered_map") parts,
-    // If true, it equals an upset operation.
+    // If true, it equals an upsert operation.
     3: bool overwritable,
 }
 
@@ -156,7 +156,7 @@ struct AddEdgesRequest {
     1: common.GraphSpaceID space_id,
     // partId => edges
     2: map<common.PartitionID, list<Edge>>(cpp.template = "std::unordered_map") parts,
-    // If true, it equals an upset operation.
+    // If true, it equals an upsert operation.
     3: bool overwritable,
 }
 

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -148,7 +148,7 @@ struct AddVerticesRequest {
     1: common.GraphSpaceID space_id,
     // partId => vertices
     2: map<common.PartitionID, list<Vertex>>(cpp.template = "std::unordered_map") parts,
-    // If true, it equals an upsert operation.
+    // If true, it equals an upset operation.
     3: bool overwritable,
 }
 
@@ -156,7 +156,7 @@ struct AddEdgesRequest {
     1: common.GraphSpaceID space_id,
     // partId => edges
     2: map<common.PartitionID, list<Edge>>(cpp.template = "std::unordered_map") parts,
-    // If true, it equals an upsert operation.
+    // If true, it equals an upset operation.
     3: bool overwritable,
 }
 

--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -25,18 +25,23 @@ namespace meta {
 using nebula::cpp2::SupportedType;
 using nebula::cpp2::ValueType;
 using apache::thrift::FragileConstructor::FRAGILE;
+using nebula::network::NetworkUtils;
 
 TEST(MetaClientTest, InterfacesTest) {
     FLAGS_load_data_interval_secs = 1;
     fs::TempDir rootPath("/tmp/MetaClientTest.XXXXXX");
-    auto sc = TestUtils::mockServer(10001, rootPath.path());
+
+    // use an ephemeral port
+    int32_t localMetaPort = NetworkUtils::getAvailablePort();
+    auto sc = TestUtils::mockServer(localMetaPort, rootPath.path());
 
     GraphSpaceID spaceId = 0;
     auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     uint32_t localIp;
-    network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
+    NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     auto client = std::make_shared<MetaClient>(threadPool,
-                                               std::vector<HostAddr>{HostAddr(localIp, 10001)});
+        std::vector<HostAddr>{HostAddr(localIp, localMetaPort)});
+
     client->init();
     {
         // Test addHost, listHosts interface.
@@ -267,14 +272,18 @@ TEST(MetaClientTest, InterfacesTest) {
 TEST(MetaClientTest, TagTest) {
     FLAGS_load_data_interval_secs = 1;
     fs::TempDir rootPath("/tmp/MetaClientTagTest.XXXXXX");
-    auto sc = TestUtils::mockServer(10001, rootPath.path());
+
+    // use an ephemeral port
+    int32_t localMetaPort = NetworkUtils::getAvailablePort();
+    auto sc = TestUtils::mockServer(localMetaPort, rootPath.path());
 
     GraphSpaceID spaceId = 0;
     auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     uint32_t localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     auto client = std::make_shared<MetaClient>(threadPool,
-                                               std::vector<HostAddr>{HostAddr(localIp, 10001)});
+       std::vector<HostAddr>{HostAddr(localIp, localMetaPort)});
+
     client->init();
     std::vector<HostAddr> hosts = {{0, 0}, {1, 1}, {2, 2}, {3, 3}};
     auto r = client->addHosts(hosts).get();
@@ -360,14 +369,18 @@ public:
 TEST(MetaClientTest, DiffTest) {
     FLAGS_load_data_interval_secs = 1;
     fs::TempDir rootPath("/tmp/MetaClientTest.XXXXXX");
-    auto sc = TestUtils::mockServer(10001, rootPath.path());
+
+    // use an ephemeral port
+    int32_t localMetaPort = NetworkUtils::getAvailablePort();
+    auto sc = TestUtils::mockServer(localMetaPort, rootPath.path());
 
     auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     uint32_t localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     auto listener = std::make_unique<TestListener>();
     auto client = std::make_shared<MetaClient>(threadPool,
-                                               std::vector<HostAddr>{HostAddr(localIp, 10001)});
+        std::vector<HostAddr>{HostAddr(localIp, localMetaPort)});
+
     client->registerListener(listener.get());
     client->init();
     {

--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -25,22 +25,21 @@ namespace meta {
 using nebula::cpp2::SupportedType;
 using nebula::cpp2::ValueType;
 using apache::thrift::FragileConstructor::FRAGILE;
-using nebula::network::NetworkUtils;
 
 TEST(MetaClientTest, InterfacesTest) {
     FLAGS_load_data_interval_secs = 1;
     fs::TempDir rootPath("/tmp/MetaClientTest.XXXXXX");
 
-    // use an ephemeral port
-    int32_t localMetaPort = NetworkUtils::getAvailablePort();
+    // Let the system choose an available port for us
+    uint32_t localMetaPort = 0;
     auto sc = TestUtils::mockServer(localMetaPort, rootPath.path());
 
     GraphSpaceID spaceId = 0;
     auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     uint32_t localIp;
-    NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
+    network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     auto client = std::make_shared<MetaClient>(threadPool,
-        std::vector<HostAddr>{HostAddr(localIp, localMetaPort)});
+        std::vector<HostAddr>{HostAddr(localIp, sc->port_)});
 
     client->init();
     {
@@ -273,8 +272,8 @@ TEST(MetaClientTest, TagTest) {
     FLAGS_load_data_interval_secs = 1;
     fs::TempDir rootPath("/tmp/MetaClientTagTest.XXXXXX");
 
-    // use an ephemeral port
-    int32_t localMetaPort = NetworkUtils::getAvailablePort();
+    // Let the system choose an available port for us
+    int32_t localMetaPort = 0;
     auto sc = TestUtils::mockServer(localMetaPort, rootPath.path());
 
     GraphSpaceID spaceId = 0;
@@ -282,7 +281,7 @@ TEST(MetaClientTest, TagTest) {
     uint32_t localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     auto client = std::make_shared<MetaClient>(threadPool,
-       std::vector<HostAddr>{HostAddr(localIp, localMetaPort)});
+        std::vector<HostAddr>{HostAddr(localIp, sc->port_)});
 
     client->init();
     std::vector<HostAddr> hosts = {{0, 0}, {1, 1}, {2, 2}, {3, 3}};
@@ -370,8 +369,8 @@ TEST(MetaClientTest, DiffTest) {
     FLAGS_load_data_interval_secs = 1;
     fs::TempDir rootPath("/tmp/MetaClientTest.XXXXXX");
 
-    // use an ephemeral port
-    int32_t localMetaPort = NetworkUtils::getAvailablePort();
+    // Let the system choose an available port for us
+    int32_t localMetaPort = 0;
     auto sc = TestUtils::mockServer(localMetaPort, rootPath.path());
 
     auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
@@ -379,7 +378,7 @@ TEST(MetaClientTest, DiffTest) {
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     auto listener = std::make_unique<TestListener>();
     auto client = std::make_shared<MetaClient>(threadPool,
-        std::vector<HostAddr>{HostAddr(localIp, localMetaPort)});
+        std::vector<HostAddr>{HostAddr(localIp, sc->port_)});
 
     client->registerListener(listener.get());
     client->init();

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -178,8 +178,8 @@ public:
 
             LOG(INFO) << "Stop the server...";
         });
-        while (!sc->server_->getServeEventBase()
-               || !sc->server_->getServeEventBase()->isRunning()) {
+        while (!sc->server_->getServeEventBase() ||
+               !sc->server_->getServeEventBase()->isRunning()) {
         }
         sc->port_ = sc->server_->getAddress().getPort();
         LOG(INFO) << "Starting the Meta Daemon on port " << sc->port_

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -161,6 +161,7 @@ public:
 
         std::unique_ptr<apache::thrift::ThriftServer> server_;
         std::unique_ptr<std::thread> serverT_;
+        uint32_t port_;
     };
 
     static std::unique_ptr<ServerContext> mockServer(uint32_t port, const char* dataPath) {
@@ -177,7 +178,12 @@ public:
 
             LOG(INFO) << "Stop the server...";
         });
-        sleep(1);
+        while (!sc->server_->getServeEventBase()
+               || !sc->server_->getServeEventBase()->isRunning()) {
+        }
+        sc->port_ = sc->server_->getAddress().getPort();
+        LOG(INFO) << "Starting the Meta Daemon on port " << sc->port_
+                  << ", path " << dataPath;
         return sc;
     }
 };

--- a/src/storage/test/StorageClientTest.cpp
+++ b/src/storage/test/StorageClientTest.cpp
@@ -28,14 +28,16 @@ TEST(StorageClientTest, VerticesInterfacesTest) {
     uint32_t localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
 
-    // use an ephemeral port
-    uint32_t localMetaPort = network::NetworkUtils::getAvailablePort();;
-    uint32_t localDataPort = network::NetworkUtils::getAvailablePort();;
-    FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", localMetaPort);
+    // Let the system choose an available port for us
+    uint32_t localMetaPort = 0;
+
+    // for mockStorageServer MetaServerBasedPartManager, use ephemeral port
+    uint32_t localDataPort = network::NetworkUtils::getAvailablePort();
 
     LOG(INFO) << "Start meta server....";
     std::string metaPath = folly::stringPrintf("%s/meta", rootPath.path());
     auto metaServerContext = meta::TestUtils::mockServer(localMetaPort, metaPath.c_str());
+    FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", metaServerContext->port_);
 
     LOG(INFO) << "Create meta client...";
     auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);

--- a/src/storage/test/StorageClientTest.cpp
+++ b/src/storage/test/StorageClientTest.cpp
@@ -30,10 +30,6 @@ TEST(StorageClientTest, VerticesInterfacesTest) {
 
     // Let the system choose an available port for us
     uint32_t localMetaPort = 0;
-
-    // for mockStorageServer MetaServerBasedPartManager, use ephemeral port
-    uint32_t localDataPort = network::NetworkUtils::getAvailablePort();
-
     LOG(INFO) << "Start meta server....";
     std::string metaPath = folly::stringPrintf("%s/meta", rootPath.path());
     auto metaServerContext = meta::TestUtils::mockServer(localMetaPort, metaPath.c_str());
@@ -49,6 +45,9 @@ TEST(StorageClientTest, VerticesInterfacesTest) {
     mClient->init();
 
     LOG(INFO) << "Start data server....";
+
+    // for mockStorageServer MetaServerBasedPartManager, use ephemeral port
+    uint32_t localDataPort = network::NetworkUtils::getAvailablePort();
     std::string dataPath = folly::stringPrintf("%s/data", rootPath.path());
     auto sc = TestUtils::mockServer(mClient.get(), dataPath.c_str(), localIp, localDataPort);
 

--- a/src/storage/test/StorageClientTest.cpp
+++ b/src/storage/test/StorageClientTest.cpp
@@ -33,7 +33,7 @@ TEST(StorageClientTest, VerticesInterfacesTest) {
     LOG(INFO) << "Start meta server....";
     std::string metaPath = folly::stringPrintf("%s/meta", rootPath.path());
     auto metaServerContext = meta::TestUtils::mockServer(localMetaPort, metaPath.c_str());
-    FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", metaServerContext->port_);
+    localMetaPort =  metaServerContext->port_;
 
     LOG(INFO) << "Create meta client...";
     auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);

--- a/src/storage/test/StorageClientTest.cpp
+++ b/src/storage/test/StorageClientTest.cpp
@@ -13,6 +13,7 @@
 #include "dataman/RowReader.h"
 #include "dataman/RowWriter.h"
 #include "dataman/RowSetReader.h"
+#include "network/NetworkUtils.h"
 
 DECLARE_string(meta_server_addrs);
 DECLARE_int32(load_data_interval_secs);
@@ -26,12 +27,15 @@ TEST(StorageClientTest, VerticesInterfacesTest) {
     GraphSpaceID spaceId = 0;
     uint32_t localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
-    uint32_t localMetaPort = 10001;
-    uint32_t localDataPort = 20002;
+
+    // use an ephemeral port
+    uint32_t localMetaPort = network::NetworkUtils::getAvailablePort();;
+    uint32_t localDataPort = network::NetworkUtils::getAvailablePort();;
+    FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", localMetaPort);
 
     LOG(INFO) << "Start meta server....";
     std::string metaPath = folly::stringPrintf("%s/meta", rootPath.path());
-    auto metaServerContext = meta::TestUtils::mockServer(10001, metaPath.c_str());
+    auto metaServerContext = meta::TestUtils::mockServer(localMetaPort, metaPath.c_str());
 
     LOG(INFO) << "Create meta client...";
     auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);

--- a/src/storage/test/TestUtils.h
+++ b/src/storage/test/TestUtils.h
@@ -165,7 +165,8 @@ public:
         uint32_t port_;
     };
 
-    static std::unique_ptr<ServerContext> mockServer(const char* dataPath,
+    static std::unique_ptr<ServerContext> mockServer(meta::MetaClient* mClient,
+                                                     const char* dataPath,
                                                      uint32_t ip,
                                                      uint32_t port = 0) {
         auto sc = std::make_unique<ServerContext>();

--- a/src/storage/test/TestUtils.h
+++ b/src/storage/test/TestUtils.h
@@ -154,24 +154,23 @@ public:
     }
 
     struct ServerContext {
-         ~ServerContext() {
-             server_->stop();
-             serverT_->join();
-             VLOG(3) << "~ServerContext";
-         }
+        ~ServerContext() {
+            server_->stop();
+            serverT_->join();
+            VLOG(3) << "~ServerContext";
+        }
 
-         std::unique_ptr<apache::thrift::ThriftServer> server_;
-         std::unique_ptr<std::thread> serverT_;
-         uint32_t port_;
-     };
+        std::unique_ptr<apache::thrift::ThriftServer> server_;
+        std::unique_ptr<std::thread> serverT_;
+        uint32_t port_;
+    };
 
-     static std::unique_ptr<ServerContext> mockServer(meta::MetaClient* mClient,
-                                                      const char* dataPath,
-                                                      uint32_t ip,
-                                                      uint32_t port = 0) {
-         auto sc = std::make_unique<ServerContext>();
-         sc->server_ = std::make_unique<apache::thrift::ThriftServer>();
-         sc->serverT_ = std::make_unique<std::thread>([&]() {
+    static std::unique_ptr<ServerContext> mockServer(const char* dataPath,
+                                                     uint32_t ip,
+                                                     uint32_t port = 0) {
+        auto sc = std::make_unique<ServerContext>();
+        sc->server_ = std::make_unique<apache::thrift::ThriftServer>();
+        sc->serverT_ = std::make_unique<std::thread>([&]() {
             std::vector<std::string> paths;
             paths.push_back(folly::stringPrintf("%s/disk1", dataPath));
             paths.push_back(folly::stringPrintf("%s/disk2", dataPath));
@@ -182,26 +181,25 @@ public:
                 = std::make_unique<kvstore::MetaServerBasedPartManager>(options.local_, mClient);
             kvstore::NebulaStore* kvPtr = static_cast<kvstore::NebulaStore*>(
                                         kvstore::KVStore::instance(std::move(options)));
-             std::unique_ptr<kvstore::KVStore> kv(kvPtr);
-             auto schemaMan = TestUtils::mockSchemaMan(1);
-             auto handler
-                    = std::make_shared<nebula::storage::StorageServiceHandler>(
-                                                                            kv.get(),
+            std::unique_ptr<kvstore::KVStore> kv(kvPtr);
+            auto schemaMan = TestUtils::mockSchemaMan(1);
+            auto handler
+                 = std::make_shared<nebula::storage::StorageServiceHandler>(kv.get(),
                                                                             std::move(schemaMan));
-             CHECK(!!sc->server_) << "Failed to create the thrift server";
-             sc->server_->setInterface(handler);
-             sc->server_->setPort(port);
-             sc->server_->serve();  // Will wait until the server shuts down
-             LOG(INFO) << "Stop the server...";
-         });
-         while (!sc->server_->getServeEventBase()
-                 || !sc->server_->getServeEventBase()->isRunning()) {
-         }
-         sc->port_ = sc->server_->getAddress().getPort();
-         LOG(INFO) << "Starting the storage Daemon on port " << sc->port_
-                   << ", path " << dataPath;
-         return sc;
-     }
+            CHECK(!!sc->server_) << "Failed to create the thrift server";
+            sc->server_->setInterface(handler);
+            sc->server_->setPort(port);
+            sc->server_->serve();  // Will wait until the server shuts down
+            LOG(INFO) << "Stop the server...";
+        });
+        while (!sc->server_->getServeEventBase() ||
+               !sc->server_->getServeEventBase()->isRunning()) {
+        }
+        sc->port_ = sc->server_->getAddress().getPort();
+        LOG(INFO) << "Starting the storage Daemon on port " << sc->port_
+                  << ", path " << dataPath;
+        return sc;
+    }
 };
 
 }  // namespace storage


### PR DESCRIPTION
Use ephemeral port to bind on in tests #260

Sometimes you need a program to bind to a port that can't be hard-coded. Generally this is when you want to run several of them in parallel; if they all bind to port a specified port, only one of them can succeed.

so use system unused ephemeral port 

This will close #260 
