### PR TITLE
Fixed UpgradedHolder-related race condition in ActiveHostsMan

### DIFF
--- a/src/graph/test/CMakeLists.txt
+++ b/src/graph/test/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(graph_test_common_obj OBJECT
     TestBase.cpp
 )
 
+add_dependencies(graph_test_common_obj meta_thrift_obj graph_thrift_obj)
+
 
 add_executable(
     session_manager_test


### PR DESCRIPTION
`UpgradedHolder` makes a `RWSpinLock` or `ReadHolder` progress to the `UPGRADED` phase. And `UPGRADED` is an intermediate phase to transit(upgrade) from `READ` to `WRITE`.