### PR TITLE
To link executables with -no-pie

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ endif()
 
 set(CMAKE_CXX_STANDARD 14)
 
-set(CMAKE_EXE_LINKER_FLAGS "-static-libstdc++")
+set(CMAKE_EXE_LINKER_FLAGS "-static-libstdc++ -no-pie")
 
 # CMake macro to specify number of jobs to build third-party
 if (NOT THIRD_PARTY_JOBS)


### PR DESCRIPTION
Some compilers are built with `-enable-default-pie`. That is no problem generally, but glog is buggy to deal with this when retrieve the backtrace. So we disable pie from our own side.