### PR TITLE
Fix failed data_test/go_test.

### DIFF
--- a/src/graph/test/TestEnv.cpp
+++ b/src/graph/test/TestEnv.cpp
@@ -69,6 +69,8 @@ void TestEnv::SetUp() {
 
 
 void TestEnv::TearDown() {
+    // TO make sure the drop space be invoked on storage server
+    sleep(FLAGS_load_data_interval_secs + 1);
     graphServer_.reset();
     storageServer_.reset();
     metaServer_.reset();

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -57,6 +57,8 @@ namespace nebula {
 namespace kvstore {
 
 NebulaStore::~NebulaStore() {
+    LOG(INFO) << "Cut off the relationship with meta client";
+    options_.partMan_.reset();
     workers_->stop();
     workers_->wait();
     LOG(INFO) << "Stop the raft service...";

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -45,7 +45,6 @@ public:
             , storeSvcAddr_(serviceAddr)
             , raftAddr_(getRaftAddr(serviceAddr))
             , options_(std::move(options)) {
-        partMan_ = std::move(options_.partMan_);
         init();
     }
 
@@ -86,7 +85,7 @@ public:
     ErrorOr<ResultCode, HostAddr> partLeader(GraphSpaceID spaceId, PartitionID partId) override;
 
     PartManager* partManager() const override {
-        return partMan_.get();
+        return options_.partMan_.get();
     }
 
     ResultCode get(GraphSpaceID spaceId,
@@ -188,8 +187,6 @@ private:
     HostAddr storeSvcAddr_;
     HostAddr raftAddr_;
     KVOptions options_;
-
-    std::unique_ptr<PartManager> partMan_{nullptr};
 
     std::shared_ptr<raftex::RaftexService> raftService_;
     std::unique_ptr<wal::BufferFlusher> flusher_;

--- a/src/kvstore/test/NebulaStoreTest.cpp
+++ b/src/kvstore/test/NebulaStoreTest.cpp
@@ -192,7 +192,7 @@ TEST(NebulaStoreTest, PartsTest) {
         ASSERT_EQ(9, parts[4]);
     }
 
-    auto* pm = dynamic_cast<MemPartManager*>(store->partMan_.get());
+    auto* pm = dynamic_cast<MemPartManager*>(store->options_.partMan_.get());
     // Let's create another space with 10 parts.
     for (auto partId = 0; partId < 10; partId++) {
         pm->addPart(1, partId);


### PR DESCRIPTION
The reason is that go_test/data_test will drop space before exit.  And the procedure of drop space  is update information on meta,  then notify storage server asynchronously.  Maybe meta client receive the notification after the storage server stopped,  so it will crash.

To fix it,  we should cut-off the relationship with metaclient before kvstore clean up parts.  But i still want "drop space "could be invoked on storage server,  so i add sleep to ensure it. 