### PR TITLE
Fix bug about accessing meta client local cache before it is ready

### DIFF
--- a/src/meta/SchemaManager.h
+++ b/src/meta/SchemaManager.h
@@ -30,7 +30,7 @@ public:
                                                                  SchemaVer ver = -1) = 0;
 
     // Returns a negative number when the schema does not exist
-    virtual SchemaVer getNewestTagSchemaVer(GraphSpaceID space, TagID tag) = 0;
+    virtual StatusOr<SchemaVer> getNewestTagSchemaVer(GraphSpaceID space, TagID tag) = 0;
 
     virtual SchemaVer getNewestTagSchemaVer(folly::StringPiece spaceName,
                                             folly::StringPiece tagName) = 0;
@@ -44,7 +44,7 @@ public:
                                                                   SchemaVer ver = -1) = 0;
 
     // Returns a negative number when the schema does not exist
-    virtual SchemaVer getNewestEdgeSchemaVer(GraphSpaceID space, EdgeType edge) = 0;
+    virtual StatusOr<SchemaVer> getNewestEdgeSchemaVer(GraphSpaceID space, EdgeType edge) = 0;
 
     virtual SchemaVer getNewestEdgeSchemaVer(folly::StringPiece spaceName,
                                              folly::StringPiece typeName) = 0;

--- a/src/meta/ServerBasedSchemaManager.cpp
+++ b/src/meta/ServerBasedSchemaManager.cpp
@@ -27,7 +27,11 @@ ServerBasedSchemaManager::getTagSchema(GraphSpaceID space, TagID tag, SchemaVer 
     CHECK(metaClient_);
     // ver less 0, get the newest ver
     if (ver < 0) {
-        ver = getNewestTagSchemaVer(space, tag);
+        auto ret = getNewestTagSchemaVer(space, tag);
+        if (!ret.ok()) {
+            return std::shared_ptr<const SchemaProviderIf>();
+        }
+        ver = ret.value();
     }
     auto ret = metaClient_->getTagSchemaFromCache(space, tag, ver);
     if (ret.ok()) {
@@ -55,7 +59,8 @@ ServerBasedSchemaManager::getTagSchema(folly::StringPiece spaceName,
 }
 
 // Returns a negative number when the schema does not exist
-SchemaVer ServerBasedSchemaManager::getNewestTagSchemaVer(GraphSpaceID space, TagID tag) {
+StatusOr<SchemaVer> ServerBasedSchemaManager::getNewestTagSchemaVer(GraphSpaceID space,
+                                                                    TagID tag) {
     CHECK(metaClient_);
     return  metaClient_->getNewestTagVerFromCache(space, tag);
 }
@@ -72,7 +77,11 @@ SchemaVer ServerBasedSchemaManager::getNewestTagSchemaVer(folly::StringPiece spa
         return -1;
     }
     auto tagId = tagStatus.value();
-    return getNewestTagSchemaVer(spaceId, tagId);
+    auto ret = getNewestTagSchemaVer(spaceId, tagId);
+    if (!ret.ok()) {
+        return -1;
+    }
+    return ret.value();
 }
 
 std::shared_ptr<const SchemaProviderIf>
@@ -81,7 +90,11 @@ ServerBasedSchemaManager::getEdgeSchema(GraphSpaceID space, EdgeType edge, Schem
     CHECK(metaClient_);
     // ver less 0, get the newest ver
     if (ver < 0) {
-        ver = getNewestEdgeSchemaVer(space, edge);
+        auto ret = getNewestEdgeSchemaVer(space, edge);
+        if (!ret.ok()) {
+            return std::shared_ptr<const SchemaProviderIf>();
+        }
+        ver = ret.value();
     }
 
     auto ret = metaClient_->getEdgeSchemaFromCache(space, edge, ver);
@@ -110,8 +123,8 @@ ServerBasedSchemaManager::getEdgeSchema(folly::StringPiece spaceName,
 }
 
 // Returns a negative number when the schema does not exist
-SchemaVer ServerBasedSchemaManager::getNewestEdgeSchemaVer(GraphSpaceID space,
-                                                           EdgeType edge) {
+StatusOr<SchemaVer> ServerBasedSchemaManager::getNewestEdgeSchemaVer(GraphSpaceID space,
+                                                                     EdgeType edge) {
     CHECK(metaClient_);
     return  metaClient_->getNewestEdgeVerFromCache(space, edge);
 }
@@ -128,7 +141,11 @@ SchemaVer ServerBasedSchemaManager::getNewestEdgeSchemaVer(folly::StringPiece sp
         return -1;
     }
     auto edgeType = edgeStatus.value();
-    return getNewestEdgeSchemaVer(spaceId, edgeType);
+    auto ret = getNewestEdgeSchemaVer(spaceId, edgeType);
+    if (!ret.ok()) {
+        return -1;
+    }
+    return ret.value();
 }
 
 StatusOr<GraphSpaceID> ServerBasedSchemaManager::toGraphSpaceID(folly::StringPiece spaceName) {

--- a/src/meta/ServerBasedSchemaManager.h
+++ b/src/meta/ServerBasedSchemaManager.h
@@ -30,7 +30,7 @@ public:
         SchemaVer ver = -1) override;
 
     // Returns a negative number when the schema does not exist
-    SchemaVer getNewestTagSchemaVer(GraphSpaceID space, TagID tag) override;
+    StatusOr<SchemaVer> getNewestTagSchemaVer(GraphSpaceID space, TagID tag) override;
 
     SchemaVer getNewestTagSchemaVer(folly::StringPiece spaceName,
                                     folly::StringPiece tagName) override;
@@ -45,7 +45,7 @@ public:
         SchemaVer ver = -1) override;
 
     // Returns a negative number when the schema does not exist
-    SchemaVer getNewestEdgeSchemaVer(GraphSpaceID space, EdgeType edge) override;
+    StatusOr<SchemaVer> getNewestEdgeSchemaVer(GraphSpaceID space, EdgeType edge) override;
 
     SchemaVer getNewestEdgeSchemaVer(folly::StringPiece spaceName,
                                      folly::StringPiece typeName) override;

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -129,6 +129,7 @@ void MetaClient::loadDataThreadFunc() {
         spaceNewestTagVerMap_ = std::move(spaceNewestTagVerMap);
         spaceNewestEdgeVerMap_ = std::move(spaceNewestEdgeVerMap);
     }
+    ready_ = true;
     LOG(INFO) << "Load data completed!";
 }
 
@@ -517,6 +518,9 @@ MetaClient::getPartsAlloc(GraphSpaceID spaceId) {
 
 StatusOr<GraphSpaceID>
 MetaClient::getSpaceIdByNameFromCache(const std::string& name) {
+    if (!ready_) {
+        return Status::Error("Not ready!");
+    }
     folly::RWSpinLock::ReadHolder holder(localCacheLock_);
     auto it = spaceIndexByName_.find(name);
     if (it != spaceIndexByName_.end()) {
@@ -528,6 +532,9 @@ MetaClient::getSpaceIdByNameFromCache(const std::string& name) {
 
 StatusOr<TagID> MetaClient::getTagIDByNameFromCache(const GraphSpaceID& space,
                                                     const std::string& name) {
+    if (!ready_) {
+        return Status::Error("Not ready!");
+    }
     folly::RWSpinLock::ReadHolder holder(localCacheLock_);
     auto it = spaceTagIndexByName_.find(make_pair(space, name));
     if (it == spaceTagIndexByName_.end()) {
@@ -539,6 +546,9 @@ StatusOr<TagID> MetaClient::getTagIDByNameFromCache(const GraphSpaceID& space,
 
 StatusOr<EdgeType> MetaClient::getEdgeTypeByNameFromCache(const GraphSpaceID& space,
                                                           const std::string& name) {
+    if (!ready_) {
+        return Status::Error("Not ready!");
+    }
     folly::RWSpinLock::ReadHolder holder(localCacheLock_);
     auto it = spaceEdgeIndexByName_.find(make_pair(space, name));
     if (it == spaceEdgeIndexByName_.end()) {
@@ -862,6 +872,9 @@ MetaClient::dropEdgeSchema(GraphSpaceID spaceId, std::string name) {
 
 StatusOr<std::shared_ptr<const SchemaProviderIf>>
 MetaClient::getTagSchemaFromCache(GraphSpaceID spaceId, TagID tagID, SchemaVer ver) {
+    if (!ready_) {
+        return Status::Error("Not ready!");
+    }
     folly::RWSpinLock::ReadHolder holder(localCacheLock_);
     auto spaceIt = localCache_.find(spaceId);
     if (spaceIt == localCache_.end()) {
@@ -880,6 +893,9 @@ MetaClient::getTagSchemaFromCache(GraphSpaceID spaceId, TagID tagID, SchemaVer v
 
 StatusOr<std::shared_ptr<const SchemaProviderIf>> MetaClient::getEdgeSchemaFromCache(
         GraphSpaceID spaceId, EdgeType edgeType, SchemaVer ver) {
+    if (!ready_) {
+        return Status::Error("Not ready!");
+    }
     folly::RWSpinLock::ReadHolder holder(localCacheLock_);
     auto spaceIt = localCache_.find(spaceId);
     if (spaceIt == localCache_.end()) {
@@ -899,7 +915,11 @@ StatusOr<std::shared_ptr<const SchemaProviderIf>> MetaClient::getEdgeSchemaFromC
 }
 
 
-SchemaVer MetaClient::getNewestTagVerFromCache(const GraphSpaceID& space, const TagID& tagId) {
+StatusOr<SchemaVer> MetaClient::getNewestTagVerFromCache(const GraphSpaceID& space,
+                                                         const TagID& tagId) {
+    if (!ready_) {
+        return Status::Error("Not ready!");
+    }
     folly::RWSpinLock::ReadHolder holder(localCacheLock_);
     auto it = spaceNewestTagVerMap_.find(std::make_pair(space, tagId));
     if (it == spaceNewestTagVerMap_.end()) {
@@ -909,8 +929,11 @@ SchemaVer MetaClient::getNewestTagVerFromCache(const GraphSpaceID& space, const 
 }
 
 
-SchemaVer MetaClient::getNewestEdgeVerFromCache(const GraphSpaceID& space,
-                                                const EdgeType& edgeType) {
+StatusOr<SchemaVer> MetaClient::getNewestEdgeVerFromCache(const GraphSpaceID& space,
+                                                          const EdgeType& edgeType) {
+    if (!ready_) {
+        return Status::Error("Not ready!");
+    }
     folly::RWSpinLock::ReadHolder holder(localCacheLock_);
     auto it = spaceNewestEdgeVerMap_.find(std::make_pair(space, edgeType));
     if (it == spaceNewestEdgeVerMap_.end()) {

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -165,9 +165,10 @@ public:
     StatusOr<EdgeType> getEdgeTypeByNameFromCache(const GraphSpaceID& space,
                                                   const std::string& name);
 
-    SchemaVer getNewestTagVerFromCache(const GraphSpaceID& space, const TagID& tagId);
+    StatusOr<SchemaVer> getNewestTagVerFromCache(const GraphSpaceID& space, const TagID& tagId);
 
-    SchemaVer getNewestEdgeVerFromCache(const GraphSpaceID& space, const EdgeType& edgeType);
+    StatusOr<SchemaVer> getNewestEdgeVerFromCache(const GraphSpaceID& space,
+                                                  const EdgeType& edgeType);
 
     PartsMap getPartsMapFromCache(const HostAddr& host);
 
@@ -258,6 +259,7 @@ private:
     folly::RWSpinLock     localCacheLock_;
     MetaChangedListener*  listener_{nullptr};
     bool                  sendHeartBeat_ = false;
+    std::atomic_bool      ready_{false};
 };
 }  // namespace meta
 }  // namespace nebula

--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -113,8 +113,10 @@ TEST(MetaClientTest, InterfacesTest) {
 
             // getTagSchemaFromCache
             sleep(FLAGS_load_data_interval_secs + 1);
-            auto ver = client->getNewestTagVerFromCache(spaceId,
+            auto ret = client->getNewestTagVerFromCache(spaceId,
                                                         ret1.value().begin()->tag_id);
+            CHECK(ret.ok());
+            auto ver = ret.value();
             auto ret2 = client->getTagSchemaFromCache(spaceId,
                                                       ret1.value().begin()->tag_id, ver);
             ASSERT_TRUE(ret2.ok()) << ret2.status();
@@ -128,7 +130,9 @@ TEST(MetaClientTest, InterfacesTest) {
             auto outSchema = schemaMan->getTagSchema(spaceId, tagId);
             ASSERT_EQ(5, outSchema->getNumFields());
             ASSERT_STREQ("tagItem0", outSchema->getFieldName(0));
-            auto version = schemaMan->getNewestTagSchemaVer(spaceId, tagId);
+            auto retVer = schemaMan->getNewestTagSchemaVer(spaceId, tagId);
+            ASSERT_TRUE(retVer.ok());
+            auto version = retVer.value();
             ASSERT_EQ(0, version);
             auto outSchema1 = schemaMan->getTagSchema(spaceId, tagId, version);
             ASSERT_TRUE(outSchema1 != nullptr);
@@ -143,8 +147,10 @@ TEST(MetaClientTest, InterfacesTest) {
             ASSERT_NE(ret1.value().begin()->edge_type, 0);
 
             // getEdgeSchemaFromCache
-            auto ver = client->getNewestEdgeVerFromCache(spaceId,
-                                                         ret1.value().begin()->edge_type);
+            auto retVer = client->getNewestEdgeVerFromCache(spaceId,
+                                                            ret1.value().begin()->edge_type);
+            CHECK(retVer.ok());
+            auto ver = retVer.value();
             auto ret2 = client->getEdgeSchemaFromCache(spaceId,
                                                        ret1.value().begin()->edge_type, ver);
             ASSERT_TRUE(ret2.ok()) << ret2.status();
@@ -157,7 +163,9 @@ TEST(MetaClientTest, InterfacesTest) {
             auto outSchema = schemaMan->getEdgeSchema(spaceId, edgeType);
             ASSERT_EQ(5, outSchema->getNumFields());
             ASSERT_STREQ("edgeItem0", outSchema->getFieldName(0));
-            auto version = schemaMan->getNewestEdgeSchemaVer(spaceId, edgeType);
+            auto versionRet = schemaMan->getNewestEdgeSchemaVer(spaceId, edgeType);
+            ASSERT_TRUE(versionRet.ok());
+            auto version = versionRet.value();
             ASSERT_EQ(0, version);
             auto outSchema1 = schemaMan->getEdgeSchema(spaceId, edgeType, version);
             ASSERT_TRUE(outSchema1 != nullptr);

--- a/src/storage/CompactionFilter.h
+++ b/src/storage/CompactionFilter.h
@@ -50,7 +50,8 @@ public:
     bool schemaValid(GraphSpaceID spaceId, const folly::StringPiece& key) const {
         if (NebulaKeyUtils::isVertex(key)) {
             auto tagId = NebulaKeyUtils::getTagId(key);
-            if (schemaMan_->getNewestTagSchemaVer(spaceId, tagId) < 0) {
+            auto ret = schemaMan_->getNewestTagSchemaVer(spaceId, tagId);
+            if (ret.ok() && ret.value() == -1) {
                 VLOG(3) << "Space " << spaceId << ", Tag " << tagId << " invalid";
                 return false;
             }
@@ -60,7 +61,8 @@ public:
             if (edgeType < 0) {
                 edgeType = -edgeType;
             }
-            if (schemaMan_->getNewestEdgeSchemaVer(spaceId, edgeType) < 0) {
+            auto ret = schemaMan_->getNewestEdgeSchemaVer(spaceId, edgeType);
+            if (ret.ok() && ret.value() == -1) {
                 VLOG(3) << "Space " << spaceId << ", EdgeType " << edgeType << " invalid";
                 return false;
             }

--- a/src/storage/test/AdHocSchemaManager.cpp
+++ b/src/storage/test/AdHocSchemaManager.cpp
@@ -81,7 +81,7 @@ SchemaVer AdHocSchemaManager::getNewestTagSchemaVer(folly::StringPiece spaceName
     return -1;
 }
 
-SchemaVer AdHocSchemaManager::getNewestTagSchemaVer(GraphSpaceID space, TagID tag) {
+StatusOr<SchemaVer> AdHocSchemaManager::getNewestTagSchemaVer(GraphSpaceID space, TagID tag) {
     folly::RWSpinLock::ReadHolder rh(tagLock_);
     auto it = tagSchemas_.find(std::make_pair(space, tag));
     if (it == tagSchemas_.end() || it->second.empty()) {
@@ -143,7 +143,7 @@ SchemaVer AdHocSchemaManager::getNewestEdgeSchemaVer(folly::StringPiece spaceNam
     return -1;
 }
 
-SchemaVer AdHocSchemaManager::getNewestEdgeSchemaVer(GraphSpaceID space, EdgeType edge) {
+StatusOr<SchemaVer> AdHocSchemaManager::getNewestEdgeSchemaVer(GraphSpaceID space, EdgeType edge) {
     folly::RWSpinLock::ReadHolder rh(edgeLock_);
 
     auto it = edgeSchemas_.find(std::make_pair(space, edge));

--- a/src/storage/test/AdHocSchemaManager.h
+++ b/src/storage/test/AdHocSchemaManager.h
@@ -43,7 +43,7 @@ public:
                  SchemaVer version = -1) override;
 
     // Returns a negative number when the schema does not exist
-    SchemaVer getNewestTagSchemaVer(GraphSpaceID space, TagID tag) override;
+    StatusOr<SchemaVer> getNewestTagSchemaVer(GraphSpaceID space, TagID tag) override;
 
     // This interface is disabled
     SchemaVer getNewestTagSchemaVer(folly::StringPiece spaceName,
@@ -61,7 +61,7 @@ public:
                   SchemaVer version = -1) override;
 
     // Returns a negative number when the schema does not exist
-    SchemaVer getNewestEdgeSchemaVer(GraphSpaceID space, EdgeType edge) override;
+    StatusOr<SchemaVer> getNewestEdgeSchemaVer(GraphSpaceID space, EdgeType edge) override;
 
     // This interface is disabled
     SchemaVer getNewestEdgeSchemaVer(folly::StringPiece spaceName,


### PR DESCRIPTION
Now compaction will remove the data without schema.  And the process maybe happened before meta client cache loaded. 

So we should distinguish whether the schema is not existed or not ready? 