### PR TITLE
Fixed a bug where the storage service might crash (#583)

### DIFF
--- a/src/daemons/StorageDaemon.cpp
+++ b/src/daemons/StorageDaemon.cpp
@@ -200,10 +200,12 @@ int main(int argc, char *argv[]) {
         gServer->setIOThreadPool(ioThreadPool);
         gServer->serve();  // Will wait until the server shuts down
     } catch (const std::exception& e) {
+        metaClient.reset();
         LOG(ERROR) << "Start thrift server failed, error:" << e.what();
         return EXIT_FAILURE;
     }
 
+    metaClient.reset();
     LOG(INFO) << "The storage Daemon stopped";
 }
 


### PR DESCRIPTION
 When the storage service deamon is started, the nebula::meta::MetaClient will use the MetaServerBasedPartManager object(MetaClient::registerListener), but the MetaServerBasedPartManager object will be released before nebula::meta::MetaClient(through KVStore object),so we need to manually release nebula::meta::MetaClient here before release KVStore object.