### PR TITLE
Adjust meta client ctor  && implement heartbeat logic inside.

### DIFF
--- a/src/common/network/NetworkUtils.cpp
+++ b/src/common/network/NetworkUtils.cpp
@@ -204,36 +204,42 @@ std::string NetworkUtils::intToIPv4(uint32_t ip) {
     return buf;
 }
 
-
-HostAddr NetworkUtils::toHostAddr(const folly::StringPiece ip, int32_t port) {
+StatusOr<HostAddr> NetworkUtils::toHostAddr(folly::StringPiece ip, int32_t port) {
     uint32_t ipV4;
-    CHECK(ipv4ToInt(ip.toString(), ipV4));
+    if (!ipv4ToInt(ip.toString(), ipV4)) {
+        return Status::Error("Bad ip format:%s", ip.start());
+    }
     return std::make_pair(ipV4, port);
 }
 
-
-HostAddr NetworkUtils::toHostAddr(const folly::StringPiece ipPort) {
+StatusOr<HostAddr> NetworkUtils::toHostAddr(folly::StringPiece ipPort) {
     auto pos = ipPort.find(':');
-    CHECK_NE(pos, folly::StringPiece::npos);
+    if (pos == folly::StringPiece::npos) {
+        return Status::Error("Bad peer format: %s", ipPort.start());
+    }
 
     int32_t port;
     try {
         port = folly::to<int32_t>(ipPort.subpiece(pos + 1));
     } catch (const std::exception& ex) {
-        LOG(FATAL) << "Bad ipPort: " << ex.what();
+        return Status::Error("Bad port number, error: %s", ex.what());
     }
 
     return toHostAddr(ipPort.subpiece(0, pos), port);
 }
 
-std::vector<HostAddr> NetworkUtils::toHosts(const std::string& peersStr) {
+StatusOr<std::vector<HostAddr>> NetworkUtils::toHosts(const std::string& peersStr) {
     std::vector<HostAddr> hosts;
     std::vector<std::string> peers;
     folly::split(",", peersStr, peers, true);
-    hosts.resize(peers.size());
-    std::transform(peers.begin(), peers.end(), hosts.begin(), [](auto& p) {
-        return network::NetworkUtils::toHostAddr(folly::trimWhitespace(p));
-    });
+    hosts.reserve(peers.size());
+    for (auto& peerStr : peers) {
+        auto hostAddr = network::NetworkUtils::toHostAddr(folly::trimWhitespace(peerStr));
+        if (!hostAddr.ok()) {
+            return hostAddr.status();
+        }
+        hosts.emplace_back(hostAddr.value());
+    }
     return hosts;
 }
 

--- a/src/common/network/NetworkUtils.h
+++ b/src/common/network/NetworkUtils.h
@@ -34,9 +34,9 @@ public:
     static uint16_t getAvailablePort();
 
     // Convert the given IP (must be in the form of "xx.xx.xx.xx") and Port to a HostAddr
-    static HostAddr toHostAddr(const folly::StringPiece ip, int32_t port);
+    static StatusOr<HostAddr> toHostAddr(folly::StringPiece ip, int32_t port);
     // Convert the given IP/Port (must be in the form of "xx.xx.xx.xx:pp") to a HostAddr
-    static HostAddr toHostAddr(const folly::StringPiece ipPort);
+    static StatusOr<HostAddr> toHostAddr(folly::StringPiece ipPort);
     // Retrieve the string-form IP from the given HostAddr
     static std::string ipFromHostAddr(const HostAddr& host);
     // Retrieve the port number from the given HostAddr
@@ -57,7 +57,8 @@ public:
 
     // Convert peers str which is a list of ipPort joined with comma into HostAddr list.
     // (Peers str format example: 192.168.1.1:10001, 192.168.1.2:10001)
-    static std::vector<HostAddr> toHosts(const std::string& peersStr);
+    // Return Status::Error if peersStr is invalid.
+    static StatusOr<std::vector<HostAddr>> toHosts(const std::string& peersStr);
 
 private:
 };

--- a/src/daemons/GraphDaemon.cpp
+++ b/src/daemons/GraphDaemon.cpp
@@ -112,7 +112,12 @@ int main(int argc, char *argv[]) {
         localIP = std::move(result).value();
     }
 
+    if (FLAGS_num_netio_threads <= 0) {
+        LOG(WARNING) << "Number netio threads should be greater than zero";
+        return EXIT_FAILURE;
+    }
     gServer = std::make_unique<apache::thrift::ThriftServer>();
+    gServer->getIOThreadPool()->setNumThreads(FLAGS_num_netio_threads);
     auto interface = std::make_shared<GraphService>(gServer->getIOThreadPool());
 
     gServer->setInterface(std::move(interface));
@@ -127,12 +132,6 @@ int main(int argc, char *argv[]) {
     gServer->setNumAcceptThreads(FLAGS_num_accept_threads);
     gServer->setListenBacklog(FLAGS_listen_backlog);
     gServer->setThreadStackSizeMB(5);
-    if (FLAGS_num_netio_threads > 0) {
-        gServer->setNumIOWorkerThreads(FLAGS_num_netio_threads);
-    } else {
-        LOG(WARNING) << "Number netio threads should be greater than zero";
-        return EXIT_FAILURE;
-    }
 
     // Setup the signal handlers
     status = setupSignalHandler();

--- a/src/graph/ExecutionEngine.cpp
+++ b/src/graph/ExecutionEngine.cpp
@@ -24,11 +24,11 @@ ExecutionEngine::~ExecutionEngine() {
 
 
 Status ExecutionEngine::init(std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor) {
-    if (FLAGS_meta_server_addrs.empty()) {
-        return Status::Error("The meta_server_addrs flag should not be empty!");
-    }
     auto addrs = network::NetworkUtils::toHosts(FLAGS_meta_server_addrs);
-    metaClient_ = std::make_unique<meta::MetaClient>(ioExecutor, std::move(addrs));
+    if (!addrs.ok()) {
+        return addrs.status();
+    }
+    metaClient_ = std::make_unique<meta::MetaClient>(ioExecutor, std::move(addrs.value()));
     metaClient_->init();
 
     schemaManager_ = meta::SchemaManager::create();

--- a/src/graph/GraphFlags.cpp
+++ b/src/graph/GraphFlags.cpp
@@ -25,3 +25,5 @@ DEFINE_bool(redirect_stdout, true, "Whether to redirect stdout and stderr to sep
 DEFINE_string(stdout_log_file, "graphd-stdout.log", "Destination filename of stdout");
 DEFINE_string(stderr_log_file, "graphd-stderr.log", "Destination filename of stderr");
 DEFINE_bool(daemonize, true, "Whether run as a daemon process");
+DEFINE_string(meta_server_addrs, "", "list of meta server addresses,"
+                                     "the format looks like ip1:port1, ip2:port2, ip3:port3");

--- a/src/graph/GraphFlags.h
+++ b/src/graph/GraphFlags.h
@@ -24,6 +24,7 @@ DECLARE_bool(redirect_stdout);
 DECLARE_string(stdout_log_file);
 DECLARE_string(stderr_log_file);
 DECLARE_bool(daemonize);
+DECLARE_string(meta_server_addrs);
 
 
 #endif  // GRAPH_GRAPHFLAGS_H_

--- a/src/graph/test/SchemaTest.cpp
+++ b/src/graph/test/SchemaTest.cpp
@@ -8,7 +8,7 @@
 #include "graph/test/TestEnv.h"
 #include "graph/test/TestBase.h"
 
-DECLARE_int32(load_data_interval_second);
+DECLARE_int32(load_data_interval_secs);
 
 namespace nebula {
 namespace graph {
@@ -58,7 +58,7 @@ TEST_F(SchemaTest, metaCommunication) {
         auto code = client->execute(query, resp);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
     }
-    sleep(FLAGS_load_data_interval_second + 1);
+    sleep(FLAGS_load_data_interval_secs + 1);
     {
         cpp2::ExecutionResponse resp;
         std::string query = "USE default_space";
@@ -70,10 +70,10 @@ TEST_F(SchemaTest, metaCommunication) {
         std::string query = "CREATE TAG person(name string, email_addr string, "
                             "age int, gender string, row_timestamp timestamp)";
         auto code = client->execute(query, resp);
-        sleep(FLAGS_load_data_interval_second + 1);
+        sleep(FLAGS_load_data_interval_secs + 1);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
     }
-    sleep(FLAGS_load_data_interval_second + 1);
+    sleep(FLAGS_load_data_interval_secs + 1);
     {
         cpp2::ExecutionResponse resp;
         std::string query = "DESCRIBE TAG person";
@@ -101,7 +101,7 @@ TEST_F(SchemaTest, metaCommunication) {
         auto code = client->execute(query, resp);
         ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, code);
     }
-    sleep(FLAGS_load_data_interval_second + 1);
+    sleep(FLAGS_load_data_interval_secs + 1);
     {
         cpp2::ExecutionResponse resp;
         std::string query = "DESCRIBE TAG account";
@@ -128,7 +128,7 @@ TEST_F(SchemaTest, metaCommunication) {
         auto code = client->execute(query, resp);
         ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, code);
     }
-    sleep(FLAGS_load_data_interval_second + 1);
+    sleep(FLAGS_load_data_interval_secs + 1);
     {
         cpp2::ExecutionResponse resp;
         std::string query = "DESCRIBE TAG account";
@@ -153,7 +153,7 @@ TEST_F(SchemaTest, metaCommunication) {
         auto code = client->execute(query, resp);
         ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, code);
     }
-    sleep(FLAGS_load_data_interval_second + 1);
+    sleep(FLAGS_load_data_interval_secs + 1);
     {
         cpp2::ExecutionResponse resp;
         std::string query = "DESCRIBE EDGE buy";
@@ -170,7 +170,7 @@ TEST_F(SchemaTest, metaCommunication) {
         auto code = client->execute(query, resp);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
     }
-    sleep(FLAGS_load_data_interval_second + 1);
+    sleep(FLAGS_load_data_interval_secs + 1);
     {
         cpp2::ExecutionResponse resp;
         std::string query = "DESCRIBE EDGE education";
@@ -186,7 +186,7 @@ TEST_F(SchemaTest, metaCommunication) {
         cpp2::ExecutionResponse resp;
         std::string query = "SHOW EDGES";
         auto code = client->execute(query, resp);
-        sleep(FLAGS_load_data_interval_second + 1);
+        sleep(FLAGS_load_data_interval_secs + 1);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
         std::vector<uniform_tuple_t<std::string, 1>> expected{
             {"buy"},
@@ -228,7 +228,7 @@ TEST_F(SchemaTest, metaCommunication) {
         auto code = client->execute(query, resp);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
     }
-    sleep(FLAGS_load_data_interval_second + 1);
+    sleep(FLAGS_load_data_interval_secs + 1);
     {
         cpp2::ExecutionResponse resp;
         std::string query = "USE my_space";
@@ -240,10 +240,10 @@ TEST_F(SchemaTest, metaCommunication) {
         cpp2::ExecutionResponse resp;
         std::string query = "CREATE TAG animal(name string, kind string)";
         auto code = client->execute(query, resp);
-        sleep(FLAGS_load_data_interval_second + 1);
+        sleep(FLAGS_load_data_interval_secs + 1);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
     }
-    sleep(FLAGS_load_data_interval_second + 1);
+    sleep(FLAGS_load_data_interval_secs + 1);
     {
         cpp2::ExecutionResponse resp;
         std::string query = "DESCRIBE TAG animal";
@@ -265,7 +265,7 @@ TEST_F(SchemaTest, metaCommunication) {
         cpp2::ExecutionResponse resp;
         std::string query = "SHOW TAGS";
         auto code = client->execute(query, resp);
-        sleep(FLAGS_load_data_interval_second + 1);
+        sleep(FLAGS_load_data_interval_secs + 1);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
         std::vector<uniform_tuple_t<std::string, 1>> expected{
             {"animal"},
@@ -277,7 +277,7 @@ TEST_F(SchemaTest, metaCommunication) {
         cpp2::ExecutionResponse resp;
         std::string query = "REMOVE TAG person ";
         auto code = client->execute(query, resp);
-        sleep(FLAGS_load_data_interval_second + 1);
+        sleep(FLAGS_load_data_interval_secs + 1);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
     }
     {

--- a/src/graph/test/SchemaTest.cpp
+++ b/src/graph/test/SchemaTest.cpp
@@ -210,7 +210,7 @@ TEST_F(SchemaTest, metaCommunication) {
         auto code = client->execute(query, resp);
         ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, code);
     }
-    sleep(FLAGS_load_data_interval_second + 1);
+    sleep(FLAGS_load_data_interval_secs + 1);
     {
         cpp2::ExecutionResponse resp;
         std::string query = "DESCRIBE EDGE education";

--- a/src/graph/test/TestEnv.cpp
+++ b/src/graph/test/TestEnv.cpp
@@ -7,7 +7,7 @@
 #include "base/Base.h"
 #include "graph/test/TestEnv.h"
 
-DECLARE_int32(load_data_interval_second);
+DECLARE_int32(load_data_interval_secs);
 
 namespace nebula {
 namespace graph {
@@ -24,13 +24,13 @@ TestEnv::~TestEnv() {
 
 
 void TestEnv::SetUp() {
-    FLAGS_load_data_interval_second = 1;
+    FLAGS_load_data_interval_secs = 1;
     using ThriftServer = apache::thrift::ThriftServer;
     server_ = std::make_unique<ThriftServer>();
+    server_->getIOThreadPool()->setNumThreads(1);
     auto interface = std::make_shared<GraphService>(server_->getIOThreadPool());
     server_->setInterface(std::move(interface));
     server_->setPort(0);    // Let the system choose an available port for us
-
     auto serve = [this] {
         server_->serve();
     };

--- a/src/kvstore/PartManager.cpp
+++ b/src/kvstore/PartManager.cpp
@@ -35,17 +35,8 @@ bool MemPartManager::partExist(const HostAddr& host, GraphSpaceID spaceId, Parti
 
 MetaServerBasedPartManager::MetaServerBasedPartManager(HostAddr host, meta::MetaClient *client)
     : localHost_(std::move(host)) {
-    if (nullptr == client) {
-        LOG(INFO) << "MetaClient is nullptr, create new one";
-        // multi instances use one metaclient
-        static auto clientPtr = std::make_unique<meta::MetaClient>();
-        static std::once_flag flag;
-        std::call_once(flag, std::bind(&meta::MetaClient::init, clientPtr.get()));
-        client_ = clientPtr.get();
-    } else {
-        client_ = client;
-    }
-
+    client_ = client;
+    CHECK_NOTNULL(client_);
     client_->registerListener(this);
 }
 

--- a/src/meta/SchemaManager.cpp
+++ b/src/meta/SchemaManager.cpp
@@ -6,26 +6,14 @@
 
 #include "base/Base.h"
 #include "meta/SchemaManager.h"
-#include "meta/FileBasedSchemaManager.h"
 #include "meta/ServerBasedSchemaManager.h"
-
-DECLARE_string(schema_file);
-DECLARE_string(meta_server_addrs);
 
 namespace nebula {
 namespace meta {
 
 std::unique_ptr<SchemaManager> SchemaManager::create() {
-    if (!FLAGS_schema_file.empty()) {
-        std::unique_ptr<SchemaManager> sm(new FileBasedSchemaManager());
-        return sm;
-    } else if (!FLAGS_meta_server_addrs.empty()) {
-        std::unique_ptr<SchemaManager> sm(new ServerBasedSchemaManager());
-        return sm;
-    } else {
-        std::unique_ptr<SchemaManager> sm(new AdHocSchemaManager());
-        return sm;
-    }
+    auto sm = std::unique_ptr<SchemaManager>(new ServerBasedSchemaManager());
+    return sm;
 }
 
 void AdHocSchemaManager::addTagSchema(GraphSpaceID space,

--- a/src/meta/ServerBasedSchemaManager.cpp
+++ b/src/meta/ServerBasedSchemaManager.cpp
@@ -17,15 +17,8 @@ ServerBasedSchemaManager::~ServerBasedSchemaManager() {
 }
 
 void ServerBasedSchemaManager::init(MetaClient *client) {
-    if (nullptr == client) {
-        LOG(INFO) << "MetaClient is nullptr, create new one";
-        static auto clientPtr = std::make_unique<meta::MetaClient>();
-        static std::once_flag flag;
-        std::call_once(flag, std::bind(&meta::MetaClient::init, clientPtr.get()));
-        metaClient_ = clientPtr.get();
-    } else {
-        metaClient_ = client;
-    }
+    metaClient_ = client;
+    CHECK_NOTNULL(metaClient_);
 }
 
 std::shared_ptr<const SchemaProviderIf>

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -9,26 +9,19 @@
 #include "network/NetworkUtils.h"
 #include "meta/NebulaSchemaProvider.h"
 
-DEFINE_int32(load_data_interval_second, 2 * 60, "Load data interval, unit: second");
-DEFINE_string(meta_server_addrs, "", "list of meta server addresses,"
-                                     "the format looks like ip1:port1, ip2:port2, ip3:port3");
-DEFINE_int32(meta_client_io_threads, 3, "meta client io threads");
+DEFINE_int32(load_data_interval_secs, 2 * 60, "Load data interval");
+DEFINE_int32(heartbeat_interval_secs, 10, "Heartbeat interval");
 
 namespace nebula {
 namespace meta {
 
 MetaClient::MetaClient(std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool,
-                       std::vector<HostAddr> addrs)
+                       std::vector<HostAddr> addrs,
+                       bool sendHeartBeat)
     : ioThreadPool_(ioThreadPool)
-    , addrs_(std::move(addrs)) {
-    if (ioThreadPool_ == nullptr) {
-        ioThreadPool_
-            = std::make_shared<folly::IOThreadPoolExecutor>(FLAGS_meta_client_io_threads);
-    }
-    if (addrs_.empty() && !FLAGS_meta_server_addrs.empty()) {
-        addrs_ = network::NetworkUtils::toHosts(FLAGS_meta_server_addrs);
-    }
-    CHECK(!addrs_.empty());
+    , addrs_(std::move(addrs))
+    , sendHeartBeat_(sendHeartBeat) {
+    CHECK(ioThreadPool_ != nullptr && !addrs_.empty());
     clientsMan_ = std::make_shared<thrift::ThriftClientManager<
                                     meta::cpp2::MetaServiceAsyncClient>>();
     updateHost();
@@ -36,21 +29,47 @@ MetaClient::MetaClient(std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool
 }
 
 MetaClient::~MetaClient() {
-    loadDataThread_.stop();
-    loadDataThread_.wait();
+    bgThread_.stop();
+    bgThread_.wait();
     VLOG(3) << "~MetaClient";
 }
 
 void MetaClient::init() {
     loadDataThreadFunc();
-    CHECK(loadDataThread_.start());
-    size_t delayMS = FLAGS_load_data_interval_second * 1000 + folly::Random::rand32(900);
-    loadDataThread_.addTimerTask(delayMS,
-                                 FLAGS_load_data_interval_second * 1000,
-                                 &MetaClient::loadDataThreadFunc, this);
+    CHECK(bgThread_.start());
+    {
+        size_t delayMS = FLAGS_load_data_interval_secs * 1000 + folly::Random::rand32(900);
+        LOG(INFO) << "Register timer task for load data!";
+        bgThread_.addTimerTask(delayMS,
+                               FLAGS_load_data_interval_secs * 1000,
+                               &MetaClient::loadDataThreadFunc, this);
+    }
+    if (sendHeartBeat_) {
+        LOG(INFO) << "Register time task for heartbeat!";
+        size_t delayMS = FLAGS_heartbeat_interval_secs * 1000 + folly::Random::rand32(900);
+        bgThread_.addTimerTask(delayMS,
+                               FLAGS_heartbeat_interval_secs * 1000,
+                               &MetaClient::heartBeatThreadFunc, this);
+    }
+}
+
+void MetaClient::heartBeatThreadFunc() {
+    if (listener_ == nullptr) {
+        VLOG(1) << "Can't send heartbeat due to listener_ is nullptr!";
+        return;
+    }
+    auto ret = heartbeat().get();
+    if (!ret.ok()) {
+        LOG(ERROR) << "Heartbeat failed, status:" << ret.status();
+        return;
+    }
 }
 
 void MetaClient::loadDataThreadFunc() {
+    if (ioThreadPool_->numThreads() <= 0) {
+        LOG(ERROR) << "The threads number in ioThreadPool should be greater than 0";
+        return;
+    }
     auto ret = listSpaces().get();
     if (!ret.ok()) {
         LOG(ERROR) << "List space failed, status:" << ret.status();
@@ -236,7 +255,7 @@ std::vector<HostAddr> MetaClient::to(const std::vector<nebula::cpp2::HostAddr>& 
 std::vector<SpaceIdName> MetaClient::toSpaceIdName(const std::vector<cpp2::IdName>& tIdNames) {
     std::vector<SpaceIdName> idNames;
     idNames.resize(tIdNames.size());
-    std::transform(tIdNames.begin(), tIdNames.end(), idNames.begin(), [] (const auto& tin) {
+    std::transform(tIdNames.begin(), tIdNames.end(), idNames.begin(), [](const auto& tin) {
         return SpaceIdName(tin.id.get_space_id(), tin.name);
     });
     return idNames;
@@ -824,6 +843,21 @@ SchemaVer MetaClient::getNewestEdgeVerFromCache(const GraphSpaceID& space,
         return -1;
     }
     return it->second;
+}
+
+folly::Future<StatusOr<bool>> MetaClient::heartbeat() {
+    CHECK_NOTNULL(listener_);
+    auto localHost = listener_->getLocalHost();
+    cpp2::HBReq req;
+    nebula::cpp2::HostAddr thriftHost;
+    thriftHost.set_ip(localHost.first);
+    thriftHost.set_port(localHost.second);
+    req.set_host(std::move(thriftHost));
+    return getResponse(std::move(req), [] (auto client, auto request) {
+        return client->future_heartBeat(request);
+    }, [] (cpp2::HBResp&& resp) -> bool {
+        return resp.code == cpp2::ErrorCode::SUCCEEDED;
+    }, true);
 }
 
 }  // namespace meta

--- a/src/meta/processors/HBProcessor.h
+++ b/src/meta/processors/HBProcessor.h
@@ -20,6 +20,7 @@ namespace meta {
 
 class HBProcessor : public BaseProcessor<cpp2::HBResp> {
     FRIEND_TEST(HBProcessorTest, HBTest);
+    FRIEND_TEST(MetaClientTest, HeartbeatTest);
 
 public:
     static HBProcessor* instance(kvstore::KVStore* kvstore) {

--- a/src/meta/test/MetaHttpHandlerTest.cpp
+++ b/src/meta/test/MetaHttpHandlerTest.cpp
@@ -13,7 +13,7 @@
 #include "meta/test/TestUtils.h"
 #include "fs/TempDir.h"
 
-DECLARE_int32(load_data_interval_second);
+DECLARE_int32(load_data_interval_secs);
 DECLARE_string(pid_file);
 
 namespace nebula {
@@ -42,7 +42,7 @@ public:
 
 
 TEST(MetaHttpHandlerTest, MetaStatusTest) {
-    FLAGS_load_data_interval_second = 1;
+    FLAGS_load_data_interval_secs = 1;
     fs::TempDir rootPath("/tmp/MetaClientTest.XXXXXX");
     auto sc = TestUtils::mockServer(10001, rootPath.path());
 

--- a/src/storage/client/StorageClient.cpp
+++ b/src/storage/client/StorageClient.cpp
@@ -15,16 +15,9 @@ namespace storage {
 
 StorageClient::StorageClient(std::shared_ptr<folly::IOThreadPoolExecutor> threadPool,
                              meta::MetaClient *client)
-        : ioThreadPool_(threadPool) {
-    if (nullptr == client) {
-        LOG(INFO) << "MetaClient is nullptr, create new one";
-        static auto clientPtr = std::make_unique<meta::MetaClient>();
-        static std::once_flag flag;
-        std::call_once(flag, std::bind(&meta::MetaClient::init, clientPtr.get()));
-        client_ = clientPtr.get();
-    } else {
-        client_ = client;
-    }
+        : ioThreadPool_(threadPool)
+        , client_(client) {
+    CHECK_NOTNULL(client_);
     clientsMan_
         = std::make_unique<thrift::ThriftClientManager<storage::cpp2::StorageServiceAsyncClient>>();
 }

--- a/src/storage/test/StorageClientTest.cpp
+++ b/src/storage/test/StorageClientTest.cpp
@@ -35,8 +35,11 @@ TEST(StorageClientTest, VerticesInterfacesTest) {
 
     LOG(INFO) << "Create meta client...";
     auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
-    auto addrs = network::NetworkUtils::toHosts(folly::stringPrintf("127.0.0.1:%d", localMetaPort));
-    auto mClient = std::make_unique<meta::MetaClient>(threadPool, std::move(addrs), true);
+    auto addrsRet
+        = network::NetworkUtils::toHosts(folly::stringPrintf("127.0.0.1:%d", localMetaPort));
+    CHECK(addrsRet.ok()) << addrsRet.status();
+    auto mClient
+        = std::make_unique<meta::MetaClient>(threadPool, std::move(addrsRet.value()), true);
     mClient->init();
 
     LOG(INFO) << "Start data server....";

--- a/src/storage/test/StorageClientTest.cpp
+++ b/src/storage/test/StorageClientTest.cpp
@@ -15,39 +15,41 @@
 #include "dataman/RowSetReader.h"
 
 DECLARE_string(meta_server_addrs);
-DECLARE_int32(load_data_interval_second);
+DECLARE_int32(load_data_interval_secs);
 
 namespace nebula {
 namespace storage {
 
 TEST(StorageClientTest, VerticesInterfacesTest) {
-    FLAGS_load_data_interval_second = 1;
+    FLAGS_load_data_interval_secs = 1;
     fs::TempDir rootPath("/tmp/StorageClientTest.XXXXXX");
     GraphSpaceID spaceId = 0;
     uint32_t localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     uint32_t localMetaPort = 10001;
     uint32_t localDataPort = 20002;
-    FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", localMetaPort);
 
     LOG(INFO) << "Start meta server....";
     std::string metaPath = folly::stringPrintf("%s/meta", rootPath.path());
     auto metaServerContext = meta::TestUtils::mockServer(10001, metaPath.c_str());
 
+    LOG(INFO) << "Create meta client...";
+    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
+    auto addrs = network::NetworkUtils::toHosts(folly::stringPrintf("127.0.0.1:%d", localMetaPort));
+    auto mClient = std::make_unique<meta::MetaClient>(threadPool, std::move(addrs), true);
+    mClient->init();
+
     LOG(INFO) << "Start data server....";
     std::string dataPath = folly::stringPrintf("%s/data", rootPath.path());
-    auto sc = TestUtils::mockServer(dataPath.c_str(), localIp, localDataPort);
+    auto sc = TestUtils::mockServer(mClient.get(), dataPath.c_str(), localIp, localDataPort);
 
     LOG(INFO) << "Add hosts and create space....";
-    auto mClient = std::make_unique<meta::MetaClient>();
-    mClient->init();
     auto r = mClient->addHosts({HostAddr(localIp, localDataPort)}).get();
     ASSERT_TRUE(r.ok());
     auto ret = mClient->createSpace("default", 10, 1).get();
     spaceId = ret.value();
-    sleep(2 * FLAGS_load_data_interval_second + 1);
+    sleep(2 * FLAGS_load_data_interval_secs + 1);
 
-    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     auto client = std::make_unique<StorageClient>(threadPool, mClient.get());
     // VerticesInterfacesTest(addVertices and getVertexProps)
     {

--- a/src/storage/test/StorageHttpHandlerTest.cpp
+++ b/src/storage/test/StorageHttpHandlerTest.cpp
@@ -15,7 +15,7 @@
 #include "fs/TempDir.h"
 
 DECLARE_string(meta_server_addrs);
-DECLARE_int32(load_data_interval_second);
+DECLARE_int32(load_data_interval_secs);
 
 namespace nebula {
 
@@ -43,22 +43,29 @@ public:
 
 
 TEST(StoragehHttpHandlerTest, StorageStatusTest) {
-    FLAGS_load_data_interval_second = 1;
+    FLAGS_load_data_interval_secs = 1;
 
     fs::TempDir rootPath("/tmp/StorageClientTest.XXXXXX");
     uint32_t localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     uint32_t localMetaPort = 10001;
     uint32_t localDataPort = 20002;
-    FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", localMetaPort);
 
     LOG(INFO) << "Start meta server....";
     std::string metaPath = folly::stringPrintf("%s/meta", rootPath.path());
     auto metaServerContext = meta::TestUtils::mockServer(localMetaPort, metaPath.c_str());
 
     LOG(INFO) << "Start storage server....";
+    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
+    auto addrsRet
+        = network::NetworkUtils::toHosts(folly::stringPrintf("127.0.0.1:%d", localMetaPort));
+    CHECK(addrsRet.ok()) << addrsRet.status();
+    auto mClient
+        = std::make_unique<meta::MetaClient>(threadPool, std::move(addrsRet.value()), true);
+    mClient->init();
     std::string dataPath = folly::stringPrintf("%s/data", rootPath.path());
-    auto sc = TestUtils::mockServer(dataPath.c_str(),
+    auto sc = TestUtils::mockServer(mClient.get(),
+                                    dataPath.c_str(),
                                     localIp,
                                     localDataPort);
 

--- a/src/storage/test/TestUtils.h
+++ b/src/storage/test/TestUtils.h
@@ -165,7 +165,8 @@ public:
          uint32_t port_;
      };
 
-     static std::unique_ptr<ServerContext> mockServer(const char* dataPath,
+     static std::unique_ptr<ServerContext> mockServer(meta::MetaClient* mClient,
+                                                      const char* dataPath,
                                                       uint32_t ip,
                                                       uint32_t port = 0) {
          auto sc = std::make_unique<ServerContext>();
@@ -178,7 +179,7 @@ public:
             options.local_ = HostAddr(ip, port);
             options.dataPaths_ = std::move(paths);
             options.partMan_
-                = std::make_unique<kvstore::MetaServerBasedPartManager>(options.local_);
+                = std::make_unique<kvstore::MetaServerBasedPartManager>(options.local_, mClient);
             kvstore::NebulaStore* kvPtr = static_cast<kvstore::NebulaStore*>(
                                         kvstore::KVStore::instance(std::move(options)));
              std::unique_ptr<kvstore::KVStore> kv(kvPtr);


### PR DESCRIPTION
1. Force meta client to reuse IOThreadPool outside.
2. Move meta_server_addrs flag outside, so we don't check the flag in MetaClient ctor any more.
3. Implement heartbeat logic.

Subtask of #283

After the repo to be public,  changes could NOT be rebased on the original pr #379 
So Let's use the new one to track it. 