### PR TITLE
Use folly::Function instead of std::function in kvstore callback

### DIFF
--- a/src/kvstore/Common.h
+++ b/src/kvstore/Common.h
@@ -9,6 +9,7 @@
 
 #include "base/Base.h"
 #include "rocksdb/slice.h"
+#include <folly/Function.h>
 
 namespace nebula {
 namespace kvstore {
@@ -39,7 +40,7 @@ public:
 };
 
 using KV = std::pair<std::string, std::string>;
-using KVCallback = std::function<void(ResultCode code)>;
+using KVCallback = folly::Function<void(ResultCode code)>;
 
 inline rocksdb::Slice toSlice(const folly::StringPiece& str) {
     return rocksdb::Slice(str.begin(), str.size());

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -313,7 +313,7 @@ void NebulaStore::asyncMultiRemove(GraphSpaceID spaceId,
                                    KVCallback cb) {
     folly::RWSpinLock::ReadHolder rh(&lock_);
     CHECK_FOR_WRITE(spaceId, partId, cb);
-    return partIt->second->asyncMultiRemove(std::move(keys), cb);
+    return partIt->second->asyncMultiRemove(std::move(keys), std::move(cb));
 }
 
 

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -81,7 +81,7 @@ void Part::asyncPut(folly::StringPiece key, folly::StringPiece value, KVCallback
     std::string log = encodeMultiValues(OP_PUT, key, value);
 
     appendAsync(FLAGS_cluster_id, std::move(log))
-        .then([callback = std::move(cb)] (AppendLogResult res) {
+        .then([callback = std::move(cb)] (AppendLogResult res) mutable {
             callback(toResultCode(res));
         });
 }
@@ -91,7 +91,7 @@ void Part::asyncMultiPut(const std::vector<KV>& keyValues, KVCallback cb) {
     std::string log = encodeMultiValues(OP_MULTI_PUT, keyValues);
 
     appendAsync(FLAGS_cluster_id, std::move(log))
-        .then([callback = std::move(cb)] (AppendLogResult res) {
+        .then([callback = std::move(cb)] (AppendLogResult res) mutable {
             callback(toResultCode(res));
         });
 }
@@ -101,7 +101,7 @@ void Part::asyncRemove(folly::StringPiece key, KVCallback cb) {
     std::string log = encodeSingleValue(OP_REMOVE, key);
 
     appendAsync(FLAGS_cluster_id, std::move(log))
-        .then([callback = std::move(cb)] (AppendLogResult res) {
+        .then([callback = std::move(cb)] (AppendLogResult res) mutable {
             callback(toResultCode(res));
         });
 }
@@ -111,7 +111,7 @@ void Part::asyncMultiRemove(const std::vector<std::string>& keys, KVCallback cb)
     std::string log = encodeMultiValues(OP_MULTI_REMOVE, keys);
 
     appendAsync(FLAGS_cluster_id, std::move(log))
-        .then([callback = std::move(cb)] (AppendLogResult res) {
+        .then([callback = std::move(cb)] (AppendLogResult res) mutable {
             callback(toResultCode(res));
         });
 }
@@ -121,7 +121,7 @@ void Part::asyncRemovePrefix(folly::StringPiece prefix, KVCallback cb) {
     std::string log = encodeSingleValue(OP_REMOVE_PREFIX, prefix);
 
     appendAsync(FLAGS_cluster_id, std::move(log))
-        .then([callback = std::move(cb)] (AppendLogResult res) {
+        .then([callback = std::move(cb)] (AppendLogResult res) mutable {
             callback(toResultCode(res));
         });
 }
@@ -133,7 +133,7 @@ void Part::asyncRemoveRange(folly::StringPiece start,
     std::string log = encodeMultiValues(OP_REMOVE_RANGE, start, end);
 
     appendAsync(FLAGS_cluster_id, std::move(log))
-        .then([callback = std::move(cb)] (AppendLogResult res) {
+        .then([callback = std::move(cb)] (AppendLogResult res) mutable {
             callback(toResultCode(res));
         });
 }


### PR DESCRIPTION
std::function has two defects:
1.   It must be copy constructible,  so we can't pass object which is NOT in capture list.
2.  It has problems with const-ness method.

For more information, please refer to https://github.com/facebook/folly/blob/master/folly/Function.h