### PR TITLE
Fixed bug on variable reference

### DIFF
--- a/src/graph/AssignmentExecutor.cpp
+++ b/src/graph/AssignmentExecutor.cpp
@@ -27,12 +27,7 @@ Status AssignmentExecutor::prepare() {
 
     var_ = sentence_->var();
     executor_ = TraverseExecutor::makeTraverseExecutor(sentence_->sentence(), ectx());
-    status = executor_->prepare();
-    if (!status.ok()) {
-        FLOG_ERROR("Prepare executor `%s' failed: %s",
-                    executor_->name(), status.toString().c_str());
-        return status;
-    }
+
     auto onError = [this] (Status s) {
         DCHECK(onError_);
         onError_(std::move(s));
@@ -47,6 +42,13 @@ Status AssignmentExecutor::prepare() {
     executor_->setOnError(onError);
     executor_->setOnFinish(onFinish);
     executor_->setOnResult(onResult);
+
+    status = executor_->prepare();
+    if (!status.ok()) {
+        FLOG_ERROR("Prepare executor `%s' failed: %s",
+                    executor_->name(), status.toString().c_str());
+        return status;
+    }
 
     return Status::OK();
 }

--- a/src/graph/test/CMakeLists.txt
+++ b/src/graph/test/CMakeLists.txt
@@ -24,6 +24,12 @@ set(GRAPH_TEST_LIBS
     $<TARGET_OBJECTS:thrift_obj>
 )
 
+add_library(graph_test_common_obj OBJECT
+    TestMain.cpp
+    TestEnv.cpp
+    TestBase.cpp
+)
+
 
 add_executable(
     session_manager_test
@@ -43,11 +49,9 @@ nebula_add_test(session_manager_test)
 
 add_executable(
     query_engine_test
-    TestMain.cpp
-    TestEnv.cpp
-    TestBase.cpp
     YieldTest.cpp
     SchemaTest.cpp
+    $<TARGET_OBJECTS:graph_test_common_obj>
     $<TARGET_OBJECTS:client_cpp_obj>
     $<TARGET_OBJECTS:adHocSchema_obj>
     ${GRAPH_TEST_LIBS}
@@ -64,10 +68,8 @@ nebula_add_test(query_engine_test)
 
 add_executable(
     go_test
-    TestMain.cpp
-    TestEnv.cpp
-    TestBase.cpp
     GoTest.cpp
+    $<TARGET_OBJECTS:graph_test_common_obj>
     $<TARGET_OBJECTS:client_cpp_obj>
     $<TARGET_OBJECTS:adHocSchema_obj>
     ${GRAPH_TEST_LIBS}
@@ -84,10 +86,8 @@ nebula_add_test(go_test)
 
 add_executable(
     graph_http_test
-    TestMain.cpp
-    TestEnv.cpp
-    TestBase.cpp
     GraphHttpHandlerTest.cpp
+    $<TARGET_OBJECTS:graph_test_common_obj>
     $<TARGET_OBJECTS:graph_http_handler>
     $<TARGET_OBJECTS:client_cpp_obj>
     $<TARGET_OBJECTS:ws_obj>
@@ -109,10 +109,8 @@ nebula_add_test(graph_http_test)
 
 add_executable(
     data_test
-    TestMain.cpp
-    TestEnv.cpp
-    TestBase.cpp
     DataTest.cpp
+    $<TARGET_OBJECTS:graph_test_common_obj>
     $<TARGET_OBJECTS:client_cpp_obj>
     $<TARGET_OBJECTS:adHocSchema_obj>
     ${GRAPH_TEST_LIBS}
@@ -129,10 +127,8 @@ nebula_add_test(data_test)
 
 add_executable(
     order_by_test
-    TestMain.cpp
-    TestEnv.cpp
-    TestBase.cpp
     OrderByTest.cpp
+    $<TARGET_OBJECTS:graph_test_common_obj>
     $<TARGET_OBJECTS:client_cpp_obj>
     $<TARGET_OBJECTS:adHocSchema_obj>
     ${GRAPH_TEST_LIBS}

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -114,6 +114,43 @@ TEST_F(GoTest, OneStepOutBound) {
     }
 }
 
+
+TEST_F(GoTest, AssignmentSimple) {
+    {
+        cpp2::ExecutionResponse resp;
+        auto &player = players_["Tracy McGrady"];
+        auto *fmt = "$var = GO FROM %ld OVER like; "
+                    "GO FROM $var.id OVER like";
+        auto query = folly::stringPrintf(fmt, player.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<uint64_t>> expected = {
+            {players_["Kobe Bryant"].vid()},
+            {players_["Grant Hill"].vid()},
+            {players_["Rudy Gay"].vid()},
+        };
+    }
+}
+
+
+TEST_F(GoTest, AssignmentPipe) {
+    {
+        cpp2::ExecutionResponse resp;
+        auto &player = players_["Tracy McGrady"];
+        auto *fmt = "$var = (GO FROM %ld OVER like | GO FROM $- OVER like);"
+                    "GO FROM $var OVER like";
+        auto query = folly::stringPrintf(fmt, player.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<uint64_t>> expected = {
+            {players_["Kobe Bryant"].vid()},
+            {players_["Grant Hill"].vid()},
+            {players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid()},
+        };
+    }
+}
+
 // REVERSELY not supported yet
 TEST_F(GoTest, DISABLED_OneStepInBound) {
     {

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -274,6 +274,9 @@ var_ref_expression
     : VARIABLE DOT LABEL {
         $$ = new VariablePropertyExpression($1, $3);
     }
+    | VARIABLE {
+        $$ = new VariablePropertyExpression($1, new std::string("id"));
+    }
     ;
 
 alias_ref_expression


### PR DESCRIPTION
  * Fixed a **_variable not defined_** bug, which occurs when a variable is assigned from a **PIPE** statement.
  * Added sugar syntax to variable reference when the referred column is `id`.
  * Eliminated duplicated compiling on some testing source files.