### PR TITLE
Sanitized CMAKE files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,18 +309,62 @@ if(ENABLE_ASAN)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
 endif()
 
-macro(nebula_add_test test_name)
-    add_test(NAME ${test_name} COMMAND ${test_name})
-    # e.g. cmake -DNEBULA_ASAN_PRELOAD=/path/to/libasan.so
-    # or,  cmake -DNEBULA_ASAN_PRELOAD=`/path/to/gcc --print-file-name=libasan.so`
-    if (NEBULA_ASAN_PRELOAD)
-        set_property(TEST ${test_name} PROPERTY ENVIRONMENT LD_PRELOAD=${NEBULA_ASAN_PRELOAD})
-    endif(NEBULA_ASAN_PRELOAD)
-endmacro(nebula_add_test)
+macro(nebula_add_executable)
+    cmake_parse_arguments(
+        nebula_exec                 # prefix
+        ""                          # <options>
+        "NAME"                      # <one_value_args>
+        "SOURCES;OBJECTS;LIBRARIES" # <multi_value_args>
+        ${ARGN}
+    )
+    add_executable(
+        ${nebula_exec_NAME}
+        ${nebula_exec_SOURCES}
+        ${nebula_exec_OBJECTS}
+    )
+    nebula_link_libraries(
+        ${nebula_exec_NAME}
+        ${nebula_exec_LIBRARIES}
+    )
+endmacro()
 
-macro(nebula_add_base_obj obj_name)
+macro(nebula_add_test)
+    cmake_parse_arguments(
+        nebula_test                 # prefix
+        "DISABLED"                  # <options>
+        "NAME"                      # <one_value_args>
+        "SOURCES;OBJECTS;LIBRARIES" # <multi_value_args>
+        ${ARGN}
+    )
+
+    nebula_add_executable(
+        NAME ${nebula_test_NAME}
+        SOURCES ${nebula_test_SOURCES}
+        OBJECTS ${nebula_test_OBJECTS}
+        LIBRARIES ${nebula_test_LIBRARIES}
+    )
+
+    if (NOT ${nebula_test_DISABLED})
+        add_test(NAME ${nebula_test_NAME} COMMAND ${nebula_test_NAME})
+        # e.g. cmake -DNEBULA_ASAN_PRELOAD=/path/to/libasan.so
+        # or,  cmake -DNEBULA_ASAN_PRELOAD=`/path/to/gcc --print-file-name=libasan.so`
+        if (NEBULA_ASAN_PRELOAD)
+            set_property(
+                TEST ${nebula_test_NAME}
+                PROPERTY ENVIRONMENT LD_PRELOAD=${NEBULA_ASAN_PRELOAD}
+            )
+        endif()
+    endif()
+endmacro()
+
+macro(nebula_build_after_base obj_name)
     add_dependencies(${obj_name} base_obj)
-endmacro(nebula_add_base_obj)
+endmacro()
+
+macro(nebula_add_library name type)
+    add_library(${name} ${type} ${ARGN})
+    nebula_build_after_base(${name})
+endmacro()
 
 include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/bzip2/include)
 include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/double-conversion/include)

--- a/cmake/ThriftGenerate.cmake
+++ b/cmake/ThriftGenerate.cmake
@@ -86,7 +86,7 @@ add_custom_command(
     --gen "go"
     -o "." "${file_path}/${file_name}.thrift"
   DEPENDS "${file_path}/${file_name}.thrift"
-  COMMENT "Generating ${file_name} files. Output: ${output_path}"
+  COMMENT "Generating thrift files for ${file_name}"
 )
 
 bypass_source_check(${file_name}_cpp2-SOURCES)
@@ -101,6 +101,4 @@ add_dependencies(
   "common_thrift_obj"
 )
 endif()
-
-message("Thrift will create the Object file : ${file_name}_thrift_obj")
 endmacro()

--- a/src/client/cpp/CMakeLists.txt
+++ b/src/client/cpp/CMakeLists.txt
@@ -1,5 +1,4 @@
-add_library(client_cpp_obj OBJECT GraphClient.cpp)
-nebula_add_base_obj(client_cpp_obj)
+nebula_add_library(client_cpp_obj OBJECT GraphClient.cpp)
 
 #add_subdirectory(test)
 

--- a/src/common/base/test/CMakeLists.txt
+++ b/src/common/base/test/CMakeLists.txt
@@ -1,130 +1,91 @@
-add_executable(cord_test CordTest.cpp $<TARGET_OBJECTS:base_obj>)
-nebula_link_libraries(
-    cord_test
-    gtest
-)
-nebula_add_test(cord_test)
-
-add_executable(cord_bm CordBenchmark.cpp $<TARGET_OBJECTS:base_obj>)
-nebula_link_libraries(
-    cord_bm
-    follybenchmark
-    boost_regex
+nebula_add_test(
+    NAME cord_test
+    SOURCES CordTest.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest
 )
 
-add_executable(logging_bm LoggingBenchmark.cpp $<TARGET_OBJECTS:base_obj>)
-nebula_link_libraries(
-    logging_bm
-    follybenchmark
-    boost_regex
+nebula_add_executable(
+    NAME cord_bm
+    SOURCES CordBenchmark.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
+    LIBRARIES follybenchmark boost_regex
 )
 
-add_executable(murmurhash2_test MurmurHash2Test.cpp $<TARGET_OBJECTS:base_obj>)
-nebula_link_libraries(
-    murmurhash2_test
-    gtest
-    gtest_main
-)
-nebula_add_test(murmurhash2_test)
-
-add_executable(
-    configuration_test
-    ConfigurationTest.cpp
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:base_obj>
-)
-nebula_link_libraries(
-    configuration_test
-    gtest
-    gtest_main
-)
-nebula_add_test(configuration_test)
-
-add_executable(
-    status_test
-    StatusTest.cpp
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:base_obj>
-)
-nebula_link_libraries(
-    status_test
-    gtest
-    gtest_main
-)
-nebula_add_test(status_test)
-
-add_executable(
-    status_or_test
-    StatusOrTest.cpp
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:base_obj>
-)
-nebula_link_libraries(
-    status_or_test
-    gtest
-    gtest_main
-)
-nebula_add_test(status_or_test)
-
-add_executable(
-    either_or_test
-    EitherOrTest.cpp
-    $<TARGET_OBJECTS:base_obj>
-)
-nebula_link_libraries(
-    either_or_test
-    gtest
-    gtest_main
-)
-nebula_add_test(either_or_test)
-
-add_executable(
-    error_or_test
-    ErrorOrTest.cpp
-    $<TARGET_OBJECTS:base_obj>
-)
-nebula_link_libraries(
-    error_or_test
-    gtest
-    gtest_main
-)
-nebula_add_test(error_or_test)
-
-add_executable(hash_bm HashBenchmark.cpp $<TARGET_OBJECTS:base_obj>)
-nebula_link_libraries(
-    hash_bm
-    follybenchmark
-    boost_regex
+nebula_add_executable(
+    NAME logging_bm
+    SOURCES LoggingBenchmark.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
+    LIBRARIES follybenchmark boost_regex
 )
 
-add_executable(signal_handler_test SignalHandlerTest.cpp $<TARGET_OBJECTS:base_obj>)
-nebula_link_libraries(
-    signal_handler_test
-    gtest
-    gtest_main
+nebula_add_test(
+    NAME murmurhash2_test
+    SOURCES MurmurHash2Test.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest gtest_main
 )
-nebula_add_test(signal_handler_test)
 
-add_executable(
-    nebulakey_utils_test
-    NebulaKeyUtilsTest.cpp
-    $<TARGET_OBJECTS:base_obj>
+nebula_add_test(
+    NAME configuration_test
+    SOURCES ConfigurationTest.cpp
+    OBJECTS $<TARGET_OBJECTS:fs_obj> $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest gtest_main
 )
-nebula_link_libraries(
-    nebulakey_utils_test
-    gtest
-    gtest_main
-)
-nebula_add_test(nebulakey_utils_test)
 
-add_executable(
-    range_vs_transform_bm
-    RangeVsTransformBenchmark.cpp
-    $<TARGET_OBJECTS:base_obj>
+nebula_add_test(
+    NAME status_test
+    SOURCES StatusTest.cpp
+    OBJECTS $<TARGET_OBJECTS:fs_obj> $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest gtest_main
 )
-nebula_link_libraries(
-    range_vs_transform_bm
-    follybenchmark
-    boost_regex
+
+nebula_add_test(
+    NAME status_or_test
+    SOURCES StatusOrTest.cpp
+    OBJECTS $<TARGET_OBJECTS:fs_obj> $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest gtest_main
+)
+
+nebula_add_test(
+    NAME either_or_test
+    SOURCES EitherOrTest.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest gtest_main
+)
+
+nebula_add_test(
+    NAME error_or_test
+    SOURCES ErrorOrTest.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest gtest_main
+)
+
+nebula_add_executable(
+    NAME hash_bm
+    SOURCES HashBenchmark.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
+    LIBRARIES follybenchmark boost_regex
+)
+
+nebula_add_test(
+    NAME signal_handler_test
+    SOURCES SignalHandlerTest.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest gtest_main
+)
+
+nebula_add_test(
+    NAME nebulakey_utils_test
+    SOURCES NebulaKeyUtilsTest.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest gtest_main
+)
+
+nebula_add_executable(
+    NAME range_vs_transform_bm
+    SOURCES RangeVsTransformBenchmark.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj>
+    LIBRARIES follybenchmark boost_regex
 )
 target_compile_options(range_vs_transform_bm PRIVATE -O3)

--- a/src/common/concurrent/CMakeLists.txt
+++ b/src/common/concurrent/CMakeLists.txt
@@ -1,8 +1,7 @@
-add_library(
-        concurrent_obj OBJECT
-        Barrier.cpp
-        Latch.cpp
+nebula_add_library(
+    concurrent_obj OBJECT
+    Barrier.cpp
+    Latch.cpp
 )
-nebula_add_base_obj(concurrent_obj)
 
 add_subdirectory(test)

--- a/src/common/concurrent/test/CMakeLists.txt
+++ b/src/common/concurrent/test/CMakeLists.txt
@@ -1,14 +1,13 @@
-add_executable(
-    concurrent_test
-    BarrierTest.cpp
-    LatchTest.cpp
-    $<TARGET_OBJECTS:concurrent_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:time_obj>
+nebula_add_test(
+    NAME
+        concurrent_test
+    SOURCES
+        BarrierTest.cpp LatchTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:concurrent_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:time_obj>
+    LIBRARIES
+        gtest
+        gtest_main
 )
-nebula_link_libraries(
-    concurrent_test
-    gtest
-    gtest_main
-)
-nebula_add_test(concurrent_test)

--- a/src/common/filter/CMakeLists.txt
+++ b/src/common/filter/CMakeLists.txt
@@ -1,9 +1,8 @@
-add_library(
+nebula_add_library(
         filter_obj
         OBJECT
         Expressions.cpp
         FunctionManager.cpp
 )
-nebula_add_base_obj(filter_obj)
 
 add_subdirectory(test)

--- a/src/common/filter/test/CMakeLists.txt
+++ b/src/common/filter/test/CMakeLists.txt
@@ -1,7 +1,4 @@
-add_compile_options(-Wno-parentheses)
-add_executable(
-    expression_test
-    ExpressionTest.cpp
+set(FILTER_TEST_LIBS
     $<TARGET_OBJECTS:filter_obj>
     $<TARGET_OBJECTS:parser_obj>
     $<TARGET_OBJECTS:base_obj>
@@ -9,27 +6,20 @@ add_executable(
     $<TARGET_OBJECTS:fs_obj>
     $<TARGET_OBJECTS:time_obj>
 )
-nebula_link_libraries(
-    expression_test
-    gtest
-    gtest_main
-)
-target_include_directories(expression_test SYSTEM BEFORE PUBLIC ${FLEX_INCLUDE_DIRS})
-nebula_add_test(expression_test)
 
-add_executable(
-    expression_encode_decode_bm
-    ExpressionEncodeDecodeBenchmark.cpp
-    $<TARGET_OBJECTS:filter_obj>
-    $<TARGET_OBJECTS:parser_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:parser_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:time_obj>
+
+nebula_add_test(
+    NAME expression_test
+    SOURCES ExpressionTest.cpp
+    OBJECTS ${FILTER_TEST_LIBS}
+    LIBRARIES gtest gtest_main
 )
-nebula_link_libraries(
-    expression_encode_decode_bm
-    follybenchmark
-    boost_regex
+target_compile_options(expression_test PRIVATE -Wno-parentheses)
+
+
+nebula_add_executable(
+    NAME expression_encode_decode_bm
+    SOURCES ExpressionEncodeDecodeBenchmark.cpp
+    OBJECTS ${FILTER_TEST_LIBS}
+    LIBRARIES follybenchmark boost_regex
 )

--- a/src/common/fs/CMakeLists.txt
+++ b/src/common/fs/CMakeLists.txt
@@ -1,5 +1,9 @@
-add_library(fs_obj OBJECT FileUtils.cpp TempDir.cpp TempFile.cpp)
-nebula_add_base_obj(fs_obj)
+nebula_add_library(
+    fs_obj OBJECT
+    FileUtils.cpp
+    TempDir.cpp
+    TempFile.cpp
+)
 
 add_subdirectory(test)
 

--- a/src/common/fs/test/CMakeLists.txt
+++ b/src/common/fs/test/CMakeLists.txt
@@ -1,37 +1,20 @@
-add_executable(
-    file_utils_test
-    FileUtilsTest.cpp
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:base_obj>
+nebula_add_test(
+    NAME file_utils_test
+    SOURCES FileUtilsTest.cpp
+    OBJECTS $<TARGET_OBJECTS:fs_obj> $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest
 )
-nebula_link_libraries(
-    file_utils_test
-    gtest
-)
-nebula_add_test(file_utils_test)
 
-add_executable(
-    temp_dir_test
-    TempDirTest.cpp
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:base_obj>
+nebula_add_test(
+    NAME temp_dir_test
+    SOURCES TempDirTest.cpp
+    OBJECTS $<TARGET_OBJECTS:fs_obj> $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest
 )
-nebula_link_libraries(
-    temp_dir_test
-    gtest
-)
-nebula_add_test(temp_dir_test)
 
-add_executable(
-    temp_file_test
-    TempFileTest.cpp
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:base_obj>
+nebula_add_test(
+    NAME temp_file_test
+    SOURCES TempFileTest.cpp
+    OBJECTS $<TARGET_OBJECTS:fs_obj> $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest gtest_main
 )
-nebula_link_libraries(
-    temp_file_test
-    gtest
-    gtest_main
-)
-nebula_add_test(temp_file_test)
-

--- a/src/common/hdfs/CMakeLists.txt
+++ b/src/common/hdfs/CMakeLists.txt
@@ -1,5 +1,6 @@
-add_library(hdfs_helper_obj OBJECT HdfsCommandHelper.cpp)
-
-add_dependencies(hdfs_helper_obj fs_obj base_obj)
+nebula_add_library(
+    hdfs_helper_obj OBJECT
+    HdfsCommandHelper.cpp
+)
 
 add_subdirectory(test)

--- a/src/common/hdfs/test/CMakeLists.txt
+++ b/src/common/hdfs/test/CMakeLists.txt
@@ -1,14 +1,14 @@
-add_executable(
+nebula_add_test(
+    NAME
         hdfs_helper_test
+    SOURCES
         HdfsHelperTest.cpp
+    OBJECTS
         $<TARGET_OBJECTS:hdfs_helper_obj>
         $<TARGET_OBJECTS:process_obj>
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:base_obj>
-)
-nebula_link_libraries(
-        hdfs_helper_test
+    LIBRARIES
         gtest
         gtest_main
 )
-nebula_add_test(hdfs_helper_test)

--- a/src/common/network/CMakeLists.txt
+++ b/src/common/network/CMakeLists.txt
@@ -1,5 +1,7 @@
-add_library(network_obj OBJECT NetworkUtils.cpp)
-nebula_add_base_obj(network_obj)
+nebula_add_library(
+    network_obj OBJECT
+    NetworkUtils.cpp
+)
 
 add_subdirectory(test)
 

--- a/src/common/network/test/CMakeLists.txt
+++ b/src/common/network/test/CMakeLists.txt
@@ -1,29 +1,30 @@
-add_executable(
-    network_utils_test
-    NetworkUtilsTest.cpp
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:fs_obj>
+nebula_add_test(
+    NAME
+        network_utils_test
+    SOURCES
+        NetworkUtilsTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:fs_obj>
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
 )
-nebula_link_libraries(
-    network_utils_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(network_utils_test)
 
-add_executable(
-    network_utils_bm
-    NetworkUtilsBenchmark.cpp
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:fs_obj>
-)
-nebula_link_libraries(
-    network_utils_bm
-    ${THRIFT_LIBRARIES}
-    wangle
-    follybenchmark
-    boost_regex
+
+nebula_add_executable(
+    NAME
+        network_utils_bm
+    SOURCES
+        NetworkUtilsBenchmark.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:fs_obj>
+    LIBRARIES
+        wangle
+        follybenchmark
+        boost_regex
 )

--- a/src/common/process/CMakeLists.txt
+++ b/src/common/process/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_library(process_obj OBJECT ProcessUtils.cpp)
-nebula_add_base_obj(process_obj)
+nebula_add_library(
+    process_obj OBJECT
+    ProcessUtils.cpp
+)
 
 add_subdirectory(test)

--- a/src/common/process/test/CMakeLists.txt
+++ b/src/common/process/test/CMakeLists.txt
@@ -1,13 +1,13 @@
-add_executable(
-    process_test
-    ProcessTest.cpp
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:base_obj>
+nebula_add_test(
+    NAME
+        process_test
+    SOURCES
+        ProcessTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:base_obj>
+    LIBRARIES
+        gtest
+        gtest_main
 )
-nebula_link_libraries(
-    process_test
-    gtest
-    gtest_main
-)
-nebula_add_test(process_test)

--- a/src/common/stats/CMakeLists.txt
+++ b/src/common/stats/CMakeLists.txt
@@ -1,5 +1,8 @@
-add_library(stats_obj OBJECT StatsManager.cpp)
-nebula_add_base_obj(stats_obj)
+nebula_add_library(
+    stats_obj
+    OBJECT
+    StatsManager.cpp
+)
 
 add_subdirectory(test)
 

--- a/src/common/stats/test/CMakeLists.txt
+++ b/src/common/stats/test/CMakeLists.txt
@@ -1,23 +1,14 @@
-add_executable(
-    stats_manager_test
-    StatsManagerTest.cpp
-    $<TARGET_OBJECTS:stats_obj>
-    $<TARGET_OBJECTS:base_obj>
+nebula_add_test(
+    NAME stats_manager_test
+    SOURCES StatsManagerTest.cpp
+    OBJECTS $<TARGET_OBJECTS:stats_obj> $<TARGET_OBJECTS:base_obj>
+    LIBRARIES gtest
 )
-nebula_link_libraries(
-    stats_manager_test
-    gtest
-)
-nebula_add_test(stats_manager_test)
 
 
-add_executable(
-    stats_manager_bm
-    StatsManagerBenchmark.cpp
-    $<TARGET_OBJECTS:stats_obj>
-)
-nebula_link_libraries(
-    stats_manager_bm
-    follybenchmark
-    boost_regex
+nebula_add_executable(
+    NAME stats_manager_bm
+    SOURCES StatsManagerBenchmark.cpp
+    OBJECTS $<TARGET_OBJECTS:stats_obj>
+    LIBRARIES follybenchmark boost_regex
 )

--- a/src/common/thread/CMakeLists.txt
+++ b/src/common/thread/CMakeLists.txt
@@ -1,9 +1,8 @@
-add_library(
-        thread_obj OBJECT
-        NamedThread.cpp
-        GenericWorker.cpp
-        GenericThreadPool.cpp
+nebula_add_library(
+    thread_obj OBJECT
+    NamedThread.cpp
+    GenericWorker.cpp
+    GenericThreadPool.cpp
 )
-nebula_add_base_obj(thread_obj)
 
 add_subdirectory(test)

--- a/src/common/thread/test/CMakeLists.txt
+++ b/src/common/thread/test/CMakeLists.txt
@@ -1,15 +1,15 @@
-add_executable(
+nebula_add_test(
+    NAME
         thread_test
+    SOURCES
         ThreadTest.cpp
         GenericWorkerTest.cpp
         GenericThreadPoolTest.cpp
+    OBJECTS
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:concurrent_obj>
         $<TARGET_OBJECTS:time_obj>
+    LIBRARIES
+        gtest
+        gtest_main
 )
-nebula_link_libraries(
-    thread_test
-    gtest
-    gtest_main
-)
-nebula_add_test(thread_test)

--- a/src/common/thrift/CMakeLists.txt
+++ b/src/common/thrift/CMakeLists.txt
@@ -1,10 +1,5 @@
-
-add_library(
+nebula_add_library(
     thrift_obj OBJECT
     ReconnectingRequestChannel.cpp
     ThriftClientManager.cpp
 )
-nebula_add_base_obj(thrift_obj)
-
-# add_subdirectory(test)
-

--- a/src/common/time/CMakeLists.txt
+++ b/src/common/time/CMakeLists.txt
@@ -1,10 +1,8 @@
-add_library(
+nebula_add_library(
     time_obj OBJECT
     detail/TscHelper.cpp
     Duration.cpp
     WallClock.cpp
 )
-nebula_add_base_obj(time_obj)
 
 add_subdirectory(test)
-

--- a/src/common/time/test/CMakeLists.txt
+++ b/src/common/time/test/CMakeLists.txt
@@ -1,48 +1,45 @@
-add_executable(
-    duration_test
-    DurationTest.cpp
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:thread_obj>
-)
-nebula_link_libraries(
-    duration_test
-    gtest
-)
-nebula_add_test(duration_test)
-
-add_executable(
-    wallclock_test
-    WallClockTest.cpp
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:thread_obj>
-)
-nebula_link_libraries(
-    wallclock_test
-    gtest
-)
-nebula_add_test(wallclock_test)
-
-add_executable(
-    duration_bm
-    DurationBenchmark.cpp
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:thread_obj>
-)
-nebula_link_libraries(
-    duration_bm
-    follybenchmark
-    boost_regex
+nebula_add_test(
+    NAME
+        duration_test
+    SOURCES
+        DurationTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:thread_obj>
+    LIBRARIES
+        gtest
 )
 
-add_executable(
-    wallclock_bm
-    WallClockBenchmark.cpp
-    $<TARGET_OBJECTS:time_obj>
+nebula_add_test(
+    NAME
+        wallclock_test
+    SOURCES
+        WallClockTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:thread_obj>
+    LIBRARIES
+        gtest
 )
-nebula_link_libraries(
-    wallclock_bm
-    follybenchmark
-    boost_regex
+
+nebula_add_executable(
+    NAME
+        duration_bm
+    SOURCES
+        DurationBenchmark.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:thread_obj>
+    LIBRARIES
+        follybenchmark
+        boost_regex
+)
+
+nebula_add_executable(
+    NAME wallclock_bm
+    SOURCES WallClockBenchmark.cpp
+    OBJECTS $<TARGET_OBJECTS:time_obj>
+    LIBRARIES follybenchmark boost_regex
 )

--- a/src/console/CMakeLists.txt
+++ b/src/console/CMakeLists.txt
@@ -1,26 +1,27 @@
-add_library(console_obj OBJECT CliManager.cpp CmdProcessor.cpp)
-nebula_add_base_obj(console_obj)
-
-add_executable(
-    nebula
-    NebulaConsole.cpp
-    $<TARGET_OBJECTS:console_obj>
-    $<TARGET_OBJECTS:client_cpp_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:graph_thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:thread_obj>
+nebula_add_library(
+    console_obj OBJECT
+    CliManager.cpp
+    CmdProcessor.cpp
 )
-nebula_link_libraries(
-    nebula
-    ${THRIFT_LIBRARIES}
-    wangle
-    ${Readline_LIBRARY}
-    ${NCURSES_LIBRARY}
+
+nebula_add_executable(
+    NAME
+        nebula
+    SOURCES
+        NebulaConsole.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:console_obj>
+        $<TARGET_OBJECTS:client_cpp_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:graph_thrift_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:thread_obj>
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        wangle
+        ${Readline_LIBRARY}
+        ${NCURSES_LIBRARY}
 )
 
 install(TARGETS nebula DESTINATION bin)
-
-#add_subdirectory(test)
-

--- a/src/daemons/CMakeLists.txt
+++ b/src/daemons/CMakeLists.txt
@@ -1,109 +1,112 @@
-add_executable(
-    nebula-graphd
-    GraphDaemon.cpp
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:graph_http_handler>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:graph_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:graph_thrift_obj>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:storage_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:stats_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:parser_obj>
-    $<TARGET_OBJECTS:filter_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:ws_obj>
-    $<TARGET_OBJECTS:dataman_obj>
-)
-nebula_link_libraries(
-    nebula-graphd
-    proxygenhttpserver
-    proxygenlib
-    ${THRIFT_LIBRARIES}
-    wangle
-)
-
-
-add_executable(
-    nebula-storaged
-    StorageDaemon.cpp
-    $<TARGET_OBJECTS:storage_service_handler>
-    $<TARGET_OBJECTS:storage_http_handler>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:dataman_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:hdfs_helper_obj>
-    $<TARGET_OBJECTS:filter_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:stats_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:ws_obj>
-)
-nebula_link_libraries(
-    nebula-storaged
-    proxygenhttpserver
-    proxygenlib
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
+nebula_add_executable(
+    NAME
+        nebula-graphd
+    SOURCES
+        GraphDaemon.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:graph_http_handler>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:graph_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:graph_thrift_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:storage_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:parser_obj>
+        $<TARGET_OBJECTS:filter_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:dataman_obj>
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        ${THRIFT_LIBRARIES}
+        wangle
 )
 
 
-add_executable(
-    nebula-metad
-    MetaDaemon.cpp
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:meta_http_handler>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:hdfs_helper_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:stats_obj>
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:ws_obj>
+nebula_add_executable(
+    NAME
+        nebula-storaged
+    SOURCES
+        StorageDaemon.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:storage_service_handler>
+        $<TARGET_OBJECTS:storage_http_handler>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:dataman_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:hdfs_helper_obj>
+        $<TARGET_OBJECTS:filter_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:ws_obj>
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
 )
-nebula_link_libraries(
-    nebula-metad
-    proxygenhttpserver
-    proxygenlib
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
+
+
+nebula_add_executable(
+    NAME
+        nebula-metad
+    SOURCES
+        MetaDaemon.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:meta_http_handler>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:hdfs_helper_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:ws_obj>
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
 )
 
 

--- a/src/dataman/CMakeLists.txt
+++ b/src/dataman/CMakeLists.txt
@@ -1,6 +1,4 @@
-set(CMAKE_CXX_FLAGS "-w")
-
-add_library(
+nebula_add_library(
     dataman_obj OBJECT
     ResultSchemaProvider.cpp
     SchemaWriter.cpp
@@ -11,6 +9,5 @@ add_library(
     RowWriter.cpp
     NebulaCodecImpl.cpp
 )
-nebula_add_base_obj(dataman_obj)
 
 add_subdirectory(test)

--- a/src/dataman/RowUpdater.cpp
+++ b/src/dataman/RowUpdater.cpp
@@ -33,7 +33,7 @@ std::string RowUpdater::encode() const noexcept {
     // TODO Reserve enough space so resize will not happen
     encodeTo(encoded);
 
-    return std::move(encoded);
+    return encoded;
 }
 
 

--- a/src/dataman/RowWriter.cpp
+++ b/src/dataman/RowWriter.cpp
@@ -42,7 +42,7 @@ std::string RowWriter::encode() noexcept {
     encoded.reserve(sizeof(int64_t) * blockOffsets_.size() + cord_.size() + 11);
     encodeTo(encoded);
 
-    return std::move(encoded);
+    return encoded;
 }
 
 

--- a/src/dataman/SchemaWriter.cpp
+++ b/src/dataman/SchemaWriter.cpp
@@ -19,7 +19,7 @@ Schema SchemaWriter::moveSchema() noexcept {
     schema.set_columns(std::move(columns_));
 
     nameIndex_.clear();
-    return std::move(schema);
+    return schema;
 }
 
 

--- a/src/dataman/test/CMakeLists.txt
+++ b/src/dataman/test/CMakeLists.txt
@@ -9,98 +9,56 @@ set(DATAMAN_TEST_LIBS
 )
 
 
-add_executable(
-    row_reader_test
-    RowReaderTest.cpp
-    ${DATAMAN_TEST_LIBS}
-)
-nebula_link_libraries(
-    row_reader_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(row_reader_test)
-
-
-add_executable(
-    row_writer_test
-    RowWriterTest.cpp
-    ${DATAMAN_TEST_LIBS}
-)
-nebula_link_libraries(
-    row_writer_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(row_writer_test)
-
-
-add_executable(
-    row_updater_test
-    RowUpdaterTest.cpp
-    ${DATAMAN_TEST_LIBS}
-)
-nebula_link_libraries(
-    row_updater_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(row_updater_test)
-
-
-add_executable(
-    rowset_reader_writer_test
-    RowSetReaderWriterTest.cpp
-    ${DATAMAN_TEST_LIBS}
-)
-nebula_link_libraries(
-    rowset_reader_writer_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(rowset_reader_writer_test)
-
-
-add_executable(
-    row_writer_bm
-    RowWriterBenchmark.cpp
-    ${DATAMAN_TEST_LIBS}
-)
-nebula_link_libraries(
-    row_writer_bm
-    ${THRIFT_LIBRARIES}
-    follybenchmark
-    wangle
-    boost_regex
+nebula_add_test(
+    NAME row_reader_test
+    SOURCES RowReaderTest.cpp
+    OBJECTS ${DATAMAN_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
 )
 
 
-add_executable(
-    row_reader_bm
-    RowReaderBenchmark.cpp
-    ${DATAMAN_TEST_LIBS}
-)
-nebula_link_libraries(
-    row_reader_bm
-    ${THRIFT_LIBRARIES}
-    follybenchmark
-    wangle
-    boost_regex
+nebula_add_test(
+    NAME row_writer_test
+    SOURCES RowWriterTest.cpp
+    OBJECTS ${DATAMAN_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
 )
 
-add_executable(
-    nebula_codec_test
-    NebulaCodecTest.cpp
-    ${DATAMAN_TEST_LIBS}
+
+nebula_add_test(
+    NAME row_updater_test
+    SOURCES RowUpdaterTest.cpp
+    OBJECTS ${DATAMAN_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
 )
-nebula_link_libraries(
-    nebula_codec_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
+
+
+nebula_add_test(
+    NAME rowset_reader_writer_test
+    SOURCES RowSetReaderWriterTest.cpp
+    OBJECTS ${DATAMAN_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
 )
-nebula_add_test(nebula_codec_test)
+
+
+nebula_add_executable(
+    NAME row_writer_bm
+    SOURCES RowWriterBenchmark.cpp
+    OBJECTS ${DATAMAN_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} follybenchmark wangle boost_regex
+)
+
+
+nebula_add_executable(
+    NAME row_reader_bm
+    SOURCES RowReaderBenchmark.cpp
+    OBJECTS ${DATAMAN_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} follybenchmark wangle boost_regex
+)
+
+nebula_add_test(
+    NAME nebula_codec_test
+    SOURCES NebulaCodecTest.cpp
+    OBJECTS ${DATAMAN_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
+)

--- a/src/graph/CMakeLists.txt
+++ b/src/graph/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(
+nebula_add_library(
     graph_obj OBJECT
     GraphFlags.cpp
     GraphService.cpp
@@ -37,12 +37,10 @@ add_library(
     OrderByExecutor.cpp
     SchemaHelper.cpp
 )
-nebula_add_base_obj(graph_obj)
 
-add_library(
+nebula_add_library(
     graph_http_handler OBJECT
     GraphHttpHandler.cpp
 )
 
 add_subdirectory(test)
-

--- a/src/graph/test/CMakeLists.txt
+++ b/src/graph/test/CMakeLists.txt
@@ -25,122 +25,116 @@ set(GRAPH_TEST_LIBS
     $<TARGET_OBJECTS:base_obj>
 )
 
-add_library(graph_test_common_obj OBJECT
+nebula_add_library(
+    graph_test_common_obj OBJECT
     TestMain.cpp
     TestEnv.cpp
     TestBase.cpp
 )
 
-nebula_add_base_obj(graph_test_common_obj)
-
-
-add_executable(
-    session_manager_test
-    SessionManagerTest.cpp
-    ${GRAPH_TEST_LIBS}
-)
-nebula_link_libraries(
-    session_manager_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-    gtest_main
-)
-nebula_add_test(session_manager_test)
-
-
-add_executable(
-    query_engine_test
-    YieldTest.cpp
-    SchemaTest.cpp
-    $<TARGET_OBJECTS:graph_test_common_obj>
-    $<TARGET_OBJECTS:client_cpp_obj>
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    ${GRAPH_TEST_LIBS}
-)
-nebula_link_libraries(
-    query_engine_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(query_engine_test)
-
-
-add_executable(
-    go_test
-    GoTest.cpp
-    $<TARGET_OBJECTS:graph_test_common_obj>
-    $<TARGET_OBJECTS:client_cpp_obj>
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    ${GRAPH_TEST_LIBS}
-)
-nebula_link_libraries(
-    go_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(go_test)
-
-
-add_executable(
-    graph_http_test
-    GraphHttpHandlerTest.cpp
-    $<TARGET_OBJECTS:graph_test_common_obj>
-    $<TARGET_OBJECTS:graph_http_handler>
-    $<TARGET_OBJECTS:client_cpp_obj>
-    $<TARGET_OBJECTS:ws_obj>
-    $<TARGET_OBJECTS:stats_obj>
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    ${GRAPH_TEST_LIBS}
-)
-nebula_link_libraries(
-    graph_http_test
-    proxygenhttpserver
-    proxygenlib
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(graph_http_test)
-
-add_executable(
-    data_test
-    DataTest.cpp
-    $<TARGET_OBJECTS:graph_test_common_obj>
-    $<TARGET_OBJECTS:client_cpp_obj>
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    ${GRAPH_TEST_LIBS}
-)
-nebula_link_libraries(
-    data_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(data_test)
-
-add_executable(
-    order_by_test
-    OrderByTest.cpp
-    $<TARGET_OBJECTS:graph_test_common_obj>
-    $<TARGET_OBJECTS:client_cpp_obj>
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    ${GRAPH_TEST_LIBS}
+nebula_add_test(
+    NAME
+        session_manager_test
+    SOURCES
+        SessionManagerTest.cpp
+    OBJECTS
+        ${GRAPH_TEST_LIBS}
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        ${ROCKSDB_LIBRARIES}
+        wangle
+        gtest
+        gtest_main
 )
 
-nebula_link_libraries(
-    order_by_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
+nebula_add_test(
+    NAME
+        query_engine_test
+    SOURCES
+        YieldTest.cpp
+        SchemaTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:graph_test_common_obj>
+        $<TARGET_OBJECTS:client_cpp_obj>
+        $<TARGET_OBJECTS:adHocSchema_obj>
+        ${GRAPH_TEST_LIBS}
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        ${ROCKSDB_LIBRARIES}
+        wangle
+        gtest
 )
-nebula_add_test(order_by_test)
+
+nebula_add_test(
+    NAME
+        go_test
+    SOURCES
+        GoTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:graph_test_common_obj>
+        $<TARGET_OBJECTS:client_cpp_obj>
+        $<TARGET_OBJECTS:adHocSchema_obj>
+        ${GRAPH_TEST_LIBS}
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        ${ROCKSDB_LIBRARIES}
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
+        graph_http_test
+    SOURCES
+        GraphHttpHandlerTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:graph_test_common_obj>
+        $<TARGET_OBJECTS:graph_http_handler>
+        $<TARGET_OBJECTS:client_cpp_obj>
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:adHocSchema_obj>
+        ${GRAPH_TEST_LIBS}
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        ${THRIFT_LIBRARIES}
+        ${ROCKSDB_LIBRARIES}
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
+        data_test
+    SOURCES
+        DataTest.cpp
+        OBJECTS
+        $<TARGET_OBJECTS:graph_test_common_obj>
+        $<TARGET_OBJECTS:client_cpp_obj>
+        $<TARGET_OBJECTS:adHocSchema_obj>
+        ${GRAPH_TEST_LIBS}
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        ${ROCKSDB_LIBRARIES}
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
+        order_by_test
+    SOURCES
+        OrderByTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:graph_test_common_obj>
+        $<TARGET_OBJECTS:client_cpp_obj>
+        $<TARGET_OBJECTS:adHocSchema_obj>
+        ${GRAPH_TEST_LIBS}
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        ${ROCKSDB_LIBRARIES}
+        wangle
+        gtest
+)

--- a/src/kvstore/CMakeLists.txt
+++ b/src/kvstore/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(
+nebula_add_library(
     kvstore_obj OBJECT
     Part.cpp
     RocksEngine.cpp
@@ -7,7 +7,6 @@ add_library(
     RocksEngineConfig.cpp
     LogEncoder.cpp
 )
-nebula_add_base_obj(kvstore_obj)
 
 add_subdirectory(raftex)
 add_subdirectory(wal)

--- a/src/kvstore/plugins/CMakeLists.txt
+++ b/src/kvstore/plugins/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_subdirectory(hbase)
-

--- a/src/kvstore/plugins/hbase/CMakeLists.txt
+++ b/src/kvstore/plugins/hbase/CMakeLists.txt
@@ -5,12 +5,11 @@ include(ThriftGenerate)
 # Target object name : hbase_thrift_obj
 thrift_generate("hbase" "THBaseService" ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} "hbase")
 
-add_library(
+nebula_add_library(
     hbasestore_obj OBJECT
     HBaseStore.cpp
     HBaseClient.cpp
 )
-nebula_add_base_obj(hbasestore_obj)
 
 add_subdirectory(test)
 

--- a/src/kvstore/plugins/hbase/test/CMakeLists.txt
+++ b/src/kvstore/plugins/hbase/test/CMakeLists.txt
@@ -1,51 +1,52 @@
-add_executable(
-    hbase_client_test
-    HBaseClientTest.cpp
-    $<TARGET_OBJECTS:hbasestore_obj>
-    $<TARGET_OBJECTS:hbase_thrift_obj>
-    $<TARGET_OBJECTS:dataman_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
+nebula_add_test(
+    DISABLED
+    NAME
+        hbase_client_test
+    SOURCES
+        HBaseClientTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:hbasestore_obj>
+        $<TARGET_OBJECTS:hbase_thrift_obj>
+        $<TARGET_OBJECTS:dataman_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
 )
-nebula_link_libraries(
-    hbase_client_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-#nebula_add_test(hbase_client_test)
 
-add_executable(
-    hbase_store_test
-    HBaseStoreTest.cpp
-    $<TARGET_OBJECTS:hbasestore_obj>
-    $<TARGET_OBJECTS:hbase_thrift_obj>
-    $<TARGET_OBJECTS:dataman_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:adHocSchema_obj>
+nebula_add_test(
+    DISABLED
+    NAME
+        hbase_store_test
+    SOURCES
+        HBaseStoreTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:hbasestore_obj>
+        $<TARGET_OBJECTS:hbase_thrift_obj>
+        $<TARGET_OBJECTS:dataman_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:adHocSchema_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
 )
-nebula_link_libraries(
-    hbase_store_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-#nebula_add_test(hbase_store_test)
-

--- a/src/kvstore/raftex/CMakeLists.txt
+++ b/src/kvstore/raftex/CMakeLists.txt
@@ -1,11 +1,9 @@
-add_library(
+nebula_add_library(
     raftex_obj OBJECT
     LogStrListIterator.cpp
     RaftPart.cpp
     RaftexService.cpp
     Host.cpp
 )
-nebula_add_base_obj(raftex_obj)
 
 add_subdirectory(test)
-

--- a/src/kvstore/raftex/test/CMakeLists.txt
+++ b/src/kvstore/raftex/test/CMakeLists.txt
@@ -1,8 +1,4 @@
-add_executable(
-    leader_election_test
-    LeaderElectionTest.cpp
-    RaftexTestBase.cpp
-    TestShard.cpp
+set(RAFTEX_TEST_LIBS
     $<TARGET_OBJECTS:raftex_obj>
     $<TARGET_OBJECTS:raftex_thrift_obj>
     $<TARGET_OBJECTS:wal_obj>
@@ -13,105 +9,43 @@ add_executable(
     $<TARGET_OBJECTS:thrift_obj>
     $<TARGET_OBJECTS:time_obj>
 )
-nebula_link_libraries(
-    leader_election_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(leader_election_test)
 
 
-add_executable(
-    log_append_test
-    LogAppendTest.cpp
-    RaftexTestBase.cpp
-    TestShard.cpp
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
+nebula_add_test(
+    NAME leader_election_test
+    SOURCES LeaderElectionTest.cpp RaftexTestBase.cpp TestShard.cpp
+    OBJECTS ${RAFTEX_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
 )
-nebula_link_libraries(
-    log_append_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(log_append_test)
 
 
-add_executable(
-    log_cas_test
-    LogCASTest.cpp
-    RaftexTestBase.cpp
-    TestShard.cpp
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
+nebula_add_test(
+    NAME log_append_test
+    SOURCES LogAppendTest.cpp RaftexTestBase.cpp TestShard.cpp
+    OBJECTS ${RAFTEX_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
 )
-nebula_link_libraries(
-    log_cas_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(log_cas_test)
 
-add_executable(
-    log_command_test
-    LogCommandTest.cpp
-    RaftexTestBase.cpp
-    TestShard.cpp
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
-)
-nebula_link_libraries(
-    log_command_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(log_command_test)
 
-add_executable(
-    learner_test
-    LearnerTest.cpp
-    RaftexTestBase.cpp
-    TestShard.cpp
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
+nebula_add_test(
+    NAME log_cas_test
+    SOURCES LogCASTest.cpp RaftexTestBase.cpp TestShard.cpp
+    OBJECTS ${RAFTEX_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
 )
-nebula_link_libraries(
-    learner_test
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(learner_test)
 
+
+nebula_add_test(
+    NAME learner_test
+    SOURCES LearnerTest.cpp RaftexTestBase.cpp TestShard.cpp
+    OBJECTS ${RAFTEX_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
+)
+
+
+nebula_add_test(
+    NAME log_command_test
+    SOURCES LogCommandTest.cpp RaftexTestBase.cpp TestShard.cpp
+    OBJECTS ${RAFTEX_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
+)

--- a/src/kvstore/test/CMakeLists.txt
+++ b/src/kvstore/test/CMakeLists.txt
@@ -1,6 +1,4 @@
-add_executable(
-    part_test
-    PartTest.cpp
+set(KVSTORE_TEST_LIBS
     $<TARGET_OBJECTS:kvstore_obj>
     $<TARGET_OBJECTS:meta_client>
     $<TARGET_OBJECTS:meta_thrift_obj>
@@ -16,160 +14,71 @@ add_executable(
     $<TARGET_OBJECTS:thrift_obj>
     $<TARGET_OBJECTS:time_obj>
 )
-nebula_link_libraries(
-    part_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(part_test)
 
-add_executable(
-    rocks_engine_test
-    RocksEngineTest.cpp
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
-)
-nebula_link_libraries(
-    rocks_engine_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(rocks_engine_test)
-
-add_executable(
-    nebula_store_test
-    NebulaStoreTest.cpp
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
-)
-nebula_link_libraries(
-    nebula_store_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(nebula_store_test)
-
-add_executable(
-    load_test
-    LoadTest.cpp
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
-)
-nebula_link_libraries(
-    load_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(load_test)
-
-add_executable(
-    rocks_engine_config_test
-    RocksEngineConfigTest.cpp
-    ../RocksEngine.cpp
-    ../RocksEngineConfig.cpp
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
-)
-nebula_link_libraries(
-    rocks_engine_config_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(rocks_engine_config_test)
-
-add_executable(
-    log_encoder_test
-    LogEncoderTest.cpp
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
-)
-nebula_link_libraries(
-    log_encoder_test
-    ${THRIFT_LIBRARIES}
-    ${ROCKSDB_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(log_encoder_test)
-
-add_executable(
-    multi_versions_perf_test_bm
-    MultiVersionBenchmark.cpp
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:fs_obj>
+nebula_add_test(
+    NAME part_test
+    SOURCES PartTest.cpp
+    OBJECTS ${KVSTORE_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} ${ROCKSDB_LIBRARIES} wangle gtest
 )
 
-nebula_link_libraries(
-    multi_versions_perf_test_bm
-    follybenchmark
-    ${ROCKSDB_LIBRARIES}
-    boost_regex
+nebula_add_test(
+    NAME rocks_engine_test
+    SOURCES RocksEngineTest.cpp
+    OBJECTS ${KVSTORE_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} ${ROCKSDB_LIBRARIES} wangle gtest
 )
 
-# nebula_add_test(multi_versions_perf_test_bm)
+nebula_add_test(
+    NAME nebula_store_test
+    SOURCES NebulaStoreTest.cpp
+    OBJECTS ${KVSTORE_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} ${ROCKSDB_LIBRARIES} wangle gtest
+)
 
+nebula_add_test(
+    NAME load_test
+    SOURCES LoadTest.cpp
+    OBJECTS ${KVSTORE_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} ${ROCKSDB_LIBRARIES} wangle gtest
+)
+
+
+nebula_add_test(
+    NAME
+        rocks_engine_config_test
+    SOURCES
+        RocksEngineConfigTest.cpp
+        ../RocksEngine.cpp
+        ../RocksEngineConfig.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:time_obj>
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        ${ROCKSDB_LIBRARIES}
+        wangle
+        gtest
+)
+
+
+nebula_add_test(
+    NAME log_encoder_test
+    SOURCES LogEncoderTest.cpp
+    OBJECTS ${KVSTORE_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} ${ROCKSDB_LIBRARIES} wangle gtest
+)
+
+nebula_add_executable(
+    NAME multi_versions_perf_test_bm
+    SOURCES MultiVersionBenchmark.cpp
+    OBJECTS $<TARGET_OBJECTS:base_obj> $<TARGET_OBJECTS:fs_obj>
+    LIBRARIES follybenchmark ${ROCKSDB_LIBRARIES} boost_regex
+)

--- a/src/kvstore/wal/CMakeLists.txt
+++ b/src/kvstore/wal/CMakeLists.txt
@@ -1,11 +1,9 @@
-add_library(
+nebula_add_library(
     wal_obj OBJECT
     BufferFlusher.cpp
     InMemoryLogBuffer.cpp
     FileBasedWalIterator.cpp
     FileBasedWal.cpp
 )
-nebula_add_base_obj(wal_obj)
 
 add_subdirectory(test)
-

--- a/src/kvstore/wal/test/CMakeLists.txt
+++ b/src/kvstore/wal/test/CMakeLists.txt
@@ -1,15 +1,14 @@
-add_executable(
-    file_based_wal_test
-    FileBasedWalTest.cpp
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:time_obj>
+nebula_add_test(
+    NAME
+        file_based_wal_test
+    SOURCES
+        FileBasedWalTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:time_obj>
+    LIBRARIES
+        gtest
 )
-nebula_link_libraries(
-    file_based_wal_test
-    gtest
-)
-nebula_add_test(file_based_wal_test)
-

--- a/src/meta/CMakeLists.txt
+++ b/src/meta/CMakeLists.txt
@@ -1,12 +1,11 @@
-add_library(
+nebula_add_library(
     schema_obj OBJECT
     SchemaManager.cpp
     ServerBasedSchemaManager.cpp
     NebulaSchemaProvider.cpp
 )
-nebula_add_base_obj(schema_obj)
 
-add_library(
+nebula_add_library(
     meta_service_handler OBJECT
     MetaServiceHandler.cpp
     MetaServiceUtils.cpp
@@ -43,19 +42,16 @@ add_library(
     processors/admin/BalanceTask.cpp
     processors/admin/AdminClient.cpp
 )
-nebula_add_base_obj(meta_service_handler)
 
-add_library(
+nebula_add_library(
     meta_http_handler OBJECT
     MetaHttpDownloadHandler.cpp
     MetaHttpStatusHandler.cpp
 )
-nebula_add_base_obj(meta_http_handler)
 
-add_library(
+nebula_add_library(
     meta_client OBJECT
     client/MetaClient.cpp
 )
-nebula_add_base_obj(meta_client)
 
 add_subdirectory(test)

--- a/src/meta/test/CMakeLists.txt
+++ b/src/meta/test/CMakeLists.txt
@@ -1,337 +1,339 @@
-add_executable(
-    meta_utils_test
-    MetaServiceUtilsTest.cpp
-    ../MetaServiceUtils.cpp
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thread_obj>
-)
-nebula_link_libraries(
-    meta_utils_test
-    ${THRIFT_LIBRARIES}
-    gtest
-)
-nebula_add_test(meta_utils_test)
-
-
-add_executable(
-    processor_test
-    ProcessorTest.cpp
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:process_obj>
-)
-nebula_link_libraries(
-    processor_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(processor_test)
-
-
-add_executable(
-    hb_processor_test
-    HBProcessorTest.cpp
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:schema_obj>
-)
-nebula_link_libraries(
-    hb_processor_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(hb_processor_test)
-
-
-add_executable(
-    meta_client_test
-    MetaClientTest.cpp
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:process_obj>
-)
-nebula_link_libraries(
-    meta_client_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(meta_client_test)
-
-
-add_executable(
-    active_hosts_man_test
-    ActiveHostsManTest.cpp
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-)
-nebula_link_libraries(
-    active_hosts_man_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(active_hosts_man_test)
-
-add_executable(
-    meta_http_status_test
-    MetaHttpStatusHandlerTest.cpp
-    $<TARGET_OBJECTS:meta_http_handler>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:ws_obj>
-    $<TARGET_OBJECTS:hdfs_helper_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:stats_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:schema_obj>
-)
-nebula_link_libraries(
-    meta_http_status_test
-    proxygenhttpserver
-    proxygenlib
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(meta_http_status_test)
-
-add_executable(
-    meta_http_download_test
-    MetaHttpDownloadHandlerTest.cpp
-    $<TARGET_OBJECTS:storage_http_handler>
-    $<TARGET_OBJECTS:meta_http_handler>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:ws_obj>
-    $<TARGET_OBJECTS:hdfs_helper_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:stats_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:schema_obj>
-)
-nebula_link_libraries(
-    meta_http_download_test
-    proxygenhttpserver
-    proxygenlib
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(meta_http_download_test)
-
-add_executable(
-    balancer_test
-    BalancerTest.cpp
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-)
-nebula_link_libraries(
-    balancer_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(balancer_test)
-
-add_executable(
-    balance_integration_test
-    BalanceIntegrationTest.cpp
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:storage_service_handler>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:dataman_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:filter_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-)
-nebula_link_libraries(
-    balance_integration_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(balance_integration_test)
-
-add_executable(
-    admin_client_test
-    AdminClientTest.cpp
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:dataman_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-)
-nebula_link_libraries(
-    admin_client_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(admin_client_test)
-
-add_executable(
-    authentication_test
-    AuthProcessorTest.cpp
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:schema_obj>
-)
-nebula_link_libraries(
-    authentication_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
+nebula_add_test(
+    NAME
+        meta_utils_test
+    SOURCES
+        MetaServiceUtilsTest.cpp
+        ../MetaServiceUtils.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:thread_obj>
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        gtest
 )
 
-nebula_add_test(authentication_test)
 
+nebula_add_test(
+    NAME
+        processor_test
+    SOURCES
+        ProcessorTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:process_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+
+nebula_add_test(
+    NAME
+        hb_processor_test
+    SOURCES
+        HBProcessorTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:schema_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+
+nebula_add_test(
+    NAME
+        meta_client_test
+    SOURCES
+        MetaClientTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:process_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+
+nebula_add_test(
+    NAME
+        active_hosts_man_test
+    SOURCES
+        ActiveHostsManTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
+        meta_http_status_test
+    SOURCES
+        MetaHttpStatusHandlerTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:meta_http_handler>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:hdfs_helper_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:schema_obj>
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+
+nebula_add_test(
+    NAME
+        meta_http_download_test
+    SOURCES
+        MetaHttpDownloadHandlerTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:storage_http_handler>
+        $<TARGET_OBJECTS:meta_http_handler>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:hdfs_helper_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:schema_obj>
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
+        balancer_test
+    SOURCES
+        BalancerTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:network_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+
+nebula_add_test(
+    NAME
+        balance_integration_test
+    SOURCES
+        BalanceIntegrationTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:storage_service_handler>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:dataman_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:filter_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:network_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+
+nebula_add_test(
+    NAME
+        admin_client_test
+    SOURCES
+        AdminClientTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:dataman_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:network_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+
+nebula_add_test(
+    NAME
+        authentication_test
+    SOURCES
+        AuthProcessorTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:schema_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -8,19 +8,17 @@ add_flex_bison_dependency(Scanner Parser)
 
 add_compile_options(-Wno-error=sign-compare)
 
-add_library(
-        parser_obj
-        OBJECT
-        ${FLEX_Scanner_OUTPUTS}
-        ${BISON_Parser_OUTPUTS}
-        Clauses.cpp
-        SequentialSentences.cpp
-        MaintainSentences.cpp
-        MutateSentences.cpp
-        TraverseSentences.cpp
-        AdminSentences.cpp
-        UserSentences.cpp
+nebula_add_library(
+    parser_obj OBJECT
+    ${FLEX_Scanner_OUTPUTS}
+    ${BISON_Parser_OUTPUTS}
+    Clauses.cpp
+    SequentialSentences.cpp
+    MaintainSentences.cpp
+    MutateSentences.cpp
+    TraverseSentences.cpp
+    AdminSentences.cpp
+    UserSentences.cpp
 )
-nebula_add_base_obj(parser_obj)
 
 add_subdirectory(test)

--- a/src/parser/test/CMakeLists.txt
+++ b/src/parser/test/CMakeLists.txt
@@ -13,7 +13,6 @@ nebula_add_test(
     OBJECTS ${PARSER_TEST_LIBS}
     LIBRARIES gtest gtest_main
 )
-target_include_directories(parser_test SYSTEM BEFORE PUBLIC ${FLEX_INCLUDE_DIRS})
 
 nebula_add_test(
     NAME scanner_test
@@ -21,7 +20,6 @@ nebula_add_test(
     OBJECTS ${PARSER_TEST_LIBS}
     LIBRARIES gtest gtest_main
 )
-target_include_directories(scanner_test SYSTEM BEFORE PUBLIC ${FLEX_INCLUDE_DIRS})
 
 nebula_add_executable(
     NAME parser_benchmark

--- a/src/parser/test/CMakeLists.txt
+++ b/src/parser/test/CMakeLists.txt
@@ -1,6 +1,4 @@
-add_executable(
-    parser_test
-    ParserTest.cpp
+set(PARSER_TEST_LIBS
     $<TARGET_OBJECTS:parser_obj>
     $<TARGET_OBJECTS:filter_obj>
     $<TARGET_OBJECTS:base_obj>
@@ -8,44 +6,26 @@ add_executable(
     $<TARGET_OBJECTS:fs_obj>
     $<TARGET_OBJECTS:time_obj>
 )
-nebula_link_libraries(
-    parser_test
-    gtest
-    gtest_main
+
+nebula_add_test(
+    NAME parser_test
+    SOURCES ParserTest.cpp
+    OBJECTS ${PARSER_TEST_LIBS}
+    LIBRARIES gtest gtest_main
 )
 target_include_directories(parser_test SYSTEM BEFORE PUBLIC ${FLEX_INCLUDE_DIRS})
-nebula_add_test(parser_test)
 
-add_executable(
-    scanner_test
-    ScannerTest.cpp
-    $<TARGET_OBJECTS:parser_obj>
-    $<TARGET_OBJECTS:filter_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:time_obj>
-)
-nebula_link_libraries(
-    scanner_test
-    gtest
-    gtest_main
+nebula_add_test(
+    NAME scanner_test
+    SOURCES ScannerTest.cpp
+    OBJECTS ${PARSER_TEST_LIBS}
+    LIBRARIES gtest gtest_main
 )
 target_include_directories(scanner_test SYSTEM BEFORE PUBLIC ${FLEX_INCLUDE_DIRS})
-nebula_add_test(scanner_test)
 
-add_executable(
-    parser_benchmark
-    ParserBenchmark.cpp
-    $<TARGET_OBJECTS:parser_obj>
-    $<TARGET_OBJECTS:filter_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:time_obj>
-)
-nebula_link_libraries(
-    parser_benchmark
-    follybenchmark
-    boost_regex
+nebula_add_executable(
+    NAME parser_benchmark
+    SOURCES ParserBenchmark.cpp
+    OBJECTS ${PARSER_TEST_LIBS}
+    LIBRARIES follybenchmark boost_regex
 )

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(
+nebula_add_library(
     storage_service_handler OBJECT
     StorageServiceHandler.cpp
     QueryBaseProcessor.cpp
@@ -9,19 +9,16 @@ add_library(
     QueryEdgePropsProcessor.cpp
     QueryStatsProcessor.cpp
 )
-nebula_add_base_obj(storage_service_handler)
 
-add_library(
+nebula_add_library(
     storage_http_handler OBJECT
     StorageHttpStatusHandler.cpp
     StorageHttpDownloadHandler.cpp
 )
-nebula_add_base_obj(storage_http_handler)
 
-add_library(
+nebula_add_library(
     storage_client OBJECT
     client/StorageClient.cpp
 )
-nebula_add_base_obj(storage_client)
 
 add_subdirectory(test)

--- a/src/storage/test/CMakeLists.txt
+++ b/src/storage/test/CMakeLists.txt
@@ -20,231 +20,176 @@ set(storage_test_deps
 )
 
 
-add_library(
+nebula_add_library(
     adHocSchema_obj OBJECT
     AdHocSchemaManager.cpp
 )
-nebula_add_base_obj(adHocSchema_obj)
 
-
-add_executable(
-    add_vertices_test
-    AddVerticesTest.cpp
-    ${storage_test_deps}
-)
-nebula_link_libraries(
-    add_vertices_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(add_vertices_test)
-
-
-add_executable(
-    storage_service_handler_test
-    StorageServiceHandlerTest.cpp
-    ${storage_test_deps}
-)
-nebula_link_libraries(
-    storage_service_handler_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(storage_service_handler_test)
-
-
-add_executable(
-    add_edges_test
-    AddEdgesTest.cpp
-    ${storage_test_deps}
-)
-nebula_link_libraries(
-    add_edges_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(add_edges_test)
-
-
-add_executable(
-    query_bound_test
-    QueryBoundTest.cpp
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    ${storage_test_deps}
-)
-nebula_link_libraries(
-    query_bound_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(query_bound_test)
-
-
-add_executable(
-    vertex_props_test
-    QueryVertexPropsTest.cpp
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    ${storage_test_deps}
-)
-nebula_link_libraries(
-    vertex_props_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(vertex_props_test)
-
-
-add_executable(
-    edge_props_test
-    QueryEdgePropsTest.cpp
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    ${storage_test_deps}
-)
-nebula_link_libraries(
-    edge_props_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(edge_props_test)
-
-
-add_executable(
-    query_stats_test
-    QueryStatsTest.cpp
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    ${storage_test_deps}
-)
-nebula_link_libraries(
-    query_stats_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(query_stats_test)
-
-
-add_executable(
-    storage_client_test
-    StorageClientTest.cpp
-    $<TARGET_OBJECTS:storage_client>
-    $<TARGET_OBJECTS:meta_service_handler>
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    ${storage_test_deps}
-)
-nebula_link_libraries(
-    storage_client_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(storage_client_test)
-
-
-add_executable(
-    storage_http_status_test
-    StorageHttpStatusHandlerTest.cpp
-    $<TARGET_OBJECTS:storage_http_handler>
-    $<TARGET_OBJECTS:ws_obj>
-    $<TARGET_OBJECTS:stats_obj>
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    $<TARGET_OBJECTS:meta_service_handler>
-    ${storage_test_deps}
-)
-nebula_link_libraries(
-    storage_http_status_test
-    proxygenhttpserver
-    proxygenlib
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(storage_http_status_test)
-
-add_executable(
-    storage_http_download_test
-    StorageHttpDownloadHandlerTest.cpp
-    $<TARGET_OBJECTS:storage_http_handler>
-    $<TARGET_OBJECTS:ws_obj>
-    $<TARGET_OBJECTS:stats_obj>
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    $<TARGET_OBJECTS:meta_service_handler>
-    ${storage_test_deps}
-)
-nebula_link_libraries(
-    storage_http_download_test
-    proxygenhttpserver
-    proxygenlib
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(storage_http_download_test)
-
-add_executable(
-    compaction_test
-    CompactionTest.cpp
-    $<TARGET_OBJECTS:adHocSchema_obj>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:dataman_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:filter_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:stats_obj>
-    $<TARGET_OBJECTS:network_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:process_obj>
+nebula_add_test(
+    NAME add_vertices_test
+    SOURCES AddVerticesTest.cpp
+    OBJECTS ${storage_test_deps}
+    LIBRARIES ${ROCKSDB_LIBRARIES} ${THRIFT_LIBRARIES} wangle gtest
 )
 
-nebula_link_libraries(
-    compaction_test
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
-)
-nebula_add_test(compaction_test)
 
-add_executable(
-    query_bound_bm
-    QueryBoundBenchmark.cpp
-    ${storage_test_deps}
-    $<TARGET_OBJECTS:adHocSchema_obj>
+nebula_add_test(
+    NAME storage_service_handler_test
+    SOURCES StorageServiceHandlerTest.cpp
+    OBJECTS ${storage_test_deps}
+    LIBRARIES ${ROCKSDB_LIBRARIES} ${THRIFT_LIBRARIES} wangle gtest
 )
 
-nebula_link_libraries(
-    query_bound_bm
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    follybenchmark
-    wangle
-    boost_regex
+
+nebula_add_test(
+    NAME add_edges_test
+    SOURCES AddEdgesTest.cpp
+    OBJECTS ${storage_test_deps}
+    LIBRARIES ${ROCKSDB_LIBRARIES} ${THRIFT_LIBRARIES} wangle gtest
+)
+
+
+nebula_add_test(
+    NAME query_bound_test
+    SOURCES QueryBoundTest.cpp
+    OBJECTS $<TARGET_OBJECTS:adHocSchema_obj> ${storage_test_deps}
+    LIBRARIES ${ROCKSDB_LIBRARIES} ${THRIFT_LIBRARIES} wangle gtest
+)
+
+
+nebula_add_test(
+    NAME vertex_props_test
+    SOURCES QueryVertexPropsTest.cpp
+    OBJECTS $<TARGET_OBJECTS:adHocSchema_obj> ${storage_test_deps}
+    LIBRARIES ${ROCKSDB_LIBRARIES} ${THRIFT_LIBRARIES} wangle gtest
+)
+
+
+nebula_add_test(
+    NAME edge_props_test
+    SOURCES QueryEdgePropsTest.cpp
+    OBJECTS $<TARGET_OBJECTS:adHocSchema_obj> ${storage_test_deps}
+    LIBRARIES ${ROCKSDB_LIBRARIES} ${THRIFT_LIBRARIES} wangle gtest
+)
+
+
+nebula_add_test(
+    NAME query_stats_test
+    SOURCES QueryStatsTest.cpp
+    OBJECTS $<TARGET_OBJECTS:adHocSchema_obj> ${storage_test_deps}
+    LIBRARIES ${ROCKSDB_LIBRARIES} ${THRIFT_LIBRARIES} wangle gtest
+)
+
+
+nebula_add_test(
+    NAME
+        storage_client_test
+    SOURCES
+        StorageClientTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:storage_client>
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:adHocSchema_obj>
+        ${storage_test_deps}
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+
+nebula_add_test(
+    NAME
+        storage_http_status_test
+    SOURCES
+        StorageHttpStatusHandlerTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:storage_http_handler>
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:adHocSchema_obj>
+        $<TARGET_OBJECTS:meta_service_handler>
+        ${storage_test_deps}
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
+        storage_http_download_test
+    SOURCES
+        StorageHttpDownloadHandlerTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:storage_http_handler>
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:adHocSchema_obj>
+        $<TARGET_OBJECTS:meta_service_handler>
+        ${storage_test_deps}
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
+        compaction_test
+    SOURCES
+        CompactionTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:adHocSchema_obj>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:dataman_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:filter_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:process_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+
+nebula_add_executable(
+    NAME
+        query_bound_bm
+    SOURCES
+        QueryBoundBenchmark.cpp
+    OBJECTS
+        ${storage_test_deps}
+        $<TARGET_OBJECTS:adHocSchema_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        follybenchmark
+        wangle
+        boost_regex
 )
 

--- a/src/tools/native-client/CMakeLists.txt
+++ b/src/tools/native-client/CMakeLists.txt
@@ -2,7 +2,7 @@
 include_directories($ENV{JAVA_HOME}/include
                     $ENV{JAVA_HOME}/include/linux)
 
-add_library(nebula_native_client SHARED
+nebula_add_library(nebula_native_client SHARED
             $<TARGET_OBJECTS:dataman_obj>
             $<TARGET_OBJECTS:fs_obj>
             $<TARGET_OBJECTS:base_obj>

--- a/src/tools/storage-perf/CMakeLists.txt
+++ b/src/tools/storage-perf/CMakeLists.txt
@@ -1,31 +1,32 @@
-add_executable(
-    storage_perf
-    StoragePerfTool.cpp
-    $<TARGET_OBJECTS:storage_client>
-    $<TARGET_OBJECTS:storage_service_handler>
-    $<TARGET_OBJECTS:storage_thrift_obj>
-    $<TARGET_OBJECTS:kvstore_obj>
-    $<TARGET_OBJECTS:meta_client>
-    $<TARGET_OBJECTS:meta_thrift_obj>
-    $<TARGET_OBJECTS:common_thrift_obj>
-    $<TARGET_OBJECTS:raftex_obj>
-    $<TARGET_OBJECTS:raftex_thrift_obj>
-    $<TARGET_OBJECTS:wal_obj>
-    $<TARGET_OBJECTS:thrift_obj>
-    $<TARGET_OBJECTS:dataman_obj>
-    $<TARGET_OBJECTS:schema_obj>
-    $<TARGET_OBJECTS:filter_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:thread_obj>
-    $<TARGET_OBJECTS:time_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:network_obj>
-)
-nebula_link_libraries(
-    storage_perf
-    ${ROCKSDB_LIBRARIES}
-    ${THRIFT_LIBRARIES}
-    wangle
-    gtest
+nebula_add_executable(
+    NAME
+        storage_perf
+    SOURCES
+        StoragePerfTool.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:storage_client>
+        $<TARGET_OBJECTS:storage_service_handler>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:dataman_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:filter_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:network_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
 )
 

--- a/src/webservice/CMakeLists.txt
+++ b/src/webservice/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(
+nebula_add_library(
     ws_obj OBJECT
     WebService.cpp
     NotFoundHandler.cpp
@@ -6,7 +6,5 @@ add_library(
     SetFlagsHandler.cpp
     GetStatsHandler.cpp
 )
-nebula_add_base_obj(ws_obj)
 
 add_subdirectory(test)
-

--- a/src/webservice/test/CMakeLists.txt
+++ b/src/webservice/test/CMakeLists.txt
@@ -1,35 +1,36 @@
-add_executable(
-    flags_access_test
-    FlagsAccessTest.cpp
-    $<TARGET_OBJECTS:ws_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:stats_obj>
+nebula_add_test(
+    NAME
+        flags_access_test
+    SOURCES
+        FlagsAccessTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:stats_obj>
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        wangle
+        gtest
 )
-nebula_link_libraries(
-    flags_access_test
-    proxygenhttpserver
-    proxygenlib
-    wangle
-    gtest
-)
-nebula_add_test(flags_access_test)
 
-add_executable(
-    stats_read_test
-    StatsReaderTest.cpp
-    $<TARGET_OBJECTS:ws_obj>
-    $<TARGET_OBJECTS:base_obj>
-    $<TARGET_OBJECTS:process_obj>
-    $<TARGET_OBJECTS:fs_obj>
-    $<TARGET_OBJECTS:stats_obj>
+
+nebula_add_test(
+    NAME
+        stats_read_test
+    SOURCES
+        StatsReaderTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:stats_obj>
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        wangle
+        gtest
 )
-nebula_link_libraries(
-    stats_read_test
-    proxygenhttpserver
-    proxygenlib
-    wangle
-    gtest
-)
-nebula_add_test(stats_read_test)


### PR DESCRIPTION
Added macro wrappers on `add_library`, `add_executable` and `add_test` to make the cmake files tight and clean. At the same time, all our own code now implicitly depends on `base_obj`, which in turn depends on all of those auto generated thrift objects.