### PR TITLE
fix crash problem when stop process.

### DIFF
--- a/src/graph/ExecutionEngine.cpp
+++ b/src/graph/ExecutionEngine.cpp
@@ -28,7 +28,7 @@ Status ExecutionEngine::init(std::shared_ptr<folly::IOThreadPoolExecutor> ioExec
     if (!addrs.ok()) {
         return addrs.status();
     }
-    metaClient_ = std::make_unique<meta::MetaClient>(ioExecutor, std::move(addrs.value()));
+    metaClient_ = std::make_unique<meta::MetaClient>(std::move(addrs.value()));
     // load data try 3 time
     bool loadDataOk = metaClient_->waitForMetadReady(3);
     if (!loadDataOk) {

--- a/src/graph/test/TestEnv.cpp
+++ b/src/graph/test/TestEnv.cpp
@@ -35,7 +35,6 @@ void TestEnv::SetUp() {
     FLAGS_meta_server_addrs = folly::stringPrintf("127.0.0.1:%d", metaServerPort());
 
     // Create storageServer
-    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     auto addrsRet
         = network::NetworkUtils::toHosts(folly::stringPrintf("127.0.0.1:%d", metaServerPort()));
     CHECK(addrsRet.ok()) << addrsRet.status();
@@ -45,8 +44,7 @@ void TestEnv::SetUp() {
         LOG(ERROR) << "Bad local host addr, status:" << hostRet.status();
     }
     auto& localhost = hostRet.value();
-    mClient_ = std::make_unique<meta::MetaClient>(threadPool,
-                                                  std::move(addrsRet.value()),
+    mClient_ = std::make_unique<meta::MetaClient>(std::move(addrsRet.value()),
                                                   localhost,
                                                   true);
     auto r = mClient_->addHosts({localhost}).get();

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -37,6 +37,7 @@ namespace nebula {
 namespace kvstore {
 
 NebulaStore::~NebulaStore() {
+    // we must stop worker before raft service, because raftservice will stop io thread pool
     workers_->stop();
     workers_->wait();
     LOG(INFO) << "Stop the raft service...";
@@ -50,7 +51,7 @@ bool NebulaStore::init() {
     LOG(INFO) << "Start the raft service...";
     workers_ = std::make_shared<thread::GenericThreadPool>();
     workers_->start(FLAGS_num_workers);
-    raftService_ = raftex::RaftexService::createService(ioPool_, raftAddr_.second);
+    raftService_ = raftex::RaftexService::createService(ioPool_, acceptPool_, raftAddr_.second);
     if (!raftService_->start()) {
         LOG(ERROR) << "Start the raft service failed";
         return false;

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -40,8 +40,10 @@ class NebulaStore : public KVStore, public Handler {
 public:
     NebulaStore(KVOptions options,
                 std::shared_ptr<folly::IOThreadPoolExecutor> ioPool,
+                std::shared_ptr<folly::IOThreadPoolExecutor> acceptPool,
                 HostAddr serviceAddr)
             : ioPool_(ioPool)
+            , acceptPool_(acceptPool)
             , storeSvcAddr_(serviceAddr)
             , raftAddr_(getRaftAddr(serviceAddr))
             , options_(std::move(options)) {
@@ -187,6 +189,7 @@ private:
     std::unordered_map<GraphSpaceID, std::shared_ptr<SpacePartInfo>> spaces_;
 
     std::shared_ptr<folly::IOThreadPoolExecutor> ioPool_;
+    std::shared_ptr<folly::IOThreadPoolExecutor> acceptPool_;
     std::shared_ptr<thread::GenericThreadPool> workers_;
     HostAddr storeSvcAddr_;
     HostAddr raftAddr_;

--- a/src/kvstore/raftex/RaftexService.cpp
+++ b/src/kvstore/raftex/RaftexService.cpp
@@ -66,7 +66,7 @@ void RaftexService::initThriftServer(std::shared_ptr<folly::IOThreadPoolExecutor
     server_->setPort(port);
     if (ioPool != nullptr && acceptPool != nullptr) {
         server_->setIOThreadPool(ioPool);
-        server_->setIOThreadPool(acceptPool);
+        server_->setAcceptExecutor(acceptPool);
         server_->setStopWorkersOnStopListening(false);
     }
 }

--- a/src/kvstore/raftex/RaftexService.h
+++ b/src/kvstore/raftex/RaftexService.h
@@ -23,7 +23,8 @@ class IOThreadPoolObserver;
 class RaftexService : public cpp2::RaftexServiceSvIf {
 public:
     static std::shared_ptr<RaftexService> createService(
-        std::shared_ptr<folly::IOThreadPoolExecutor> pool,
+        std::shared_ptr<folly::IOThreadPoolExecutor> ioPool,
+        std::shared_ptr<folly::IOThreadPoolExecutor> acceptPool,
         uint16_t port = 0);
     virtual ~RaftexService();
 
@@ -47,7 +48,9 @@ public:
     void removePartition(std::shared_ptr<RaftPart> part);
 
 private:
-    void initThriftServer(std::shared_ptr<folly::IOThreadPoolExecutor> pool, uint16_t port = 0);
+    void initThriftServer(std::shared_ptr<folly::IOThreadPoolExecutor> ioPool,
+        std::shared_ptr<folly::IOThreadPoolExecutor> acceptPool,
+        uint16_t port = 0);
     bool setup();
     void serve();
 

--- a/src/kvstore/raftex/test/RaftexTestBase.cpp
+++ b/src/kvstore/raftex/test/RaftexTestBase.cpp
@@ -173,7 +173,7 @@ void setupRaft(
 
     // Set up services
     for (int i = 0; i < numCopies; ++i) {
-        services.emplace_back(RaftexService::createService(nullptr));
+        services.emplace_back(RaftexService::createService(nullptr, nullptr));
         if (!services.back()->start())
             return;
         uint16_t port = services.back()->getServerPort();

--- a/src/kvstore/test/NebulaStoreTest.cpp
+++ b/src/kvstore/test/NebulaStoreTest.cpp
@@ -19,8 +19,6 @@ DECLARE_uint32(heartbeat_interval);
 namespace nebula {
 namespace kvstore {
 
-auto ioThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(4);
-auto acceptThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
 
 template<typename T>
 void dump(const std::vector<T>& v) {
@@ -57,6 +55,10 @@ TEST(NebulaStoreTest, SimpleTest) {
     options.dataPaths_ = std::move(paths);
     options.partMan_ = std::move(partMan);
     HostAddr local = {0, 0};
+
+    auto ioThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(4);
+    auto acceptThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
+
     auto store = std::make_unique<NebulaStore>(std::move(options),
                                                ioThreadPool,
                                                acceptThreadPool,
@@ -157,6 +159,10 @@ TEST(NebulaStoreTest, PartsTest) {
     options.dataPaths_ = std::move(paths);
     options.partMan_ = std::move(partMan);
     HostAddr local = {0, 0};
+
+    auto ioThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(4);
+    auto acceptThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
+
     auto store = std::make_unique<NebulaStore>(std::move(options),
                                                ioThreadPool,
                                                acceptThreadPool,

--- a/src/kvstore/test/NebulaStoreTest.cpp
+++ b/src/kvstore/test/NebulaStoreTest.cpp
@@ -20,6 +20,7 @@ namespace nebula {
 namespace kvstore {
 
 auto ioThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(4);
+auto acceptThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
 
 template<typename T>
 void dump(const std::vector<T>& v) {
@@ -58,6 +59,7 @@ TEST(NebulaStoreTest, SimpleTest) {
     HostAddr local = {0, 0};
     auto store = std::make_unique<NebulaStore>(std::move(options),
                                                ioThreadPool,
+                                               acceptThreadPool,
                                                local);
     store->init();
     sleep(1);
@@ -157,6 +159,7 @@ TEST(NebulaStoreTest, PartsTest) {
     HostAddr local = {0, 0};
     auto store = std::make_unique<NebulaStore>(std::move(options),
                                                ioThreadPool,
+                                               acceptThreadPool,
                                                local);
     store->init();
     auto check = [&](GraphSpaceID spaceId) {
@@ -244,6 +247,7 @@ TEST(NebulaStoreTest, ThreeCopiesTest) {
                               const std::string& path) -> std::unique_ptr<NebulaStore> {
         LOG(INFO) << "Start nebula store on " << peers[index];
         auto sIoThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(4);
+        auto sAcceptThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
         auto partMan = std::make_unique<MemPartManager>();
         for (auto partId = 0; partId < 3; partId++) {
             PartMeta pm;
@@ -260,6 +264,7 @@ TEST(NebulaStoreTest, ThreeCopiesTest) {
         HostAddr local = peers[index];
         return std::make_unique<NebulaStore>(std::move(options),
                                              sIoThreadPool,
+                                             sAcceptThreadPool,
                                              local);
     };
     int32_t replicas = 3;

--- a/src/meta/MetaServiceHandler.h
+++ b/src/meta/MetaServiceHandler.h
@@ -20,6 +20,9 @@ public:
     explicit MetaServiceHandler(kvstore::KVStore* kv)
                 : kvstore_(kv) {}
 
+    ~MetaServiceHandler() {
+        LOG(INFO) << "~MetaServiceHandler";
+    }
     /**
      * Parts distribution related operations.
      * */

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -61,8 +61,7 @@ public:
 
 class MetaClient {
 public:
-    explicit MetaClient(std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool,
-                        std::vector<HostAddr> addrs,
+    explicit MetaClient(std::vector<HostAddr> addrs,
                         HostAddr localHost = HostAddr(0, 0),
                         bool sendHeartBeat = false);
 
@@ -259,7 +258,7 @@ protected:
                            const LocalCache& localCache);
 
 private:
-    std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool_;
+    std::unique_ptr<folly::IOThreadPoolExecutor> ioThreadPool_{nullptr};
     std::shared_ptr<thrift::ThriftClientManager<meta::cpp2::MetaServiceAsyncClient>> clientsMan_;
 
     LocalCache localCache_;

--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -36,13 +36,11 @@ TEST(MetaClientTest, InterfacesTest) {
     auto sc = TestUtils::mockMetaServer(localMetaPort, rootPath.path());
 
     GraphSpaceID spaceId = 0;
-    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     IPv4 localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     auto clientPort = network::NetworkUtils::getAvailablePort();
     HostAddr localHost{localIp, clientPort};
-    auto client = std::make_shared<MetaClient>(threadPool,
-                                               std::vector<HostAddr>{HostAddr(localIp, sc->port_)},
+    auto client = std::make_shared<MetaClient>(std::vector<HostAddr>{HostAddr(localIp, sc->port_)},
                                                localHost);
     client->waitForMetadReady();
     {
@@ -301,11 +299,9 @@ TEST(MetaClientTest, TagTest) {
     auto sc = TestUtils::mockMetaServer(localMetaPort, rootPath.path());
 
     GraphSpaceID spaceId = 0;
-    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     IPv4 localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
-    auto client = std::make_shared<MetaClient>(threadPool,
-        std::vector<HostAddr>{HostAddr(localIp, sc->port_)});
+    auto client = std::make_shared<MetaClient>(std::vector<HostAddr>{HostAddr(localIp, sc->port_)});
     std::vector<HostAddr> hosts = {{0, 0}, {1, 1}, {2, 2}, {3, 3}};
     auto r = client->addHosts(hosts).get();
     ASSERT_TRUE(r.ok());
@@ -410,12 +406,10 @@ TEST(MetaClientTest, DiffTest) {
     int32_t localMetaPort = 0;
     auto sc = TestUtils::mockMetaServer(localMetaPort, rootPath.path());
 
-    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     IPv4 localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     auto listener = std::make_unique<TestListener>();
-    auto client = std::make_shared<MetaClient>(threadPool,
-                                               std::vector<HostAddr>{HostAddr(localIp, sc->port_)});
+    auto client = std::make_shared<MetaClient>(std::vector<HostAddr>{HostAddr(localIp, sc->port_)});
     client->waitForMetadReady();
     client->registerListener(listener.get());
     {
@@ -462,14 +456,12 @@ TEST(MetaClientTest, HeartbeatTest) {
     fs::TempDir rootPath("/tmp/MetaClientTest.XXXXXX");
     auto sc = TestUtils::mockMetaServer(10001, rootPath.path());
 
-    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
     IPv4 localIp;
     network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
     auto listener = std::make_unique<TestListener>();
     auto clientPort = network::NetworkUtils::getAvailablePort();
     HostAddr localHost{localIp, clientPort};
-    auto client = std::make_shared<MetaClient>(threadPool,
-                                               std::vector<HostAddr>{HostAddr(localIp, 10001)},
+    auto client = std::make_shared<MetaClient>(std::vector<HostAddr>{HostAddr(localIp, 10001)},
                                                localHost,
                                                true);  // send heartbeat
     client->addHosts({localHost});

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -33,6 +33,7 @@ class TestUtils {
 public:
     static std::unique_ptr<kvstore::KVStore> initKV(const char* rootPath) {
         auto ioPool = std::make_shared<folly::IOThreadPoolExecutor>(4);
+        auto acceptThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
         auto partMan = std::make_unique<kvstore::MemPartManager>();
 
         // GraphSpaceID =>  {PartitionIDs}
@@ -50,6 +51,7 @@ public:
 
         auto store = std::make_unique<kvstore::NebulaStore>(std::move(options),
                                                             ioPool,
+                                                            acceptThreadPool,
                                                             localhost);
         store->init();
         sleep(1);

--- a/src/storage/StorageServiceHandler.h
+++ b/src/storage/StorageServiceHandler.h
@@ -25,6 +25,9 @@ public:
         : kvstore_(kvstore)
         , schemaMan_(schemaMan) {}
 
+    ~StorageServiceHandler() {
+        LOG(INFO) << "~StorageServiceHandler";
+    }
     folly::Future<cpp2::QueryResponse>
     future_getOutBound(const cpp2::GetNeighborsRequest& req) override;
 

--- a/src/storage/test/StorageClientTest.cpp
+++ b/src/storage/test/StorageClientTest.cpp
@@ -46,8 +46,7 @@ TEST(StorageClientTest, VerticesInterfacesTest) {
     uint32_t localDataPort = network::NetworkUtils::getAvailablePort();
     auto hostRet = nebula::network::NetworkUtils::toHostAddr("127.0.0.1", localDataPort);
     auto& localHost = hostRet.value();
-    auto mClient
-        = std::make_unique<meta::MetaClient>(threadPool, std::move(addrs), localHost, true);
+    auto mClient = std::make_unique<meta::MetaClient>(std::move(addrs), localHost, true);
     LOG(INFO) << "Add hosts and create space....";
     auto r = mClient->addHosts({HostAddr(localIp, localDataPort)}).get();
     ASSERT_TRUE(r.ok());

--- a/src/storage/test/TestUtils.h
+++ b/src/storage/test/TestUtils.h
@@ -35,6 +35,7 @@ public:
             bool useMetaServer = false,
             std::shared_ptr<kvstore::KVCompactionFilterFactory> cfFactory = nullptr) {
         auto ioPool = std::make_shared<folly::IOThreadPoolExecutor>(4);
+        auto acceptThreadPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
 
         kvstore::KVOptions options;
         if (useMetaServer) {
@@ -62,6 +63,7 @@ public:
         options.cfFactory_ = std::move(cfFactory);
         auto store = std::make_unique<kvstore::NebulaStore>(std::move(options),
                                                             ioPool,
+                                                            acceptThreadPool,
                                                             localhost);
         store->init();
         sleep(1);


### PR DESCRIPTION
fix crash problem when stop process that meta client and raft part depend io thread pool, but the io thread pool will stopped first by gServer:
1, raft bt.
(gdb) bt
#0  0x000000000208f587 in folly::IOThreadPoolExecutor::getEventBase (this=<optimized out>) at /usr/include/c++/8/bits/shared_ptr_base.h:1018
#1  0x0000000001b48970 in nebula::raftex::RaftPart::appendLogsInternal (this=0x7fbfdc168c10, iter=..., termId=8) at /home/wade.liu/rd/nebula/src/kvstore/raftex/RaftPart.cpp:512
#2  0x0000000001b47dd0 in nebula::raftex::RaftPart::appendLogAsync (this=0x7fbfdc168c10, source=0 '\000', logType=nebula::raftex::LogType::NORMAL, log="")
    at /home/wade.liu/rd/nebula/src/kvstore/raftex/RaftPart.cpp:452
#3  0x0000000001b501ff in nebula::raftex::RaftPart::sendHeartbeat (this=0x7fbfdc168c10) at /home/wade.liu/rd/nebula/src/kvstore/raftex/RaftPart.cpp:1270
#4  0x0000000001b4ce4f in nebula::raftex::RaftPart::statusPolling (this=0x7fbfdc168c10) at /home/wade.liu/rd/nebula/src/kvstore/raftex/RaftPart.cpp:940
#5  0x0000000001b4c9d8 in nebula::raftex::RaftPart::<lambda()>::operator()(void) const (__closure=0x7fbfd7ce7400) at /home/wade.liu/rd/nebula/src/kvstore/raftex/RaftPart.cpp:949
#6  0x0000000001b5d36c in std::__invoke_impl<void, nebula::raftex::RaftPart::statusPolling()::<lambda()>&>(std::__invoke_other, nebula::raftex::RaftPart::<lambda()> &) (__f=...)
    at /usr/include/c++/8/bits/invoke.h:60
#7  0x0000000001b5d2a1 in std::__invoke<nebula::raftex::RaftPart::statusPolling()::<lambda()>&>(nebula::raftex::RaftPart::<lambda()> &) (__fn=...) at /usr/include/c++/8/bits/invoke.h:95
#8  0x0000000001b5d19a in std::_Bind<nebula::raftex::RaftPart::statusPolling()::<lambda()>()>::__call<void>(std::tuple<> &&, std::_Index_tuple<>) (this=0x7fbfd7ce7400, __args=...)
    at /usr/include/c++/8/functional:400
#9  0x0000000001b5ccaa in std::_Bind<nebula::raftex::RaftPart::statusPolling()::<lambda()>()>::operator()<>(void) (this=0x7fbfd7ce7400) at /usr/include/c++/8/functional:484
#10 0x0000000001b5c647 in std::_Function_handler<void(), std::_Bind<nebula::raftex::RaftPart::statusPolling()::<lambda()>()> >::_M_invoke(const std::_Any_data &) (__functor=...)
    at /usr/include/c++/8/bits/std_function.h:297


2, meta bt.
#0  0x000000000208dc37 in folly::IOThreadPoolExecutor::getEventBase (this=<optimized out>) at /usr/include/c++/8/bits/shared_ptr_base.h:1018
#1  0x00000000018169eb in nebula::meta::MetaClient::getResponse<nebula::meta::cpp2::HBReq, nebula::meta::MetaClient::heartbeat()::<lambda(auto:110, auto:111)>, nebula::meta::MetaClient::heartbeat()::<lambda(nebula::meta::cpp2::HBResp&&)> >(nebula::meta::cpp2::HBReq, nebula::meta::MetaClient::<lambda(auto:110, auto:111)>, nebula::meta::MetaClient::<lambda(nebula::meta::cpp2::HBResp&&)>, bool) (
    this=0x7f7642d60600, req=..., remoteFunc=..., respGen=..., toLeader=true) at /home/wade.liu/rd/nebula/src/meta/client/MetaClient.cpp:254
#2  0x000000000180d6f6 in nebula::meta::MetaClient::heartbeat (this=0x7f7642d60600) at /home/wade.liu/rd/nebula/src/meta/client/MetaClient.cpp:987
#3  0x0000000001806204 in nebula::meta::MetaClient::heartBeatThreadFunc (this=0x7f7642d60600) at /home/wade.liu/rd/nebula/src/meta/client/MetaClient.cpp:85
#4  0x00000000018876da in std::__invoke_impl<void, void (nebula::meta::MetaClient::*&)(), nebula::meta::MetaClient*&> (
    __f=@0x7f7642dc1ea0: (void (nebula::meta::MetaClient::*)(nebula::meta::MetaClient * const)) 0x18061e0 <nebula::meta::MetaClient::heartBeatThreadFunc()>, __t=@0x7f7642dc1eb0: 0x7f7642d60600)
    at /usr/include/c++/8/bits/invoke.h:73