### PR TITLE
Do prepare after setting onResult_ in PipeExecutor::prepare

### DIFF
--- a/src/graph/PipeExecutor.cpp
+++ b/src/graph/PipeExecutor.cpp
@@ -27,22 +27,6 @@ Status PipeExecutor::prepare() {
     DCHECK(left_ != nullptr);
     DCHECK(right_ != nullptr);
 
-    status = left_->prepare();
-    if (!status.ok()) {
-        FLOG_ERROR("Prepare executor `%s' failed: %s",
-                    left_->name(), status.toString().c_str());
-        return status;
-    }
-
-    right_->setInputResultSchema(left_->resultSchema());
-
-    status = right_->prepare();
-    if (!status.ok()) {
-        FLOG_ERROR("Prepare executor `%s' failed: %s",
-                    right_->name(), status.toString().c_str());
-        return status;
-    }
-
     auto onError = [this] (Status s) {
         /**
          * TODO(dutor)
@@ -89,6 +73,21 @@ Status PipeExecutor::prepare() {
 
         right_->setOnError(onError);
     }
+
+    status = left_->prepare();
+    if (!status.ok()) {
+        FLOG_ERROR("Prepare executor `%s' failed: %s",
+                    left_->name(), status.toString().c_str());
+        return status;
+    }
+
+    status = right_->prepare();
+    if (!status.ok()) {
+        FLOG_ERROR("Prepare executor `%s' failed: %s",
+                    right_->name(), status.toString().c_str());
+        return status;
+    }
+
 
     return Status::OK();
 }

--- a/src/graph/PipeExecutor.h
+++ b/src/graph/PipeExecutor.h
@@ -29,14 +29,6 @@ public:
 
     void setupResponse(cpp2::ExecutionResponse &resp) override;
 
-    ResultSchema* resultSchema() const override {
-        return right_->resultSchema();
-    }
-
-    void setInputResultSchema(ResultSchema *schema) override {
-        left_->setInputResultSchema(schema);
-    }
-
 private:
     PipedSentence                              *sentence_{nullptr};
     std::unique_ptr<TraverseExecutor>           left_;

--- a/src/graph/TraverseExecutor.h
+++ b/src/graph/TraverseExecutor.h
@@ -70,14 +70,6 @@ public:
         onResult_ = std::move(onResult);
     }
 
-    virtual ResultSchema* resultSchema() const {
-        return resultSchema_.get();
-    }
-
-    virtual void setInputResultSchema(ResultSchema *schema) {
-        inputResultSchema_ = schema;
-    }
-
     static std::unique_ptr<TraverseExecutor>
     makeTraverseExecutor(Sentence *sentence, ExecutionContext *ectx);
 
@@ -86,8 +78,6 @@ protected:
 
 protected:
     OnResult                                    onResult_;
-    std::unique_ptr<ResultSchema>               resultSchema_;
-    ResultSchema                               *inputResultSchema_{nullptr};
 };
 
 }   // namespace graph

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -829,6 +829,44 @@ TEST_F(GoTest, OneStepOutBound) {
         };
         ASSERT_TRUE(verifyResult(resp, expected));
     }
+    {
+        cpp2::ExecutionResponse resp;
+        auto &player = players_["Boris Diaw"];
+        auto *fmt = "GO FROM %ld OVER like "
+                    "| GO FROM $-.id OVER like | GO FROM $-.id OVER serve";
+        auto query = folly::stringPrintf(fmt, player.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<int64_t>> expected = {
+            {teams_["Spurs"].vid()},
+            {teams_["Spurs"].vid()},
+            {teams_["Spurs"].vid()},
+            {teams_["Spurs"].vid()},
+            {teams_["Spurs"].vid()},
+            {teams_["Hornets"].vid()},
+            {teams_["Trail Blazers"].vid()},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto &player = players_["Boris Diaw"];
+        auto *fmt = "GO FROM %ld OVER like "
+                    "| ( GO FROM $-.id OVER like | GO FROM $-.id OVER serve )";
+        auto query = folly::stringPrintf(fmt, player.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<int64_t>> expected = {
+            {teams_["Spurs"].vid()},
+            {teams_["Spurs"].vid()},
+            {teams_["Spurs"].vid()},
+            {teams_["Spurs"].vid()},
+            {teams_["Spurs"].vid()},
+            {teams_["Hornets"].vid()},
+            {teams_["Trail Blazers"].vid()},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
 }
 
 // REVERSELY not supported yet


### PR DESCRIPTION
Do prepare after setting onResult_ in PipeExecutor::prepare, or these cases will not work well:
***GO ... | GO ... | GO ...***
***GO ... | (GO ... | GO ...)***