### PR TITLE
Collect and modify push_back to emplace_back

### DIFF
--- a/src/common/fs/FileUtils.cpp
+++ b/src/common/fs/FileUtils.cpp
@@ -278,8 +278,6 @@ void FileUtils::dividePath(const folly::StringPiece path,
     } else {
         parent = folly::StringPiece(pathToLook.begin(), pos);
     }
-
-    return;
 }
 
 
@@ -344,10 +342,7 @@ bool FileUtils::makeDir(const std::string& dir) {
 
     int err = mkdir(dir.c_str(), S_IRWXU);
     if (err != 0) {
-        if (fileType(dir.c_str()) == FileType::DIRECTORY) {
-            return true;
-        }
-        return false;
+        return fileType(dir.c_str()) == FileType::DIRECTORY;
     }
     return true;
 }
@@ -361,13 +356,13 @@ std::vector<std::string> FileUtils::listAllTypedEntitiesInDir(
     std::vector<std::string> entities;
     struct dirent *dirInfo;
     DIR *dir = opendir(dirpath);
-    if (dir == NULL) {
+    if (dir == nullptr) {
         LOG(ERROR)<< "Failed to read the directory \"" << dirpath
                   << "\" (" << errno << "): " << strerror(errno);
         return entities;
     }
 
-    while ((dirInfo = readdir(dir)) != NULL) {
+    while ((dirInfo = readdir(dir)) != nullptr) {
         if ((type == FileType::REGULAR && dirInfo->d_type == DT_REG) ||
             (type == FileType::DIRECTORY && dirInfo->d_type == DT_DIR) ||
             (type == FileType::SYM_LINK && dirInfo->d_type == DT_LNK) ||
@@ -386,7 +381,7 @@ std::vector<std::string> FileUtils::listAllTypedEntitiesInDir(
             }
 
             // We found one entity
-            entities.push_back(
+            entities.emplace_back(
                 returnFullPath ? joinPath(dirpath, std::string(dirInfo->d_name))
                                : std::string(dirInfo->d_name));
         }
@@ -466,7 +461,7 @@ void FileUtils::Iterator::dirNext() {
     CHECK(type_ == FileType::DIRECTORY);
     CHECK(dir_ != nullptr);
     struct dirent *dent;
-    while ((dent = ::readdir(dir_)) != NULL) {
+    while ((dent = ::readdir(dir_)) != nullptr) {
         if (dent->d_name[0] == '.') {
             continue;
         }

--- a/src/common/stats/StatsManager.cpp
+++ b/src/common/stats/StatsManager.cpp
@@ -333,7 +333,7 @@ StatsManager::VT StatsManager::readHisto(const std::string& counterName,
 
     std::lock_guard<std::mutex> g(*(sm.histograms_[index].first));
     sm.histograms_[index].second->update(Clock::now());
-    size_t level = static_cast<size_t>(range);
+    auto level = static_cast<size_t>(range);
     return sm.histograms_[index].second->getPercentileEstimate(pct, level);
 }
 

--- a/src/common/thread/GenericWorker.cpp
+++ b/src/common/thread/GenericWorker.cpp
@@ -12,8 +12,7 @@
 namespace nebula {
 namespace thread {
 
-GenericWorker::GenericWorker() {
-}
+GenericWorker::GenericWorker() = default;
 
 GenericWorker::~GenericWorker() {
     stop();
@@ -99,7 +98,7 @@ void GenericWorker::notify() {
 
 void GenericWorker::onNotify() {
     if (stopped_.load(std::memory_order_acquire)) {
-        event_base_loopexit(evbase_, NULL);
+        event_base_loopexit(evbase_, nullptr);
         // Even been broken, we still fall through to finish the current loop.
     }
     {
@@ -165,7 +164,7 @@ GenericWorker::Timer::~Timer() {
 void GenericWorker::purgeTimerTask(uint64_t id) {
     {
         std::lock_guard<std::mutex> guard(lock_);
-        purgingingTimers_.push_back(id);
+        purgingingTimers_.emplace_back(id);
     }
     notify();
 }

--- a/src/dataman/RowReader.cpp
+++ b/src/dataman/RowReader.cpp
@@ -244,14 +244,14 @@ bool RowReader::processHeader(folly::StringPiece row) {
     }
     offsets_.resize(numFields + 1, -1);
     offsets_[0] = 0;
-    blockOffsets_.push_back(std::make_pair(0, 0));
+    blockOffsets_.emplace_back(std::make_pair(0, 0));
     blockOffsets_.reserve(numOffsets);
     for (uint32_t i = 0; i < numOffsets; i++) {
         int64_t offset = 0;
         for (int32_t j = 0; j < numBytesForOffset_; j++) {
             offset |= (uint64_t(*(it++)) << (8 * j));
         }
-        blockOffsets_.push_back(std::make_pair(offset, 0));
+        blockOffsets_.emplace_back(std::make_pair(offset, 0));
         offsets_[16 * (i + 1)] = offset;
     }
     // Now done with the header

--- a/src/dataman/RowReader.cpp
+++ b/src/dataman/RowReader.cpp
@@ -244,14 +244,14 @@ bool RowReader::processHeader(folly::StringPiece row) {
     }
     offsets_.resize(numFields + 1, -1);
     offsets_[0] = 0;
-    blockOffsets_.emplace_back(std::make_pair(0, 0));
+    blockOffsets_.emplace_back(0, 0);
     blockOffsets_.reserve(numOffsets);
     for (uint32_t i = 0; i < numOffsets; i++) {
         int64_t offset = 0;
         for (int32_t j = 0; j < numBytesForOffset_; j++) {
             offset |= (uint64_t(*(it++)) << (8 * j));
         }
-        blockOffsets_.emplace_back(std::make_pair(offset, 0));
+        blockOffsets_.emplace_back(offset, 0);
         offsets_[16 * (i + 1)] = offset;
     }
     // Now done with the header

--- a/src/dataman/RowWriter.cpp
+++ b/src/dataman/RowWriter.cpp
@@ -254,7 +254,7 @@ RowWriter& RowWriter::operator<<(Skip&& skip) noexcept {
         // Update block offsets
         if (i != 0 && (i >> 4 << 4) == i) {
             // We need to record block offset for every 16 fields
-            blockOffsets_.push_back(cord_.size());
+            blockOffsets_.emplace_back(cord_.size());
         }
     }
     colNum_ = skipTo;

--- a/src/dataman/RowWriter.h
+++ b/src/dataman/RowWriter.h
@@ -144,7 +144,7 @@ private:
     colNum_++; \
     if (colNum_ != 0 && (colNum_ >> 4 << 4) == colNum_) { \
         /* We need to record offset for every 16 fields */ \
-        blockOffsets_.push_back(cord_.size()); \
+        blockOffsets_.emplace_back(cord_.size()); \
     } \
     if (colNum_ > static_cast<int64_t>(schema_->getNumFields())) { \
         /* Need to append the new column type to the schema */ \

--- a/src/dataman/test/NebulaCodecTest.cpp
+++ b/src/dataman/test/NebulaCodecTest.cpp
@@ -16,11 +16,11 @@ namespace nebula {
 
 TEST(NebulaCodec, encode) {
     std::vector<boost::any> v;
-    v.push_back(1);
-    v.push_back(false);
-    v.push_back(3.14F);
-    v.push_back(3.14);
-    v.push_back(std::string("hi"));
+    v.emplace_back(1);
+    v.emplace_back(false);
+    v.emplace_back(3.14F);
+    v.emplace_back(3.14);
+    v.emplace_back(std::string("hi"));
 
     EXPECT_EQ(boost::any_cast<int>(v[0]), 1);
     EXPECT_EQ(boost::any_cast<bool>(v[1]), false);

--- a/src/graph/InterimResult.cpp
+++ b/src/graph/InterimResult.cpp
@@ -34,7 +34,7 @@ std::vector<VertexID> InterimResult::getVIDs(const std::string &col) const {
         VertexID vid;
         auto rc = iter->getVid(col, vid);
         CHECK(rc == ResultType::SUCCEEDED);
-        result.push_back(vid);
+        result.emplace_back(vid);
         ++iter;
     }
     return result;

--- a/src/graph/ShowExecutor.cpp
+++ b/src/graph/ShowExecutor.cpp
@@ -72,9 +72,9 @@ void ShowExecutor::showHosts() {
         std::vector<std::string> header;
         resp_ = std::make_unique<cpp2::ExecutionResponse>();
 
-        header.push_back("Ip");
-        header.push_back("Port");
-        header.push_back("Status");
+        header.emplace_back("Ip");
+        header.emplace_back("Port");
+        header.emplace_back("Status");
         resp_->set_column_names(std::move(header));
 
         for (auto &status : retShowHosts) {
@@ -119,7 +119,7 @@ void ShowExecutor::showSpaces() {
         std::vector<std::string> header;
         resp_ = std::make_unique<cpp2::ExecutionResponse>();
 
-        header.push_back("Name");
+        header.emplace_back("Name");
         resp_->set_column_names(std::move(header));
 
         for (auto &space : retShowSpaces) {

--- a/src/kvstore/raftex/test/RaftexTestBase.cpp
+++ b/src/kvstore/raftex/test/RaftexTestBase.cpp
@@ -135,7 +135,7 @@ void setupRaft(
 
     // Set up services
     for (int i = 0; i < numCopies; ++i) {
-        services.push_back(RaftexService::createService(nullptr));
+        services.emplace_back(RaftexService::createService(nullptr));
         services.back()->waitUntilReady();
         uint16_t port = services.back()->getServerPort();
         allHosts.emplace_back(ipInt, port);

--- a/src/kvstore/test/NebulaStoreTest.cpp
+++ b/src/kvstore/test/NebulaStoreTest.cpp
@@ -48,8 +48,8 @@ TEST(NebulaStoreTest, SimpleTest) {
 
     fs::TempDir rootPath("/tmp/nebula_store_test.XXXXXX");
     std::vector<std::string> paths;
-    paths.push_back(folly::stringPrintf("%s/disk1", rootPath.path()));
-    paths.push_back(folly::stringPrintf("%s/disk2", rootPath.path()));
+    paths.emplace_back(folly::stringPrintf("%s/disk1", rootPath.path()));
+    paths.emplace_back(folly::stringPrintf("%s/disk2", rootPath.path()));
 
     KVOptions options;
     options.dataPaths_ = std::move(paths);
@@ -131,8 +131,8 @@ TEST(NebulaStoreTest, PartsTest) {
     }
 
     std::vector<std::string> paths;
-    paths.push_back(folly::stringPrintf("%s/disk1", rootPath.path()));
-    paths.push_back(folly::stringPrintf("%s/disk2", rootPath.path()));
+    paths.emplace_back(folly::stringPrintf("%s/disk1", rootPath.path()));
+    paths.emplace_back(folly::stringPrintf("%s/disk2", rootPath.path()));
 
     for (size_t i = 0; i < paths.size(); i++) {
         auto db = std::make_unique<RocksEngine>(
@@ -176,7 +176,7 @@ TEST(NebulaStoreTest, PartsTest) {
     };
     check(0);
 
-    auto* pm = static_cast<MemPartManager*>(store->partMan_.get());
+    auto* pm = dynamic_cast<MemPartManager*>(store->partMan_.get());
     // Let's create another space with 10 parts.
     for (auto partId = 0; partId < 10; partId++) {
         pm->addPart(1, partId);

--- a/src/meta/NebulaSchemaProvider.cpp
+++ b/src/meta/NebulaSchemaProvider.cpp
@@ -77,7 +77,7 @@ std::shared_ptr<const SchemaProviderIf::Field> NebulaSchemaProvider::field(
 
 void NebulaSchemaProvider::addField(folly::StringPiece name,
                                     nebula::cpp2::ValueType&& type) {
-    fields_.push_back(std::make_shared<SchemaField>(name.toString(),
+    fields_.emplace_back(std::make_shared<SchemaField>(name.toString(),
                                                     std::move(type)));
     fieldNameIndex_.emplace(name.toString(),
                             static_cast<int64_t>(fields_.size() - 1));

--- a/src/meta/test/ProcessorTest.cpp
+++ b/src/meta/test/ProcessorTest.cpp
@@ -888,7 +888,7 @@ TEST(ProcessorTest, AlterTagTest) {
         auto addItem = cpp2::AlterSchemaItem(FRAGILE,
                                              cpp2::AlterSchemaOp::ADD,
                                              std::move(addSch));
-        items.push_back(std::move(addItem));
+        items.emplace_back(std::move(addItem));
         req.set_space_id(1);
         req.set_tag_name("tag_0");
         req.set_tag_items(items);
@@ -910,7 +910,7 @@ TEST(ProcessorTest, AlterTagTest) {
         auto addItem = cpp2::AlterSchemaItem(FRAGILE,
                                              cpp2::AlterSchemaOp::CHANGE,
                                              std::move(addSch));
-        items.push_back(std::move(addItem));
+        items.emplace_back(std::move(addItem));
         req.set_space_id(1);
         req.set_tag_name("tag_0");
         req.set_tag_items(items);

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -42,7 +42,7 @@ public:
         partsMap[0][0] = PartMeta();
 
         std::vector<std::string> paths;
-        paths.push_back(folly::stringPrintf("%s/disk1", rootPath));
+        paths.emplace_back(folly::stringPrintf("%s/disk1", rootPath));
 
         kvstore::KVOptions options;
         options.dataPaths_ = std::move(paths);

--- a/src/parser/Clauses.h
+++ b/src/parser/Clauses.h
@@ -37,7 +37,7 @@ private:
 class SourceNodeList final {
 public:
     void addNodeId(int64_t id) {
-        nodes_.push_back(id);
+        nodes_.emplace_back(id);
     }
 
     const std::vector<int64_t>& nodeIds() const {

--- a/src/storage/client/StorageClient.h
+++ b/src/storage/client/StorageClient.h
@@ -167,7 +167,7 @@ private:
             auto partMeta = client_->getPartMetaFromCache(spaceId, part);
             CHECK_GT(partMeta.peers_.size(), 0U);
             // TODO We need to use the leader here
-            clusters[partMeta.peers_.front()][part].push_back(std::move(id));
+            clusters[partMeta.peers_.front()][part].emplace_back(std::move(id));
         }
         return clusters;
     }

--- a/src/storage/test/QueryBoundTest.cpp
+++ b/src/storage/test/QueryBoundTest.cpp
@@ -78,7 +78,7 @@ void buildRequest(cpp2::GetNeighborsRequest& req, bool outBound = true) {
     decltype(req.parts) tmpIds;
     for (auto partId = 0; partId < 3; partId++) {
         for (auto vertexId =  partId * 10; vertexId < (partId + 1) * 10; vertexId++) {
-            tmpIds[partId].push_back(vertexId);
+            tmpIds[partId].emplace_back(vertexId);
         }
     }
     req.set_parts(std::move(tmpIds));

--- a/src/storage/test/QueryStatsTest.cpp
+++ b/src/storage/test/QueryStatsTest.cpp
@@ -60,7 +60,7 @@ void buildRequest(cpp2::GetNeighborsRequest& req) {
     decltype(req.parts) tmpIds;
     for (auto partId = 0; partId < 3; partId++) {
         for (auto vertexId =  partId * 10; vertexId < (partId + 1) * 10; vertexId++) {
-            tmpIds[partId].push_back(vertexId);
+            tmpIds[partId].emplace_back(vertexId);
         }
     }
     req.set_parts(std::move(tmpIds));

--- a/src/storage/test/QueryVertexPropsTest.cpp
+++ b/src/storage/test/QueryVertexPropsTest.cpp
@@ -58,7 +58,7 @@ TEST(QueryVertexPropsTest, SimpleTest) {
         for (auto vertexId =  partId * 10;
              vertexId < (partId + 1) * 10;
              vertexId++) {
-            tmpIds[partId].push_back(vertexId);
+            tmpIds[partId].emplace_back(vertexId);
         }
     }
     req.set_parts(std::move(tmpIds));

--- a/src/storage/test/TestUtils.h
+++ b/src/storage/test/TestUtils.h
@@ -52,12 +52,12 @@ public:
         }
 
         std::vector<std::string> paths;
-        paths.push_back(folly::stringPrintf("%s/disk1", rootPath));
-        paths.push_back(folly::stringPrintf("%s/disk2", rootPath));
+        paths.emplace_back(folly::stringPrintf("%s/disk1", rootPath));
+        paths.emplace_back(folly::stringPrintf("%s/disk2", rootPath));
 
         // Prepare KVStore
         options.dataPaths_ = std::move(paths);
-        options.cfFactory_ = cfFactory;
+        options.cfFactory_ = std::move(cfFactory);
         auto store = std::make_unique<kvstore::NebulaStore>(std::move(options),
                                                             ioPool,
                                                             workers,
@@ -170,7 +170,7 @@ public:
                                  std::string name,
                                  cpp2::StatType type,
                                  TagID tagId = -1) {
-        auto prop = TestUtils::propDef(owner, name, tagId);
+        auto prop = TestUtils::propDef(owner, std::move(name), tagId);
         prop.set_stat(type);
         return prop;
     }


### PR DESCRIPTION
1. Changed from `push_back` to `emplace_back`, let avoid unnecessary memory copy/move.
2. Normalize the some codes.