### PR TITLE
Make schema_obj depend on meta_thrift_obj explicitly

### DIFF
--- a/src/meta/CMakeLists.txt
+++ b/src/meta/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(
     ServerBasedSchemaManager.cpp
     NebulaSchemaProvider.cpp
 )
-add_dependencies(schema_obj base_obj)
+add_dependencies(schema_obj base_obj common_thrift_obj meta_thrift_obj)
 
 
 add_library(


### PR DESCRIPTION
This is an adhoc fix on build failures due to module dependencies. For a thorough solution, please refer to this issue #406 