### PR TITLE
Fix use-after-free problem in BalancerPlan

### DIFF
--- a/src/meta/processors/admin/BalancePlan.cpp
+++ b/src/meta/processors/admin/BalancePlan.cpp
@@ -92,12 +92,12 @@ void BalancePlan::invoke() {
         }  // for (auto j = 0; j < buckets_[i].size(); j++)
     }  // for (auto i = 0; i < buckets_.size(); i++)
 
+    saveInStore(true);
     for (auto& bucket : buckets_) {
         if (!bucket.empty()) {
             tasks_[bucket[0]].invoke();
         }
     }
-    saveInStore(true);
 }
 
 bool BalancePlan::saveInStore(bool onlyPlan) {


### PR DESCRIPTION
In balancePlan,  after all tasks finished,  the plan will be destroyed.  
So we should save the plan firstly before tasks invoke to avoid the potential risk. 