### PR TITLE
Fix bugs in RAFT

### DIFF
--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -37,6 +37,7 @@ enum class AppendLogResult {
     E_NOT_READY = -4,
     E_BUFFER_OVERFLOW = -5,
     E_WAL_FAILURE = -6,
+    E_TERM_OUT_OF_DATE = -7,
 };
 
 class Host;


### PR DESCRIPTION
The pr fix four bugs: 
1.  When commit logs, we hope it is under protection by raftLock_.  
2.  Write WALs should be protected by raftLock_.
3.  Term maybe changed when committed,  we should handle it. 
4.  When write wal failed, reset replicatingLogs_ to be false. 