### PR TITLE
Fix use-after-free problem in UT

### DIFF
--- a/src/graph/test/TestEnv.cpp
+++ b/src/graph/test/TestEnv.cpp
@@ -69,10 +69,10 @@ void TestEnv::SetUp() {
 
 
 void TestEnv::TearDown() {
-    mClient_.reset();
     graphServer_.reset();
     storageServer_.reset();
     metaServer_.reset();
+    mClient_.reset();
 }
 
 


### PR DESCRIPTION
All servers depend on metaClient. 

So release meta client after servers. 