### PR TITLE
Make heartbeat to be a special empty log

### DIFF
--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -155,6 +155,11 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
     while (iter->valid()) {
         lastId = iter->logId();
         auto log = iter->logMsg();
+        if (log.empty()) {
+            VLOG(3) << idStr_ << "Skip the heartbeat!";
+            ++(*iter);
+            continue;
+        }
         DCHECK_GE(log.size(), sizeof(int64_t) + 1 + sizeof(uint32_t));
         // Skip the timestamp (type of int64_t)
         switch (log[sizeof(int64_t)]) {

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -248,11 +248,8 @@ private:
     /*****************************************************************
      * Asynchronously send a heartbeat (An empty log entry)
      *
-     * The code path is similar to appendLog() and the heartbeat will
-     * be put into the log batch, but will not be added to WAL
      ****************************************************************/
     folly::Future<AppendLogResult> sendHeartbeat();
-    void doneHeartbeat();
 
     /****************************************************
      *

--- a/src/kvstore/raftex/test/LogAppendTest.cpp
+++ b/src/kvstore/raftex/test/LogAppendTest.cpp
@@ -56,7 +56,7 @@ TEST(LogAppend, SimpleAppendWithOneCopy) {
         ASSERT_EQ(100, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader->firstCommittedLogId_;
     for (int i = 0; i < 100; ++i, ++id) {
         for (auto& c : copies) {
             folly::StringPiece msg;
@@ -103,7 +103,7 @@ TEST(LogAppend, SimpleAppendWithThreeCopies) {
         ASSERT_EQ(100, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader->firstCommittedLogId_;
     for (int i = 0; i < 100; ++i, ++id) {
         for (auto& c : copies) {
             folly::StringPiece msg;
@@ -172,7 +172,7 @@ TEST(LogAppend, MultiThreadAppend) {
         ASSERT_EQ(numThreads * numLogs, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader->firstCommittedLogId_;
     for (int i = 0; i < numThreads * numLogs; ++i, ++id) {
         folly::StringPiece msg;
         ASSERT_TRUE(leader->getLogMsg(id, msg));

--- a/src/kvstore/raftex/test/LogCASTest.cpp
+++ b/src/kvstore/raftex/test/LogCASTest.cpp
@@ -53,7 +53,7 @@ TEST_F(LogCASTest, StartWithValidCAS) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;
@@ -88,7 +88,7 @@ TEST_F(LogCASTest, StartWithInvalidCAS) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;
@@ -131,7 +131,7 @@ TEST_F(LogCASTest, ValidCASInMiddle) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;
@@ -173,7 +173,7 @@ TEST_F(LogCASTest, InvalidCASInMiddle) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;
@@ -209,7 +209,7 @@ TEST_F(LogCASTest, EndWithValidCAS) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;
@@ -243,7 +243,7 @@ TEST_F(LogCASTest, EndWithInvalidCAS) {
         ASSERT_EQ(8, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 8; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;
@@ -276,7 +276,7 @@ TEST_F(LogCASTest, AllValidCAS) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;

--- a/src/kvstore/raftex/test/LogCommandTest.cpp
+++ b/src/kvstore/raftex/test/LogCommandTest.cpp
@@ -54,7 +54,7 @@ TEST_F(LogCommandTest, StartWithCommandLog) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;
@@ -97,7 +97,7 @@ TEST_F(LogCommandTest, CommandInMiddle) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;
@@ -131,7 +131,7 @@ TEST_F(LogCommandTest, EndWithCommand) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;
@@ -164,7 +164,7 @@ TEST_F(LogCommandTest, AllCommandLogs) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;
@@ -228,7 +228,7 @@ TEST_F(LogCommandTest, MixedLogs) {
         ASSERT_EQ(10, c->getNumLogs());
     }
 
-    LogID id = 1;
+    LogID id = leader_->firstCommittedLogId_;
     for (int i = 0; i < 10; ++i, ++id) {
         for (auto& c : copies_) {
             folly::StringPiece msg;

--- a/src/kvstore/raftex/test/TestShard.cpp
+++ b/src/kvstore/raftex/test/TestShard.cpp
@@ -69,16 +69,25 @@ bool TestShard::commitLogs(std::unique_ptr<LogIterator> iter) {
     VLOG(2) << "TestShard: Committing logs";
     LogID firstId = -1;
     LogID lastId = -1;
+    int32_t commitLogsNum = 0;
     while (iter->valid()) {
         if (firstId < 0) {
             firstId = iter->logId();
         }
         lastId = iter->logId();
-        data_.emplace(iter->logId(), iter->logMsg().toString());
+        if (!iter->logMsg().empty()) {
+            if (firstCommittedLogId_ < 0) {
+                firstCommittedLogId_ = iter->logId();
+            }
+            data_.emplace(iter->logId(), iter->logMsg().toString());
+            commitLogsNum++;
+        }
         ++(*iter);
     }
     VLOG(2) << "TestShard: Committed log " << firstId << " to " << lastId;
-    commitTimes_++;
+    if (commitLogsNum > 0) {
+        commitTimes_++;
+    }
     return true;
 }
 

--- a/src/kvstore/raftex/test/TestShard.h
+++ b/src/kvstore/raftex/test/TestShard.h
@@ -56,6 +56,7 @@ public:
 
 public:
     int32_t commitTimes_ = 0;
+    int32_t firstCommittedLogId_ = -1;
 
 private:
     const size_t idx_;


### PR DESCRIPTION
This pr is to fix the problem that when follower becomes leader,  it will not commit the log with previous term.  As the paper said,  the logic is correct.  But the problem is that as current heart beat implementation, we will not commit anything when received response from followers.  It is incorrect. 

So this pr will use a special empty log to represent heartbeat,   the log will be written into WAL but skipped when committing.   It has no harm to performance because we don't send heartbeat when replicating logs.   And it will force the uncommitted logs to commit when the new leader send heartbeat with it's current term.  