### PR TITLE
Issue#424 to make `Expression::eval` to be able to do error handling.

### DIFF
--- a/src/common/filter/Expressions.cpp
+++ b/src/common/filter/Expressions.cpp
@@ -144,7 +144,7 @@ std::string InputPropertyExpression::toString() const {
 }
 
 
-VariantType InputPropertyExpression::eval() const {
+OptVariantType InputPropertyExpression::eval() const {
     return context_->getters().getInputProp(*prop_);
 }
 
@@ -180,7 +180,7 @@ std::string DestPropertyExpression::toString() const {
 }
 
 
-VariantType DestPropertyExpression::eval() const {
+OptVariantType DestPropertyExpression::eval() const {
     return context_->getters().getDstTagProp(*tag_, *prop_);
 }
 
@@ -234,12 +234,10 @@ std::string VariablePropertyExpression::toString() const {
     return buf;
 }
 
-
-VariantType VariablePropertyExpression::eval() const {
+OptVariantType VariablePropertyExpression::eval() const {
     // TODO(dutor)
-    return toString();
+    return OptVariantType(toString());
 }
-
 
 Status VariablePropertyExpression::prepare() {
     // TODO(dutor)
@@ -290,7 +288,7 @@ std::string EdgePropertyExpression::toString() const {
 }
 
 
-VariantType EdgePropertyExpression::eval() const {
+OptVariantType EdgePropertyExpression::eval() const {
     return context_->getters().getEdgeProp(*prop_);
 }
 
@@ -342,11 +340,7 @@ std::string EdgeTypeExpression::toString() const {
     return buf;
 }
 
-
-VariantType EdgeTypeExpression::eval() const {
-    return *alias_;
-}
-
+OptVariantType EdgeTypeExpression::eval() const { return OptVariantType(*alias_); }
 
 Status EdgeTypeExpression::prepare() {
     return context_->addAliasProp(*alias_, "_type");
@@ -382,7 +376,7 @@ std::string EdgeSrcIdExpression::toString() const {
 }
 
 
-VariantType EdgeSrcIdExpression::eval() const {
+OptVariantType EdgeSrcIdExpression::eval() const {
     return context_->getters().getEdgeProp("_src");
 }
 
@@ -421,7 +415,7 @@ std::string EdgeDstIdExpression::toString() const {
 }
 
 
-VariantType EdgeDstIdExpression::eval() const {
+OptVariantType EdgeDstIdExpression::eval() const {
     return context_->getters().getEdgeProp("_dst");
 }
 
@@ -460,7 +454,7 @@ std::string EdgeRankExpression::toString() const {
 }
 
 
-VariantType EdgeRankExpression::eval() const {
+OptVariantType EdgeRankExpression::eval() const {
     return context_->getters().getEdgeProp("_rank");
 }
 
@@ -501,7 +495,7 @@ std::string SourcePropertyExpression::toString() const {
 }
 
 
-VariantType SourcePropertyExpression::eval() const {
+OptVariantType SourcePropertyExpression::eval() const {
     return context_->getters().getSrcTagProp(*tag_, *prop_);
 }
 
@@ -562,24 +556,20 @@ std::string PrimaryExpression::toString() const {
     return buf;
 }
 
-
-VariantType PrimaryExpression::eval() const {
+OptVariantType PrimaryExpression::eval() const {
     switch (operand_.which()) {
         case kBool:
-            return boost::get<bool>(operand_);
-            break;
+            return OptVariantType(boost::get<bool>(operand_));
         case kInt:
-            return boost::get<int64_t>(operand_);
-            break;
+            return OptVariantType(boost::get<int64_t>(operand_));
         case kDouble:
-            return boost::get<double>(operand_);
-            break;
+            return OptVariantType(boost::get<double>(operand_));
         case kString:
-            return boost::get<std::string>(operand_);
+            return OptVariantType(boost::get<std::string>(operand_));
     }
-    return std::string("Unknown");
-}
 
+    return OptVariantType(Status::Error("Unknown type"));
+}
 
 Status PrimaryExpression::prepare() {
     return Status::OK();
@@ -662,17 +652,21 @@ std::string FunctionCallExpression::toString() const {
     return buf;
 }
 
-
-VariantType FunctionCallExpression::eval() const {
+OptVariantType FunctionCallExpression::eval() const {
     std::vector<VariantType> args;
-    args.resize(args_.size());
-    auto eval = [] (auto &expr) {
-        return expr->eval();
-    };
-    std::transform(args_.begin(), args_.end(), args.begin(), eval);
-    return function_(args);
-}
 
+    for (auto it = args_.cbegin(); it != args_.cend(); ++it) {
+        auto result = (*it)->eval();
+        if (!result.ok()) {
+            return result;
+        }
+        args.push_back(std::move(result.value()));
+    }
+
+    // TODO(simon.liu)
+    auto r = function_(args);
+    return OptVariantType(r);
+}
 
 Status FunctionCallExpression::prepare() {
     auto result = FunctionManager::get(*name_, args_.size());
@@ -749,23 +743,25 @@ std::string UnaryExpression::toString() const {
     return buf;
 }
 
-
-VariantType UnaryExpression::eval() const {
+OptVariantType UnaryExpression::eval() const {
     auto value = operand_->eval();
-    if (op_ == PLUS) {
-        return value;
-    } else if (op_ == NEGATE) {
-        if (isInt(value)) {
-            return -asInt(value);
-        } else if (isDouble(value)) {
-            return -asDouble(value);
+    if (value.ok()) {
+        if (op_ == PLUS) {
+            return value;
+        } else if (op_ == NEGATE) {
+            if (isInt(value.value())) {
+                return OptVariantType(-asInt(value.value()));
+            } else if (isDouble(value.value())) {
+                return OptVariantType(-asDouble(value.value()));
+            }
+        } else {
+            return OptVariantType(!asBool(value.value()));
         }
-    } else {
-        return !asBool(value);
     }
-    return value;
-}
 
+    return OptVariantType(Status::Error(folly::sformat(
+        "attempt to perform unary arithmetic on a {}", value.value().type().name())));
+}
 
 Status UnaryExpression::prepare() {
     return operand_->prepare();
@@ -813,11 +809,9 @@ std::string TypeCastingExpression::toString() const {
     return "";
 }
 
-
-VariantType TypeCastingExpression::eval() const {
-    return toString();
+OptVariantType TypeCastingExpression::eval() const {
+    return OptVariantType(toString());
 }
-
 
 Status TypeCastingExpression::prepare() {
     return operand_->prepare();
@@ -856,48 +850,69 @@ std::string ArithmeticExpression::toString() const {
     return buf;
 }
 
-
-VariantType ArithmeticExpression::eval() const {
-    auto left = left_->eval();
-    auto right = right_->eval();
-    switch (op_) {
-    case ADD:
-        assert((isArithmetic(left) && isArithmetic(right))
-                || (isString(left) && isString(right)));
-        if (isArithmetic(left) && isArithmetic(right)) {
-            if (isDouble(left) || isDouble(right)) {
-                return asDouble(left) + asDouble(right);
-            }
-            return asInt(left) + asInt(right);
-        }
-        return asString(left) + asString(right);
-    case SUB:
-        assert(isArithmetic(left) && isArithmetic(right));
-        if (isDouble(left) || isDouble(right)) {
-            return asDouble(left) - asDouble(right);
-        }
-        return asInt(left) - asInt(right);
-    case MUL:
-        assert(isArithmetic(left) && isArithmetic(right));
-        if (isDouble(left) || isDouble(right)) {
-            return asDouble(left) * asDouble(right);
-        }
-        return asInt(left) * asInt(right);
-    case DIV:
-        assert(isArithmetic(left) && isArithmetic(right));
-        if (isDouble(left) || isDouble(right)) {
-            return asDouble(left) / asDouble(right);
-        }
-        return asInt(left) / asInt(right);
-    case MOD:
-        assert(isInt(left) && isInt(right));
-        return asInt(left) % asInt(right);
-    default:
-        DCHECK(false);
+OptVariantType ArithmeticExpression::eval() const {
+    auto oleft = left_->eval();
+    auto oright = right_->eval();
+    if (!oleft.ok()) {
+        return oleft;
     }
-    return false;
-}
 
+    if (!oright.ok()) {
+        return oright;
+    }
+
+    auto left = oleft.value();
+    auto right = oright.value();
+
+    switch (op_) {
+        case ADD:
+            if (isArithmetic(left) && isArithmetic(right)) {
+                if (isDouble(left) || isDouble(right)) {
+                    return OptVariantType(asDouble(left) + asDouble(right));
+                }
+                return OptVariantType(asInt(left) + asInt(right));
+            }
+
+            if (isString(left) && isString(right)) {
+                return OptVariantType(asString(left) + asString(right));
+            }
+            break;
+        case SUB:
+            if (isArithmetic(left) && isArithmetic(right)) {
+                if (isDouble(left) || isDouble(right)) {
+                    return OptVariantType(asDouble(left) - asDouble(right));
+                }
+                return OptVariantType(asInt(left) - asInt(right));
+            }
+            break;
+        case MUL:
+            if (isArithmetic(left) && isArithmetic(right)) {
+                if (isDouble(left) || isDouble(right)) {
+                    return OptVariantType(asDouble(left) * asDouble(right));
+                }
+                return OptVariantType(asInt(left) * asInt(right));
+            }
+            break;
+        case DIV:
+            if (isArithmetic(left) && isArithmetic(right)) {
+                if (isDouble(left) || isDouble(right)) {
+                    return OptVariantType(asDouble(left) / asDouble(right));
+                }
+                return OptVariantType(asInt(left) / asInt(right));
+            }
+            break;
+        case MOD:
+            if (isInt(left) && isInt(right)) {
+                return OptVariantType(asInt(left) % asInt(right));
+            }
+            break;
+        default:
+            DCHECK(false);
+    }
+
+    return OptVariantType(Status::Error(folly::sformat(
+        "attempt to perform arithmetic on {} with {}", left.type().name(), right.type().name())));
+}
 
 Status ArithmeticExpression::prepare() {
     auto status = left_->prepare();
@@ -964,33 +979,43 @@ std::string RelationalExpression::toString() const {
     return buf;
 }
 
-
-VariantType RelationalExpression::eval() const {
+OptVariantType RelationalExpression::eval() const {
     auto left = left_->eval();
     auto right = right_->eval();
+
+    if (!left.ok()) {
+        return left;
+    }
+
+    if (!right.ok()) {
+        return right;
+    }
+
     switch (op_) {
         case LT:
-            return left < right;
+            return OptVariantType(left.value() < right.value());
         case LE:
-            return left <= right;
+            return OptVariantType(left.value() <= right.value());
         case GT:
-            return left > right;
+            return OptVariantType(left.value() > right.value());
         case GE:
-            return left >= right;
+            return OptVariantType(left.value() >= right.value());
         case EQ:
-            if (isDouble(left) || isDouble(right)) {
-                return almostEqual(asDouble(left), asDouble(right));
+            if (isDouble(left.value()) || isDouble(right.value())) {
+                return OptVariantType(almostEqual(asDouble(left.value()),
+                                                  asDouble(right.value())));
             }
-            return left == right;
+            return OptVariantType(left.value() == right.value());
         case NE:
-            if (isDouble(left) || isDouble(right)) {
-                return !almostEqual(asDouble(left), asDouble(right));
+            if (isDouble(left.value()) || isDouble(right.value())) {
+                return OptVariantType(!almostEqual(asDouble(left.value()),
+                                                   asDouble(right.value())));
             }
-            return left != right;
+            return OptVariantType(left.value() != right.value());
     }
-    return false;
-}
 
+    return OptVariantType(Status::Error("Wrong operator"));
+}
 
 Status RelationalExpression::prepare() {
     auto status = left_->prepare();
@@ -1045,21 +1070,30 @@ std::string LogicalExpression::toString() const {
     return buf;
 }
 
+OptVariantType LogicalExpression::eval() const {
+    auto left = left_->eval();
+    auto right = right_->eval();
 
-VariantType LogicalExpression::eval() const {
+    if (!left.ok()) {
+        return left;
+    }
+
+    if (!right.ok()) {
+        return right;
+    }
+
     if (op_ == AND) {
-        if (!asBool(left_->eval())) {
-            return false;
+        if (!asBool(left.value())) {
+            return OptVariantType(false);
         }
-        return asBool(right_->eval());
+        return OptVariantType(asBool(right.value()));
     } else {
-        if (asBool(left_->eval())) {
-            return true;
+        if (asBool(left.value())) {
+            return OptVariantType(true);
         }
-        return asBool(right_->eval());
+        return OptVariantType(asBool(right.value()));
     }
 }
-
 
 Status LogicalExpression::prepare() {
     auto status = left_->prepare();

--- a/src/common/filter/Expressions.h
+++ b/src/common/filter/Expressions.h
@@ -37,6 +37,7 @@ struct AliasInfo {
 
 
 using VariantType = boost::variant<int64_t, double, bool, std::string>;
+using OptVariantType = StatusOr<VariantType>;
 
 
 class ExpressionContext final {
@@ -101,11 +102,11 @@ public:
     }
 
     struct Getters {
-        std::function<VariantType()> getEdgeRank;
-        std::function<VariantType(const std::string&)> getEdgeProp;
-        std::function<VariantType(const std::string&)> getInputProp;
-        std::function<VariantType(const std::string&, const std::string&)> getSrcTagProp;
-        std::function<VariantType(const std::string&, const std::string&)> getDstTagProp;
+        std::function<OptVariantType()> getEdgeRank;
+        std::function<OptVariantType(const std::string&)> getEdgeProp;
+        std::function<OptVariantType(const std::string&)> getInputProp;
+        std::function<OptVariantType(const std::string&, const std::string&)> getSrcTagProp;
+        std::function<OptVariantType(const std::string&, const std::string&)> getDstTagProp;
     };
 
     Getters& getters() {
@@ -135,7 +136,7 @@ public:
 
     virtual Status MUST_USE_RESULT prepare() = 0;
 
-    virtual VariantType eval() const = 0;
+    virtual OptVariantType eval() const = 0;
 
     virtual bool isInputExpression() const {
         return kind_ == kInputProp;
@@ -303,7 +304,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override {
         return Status::OK();
@@ -338,7 +339,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -368,7 +369,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -406,7 +407,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -435,7 +436,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -463,7 +464,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -491,7 +492,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -519,7 +520,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -548,7 +549,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -599,7 +600,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -645,7 +646,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -688,7 +689,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -723,7 +724,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -768,7 +769,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -811,7 +812,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -855,7 +856,7 @@ public:
 
     std::string toString() const override;
 
-    VariantType eval() const override;
+    OptVariantType eval() const override;
 
     Status MUST_USE_RESULT prepare() override;
 

--- a/src/common/filter/test/ExpressionTest.cpp
+++ b/src/common/filter/test/ExpressionTest.cpp
@@ -46,20 +46,24 @@ TEST_F(ExpressionTest, LiteralConstants) {
         auto *expr = getFilterExpr(parsed.value().get());               \
         ASSERT_NE(nullptr, expr);                                       \
         auto value = expr->eval();                                      \
-        ASSERT_TRUE(Expression::is##type(value));                       \
+        ASSERT_TRUE(value.ok());                                        \
+        auto v = value.value();                                         \
+        ASSERT_TRUE(Expression::is##type(v));                           \
         if (#type == std::string("Double")) {                           \
-            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(value));  \
+            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(v));      \
         } else {                                                        \
-            ASSERT_EQ((expr_arg), Expression::as##type(value));         \
+            ASSERT_EQ((expr_arg), Expression::as##type(v));             \
         }                                                               \
         auto decoded = Expression::decode(Expression::encode(expr));    \
         ASSERT_TRUE(decoded.ok()) << decoded.status();                  \
         value = decoded.value()->eval();                                \
-        ASSERT_TRUE(Expression::is##type(value));                       \
+        ASSERT_TRUE(value.ok());                                        \
+        v = value.value();                                              \
+        ASSERT_TRUE(Expression::is##type(v));                           \
         if (#type == std::string("Double")) {                           \
-            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(value));  \
+            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(v));      \
         } else {                                                        \
-            ASSERT_EQ((expr_arg), Expression::as##type(value));         \
+            ASSERT_EQ((expr_arg), Expression::as##type(v));             \
         }                                                               \
     } while (false)
 
@@ -85,8 +89,10 @@ TEST_F(ExpressionTest, LiteralConstants) {
         auto *expr = getFilterExpr(parsed.value().get());
         ASSERT_NE(nullptr, expr);
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isString(value));
-        ASSERT_EQ("string_literal", Expression::asString(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isString(v));
+        ASSERT_EQ("string_literal", Expression::asString(v));
 
         auto buffer = Expression::encode(expr);
         ASSERT_FALSE(buffer.empty());
@@ -94,8 +100,10 @@ TEST_F(ExpressionTest, LiteralConstants) {
         ASSERT_TRUE(decoded.ok()) << decoded.status();
         ASSERT_NE(nullptr, decoded.value());
         value = decoded.value()->eval();
-        ASSERT_TRUE(Expression::isString(value));
-        ASSERT_EQ("string_literal", Expression::asString(value));
+        ASSERT_TRUE(value.ok());
+        v = value.value();
+        ASSERT_TRUE(Expression::isString(v));
+        ASSERT_EQ("string_literal", Expression::asString(v));
     }
 }
 
@@ -110,24 +118,28 @@ TEST_F(ExpressionTest, LiteralContantsArithmetic) {
         auto *expr = getFilterExpr(parsed.value().get());               \
         ASSERT_NE(nullptr, expr);                                       \
         auto value = expr->eval();                                      \
-        ASSERT_TRUE(Expression::is##type(value));                       \
+        ASSERT_TRUE(value.ok());                                        \
+        auto v = value.value();                                         \
+        ASSERT_TRUE(Expression::is##type(v));                           \
         if (#type == std::string("Double")) {                           \
-            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(value));  \
-            ASSERT_DOUBLE_EQ((expected), Expression::as##type(value));  \
+            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(v));      \
+            ASSERT_DOUBLE_EQ((expected), Expression::as##type(v));      \
         } else {                                                        \
-            ASSERT_EQ((expr_arg), Expression::as##type(value));         \
-            ASSERT_EQ((expected), Expression::as##type(value));         \
+            ASSERT_EQ((expr_arg), Expression::as##type(v));             \
+            ASSERT_EQ((expected), Expression::as##type(v));             \
         }                                                               \
         auto decoded = Expression::decode(Expression::encode(expr));    \
         ASSERT_TRUE(decoded.ok()) << decoded.status();                  \
         value = decoded.value()->eval();                                \
-        ASSERT_TRUE(Expression::is##type(value));                       \
+        ASSERT_TRUE(value.ok());                                        \
+        v = value.value();                                              \
+        ASSERT_TRUE(Expression::is##type(v));                           \
         if (#type == std::string("Double")) {                           \
-            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(value));  \
-            ASSERT_DOUBLE_EQ((expected), Expression::as##type(value));  \
+            ASSERT_DOUBLE_EQ((expr_arg), Expression::as##type(v));      \
+            ASSERT_DOUBLE_EQ((expected), Expression::as##type(v));      \
         } else {                                                        \
-            ASSERT_EQ((expr_arg), Expression::as##type(value));         \
-            ASSERT_EQ((expected), Expression::as##type(value));         \
+            ASSERT_EQ((expr_arg), Expression::as##type(v));             \
+            ASSERT_EQ((expected), Expression::as##type(v));             \
         }                                                               \
     } while (false)
 
@@ -195,8 +207,10 @@ TEST_F(ExpressionTest, LiteralContantsArithmetic) {
         auto *expr = getFilterExpr(parsed.value().get());
         ASSERT_NE(nullptr, expr);
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isInt(value));
-        ASSERT_EQ(16, Expression::asInt(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isInt(v));
+        ASSERT_EQ(16, Expression::asInt(v));
 
         auto buffer = Expression::encode(expr);
         ASSERT_FALSE(buffer.empty());
@@ -204,8 +218,10 @@ TEST_F(ExpressionTest, LiteralContantsArithmetic) {
         ASSERT_TRUE(decoded.ok()) << decoded.status();
         ASSERT_NE(nullptr, decoded.value());
         value = decoded.value()->eval();
-        ASSERT_TRUE(Expression::isInt(value));
-        ASSERT_EQ(16, Expression::asInt(value));
+        ASSERT_TRUE(value.ok());
+        v = value.value();
+        ASSERT_TRUE(Expression::isInt(v));
+        ASSERT_EQ(16, Expression::asInt(v));
     }
 }
 
@@ -220,15 +236,19 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
         auto *expr = getFilterExpr(parsed.value().get());               \
         ASSERT_NE(nullptr, expr);                                       \
         auto value = expr->eval();                                      \
-        ASSERT_TRUE(Expression::isBool(value));                         \
-        ASSERT_EQ((expr_arg), Expression::asBool(value));               \
-        ASSERT_EQ((expected), Expression::asBool(value));               \
+        ASSERT_TRUE(value.ok());                                        \
+        auto v = value.value();                                         \
+        ASSERT_TRUE(Expression::isBool(v));                             \
+        ASSERT_EQ((expr_arg), Expression::asBool(v));                   \
+        ASSERT_EQ((expected), Expression::asBool(v));                   \
         auto decoded = Expression::decode(Expression::encode(expr));    \
         ASSERT_TRUE(decoded.ok()) << decoded.status();                  \
         value = decoded.value()->eval();                                \
-        ASSERT_TRUE(Expression::isBool(value));                         \
-        ASSERT_EQ((expr_arg), Expression::asBool(value));               \
-        ASSERT_EQ((expected), Expression::asBool(value));               \
+        ASSERT_TRUE(value.ok());                                        \
+        v = value.value();                                              \
+        ASSERT_TRUE(Expression::isBool(v));                             \
+        ASSERT_EQ((expr_arg), Expression::asBool(v));                   \
+        ASSERT_EQ((expected), Expression::asBool(v));                   \
     } while (false)
 
     TEST_EXPR(1 == 1, true);
@@ -290,13 +310,17 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
         auto *expr = getFilterExpr(parsed.value().get());
         ASSERT_NE(nullptr, expr);
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
         auto decoded = Expression::decode(Expression::encode(expr));
         ASSERT_TRUE(decoded.ok()) << decoded.status();
         value = decoded.value()->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
     }
     {
         std::string query = "GO FROM 1 OVER follow WHERE 3.14 * 3 * 3 / 2 != 3.14 * 1.5 * 1.5 / 2";
@@ -305,13 +329,17 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
         auto *expr = getFilterExpr(parsed.value().get());
         ASSERT_NE(nullptr, expr);
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
         auto decoded = Expression::decode(Expression::encode(expr));
         ASSERT_TRUE(decoded.ok()) << decoded.status();
         value = decoded.value()->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
     }
 
 #undef TEST_EXPR
@@ -328,15 +356,19 @@ TEST_F(ExpressionTest, LiteralConstantsLogical) {
         auto *expr = getFilterExpr(parsed.value().get());               \
         ASSERT_NE(nullptr, expr);                                       \
         auto value = expr->eval();                                      \
-        ASSERT_TRUE(Expression::isBool(value));                         \
-        ASSERT_EQ((expr_arg), Expression::asBool(value));               \
-        ASSERT_EQ((expected), Expression::asBool(value));               \
+        ASSERT_TRUE(value.ok());                                        \
+        auto v = value.value();                                         \
+        ASSERT_TRUE(Expression::isBool(v));                             \
+        ASSERT_EQ((expr_arg), Expression::asBool(v));                   \
+        ASSERT_EQ((expected), Expression::asBool(v));                   \
         auto decoded = Expression::decode(Expression::encode(expr));    \
         ASSERT_TRUE(decoded.ok()) << decoded.status();                  \
         value = decoded.value()->eval();                                \
-        ASSERT_TRUE(Expression::isBool(value));                         \
-        ASSERT_EQ((expr_arg), Expression::asBool(value));               \
-        ASSERT_EQ((expected), Expression::asBool(value));               \
+        ASSERT_TRUE(value.ok());                                        \
+        v = value.value();                                              \
+        ASSERT_TRUE(Expression::isBool(v));                             \
+        ASSERT_EQ((expr_arg), Expression::asBool(v));                   \
+        ASSERT_EQ((expected), Expression::asBool(v));                   \
     } while (false)
 
     // AND
@@ -418,8 +450,10 @@ TEST_F(ExpressionTest, InputReference) {
         };
         expr->setContext(ctx.get());
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isString(value));
-        ASSERT_EQ("Freddie", Expression::asString(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isString(v));
+        ASSERT_EQ("Freddie", Expression::asString(v));
     }
     {
         std::string query = "GO FROM 1 OVER follow WHERE $-.age >= 18";
@@ -437,8 +471,10 @@ TEST_F(ExpressionTest, InputReference) {
         };
         expr->setContext(ctx.get());
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
     }
 }
 
@@ -460,8 +496,10 @@ TEST_F(ExpressionTest, SourceTagReference) {
         };
         expr->setContext(ctx.get());
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_TRUE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_TRUE(Expression::asBool(v));
     }
 }
 
@@ -491,8 +529,10 @@ TEST_F(ExpressionTest, EdgeReference) {
         };
         expr->setContext(ctx.get());
         auto value = expr->eval();
-        ASSERT_TRUE(Expression::isBool(value));
-        ASSERT_FALSE(Expression::asBool(value));
+        ASSERT_TRUE(value.ok());
+        auto v = value.value();
+        ASSERT_TRUE(Expression::isBool(v));
+        ASSERT_FALSE(Expression::asBool(v));
     }
 }
 
@@ -513,15 +553,17 @@ TEST_F(ExpressionTest, FunctionCall) {
         auto status = decoded.value()->prepare();                       \
         ASSERT_TRUE(status.ok()) << status;                             \
         auto value = decoded.value()->eval();                           \
-        ASSERT_TRUE(Expression::is##type(value));                       \
+        ASSERT_TRUE(value.ok());                                        \
+        auto v = value.value();                                         \
+        ASSERT_TRUE(Expression::is##type(v));                           \
         if (#type == std::string("Double")) {                           \
             if (#op != std::string("EQ")) {                             \
-                ASSERT_##op(expected, Expression::as##type(value));     \
+                ASSERT_##op(expected, Expression::as##type(v));         \
             } else {                                                    \
-                ASSERT_DOUBLE_EQ(expected, Expression::as##type(value));\
+                ASSERT_DOUBLE_EQ(expected, Expression::as##type(v));    \
             }                                                           \
         } else {                                                        \
-            ASSERT_##op(expected, Expression::as##type(value));         \
+            ASSERT_##op(expected, Expression::as##type(v));             \
         }                                                               \
     } while (false)
 
@@ -571,6 +613,40 @@ TEST_F(ExpressionTest, FunctionCall) {
     TEST_EXPR(0, LT, strcasecmp("HelLo", "hell"), Int);
     TEST_EXPR(0, GT, strcasecmp("HelLo", "World"), Int);
 
+#undef TEST_EXPR
+}
+
+TEST_F(ExpressionTest, InvalidExpressionTest) {
+    GQLParser parser;
+
+#define TEST_EXPR(expr_arg)                                           \
+    do {                                                              \
+        std::string query = "GO FROM 1 OVER follow WHERE " #expr_arg; \
+        auto parsed = parser.parse(query);                            \
+        ASSERT_TRUE(parsed.ok()) << parsed.status();                  \
+        auto *expr = getFilterExpr(parsed.value().get());             \
+        ASSERT_NE(nullptr, expr);                                     \
+        auto decoded = Expression::decode(Expression::encode(expr));  \
+        ASSERT_TRUE(decoded.ok()) << decoded.status();                \
+        auto ctx = std::make_unique<ExpressionContext>();             \
+        decoded.value()->setContext(ctx.get());                       \
+        auto status = decoded.value()->prepare();                     \
+        ASSERT_TRUE(status.ok()) << status;                           \
+        auto value = decoded.value()->eval();                         \
+        ASSERT_TRUE(!value.ok());                                     \
+    } while (false)
+
+    TEST_EXPR("a" + 1);
+    TEST_EXPR(3.14 + "a");
+    TEST_EXPR("ab" - "c");
+    TEST_EXPR(1 - "a");
+    TEST_EXPR("a" * 1);
+    TEST_EXPR(1.0 * "a");
+    TEST_EXPR(1 / "a");
+    TEST_EXPR("a" / "b");
+    TEST_EXPR(1.0 % 2.0);
+    TEST_EXPR(1.0 % 3);
+    TEST_EXPR(-"A");
 #undef TEST_EXPR
 }
 

--- a/src/graph/GoExecutor.cpp
+++ b/src/graph/GoExecutor.cpp
@@ -10,6 +10,7 @@
 #include "dataman/RowSetReader.h"
 #include "dataman/ResultSchemaProvider.h"
 
+
 namespace nebula {
 namespace graph {
 
@@ -140,11 +141,16 @@ Status GoExecutor::prepareFrom() {
                 break;
             }
             auto value = expr->eval();
-            if (!Expression::isInt(value)) {
+            if (!value.ok()) {
+                status = Status::Error();
+                break;
+            }
+            auto v = value.value();
+            if (!Expression::isInt(v)) {
                 status = Status::Error("Vertex ID should be of type integer");
                 break;
             }
-            starts_.push_back(Expression::asInt(value));
+            starts_.push_back(Expression::asInt(v));
         }
         if (!status.ok()) {
             break;
@@ -374,21 +380,30 @@ std::vector<VertexID> GoExecutor::getDstIdsFromResp(RpcResponse &rpcResp) const 
     return std::vector<VertexID>(set.begin(), set.end());
 }
 
-
 void GoExecutor::finishExecution(RpcResponse &&rpcResp) {
-    auto outputs = setupInterimResult(std::move(rpcResp));
+    std::unique_ptr<InterimResult> outputs;
+
+    if (!setupInterimResult(std::move(rpcResp), outputs)) {
+        return;
+    }
+
     if (onResult_) {
         onResult_(std::move(outputs));
     } else {
         resp_ = std::make_unique<cpp2::ExecutionResponse>();
         resp_->set_column_names(getResultColumnNames());
-        auto rows = outputs->getRows();
+
+        std::vector<cpp2::RowValue> rows;
+
+        if (outputs != nullptr) {
+            rows = std::move(outputs->getRows());
+        }
+
         resp_->set_rows(std::move(rows));
     }
     DCHECK(onFinish_);
     onFinish_();
 }
-
 
 StatusOr<std::vector<storage::cpp2::PropDef>> GoExecutor::getStepOutProps() const {
     std::vector<storage::cpp2::PropDef> props;
@@ -500,14 +515,13 @@ std::vector<std::string> GoExecutor::getResultColumnNames() const {
     return result;
 }
 
-
-std::unique_ptr<InterimResult> GoExecutor::setupInterimResult(RpcResponse &&rpcResp) {
+bool GoExecutor::setupInterimResult(RpcResponse &&rpcResp, std::unique_ptr<InterimResult> &result) {
     // Generic results
     std::shared_ptr<SchemaWriter> schema;
     std::unique_ptr<RowSetWriter> rsWriter;
     auto uniqResult = std::make_unique<std::unordered_set<std::string>>();
     using nebula::cpp2::SupportedType;
-    auto cb = [&] (std::vector<VariantType> record) {
+    auto cb = [&](std::vector<VariantType> record) {
         if (schema == nullptr) {
             schema = std::make_shared<SchemaWriter>();
             auto colnames = getResultColumnNames();
@@ -531,9 +545,9 @@ std::unique_ptr<InterimResult> GoExecutor::setupInterimResult(RpcResponse &&rpcR
                         LOG(FATAL) << "Unknown VariantType: " << record[i].which();
                 }
                 schema->appendCol(colnames[i], type);
-            }   // for
+            }  // for
             rsWriter = std::make_unique<RowSetWriter>(schema);
-        }   // if
+        }  // if
 
         RowWriter writer(schema);
         for (auto &column : record) {
@@ -555,8 +569,8 @@ std::unique_ptr<InterimResult> GoExecutor::setupInterimResult(RpcResponse &&rpcR
             }
         }
         // TODO Consider float/double, and need to reduce mem copy.
-        std::string encode = writer.encode();
         if (distinct_) {
+            std::string encode = writer.encode();
             auto ret = uniqResult->emplace(encode);
             if (ret.second) {
                 rsWriter->addRow(writer);
@@ -565,55 +579,60 @@ std::unique_ptr<InterimResult> GoExecutor::setupInterimResult(RpcResponse &&rpcR
             rsWriter->addRow(writer);
         }
     };  // cb
-    processFinalResult(rpcResp, cb);
-    // No results populated
-    if (rsWriter == nullptr) {
-        return nullptr;
+
+    if (!processFinalResult(rpcResp, cb)) {
+        return false;
     }
-    return std::make_unique<InterimResult>(std::move(rsWriter));
+
+    if (rsWriter != nullptr) {
+        result = std::make_unique<InterimResult>(std::move(rsWriter));
+    }
+
+    return true;
 }
 
-VariantType getProp(const std::string &prop,
-                    const RowReader *reader,
-                    ResultSchemaProvider *schema) {
+
+OptVariantType getProp(const std::string &prop, const RowReader *reader,
+                       ResultSchemaProvider *schema) {
     using nebula::cpp2::SupportedType;
     auto type = schema->getFieldType(prop).type;
     switch (type) {
         case SupportedType::BOOL: {
             bool v;
             reader->getBool(prop, v);
-            return v;
+            return OptVariantType(v);
         }
         case SupportedType::INT: {
             int64_t v;
             reader->getInt(prop, v);
-            return v;
+            return OptVariantType(v);
         }
         case SupportedType::VID: {
             VertexID v;
             reader->getVid(prop, v);
-            return v;
+            return OptVariantType(v);
         }
         case SupportedType::FLOAT: {
             float v;
             reader->getFloat(prop, v);
-            return static_cast<double>(v);
+            return OptVariantType(static_cast<double>(v));
         }
         case SupportedType::DOUBLE: {
             double v;
             reader->getDouble(prop, v);
-            return v;
+            return OptVariantType(v);
         }
         case SupportedType::STRING: {
             folly::StringPiece v;
             reader->getString(prop, v);
-            return v.toString();
+            return OptVariantType(v.toString());
         }
         default:
             LOG(FATAL) << "Unknown type: " << static_cast<int32_t>(type);
-            return "";
+            return OptVariantType(Status::Error("Unknow type: %d", static_cast<int32_t>(type)));
     }
 }
+
 
 void GoExecutor::onEmptyInputs() {
     if (onResult_) {
@@ -625,7 +644,7 @@ void GoExecutor::onEmptyInputs() {
 }
 
 
-void GoExecutor::processFinalResult(RpcResponse &rpcResp, Callback cb) const {
+bool GoExecutor::processFinalResult(RpcResponse &rpcResp, Callback cb) const {
     auto all = rpcResp.responses();
     for (auto &resp : all) {
         if (resp.get_vertices() == nullptr) {
@@ -651,21 +670,35 @@ void GoExecutor::processFinalResult(RpcResponse &rpcResp, Callback cb) const {
             RowSetReader rsReader(eschema, vdata.edge_data);
             auto iter = rsReader.begin();
             while (iter) {
+                auto dst = getProp("_dst", &*iter, eschema.get());
+                if (dst.ok() && vertexHolder_ != nullptr &&
+                    !vertexHolder_->exist(boost::get<int64_t>(dst.value()))) {
+                    ++iter;
+                    continue;
+                }
+
                 auto &getters = expCtx_->getters();
-                getters.getEdgeProp = [&] (const std::string &prop) -> VariantType {
+                getters.getEdgeProp = [&] (const std::string &prop) {
                     return getProp(prop, &*iter, eschema.get());
                 };
                 getters.getSrcTagProp = [&] (const std::string&, const std::string &prop) {
                     return getProp(prop, vreader.get(), vschema.get());
                 };
-                getters.getDstTagProp = [&] (const std::string&, const std::string &prop) {
-                    auto dst = getProp("_dst", &*iter, eschema.get());
-                    return vertexHolder_->get(boost::get<int64_t>(dst), prop);
+                getters.getDstTagProp = [&](const std::string &, const std::string &prop) {
+                    if (dst.ok()) {
+                        return vertexHolder_->get(boost::get<int64_t>(dst.value()), prop);
+                    }
+                    return dst;
                 };
+
                 // Evaluate filter
                 if (filter_ != nullptr) {
                     auto value = filter_->eval();
-                    if (!Expression::asBool(value)) {
+                    if (!value.ok()) {
+                        onError_(value.status());
+                        return false;
+                    }
+                    if (!Expression::asBool(value.value())) {
                         ++iter;
                         continue;
                     }
@@ -674,23 +707,35 @@ void GoExecutor::processFinalResult(RpcResponse &rpcResp, Callback cb) const {
                 record.reserve(yields_.size());
                 for (auto *column : yields_) {
                     auto *expr = column->expr();
-                    // TODO(dutor) `eval' may fail
                     auto value = expr->eval();
-                    record.emplace_back(std::move(value));
+                    if (!value.ok()) {
+                        onError_(value.status());
+                        return false;
+                    }
+                    record.emplace_back(std::move(value.value()));
                 }
                 cb(std::move(record));
                 ++iter;
             }   // while `iter'
         }   // for `vdata'
     }   // for `resp'
+    return true;
 }
 
+bool GoExecutor::VertexHolder::exist(VertexID id) const {
+    auto iter = data_.find(id);
+    if (iter == data_.end()) {
+        return false;
+    }
 
-VariantType GoExecutor::VertexHolder::get(VertexID id, const std::string &prop) const {
+    return true;
+}
+
+OptVariantType GoExecutor::VertexHolder::get(VertexID id, const std::string &prop) const {
     DCHECK(schema_ != nullptr);
     auto iter = data_.find(id);
 
-    // TODO(dutor) We need a type to represent NULL or non-existing prop
+    // TODO(dutor) We need a type to represent NULL
     CHECK(iter != data_.end());
 
     auto reader = RowReader::getRowReader(iter->second, schema_);
@@ -704,16 +749,24 @@ void GoExecutor::VertexHolder::add(const storage::cpp2::QueryResponse &resp) {
     if (vertices == nullptr) {
         return;
     }
+
+    if (vertices->empty()) {
+        return;
+    }
+
     if (resp.get_vertex_schema() == nullptr) {
         return;
     }
+
     if (schema_ == nullptr) {
         schema_ = std::make_shared<ResultSchemaProvider>(resp.vertex_schema);
     }
 
     for (auto &vdata : *vertices) {
         DCHECK(vdata.__isset.vertex_data);
-        data_[vdata.vertex_id] = vdata.vertex_data;
+        if (!vdata.vertex_data.empty()) {
+            data_[vdata.vertex_id] = vdata.vertex_data;
+        }
     }
 }
 

--- a/src/graph/GoExecutor.h
+++ b/src/graph/GoExecutor.h
@@ -129,7 +129,7 @@ private:
      * To setup an intermediate representation of the execution result,
      * which is about to be piped to the next executor.
      */
-    std::unique_ptr<InterimResult> setupInterimResult(RpcResponse &&rpcResp);
+    bool setupInterimResult(RpcResponse &&rpcResp, std::unique_ptr<InterimResult> &result);
 
     /**
      * To setup the header of the execution result, i.e. the column names.
@@ -139,14 +139,14 @@ private:
     /**
      * To setup the body of the execution result.
      */
-    void setupResponseBody(RpcResponse &rpcResp, cpp2::ExecutionResponse &resp) const;
+    bool setupResponseBody(RpcResponse &rpcResp, cpp2::ExecutionResponse &resp) const;
 
     /**
      * To iterate on the final data collection, and evaluate the filter and yield columns.
      * For each row that matches the filter, `cb' would be invoked.
      */
     using Callback = std::function<void(std::vector<VariantType>)>;
-    void processFinalResult(RpcResponse &rpcResp, Callback cb) const;
+    bool processFinalResult(RpcResponse &rpcResp, Callback cb) const;
 
     /**
      * A container to hold the mapping from vertex id to its properties, used for lookups
@@ -154,8 +154,9 @@ private:
      */
     class VertexHolder final {
     public:
-        VariantType get(VertexID id, const std::string &prop) const;
+        OptVariantType get(VertexID id, const std::string &prop) const;
         void add(const storage::cpp2::QueryResponse &resp);
+        bool exist(VertexID id) const;
         const auto* schema() const {
             return schema_.get();
         }

--- a/src/graph/YieldExecutor.cpp
+++ b/src/graph/YieldExecutor.cpp
@@ -37,7 +37,13 @@ void YieldExecutor::execute() {
     values.reserve(size);
 
     for (auto *col : yields_) {
-        values.emplace_back(col->expr()->eval());
+        auto expr = col->expr();
+        auto v = expr->eval();
+        if (!v.ok()) {
+            onError_(v.status());
+            return;
+        }
+        values.emplace_back(v.value());
     }
 
     std::vector<cpp2::RowValue> rows;

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -183,5 +183,38 @@ TEST_F(GoTest, Distinct) {
     }
 }
 
+TEST_F(GoTest, EMPTY_DST_VERTEX) {
+    {
+        // Maybe we should insert directly when the data is generated.
+        cpp2::ExecutionResponse resp;
+        auto &team = teams_["Rockets"];
+        auto *fmt =
+            "GO FROM %ld OVER belong YIELD "
+            "$^.team.name, $$.city.name";
+        auto query = folly::stringPrintf(fmt, team.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<std::string, std::string>> expected = {
+            {"Rockets", "Houston"},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+
+    {
+        // Maybe we should insert directly when the data is generated.
+        cpp2::ExecutionResponse resp;
+        auto &team = teams_["Cavaliers"];
+        auto *fmt =
+            "GO FROM %ld OVER belong YIELD "
+            "$^.team.name as team, $$.city.name as city";
+        auto query = folly::stringPrintf(fmt, team.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<std::string, std::string>> expected = {
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+}
+
 }   // namespace graph
 }   // namespace nebula

--- a/src/storage/QueryBoundProcessor.cpp
+++ b/src/storage/QueryBoundProcessor.cpp
@@ -28,7 +28,10 @@ kvstore::ResultCode QueryBoundProcessor::processVertex(PartitionID partId,
                 return ret;
             }
         }
-        vResp.set_vertex_data(writer.encode());
+
+        if (writer.size() > 1) {
+            vResp.set_vertex_data(writer.encode());
+        }
     }
 
     if (!this->edgeContext_.props_.empty()) {


### PR DESCRIPTION
Summary:

1. When the expression is evaluated, some wrong judgments are added.
   When the expression was failed, an error will be replyed to the user.
2. When the user's destination vertex for inserting an edge does not exist,
   we need to skip this dst vertex when the user query the prop of dst vertex(Issue#580).