### PR TITLE
Remove requests queue inside Host

### DIFF
--- a/src/kvstore/raftex/Host.cpp
+++ b/src/kvstore/raftex/Host.cpp
@@ -155,7 +155,7 @@ folly::Future<cpp2::AppendLogResponse> Host::appendLogs(
         lastLogTermSent_ = prevLogTerm;
         lastLogIdSent_ = prevLogId;
         committedLogId_ = committedLogId;
-
+        pendingReq_ = std::make_tuple(0, 0, 0, 0, 0);
         promise_ = std::move(cachingPromise_);
         cachingPromise_ = folly::SharedPromise<cpp2::AppendLogResponse>();
         ret = promise_.getFuture();

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -75,17 +75,21 @@ public:
     }
 
 private:
-    cpp2::ErrorCode checkStatus(std::lock_guard<std::mutex>& lck) const;
+    cpp2::ErrorCode checkStatus() const;
 
     folly::Future<cpp2::AppendLogResponse> sendAppendLogRequest(
-        std::shared_ptr<cpp2::AppendLogRequest> req);
-
-    folly::Future<cpp2::AppendLogResponse> appendLogsInternal(
         folly::EventBase* eb,
         std::shared_ptr<cpp2::AppendLogRequest> req);
 
-    std::shared_ptr<cpp2::AppendLogRequest> prepareAppendLogRequest(
-        std::lock_guard<std::mutex>& lck) const;
+    void appendLogsInternal(
+        folly::EventBase* eb,
+        std::shared_ptr<cpp2::AppendLogRequest> req);
+
+    std::shared_ptr<cpp2::AppendLogRequest> prepareAppendLogRequest() const;
+
+    bool noRequest() const;
+
+    void setResponse(const cpp2::AppendLogResponse& r);
 
     thrift::ThriftClientManager<cpp2::RaftexServiceAsyncClient>& tcManager() {
         static thrift::ThriftClientManager<cpp2::RaftexServiceAsyncClient> manager;
@@ -93,6 +97,9 @@ private:
     }
 
 private:
+    // <term, logId, committedLogId, lastLogTermSent, lastLogIdSent>
+    using Request = std::tuple<TermID, LogID, LogID, TermID, LogID>;
+
     std::shared_ptr<RaftPart> part_;
     const HostAddr addr_;
     bool isLearner_ = false;
@@ -105,13 +112,10 @@ private:
 
     bool requestOnGoing_{false};
     std::condition_variable noMoreRequestCV_;
-    folly::Promise<cpp2::AppendLogResponse> promise_;
-    std::queue<
-        std::pair<folly::Promise<cpp2::AppendLogResponse>,
-                  // <term, logId, committedLogId,
-                  //  lastLogTermSent, lastLogIdSent>
-                  std::tuple<TermID, LogID, LogID, TermID, LogID>>
-    > requests_;
+    folly::SharedPromise<cpp2::AppendLogResponse> promise_;
+    folly::SharedPromise<cpp2::AppendLogResponse> cachingPromise_;
+
+    Request pendingReq_{0, 0, 0, 0, 0};
 
     // These logId and term pointing to the latest log we need to send
     LogID logIdToSend_{0};

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -940,6 +940,7 @@ void RaftPart::statusPolling() {
     {
         std::lock_guard<std::mutex> g(raftLock_);
         if (status_ == Status::RUNNING) {
+            VLOG(2) << idStr_ << "Schedule next polling";
             workers_->addDelayTask(
                 delay,
                 [self = shared_from_this()] {
@@ -1051,6 +1052,7 @@ void RaftPart::processAppendLogRequest(
             << ": GraphSpaceId = " << req.get_space()
             << ", partition = " << req.get_part()
             << ", current_term = " << req.get_current_term()
+//            << ", lastLogId = " << req.get_last_log_id()
             << ", committedLogId = " << req.get_committed_log_id()
             << ", leaderIp = " << req.get_leader_ip()
             << ", leaderPort = " << req.get_leader_port()
@@ -1120,7 +1122,7 @@ void RaftPart::processAppendLogRequest(
 //      }
 
     // Check the last log
-    CHECK_GE(req.get_last_log_id_sent(), committedLogId_);
+    CHECK_GE(req.get_last_log_id_sent(), committedLogId_) << idStr_;
     if (lastLogTerm_ > 0 && req.get_last_log_term_sent() != lastLogTerm_) {
         VLOG(2) << idStr_ << "The local last log term is "
                 << lastLogTerm_
@@ -1253,6 +1255,7 @@ cpp2::ErrorCode RaftPart::verifyLeader(
 
 
 folly::Future<AppendLogResult> RaftPart::sendHeartbeat() {
+    VLOG(2) << idStr_ << "Send heartbeat";
     std::string log = "";
     return appendLogAsync(clusterId_, LogType::NORMAL, std::move(log));
 }

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -59,6 +59,7 @@ class AppendLogsIterator;
 
 class RaftPart : public std::enable_shared_from_this<RaftPart> {
     friend class AppendLogsIterator;
+    friend class Host;
 public:
     virtual ~RaftPart();
 

--- a/src/kvstore/test/NebulaStoreTest.cpp
+++ b/src/kvstore/test/NebulaStoreTest.cpp
@@ -328,7 +328,6 @@ TEST(NebulaStoreTest, ThreeCopiesTest) {
         }
         sleep(FLAGS_heartbeat_interval);
         {
-            LOG(INFO) << "Check the data on all peers...";
             int32_t start = 0;
             int32_t end = 100;
             std::string s(reinterpret_cast<const char*>(&start), sizeof(int32_t));
@@ -336,22 +335,23 @@ TEST(NebulaStoreTest, ThreeCopiesTest) {
             s = prefix + s;
             e = prefix + e;
             for (int i = 0; i < replicas; i++) {
+                LOG(INFO) << "Check the data on " << stores[i]->raftAddr_ << " for part " << part;
                 auto ret = stores[i]->engine(0, part);
                 ASSERT(ok(ret));
                 auto* engine = value(std::move(ret));
                 std::unique_ptr<KVIterator> iter;
-                EXPECT_EQ(ResultCode::SUCCEEDED, engine->range(s, e, &iter));
+                ASSERT_EQ(ResultCode::SUCCEEDED, engine->range(s, e, &iter));
                 int num = 0;
                 auto prefixLen = prefix.size();
                 while (iter->valid()) {
                     auto key = *reinterpret_cast<const int32_t*>(iter->key().data() + prefixLen);
                     auto val = iter->val();
-                    EXPECT_EQ(num, key);
-                    EXPECT_EQ(folly::stringPrintf("val_%d_%d", part, num), val);
+                    ASSERT_EQ(num, key);
+                    ASSERT_EQ(folly::stringPrintf("val_%d_%d", part, num), val);
                     iter->next();
                     num++;
                 }
-                EXPECT_EQ(100, num);
+                ASSERT_EQ(100, num);
             }
         }
         // Let's try to write data on follower;


### PR DESCRIPTION
We don't need to hold all requests inside host.  There are two defects:
1.  Catch up data will be slow,  because we have to send request one by one.
2.  More memory  occupied due to the queue.  