### PR TITLE
Some minor fixes

### DIFF
--- a/src/common/base/Cord.cpp
+++ b/src/common/base/Cord.cpp
@@ -119,7 +119,7 @@ std::string Cord::str() const {
 
     appendTo(buf);
 
-    return std::move(buf);
+    return buf;
 }
 
 

--- a/src/common/filter/Expressions.h
+++ b/src/common/filter/Expressions.h
@@ -641,7 +641,7 @@ public:
 
     Status MUST_USE_RESULT prepare() override;
 
-    void setContext(ExpressionContext *ctx) {
+    void setContext(ExpressionContext *ctx) override {
         context_ = ctx;
         for (auto &arg : args_) {
             arg->setContext(ctx);

--- a/src/common/fs/FileUtils.cpp
+++ b/src/common/fs/FileUtils.cpp
@@ -230,7 +230,7 @@ std::string FileUtils::joinPath(const folly::StringPiece dir,
         buf.resize(filename.size() + 2);
         strcpy(&(buf[0]), "./");    // NOLINT
         strncpy(&(buf[2]), filename.begin(), filename.size());
-        return std::move(buf);
+        return buf;
     }
 
     if (dir[len-1] == '/') {
@@ -244,7 +244,7 @@ std::string FileUtils::joinPath(const folly::StringPiece dir,
 
     strncpy(&(buf[len]), filename.data(), filename.size());
 
-    return std::move(buf);
+    return buf;
 }
 
 
@@ -393,7 +393,7 @@ std::vector<std::string> FileUtils::listAllTypedEntitiesInDir(
     }
     closedir(dir);
 
-    return std::move(entities);
+    return entities;
 }
 
 

--- a/src/common/network/NetworkUtils.cpp
+++ b/src/common/network/NetworkUtils.cpp
@@ -120,7 +120,7 @@ std::unordered_set<uint16_t> NetworkUtils::getPortsInUse() {
         inUse.emplace(std::stoul(sm[1].str(), NULL, 16));
         ++iter;
     }
-    return std::move(inUse);
+    return inUse;
 }
 
 

--- a/src/common/network/test/NetworkUtilsBenchmark.cpp
+++ b/src/common/network/test/NetworkUtilsBenchmark.cpp
@@ -36,7 +36,7 @@ std::string intToIp(uint32_t ip) {
     std::deque<std::string> parts;
     for (int i = 0; i < 4; i++) {
         try {
-            parts.emplace_front(std::move(folly::to<std::string>(ip & 0x000000FF)));
+            parts.emplace_front(folly::to<std::string>(ip & 0x000000FF));
             ip >>= 8;
         } catch (const std::exception& ex) {
             LOG(FATAL) << "Something is wrong: " << ex.what();

--- a/src/graph/DescribeSpaceExecutor.h
+++ b/src/graph/DescribeSpaceExecutor.h
@@ -29,7 +29,6 @@ public:
 
 private:
     DescribeSpaceSentence                      *sentence_{nullptr};
-    std::string                                *tag_{nullptr};
     std::unique_ptr<cpp2::ExecutionResponse>    resp_;
 };
 

--- a/src/graph/DescribeTagExecutor.h
+++ b/src/graph/DescribeTagExecutor.h
@@ -29,7 +29,6 @@ public:
 
 private:
     DescribeTagSentence                        *sentence_{nullptr};
-    std::string                                *tag_{nullptr};
     std::unique_ptr<cpp2::ExecutionResponse>    resp_;
 };
 

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -97,7 +97,6 @@ protected:
         std::string                             name_;
         int64_t                                 vid_{0};
         int64_t                                 age_{0};
-        int64_t                                 draftYear{0};
         std::vector<Serve>                      serves_;
         std::vector<Like>                       likes_;
     };

--- a/src/meta/processors/BaseProcessor.inl
+++ b/src/meta/processors/BaseProcessor.inl
@@ -143,7 +143,7 @@ int32_t BaseProcessor<RESP>::autoIncrementId() {
     data.emplace_back(kIdKey,
                       std::string(reinterpret_cast<const char*>(&id), sizeof(id)));
     kvstore_->asyncMultiPut(kDefaultSpaceId_, kDefaultPartId_, std::move(data),
-                            [this] (kvstore::ResultCode code, HostAddr leader) {
+                            [] (kvstore::ResultCode code, HostAddr leader) {
         UNUSED(leader);
         CHECK_EQ(code, kvstore::ResultCode::SUCCEEDED);
     });

--- a/src/meta/processors/partsMan/DropSpaceProcessor.cpp
+++ b/src/meta/processors/partsMan/DropSpaceProcessor.cpp
@@ -14,7 +14,7 @@ void DropSpaceProcessor::process(const cpp2::DropSpaceReq& req) {
     auto spaceRet = getSpaceId(req.get_space_name());
 
     if (!spaceRet.ok()) {
-        resp_.set_code(to(std::move(spaceRet.status())));
+        resp_.set_code(to(spaceRet.status()));
         onFinished();
         return;;
     }

--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -331,6 +331,7 @@ TEST(MetaClientTest, TagTest) {
 
 class TestListener : public MetaChangedListener {
 public:
+    virtual ~TestListener() = default;
     void onSpaceAdded(GraphSpaceID spaceId) override {
         LOG(INFO) << "Space " << spaceId << " added";
         spaceNum++;

--- a/src/parser/MaintainSentences.cpp
+++ b/src/parser/MaintainSentences.cpp
@@ -15,7 +15,7 @@ std::string CreateTagSentence::toString() const {
     buf += "CREATE TAG ";
     buf += *name_;
     buf += " (";
-    auto colSpecs = std::move(columns_->columnSpecs());
+    auto colSpecs = columns_->columnSpecs();
     for (auto *col : colSpecs) {
         buf += *col->name();
         buf += " ";
@@ -39,7 +39,7 @@ std::string CreateEdgeSentence::toString() const {
     buf += "CREATE EDGE ";
     buf += *name_;
     buf += " (";
-    auto colSpecs = std::move(columns_->columnSpecs());
+    auto colSpecs = columns_->columnSpecs();
     for (auto &col : colSpecs) {
         buf += *col->name();
         buf += " ";
@@ -72,7 +72,7 @@ std::string AlterSchemaOptItem::toString() const {
             break;
     }
     buf += " (";
-    auto colSpecs = std::move(columns_->columnSpecs());
+    auto colSpecs = columns_->columnSpecs();
     for (auto &col : colSpecs) {
         buf += *col->name();
         buf += " ";

--- a/src/parser/UserSentences.h
+++ b/src/parser/UserSentences.h
@@ -5,7 +5,7 @@
  */
 
 #ifndef PARSER_USERSENTENCES_H_
-#define PARSER_GRAPH_USERSENTENCES_H_
+#define PARSER_USERSENTENCES_H_
 
 #include "base/Base.h"
 #include "parser/Clauses.h"

--- a/src/raftex/Host.cpp
+++ b/src/raftex/Host.cpp
@@ -173,6 +173,9 @@ folly::Future<cpp2::AppendLogResponse> Host::appendLogsInternal(
     })
     .then([eb, self = shared_from_this(), numLogs, termSent, firstId] (
             folly::Try<cpp2::AppendLogResponse>&& t) {
+        UNUSED(numLogs);
+        UNUSED(termSent);
+        UNUSED(firstId);
         VLOG(2) << self->idStr_ << "appendLogs() call got response";
 
         if (t.hasException()) {
@@ -355,7 +358,7 @@ Host::prepareAppendLogRequest(std::lock_guard<std::mutex>& lck) const {
         req->set_log_term(0);
     }
 
-    return std::move(req);
+    return req;
 }
 
 

--- a/src/raftex/test/RaftexTestBase.cpp
+++ b/src/raftex/test/RaftexTestBase.cpp
@@ -36,7 +36,7 @@ std::vector<HostAddr> getPeers(const std::vector<HostAddr>& all,
         }
     }
 
-    return std::move(peers);
+    return peers;
 }
 
 

--- a/src/storage/QueryStatsProcessor.cpp
+++ b/src/storage/QueryStatsProcessor.cpp
@@ -62,7 +62,7 @@ void QueryStatsProcessor::calcResult(std::vector<PropContext>&& props) {
     }
     s.set_columns(std::move(cols));
     resp_.set_schema(std::move(s));
-    resp_.set_data(std::move(writer.encode()));
+    resp_.set_data(writer.encode());
 }
 
 kvstore::ResultCode QueryStatsProcessor::processVertex(PartitionID partId,


### PR DESCRIPTION
One thing to remember: calling `std::move` on local objects(when `return`) and temporary objects(when passed as arguments) will make the copy elision optimization impossible.