### PR TITLE
Issue#424 to make `Expression::eval` to be able to do error handling

### DIFF
--- a/src/common/filter/Expressions.cpp
+++ b/src/common/filter/Expressions.cpp
@@ -144,7 +144,7 @@ std::string InputPropertyExpression::toString() const {
 }
 
 
-VariantType InputPropertyExpression::eval() const {
+OptVariantType InputPropertyExpression::eval() const {
     return context_->getters().getInputProp(*prop_);
 }
 
@@ -180,7 +180,7 @@ std::string DestPropertyExpression::toString() const {
 }
 
 
-VariantType DestPropertyExpression::eval() const {
+OptVariantType DestPropertyExpression::eval() const {
     return context_->getters().getDstTagProp(*tag_, *prop_);
 }
 
@@ -234,12 +234,10 @@ std::string VariablePropertyExpression::toString() const {
     return buf;
 }
 
-
-VariantType VariablePropertyExpression::eval() const {
+OptVariantType VariablePropertyExpression::eval() const {
     // TODO(dutor)
-    return toString();
+    return OptVariantType(toString());
 }
-
 
 Status VariablePropertyExpression::prepare() {
     // TODO(dutor)
@@ -290,7 +288,7 @@ std::string EdgePropertyExpression::toString() const {
 }
 
 
-VariantType EdgePropertyExpression::eval() const {
+OptVariantType EdgePropertyExpression::eval() const {
     return context_->getters().getEdgeProp(*prop_);
 }
 
@@ -343,8 +341,8 @@ std::string EdgeTypeExpression::toString() const {
 }
 
 
-VariantType EdgeTypeExpression::eval() const {
-    return *alias_;
+OptVariantType EdgeTypeExpression::eval() const {
+  return OptVariantType(*alias_);
 }
 
 
@@ -382,7 +380,7 @@ std::string EdgeSrcIdExpression::toString() const {
 }
 
 
-VariantType EdgeSrcIdExpression::eval() const {
+OptVariantType EdgeSrcIdExpression::eval() const {
     return context_->getters().getEdgeProp("_src");
 }
 
@@ -421,7 +419,7 @@ std::string EdgeDstIdExpression::toString() const {
 }
 
 
-VariantType EdgeDstIdExpression::eval() const {
+OptVariantType EdgeDstIdExpression::eval() const {
     return context_->getters().getEdgeProp("_dst");
 }
 
@@ -460,7 +458,7 @@ std::string EdgeRankExpression::toString() const {
 }
 
 
-VariantType EdgeRankExpression::eval() const {
+OptVariantType EdgeRankExpression::eval() const {
     return context_->getters().getEdgeProp("_rank");
 }
 
@@ -501,7 +499,7 @@ std::string SourcePropertyExpression::toString() const {
 }
 
 
-VariantType SourcePropertyExpression::eval() const {
+OptVariantType SourcePropertyExpression::eval() const {
     return context_->getters().getSrcTagProp(*tag_, *prop_);
 }
 
@@ -562,24 +560,20 @@ std::string PrimaryExpression::toString() const {
     return buf;
 }
 
-
-VariantType PrimaryExpression::eval() const {
+OptVariantType PrimaryExpression::eval() const {
     switch (operand_.which()) {
         case kBool:
-            return boost::get<bool>(operand_);
-            break;
+            return OptVariantType(boost::get<bool>(operand_));
         case kInt:
-            return boost::get<int64_t>(operand_);
-            break;
+            return OptVariantType(boost::get<int64_t>(operand_));
         case kDouble:
-            return boost::get<double>(operand_);
-            break;
+            return OptVariantType(boost::get<double>(operand_));
         case kString:
-            return boost::get<std::string>(operand_);
+            return OptVariantType(boost::get<std::string>(operand_));
     }
-    return std::string("Unknown");
-}
 
+    return OptVariantType(Status::Error("Unknown type"));
+}
 
 Status PrimaryExpression::prepare() {
     return Status::OK();
@@ -662,17 +656,21 @@ std::string FunctionCallExpression::toString() const {
     return buf;
 }
 
-
-VariantType FunctionCallExpression::eval() const {
+OptVariantType FunctionCallExpression::eval() const {
     std::vector<VariantType> args;
-    args.resize(args_.size());
-    auto eval = [] (auto &expr) {
-        return expr->eval();
-    };
-    std::transform(args_.begin(), args_.end(), args.begin(), eval);
-    return function_(args);
-}
 
+    for (auto it = args_.cbegin(); it != args_.cend(); ++it) {
+        auto result = (*it)->eval();
+        if (!result.ok()) {
+            return result;
+        }
+        args.push_back(std::move(result.value()));
+    }
+
+    // TODO(simon.liu)
+    auto r = function_(args);
+    return OptVariantType(r);
+}
 
 Status FunctionCallExpression::prepare() {
     auto result = FunctionManager::get(*name_, args_.size());
@@ -749,23 +747,25 @@ std::string UnaryExpression::toString() const {
     return buf;
 }
 
-
-VariantType UnaryExpression::eval() const {
+OptVariantType UnaryExpression::eval() const {
     auto value = operand_->eval();
-    if (op_ == PLUS) {
-        return value;
-    } else if (op_ == NEGATE) {
-        if (isInt(value)) {
-            return -asInt(value);
-        } else if (isDouble(value)) {
-            return -asDouble(value);
+    if (value.ok()) {
+        if (op_ == PLUS) {
+            return value;
+        } else if (op_ == NEGATE) {
+            if (isInt(value.value())) {
+                return OptVariantType(-asInt(value.value()));
+            } else if (isDouble(value.value())) {
+                return OptVariantType(-asDouble(value.value()));
+            }
+        } else {
+            return OptVariantType(!asBool(value.value()));
         }
-    } else {
-        return !asBool(value);
     }
-    return value;
-}
 
+    return OptVariantType(Status::Error(folly::sformat(
+        "attempt to perform unary arithmetic on a {}", value.value().type().name())));
+}
 
 Status UnaryExpression::prepare() {
     return operand_->prepare();
@@ -813,11 +813,9 @@ std::string TypeCastingExpression::toString() const {
     return "";
 }
 
-
-VariantType TypeCastingExpression::eval() const {
-    return toString();
+OptVariantType TypeCastingExpression::eval() const {
+    return OptVariantType(toString());
 }
-
 
 Status TypeCastingExpression::prepare() {
     return operand_->prepare();
@@ -856,48 +854,69 @@ std::string ArithmeticExpression::toString() const {
     return buf;
 }
 
-
-VariantType ArithmeticExpression::eval() const {
-    auto left = left_->eval();
-    auto right = right_->eval();
-    switch (op_) {
-    case ADD:
-        assert((isArithmetic(left) && isArithmetic(right))
-                || (isString(left) && isString(right)));
-        if (isArithmetic(left) && isArithmetic(right)) {
-            if (isDouble(left) || isDouble(right)) {
-                return asDouble(left) + asDouble(right);
-            }
-            return asInt(left) + asInt(right);
-        }
-        return asString(left) + asString(right);
-    case SUB:
-        assert(isArithmetic(left) && isArithmetic(right));
-        if (isDouble(left) || isDouble(right)) {
-            return asDouble(left) - asDouble(right);
-        }
-        return asInt(left) - asInt(right);
-    case MUL:
-        assert(isArithmetic(left) && isArithmetic(right));
-        if (isDouble(left) || isDouble(right)) {
-            return asDouble(left) * asDouble(right);
-        }
-        return asInt(left) * asInt(right);
-    case DIV:
-        assert(isArithmetic(left) && isArithmetic(right));
-        if (isDouble(left) || isDouble(right)) {
-            return asDouble(left) / asDouble(right);
-        }
-        return asInt(left) / asInt(right);
-    case MOD:
-        assert(isInt(left) && isInt(right));
-        return asInt(left) % asInt(right);
-    default:
-        DCHECK(false);
+OptVariantType ArithmeticExpression::eval() const {
+    auto oleft = left_->eval();
+    auto oright = right_->eval();
+    if (!oleft.ok()) {
+        return oleft;
     }
-    return false;
-}
 
+    if (!oright.ok()) {
+        return oright;
+    }
+
+    auto left = oleft.value();
+    auto right = oright.value();
+
+    switch (op_) {
+        case ADD:
+            if (isArithmetic(left) && isArithmetic(right)) {
+                if (isDouble(left) || isDouble(right)) {
+                    return OptVariantType(asDouble(left) + asDouble(right));
+                }
+                return OptVariantType(asInt(left) + asInt(right));
+            }
+
+            if (isString(left) && isString(right)) {
+                return OptVariantType(asString(left) + asString(right));
+            }
+            break;
+        case SUB:
+            if (isArithmetic(left) && isArithmetic(right)) {
+                if (isDouble(left) || isDouble(right)) {
+                    return OptVariantType(asDouble(left) - asDouble(right));
+                }
+                return OptVariantType(asInt(left) - asInt(right));
+            }
+            break;
+        case MUL:
+            if (isArithmetic(left) && isArithmetic(right)) {
+                if (isDouble(left) || isDouble(right)) {
+                    return OptVariantType(asDouble(left) * asDouble(right));
+                }
+                return OptVariantType(asInt(left) * asInt(right));
+            }
+            break;
+        case DIV:
+            if (isArithmetic(left) && isArithmetic(right)) {
+                if (isDouble(left) || isDouble(right)) {
+                    return OptVariantType(asDouble(left) / asDouble(right));
+                }
+                return OptVariantType(asInt(left) / asInt(right));
+            }
+            break;
+        case MOD:
+            if (isInt(left) && isInt(right)) {
+                return OptVariantType(asInt(left) % asInt(right));
+            }
+            break;
+        default:
+            DCHECK(false);
+    }
+
+    return OptVariantType(Status::Error(folly::sformat(
+        "attempt to perform arithmetic on {} with {}", left.type().name(), right.type().name())));
+}
 
 Status ArithmeticExpression::prepare() {
     auto status = left_->prepare();
@@ -964,33 +983,43 @@ std::string RelationalExpression::toString() const {
     return buf;
 }
 
-
-VariantType RelationalExpression::eval() const {
+OptVariantType RelationalExpression::eval() const {
     auto left = left_->eval();
     auto right = right_->eval();
+
+    if (!left.ok()) {
+        return left;
+    }
+
+    if (!right.ok()) {
+        return right;
+    }
+
     switch (op_) {
         case LT:
-            return left < right;
+            return OptVariantType(left.value() < right.value());
         case LE:
-            return left <= right;
+            return OptVariantType(left.value() <= right.value());
         case GT:
-            return left > right;
+            return OptVariantType(left.value() > right.value());
         case GE:
-            return left >= right;
+            return OptVariantType(left.value() >= right.value());
         case EQ:
-            if (isDouble(left) || isDouble(right)) {
-                return almostEqual(asDouble(left), asDouble(right));
+            if (isDouble(left.value()) || isDouble(right.value())) {
+                return OptVariantType(almostEqual(asDouble(left.value()),
+                                                  asDouble(right.value())));
             }
-            return left == right;
+            return OptVariantType(left.value() == right.value());
         case NE:
-            if (isDouble(left) || isDouble(right)) {
-                return !almostEqual(asDouble(left), asDouble(right));
+            if (isDouble(left.value()) || isDouble(right.value())) {
+                return OptVariantType(!almostEqual(asDouble(left.value()),
+                                                   asDouble(right.value())));
             }
-            return left != right;
+            return OptVariantType(left.value() != right.value());
     }
-    return false;
-}
 
+    return OptVariantType(Status::Error("Wrong operator"));
+}
 
 Status RelationalExpression::prepare() {
     auto status = left_->prepare();
@@ -1045,21 +1074,30 @@ std::string LogicalExpression::toString() const {
     return buf;
 }
 
+OptVariantType LogicalExpression::eval() const {
+    auto left = left_->eval();
+    auto right = right_->eval();
 
-VariantType LogicalExpression::eval() const {
+    if (!left.ok()) {
+        return left;
+    }
+
+    if (!right.ok()) {
+        return right;
+    }
+
     if (op_ == AND) {
-        if (!asBool(left_->eval())) {
-            return false;
+        if (!asBool(left.value())) {
+            return OptVariantType(false);
         }
-        return asBool(right_->eval());
+        return OptVariantType(asBool(right.value()));
     } else {
-        if (asBool(left_->eval())) {
-            return true;
+        if (asBool(left.value())) {
+            return OptVariantType(true);
         }
-        return asBool(right_->eval());
+        return OptVariantType(asBool(right.value()));
     }
 }
-
 
 Status LogicalExpression::prepare() {
     auto status = left_->prepare();

--- a/src/common/filter/Expressions.h
+++ b/src/common/filter/Expressions.h
@@ -37,6 +37,7 @@ struct AliasInfo {
 
 
 using VariantType = boost::variant<int64_t, double, bool, std::string>;
+using OptVariantType = StatusOr<VariantType>;
 
 
 class ExpressionContext final {
@@ -93,11 +94,11 @@ public:
     }
 
     struct Getters {
-        std::function<VariantType()> getEdgeRank;
-        std::function<VariantType(const std::string&)> getEdgeProp;
-        std::function<VariantType(const std::string&)> getInputProp;
-        std::function<VariantType(const std::string&, const std::string&)> getSrcTagProp;
-        std::function<VariantType(const std::string&, const std::string&)> getDstTagProp;
+        std::function<OptVariantType()> getEdgeRank;
+        std::function<OptVariantType(const std::string&)> getEdgeProp;
+        std::function<OptVariantType(const std::string&)> getInputProp;
+        std::function<OptVariantType(const std::string&, const std::string&)> getSrcTagProp;
+        std::function<OptVariantType(const std::string&, const std::string&)> getDstTagProp;
     };
 
     Getters& getters() {
@@ -127,7 +128,7 @@ public:
 
     virtual Status MUST_USE_RESULT prepare() = 0;
 
-    virtual VariantType eval() const = 0;
+    virtual OptVariantType eval() const = 0;
 
     virtual bool isInputExpression() const {
         return kind_ == kInputProp;
@@ -295,7 +296,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override {
         return Status::OK();
@@ -330,7 +331,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -360,7 +361,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -398,7 +399,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -427,7 +428,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -455,7 +456,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -483,7 +484,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -511,7 +512,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -540,7 +541,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -591,7 +592,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -637,7 +638,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -680,7 +681,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -715,7 +716,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -760,7 +761,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -803,7 +804,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -847,7 +848,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 

--- a/src/common/filter/test/ExpressionTest.cpp
+++ b/src/common/filter/test/ExpressionTest.cpp
@@ -46,20 +46,24 @@ TEST_F(ExpressionTest, LiteralConstants) {
         auto *expr = getFilterExpr(parsed.value().get());               \
         ASSERT_NE(nullptr, expr);                                       \
         auto value = expr->eval();                                      \
-        ASSERT_TRUE(Expression::is##type(value));                       \
+        ASSERT_TRUE(value.ok());                                        \
+        auto v = value.value();                                         \
+        ASSERT_TRUE(Expression::is##type(v));                           \
         if (#type == std::string("Double")) {                           \
-            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(value));  \
+            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(v));      \
         } else {                                                        \
-            ASSERT_EQ((expr_arg), Expression::as##type(value));         \
+            ASSERT_EQ((expr_arg), Expression::as##type(v));             \
         }                                                               \
         auto decoded = Expression::decode(Expression::encode(expr));    \
         ASSERT_TRUE(decoded.ok()) << decoded.status();                  \
         value = decoded.value()->eval();                                \
-        ASSERT_TRUE(Expression::is##type(value));                       \
+        ASSERT_TRUE(value.ok());                                        \
+        v = value.value();                                              \
+        ASSERT_TRUE(Expression::is##type(v));                           \
         if (#type == std::string("Double")) {                           \
-            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(value));  \
+            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(v));      \
         } else {                                                        \
-            ASSERT_EQ((expr_arg), Expression::as##type(value));         \
+            ASSERT_EQ((expr_arg), Expression::as##type(v));             \
         }                                                               \
     } while (false)
 
@@ -85,8 +89,10 @@ TEST_F(ExpressionTest, LiteralConstants) {
         auto *expr = getFilterExpr(parsed.value().get());
         ASSERT_NE(nullptr, expr);
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isString(value));
-        ASSERT_EQ("string_literal", Expression::asString(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isString(v));
+        ASSERT_EQ("string_literal", Expression::asString(v));
 
         auto buffer = Expression::encode(expr);
         ASSERT_FALSE(buffer.empty());
@@ -94,8 +100,10 @@ TEST_F(ExpressionTest, LiteralConstants) {
         ASSERT_TRUE(decoded.ok()) << decoded.status();
         ASSERT_NE(nullptr, decoded.value());
         value = decoded.value()->eval();
-        ASSERT_TRUE(Expression::isString(value));
-        ASSERT_EQ("string_literal", Expression::asString(value));
+        ASSERT_TRUE(value.ok());
+        v = value.value();
+        ASSERT_TRUE(Expression::isString(v));
+        ASSERT_EQ("string_literal", Expression::asString(v));
     }
 }
 
@@ -110,24 +118,28 @@ TEST_F(ExpressionTest, LiteralContantsArithmetic) {
         auto *expr = getFilterExpr(parsed.value().get());               \
         ASSERT_NE(nullptr, expr);                                       \
         auto value = expr->eval();                                      \
-        ASSERT_TRUE(Expression::is##type(value));                       \
+        ASSERT_TRUE(value.ok());                                        \
+        auto v = value.value();                                         \
+        ASSERT_TRUE(Expression::is##type(v));                           \
         if (#type == std::string("Double")) {                           \
-            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(value));  \
-            ASSERT_DOUBLE_EQ((expected), Expression::as##type(value));  \
+            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(v));      \
+            ASSERT_DOUBLE_EQ((expected), Expression::as##type(v));      \
         } else {                                                        \
-            ASSERT_EQ((expr_arg), Expression::as##type(value));         \
-            ASSERT_EQ((expected), Expression::as##type(value));         \
+            ASSERT_EQ((expr_arg), Expression::as##type(v));             \
+            ASSERT_EQ((expected), Expression::as##type(v));             \
         }                                                               \
         auto decoded = Expression::decode(Expression::encode(expr));    \
         ASSERT_TRUE(decoded.ok()) << decoded.status();                  \
         value = decoded.value()->eval();                                \
-        ASSERT_TRUE(Expression::is##type(value));                       \
+        ASSERT_TRUE(value.ok());                                        \
+        v = value.value();                                              \
+        ASSERT_TRUE(Expression::is##type(v));                           \
         if (#type == std::string("Double")) {                           \
-            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(value));  \
-            ASSERT_DOUBLE_EQ((expected), Expression::as##type(value));  \
+            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(v));      \
+            ASSERT_DOUBLE_EQ((expected), Expression::as##type(v));      \
         } else {                                                        \
-            ASSERT_EQ((expr_arg), Expression::as##type(value));         \
-            ASSERT_EQ((expected), Expression::as##type(value));         \
+            ASSERT_EQ((expr_arg), Expression::as##type(v));             \
+            ASSERT_EQ((expected), Expression::as##type(v));             \
         }                                                               \
     } while (false)
 
@@ -195,8 +207,10 @@ TEST_F(ExpressionTest, LiteralContantsArithmetic) {
         auto *expr = getFilterExpr(parsed.value().get());
         ASSERT_NE(nullptr, expr);
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isInt(value));
-        ASSERT_EQ(16, Expression::asInt(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isInt(v));
+        ASSERT_EQ(16, Expression::asInt(v));
 
         auto buffer = Expression::encode(expr);
         ASSERT_FALSE(buffer.empty());
@@ -204,8 +218,10 @@ TEST_F(ExpressionTest, LiteralContantsArithmetic) {
         ASSERT_TRUE(decoded.ok()) << decoded.status();
         ASSERT_NE(nullptr, decoded.value());
         value = decoded.value()->eval();
-        ASSERT_TRUE(Expression::isInt(value));
-        ASSERT_EQ(16, Expression::asInt(value));
+        ASSERT_TRUE(value.ok());
+        v = value.value();
+        ASSERT_TRUE(Expression::isInt(v));
+        ASSERT_EQ(16, Expression::asInt(v));
     }
 }
 
@@ -220,15 +236,19 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
         auto *expr = getFilterExpr(parsed.value().get());               \
         ASSERT_NE(nullptr, expr);                                       \
         auto value = expr->eval();                                      \
-        ASSERT_TRUE(Expression::isBool(value));                         \
-        ASSERT_EQ((expr_arg), Expression::asBool(value));               \
-        ASSERT_EQ((expected), Expression::asBool(value));               \
+        ASSERT_TRUE(value.ok());                                        \
+        auto v = value.value();                                         \
+        ASSERT_TRUE(Expression::isBool(v));                             \
+        ASSERT_EQ((expr_arg), Expression::asBool(v));                   \
+        ASSERT_EQ((expected), Expression::asBool(v));                   \
         auto decoded = Expression::decode(Expression::encode(expr));    \
         ASSERT_TRUE(decoded.ok()) << decoded.status();                  \
         value = decoded.value()->eval();                                \
-        ASSERT_TRUE(Expression::isBool(value));                         \
-        ASSERT_EQ((expr_arg), Expression::asBool(value));               \
-        ASSERT_EQ((expected), Expression::asBool(value));               \
+        ASSERT_TRUE(value.ok());                                        \
+        v = value.value();                                              \
+        ASSERT_TRUE(Expression::isBool(v));                             \
+        ASSERT_EQ((expr_arg), Expression::asBool(v));                   \
+        ASSERT_EQ((expected), Expression::asBool(v));                   \
     } while (false)
 
     TEST_EXPR(1 == 1, true);
@@ -290,13 +310,17 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
         auto *expr = getFilterExpr(parsed.value().get());
         ASSERT_NE(nullptr, expr);
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
         auto decoded = Expression::decode(Expression::encode(expr));
         ASSERT_TRUE(decoded.ok()) << decoded.status();
         value = decoded.value()->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
     }
     {
         std::string query = "GO FROM 1 OVER follow WHERE 3.14 * 3 * 3 / 2 != 3.14 * 1.5 * 1.5 / 2";
@@ -305,13 +329,17 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
         auto *expr = getFilterExpr(parsed.value().get());
         ASSERT_NE(nullptr, expr);
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
         auto decoded = Expression::decode(Expression::encode(expr));
         ASSERT_TRUE(decoded.ok()) << decoded.status();
         value = decoded.value()->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
     }
 
 #undef TEST_EXPR
@@ -328,15 +356,19 @@ TEST_F(ExpressionTest, LiteralConstantsLogical) {
         auto *expr = getFilterExpr(parsed.value().get());               \
         ASSERT_NE(nullptr, expr);                                       \
         auto value = expr->eval();                                      \
-        ASSERT_TRUE(Expression::isBool(value));                         \
-        ASSERT_EQ((expr_arg), Expression::asBool(value));               \
-        ASSERT_EQ((expected), Expression::asBool(value));               \
+        ASSERT_TRUE(value.ok());                                        \
+        auto v = value.value();                                         \
+        ASSERT_TRUE(Expression::isBool(v));                             \
+        ASSERT_EQ((expr_arg), Expression::asBool(v));                   \
+        ASSERT_EQ((expected), Expression::asBool(v));                   \
         auto decoded = Expression::decode(Expression::encode(expr));    \
         ASSERT_TRUE(decoded.ok()) << decoded.status();                  \
         value = decoded.value()->eval();                                \
-        ASSERT_TRUE(Expression::isBool(value));                         \
-        ASSERT_EQ((expr_arg), Expression::asBool(value));               \
-        ASSERT_EQ((expected), Expression::asBool(value));               \
+        ASSERT_TRUE(value.ok());                                        \
+        v = value.value();                                              \
+        ASSERT_TRUE(Expression::isBool(v));                             \
+        ASSERT_EQ((expr_arg), Expression::asBool(v));                   \
+        ASSERT_EQ((expected), Expression::asBool(v));                   \
     } while (false)
 
     // AND
@@ -418,8 +450,10 @@ TEST_F(ExpressionTest, InputReference) {
         };
         expr->setContext(ctx.get());
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isString(value));
-        ASSERT_EQ("Freddie", Expression::asString(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isString(v));
+        ASSERT_EQ("Freddie", Expression::asString(v));
     }
     {
         std::string query = "GO FROM 1 OVER follow WHERE $-.age >= 18";
@@ -437,8 +471,10 @@ TEST_F(ExpressionTest, InputReference) {
         };
         expr->setContext(ctx.get());
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
     }
 }
 
@@ -460,8 +496,10 @@ TEST_F(ExpressionTest, SourceTagReference) {
         };
         expr->setContext(ctx.get());
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
     }
 }
 
@@ -491,8 +529,10 @@ TEST_F(ExpressionTest, EdgeReference) {
         };
         expr->setContext(ctx.get());
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_FALSE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_FALSE(Expression::asBool(v));
     }
 }
 
@@ -513,15 +553,17 @@ TEST_F(ExpressionTest, FunctionCall) {
         auto status = decoded.value()->prepare();                       \
         ASSERT_TRUE(status.ok()) << status;                             \
         auto value = decoded.value()->eval();                           \
-        ASSERT_TRUE(Expression::is##type(value));                       \
+        ASSERT_TRUE(value.ok());                                        \
+        auto v = value.value();                                         \
+        ASSERT_TRUE(Expression::is##type(v));                           \
         if (#type == std::string("Double")) {                           \
             if (#op != std::string("EQ")) {                             \
-                ASSERT_##op(expected, Expression::as##type(value));     \
+                ASSERT_##op(expected, Expression::as##type(v));         \
             } else {                                                    \
-                ASSERT_DOUBLE_EQ(expected, Expression::as##type(value));\
+                ASSERT_DOUBLE_EQ(expected, Expression::as##type(v));    \
             }                                                           \
         } else {                                                        \
-            ASSERT_##op(expected, Expression::as##type(value));         \
+            ASSERT_##op(expected, Expression::as##type(v));             \
         }                                                               \
     } while (false)
 
@@ -571,6 +613,40 @@ TEST_F(ExpressionTest, FunctionCall) {
     TEST_EXPR(0, LT, strcasecmp("HelLo", "hell"), Int);
     TEST_EXPR(0, GT, strcasecmp("HelLo", "World"), Int);
 
+#undef TEST_EXPR
+}
+
+TEST_F(ExpressionTest, InvalidExpressionTest) {
+    GQLParser parser;
+
+#define TEST_EXPR(expr_arg)                                           \
+    do {                                                              \
+        std::string query = "GO FROM 1 OVER follow WHERE " #expr_arg; \
+        auto parsed = parser.parse(query);                            \
+        ASSERT_TRUE(parsed.ok()) << parsed.status();                  \
+        auto *expr = getFilterExpr(parsed.value().get());             \
+        ASSERT_NE(nullptr, expr);                                     \
+        auto decoded = Expression::decode(Expression::encode(expr));  \
+        ASSERT_TRUE(decoded.ok()) << decoded.status();                \
+        auto ctx = std::make_unique<ExpressionContext>();             \
+        decoded.value()->setContext(ctx.get());                       \
+        auto status = decoded.value()->prepare();                     \
+        ASSERT_TRUE(status.ok()) << status;                           \
+        auto value = decoded.value()->eval();                         \
+        ASSERT_TRUE(!value.ok());                                     \
+    } while (false)
+
+    TEST_EXPR("a" + 1);
+    TEST_EXPR(3.14 + "a");
+    TEST_EXPR("ab" - "c");
+    TEST_EXPR(1 - "a");
+    TEST_EXPR("a" * 1);
+    TEST_EXPR(1.0 * "a");
+    TEST_EXPR(1 / "a");
+    TEST_EXPR("a" / "b");
+    TEST_EXPR(1.0 % 2.0);
+    TEST_EXPR(1.0 % 3);
+    TEST_EXPR(-"A");
 #undef TEST_EXPR
 }
 

--- a/src/graph/GoExecutor.h
+++ b/src/graph/GoExecutor.h
@@ -137,14 +137,14 @@ private:
     /**
      * To setup the body of the execution result.
      */
-    void setupResponseBody(RpcResponse &rpcResp, cpp2::ExecutionResponse &resp) const;
+    bool setupResponseBody(RpcResponse &rpcResp, cpp2::ExecutionResponse &resp) const;
 
     /**
      * To iterate on the final data collection, and evaluate the filter and yield columns.
      * For each row that matches the filter, `cb' would be invoked.
      */
     using Callback = std::function<void(std::vector<VariantType>)>;
-    void processFinalResult(RpcResponse &rpcResp, Callback cb) const;
+    bool processFinalResult(RpcResponse &rpcResp, Callback cb) const;
 
     /**
      * A container to hold the mapping from vertex id to its properties, used for lookups
@@ -152,8 +152,9 @@ private:
      */
     class VertexHolder final {
     public:
-        VariantType get(VertexID id, const std::string &prop) const;
+        OptVariantType get(VertexID id, const std::string &prop) const;
         void add(const storage::cpp2::QueryResponse &resp);
+        bool exist(VertexID id) const;
 
     private:
         std::shared_ptr<ResultSchemaProvider>       schema_;

--- a/src/graph/YieldExecutor.cpp
+++ b/src/graph/YieldExecutor.cpp
@@ -37,7 +37,13 @@ void YieldExecutor::execute() {
     values.reserve(size);
 
     for (auto *col : yields_) {
-        values.emplace_back(col->expr()->eval());
+        auto expr = col->expr();
+        auto v = expr->eval();
+        if (!v.ok()) {
+            onError_(v.status());
+            return;
+        }
+        values.emplace_back(v.value());
     }
 
     std::vector<cpp2::RowValue> rows;

--- a/src/storage/QueryBoundProcessor.cpp
+++ b/src/storage/QueryBoundProcessor.cpp
@@ -28,7 +28,10 @@ kvstore::ResultCode QueryBoundProcessor::processVertex(PartitionID partId,
                 return ret;
             }
         }
-        vResp.set_vertex_data(writer.encode());
+
+        if (writer.size() > 1) {
+          vResp.set_vertex_data(writer.encode());
+        }
     }
 
     if (!this->edgeContext_.props_.empty()) {


### PR DESCRIPTION
Summary:

1. When the expression is evaluated, some wrong judgments are added.
   When the expression was failed, an error will be replied to the user.
2. When the user's destination edge for inserting an vertical does not exist,
   we need to skip this dst edge when the user query the prop of dst edge( Issue#580).