### PR TITLE
Fix graph failed to register config to meta.

### DIFF
--- a/package/nebula.spec
+++ b/package/nebula.spec
@@ -81,6 +81,7 @@ Group: Applications/Databases
 %attr(0755,root,root) %{_bindir}/nebula-metad
 %attr(0644,root,root) %{_sysconfdir}/nebula-metad.conf.default
 %attr(0755,root,root) %{_datadir}/nebula-metad.service
+%attr(0644,root,root) %{_resourcesdir}/gflags.json
 
 # After install, if config file is non-existent, copy default config file
 %post metad
@@ -94,6 +95,7 @@ fi
 %attr(0755,root,root) %{_bindir}/nebula-graphd
 %attr(0644,root,root) %config%{_sysconfdir}/nebula-graphd.conf.default
 %attr(0755,root,root) %{_datadir}/nebula-graphd.service
+%attr(0644,root,root) %{_resourcesdir}/gflags.json
 
 %post graphd
 if [[ ! -f %{_install_dir}/etc/nebula-graphd.conf ]]; then
@@ -106,6 +108,7 @@ fi
 %attr(0755,root,root) %{_bindir}/nebula-storaged
 %attr(0644,root,root) %config%{_sysconfdir}/nebula-storaged.conf.default
 %attr(0755,root,root) %{_datadir}/nebula-storaged.service
+%attr(0644,root,root) %{_resourcesdir}/gflags.json
 
 %post storaged
 if [[ ! -f %{_install_dir}/etc/nebula-storaged.conf ]]; then

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -8,3 +8,14 @@ install(
     DESTINATION
         share/resources
 )
+
+install(
+    FILES
+        resources/gflags.json
+    PERMISSIONS
+        OWNER_WRITE OWNER_READ
+        GROUP_READ
+        WORLD_READ
+    DESTINATION
+        share/resources
+)

--- a/share/resources/completion.json
+++ b/share/resources/completion.json
@@ -12,7 +12,7 @@
         },
         "SHOW" : {
             "sub_keywords": [
-                "HOSTS", "TAGS", "EDGES", "SPACES", "USERS", "ROLES", "USER"
+                "HOSTS", "TAGS", "EDGES", "SPACES", "USERS", "ROLES", "USER", "VARIABLES"
             ]
         },
         "DESCRIBE" : {
@@ -76,6 +76,16 @@
         "INTERSECT": {
         },
         "UNION": {
+        },
+        "UPDATE": {
+            "sub_keywords": [
+                "VARIABLES"
+            ]
+        },
+        "GET": {
+            "sub_keywords": [
+                "VARIABLES"
+            ]
         }
     },
     "typenames": [

--- a/share/resources/gflags.json
+++ b/share/resources/gflags.json
@@ -41,8 +41,6 @@
         "helpshort",
         "alsologtoemail",
         "version",
-        "graphd_gflags_json",
-        "metad_gflags_json",
-        "storaged_gflags_json"
+        "gflags_mode_json"
     ]
 }

--- a/share/resources/gflags.json
+++ b/share/resources/gflags.json
@@ -32,6 +32,17 @@
         "stop_logging_if_full_disk",
         "symbolize_stacktrace",
         "vmodule",
-        "v"
+        "v",
+        "help",
+        "helpon",
+        "helpxml",
+        "helpfull",
+        "helpmatch",
+        "helpshort",
+        "alsologtoemail",
+        "version",
+        "graphd_gflags_json",
+        "metad_gflags_json",
+        "storaged_gflags_json"
     ]
 }

--- a/share/resources/gflags.json
+++ b/share/resources/gflags.json
@@ -1,0 +1,37 @@
+{
+    "IMMUTABLE": [
+    ],
+    "REBOOT": [
+    ],
+    "MUTABLE": [
+        "load_data_interval_secs"
+    ],
+    "IGNORED": [
+        "logging",
+        "flagfile",
+        "fromenv",
+        "tryfromenv",
+        "undefok",
+        "tab_completion_columns",
+        "tab_completion_word",
+        "alsologtostderr",
+        "drop_log_memory",
+        "log_backtrace_at",
+        "log_dir",
+        "log_link",
+        "log_prefix",
+        "logbuflevel",
+        "logbufsecs",
+        "logemaillevel",
+        "logfile_mode",
+        "logmailer",
+        "logtostderr",
+        "max_log_size",
+        "minloglevel",
+        "stderrthreshold",
+        "stop_logging_if_full_disk",
+        "symbolize_stacktrace",
+        "vmodule",
+        "v"
+    ]
+}

--- a/src/graph/CMakeLists.txt
+++ b/src/graph/CMakeLists.txt
@@ -51,6 +51,7 @@ add_dependencies(
     graph_thrift_obj
     meta_thrift_obj
     meta_client
+    gflags_man_obj
     schema_obj
     stats_obj
     process_obj

--- a/src/graph/ExecutionEngine.cpp
+++ b/src/graph/ExecutionEngine.cpp
@@ -40,7 +40,6 @@ Status ExecutionEngine::init(std::shared_ptr<folly::IOThreadPoolExecutor> ioExec
     schemaManager_->init(metaClient_.get());
 
     gflagsManager_ = std::make_unique<meta::ClientBasedGflagsManager>(metaClient_.get());
-    gflagsManager_->init();
 
     storage_ = std::make_unique<storage::StorageClient>(ioExecutor, metaClient_.get());
     return Status::OK();

--- a/src/graph/test/ConfigTest.cpp
+++ b/src/graph/test/ConfigTest.cpp
@@ -29,8 +29,7 @@ protected:
     }
 };
 
-std::vector<meta::cpp2::ConfigItem>
-mockRegisterGflags() {
+std::vector<meta::cpp2::ConfigItem> mockRegisterGflags() {
     std::vector<meta::cpp2::ConfigItem> configItems;
     {
         auto module = meta::cpp2::ConfigModule::STORAGE;
@@ -86,7 +85,7 @@ TEST_F(ConfigTest, ConfigTest) {
     ASSERT_NE(nullptr, client);
 
     auto configItems = mockRegisterGflags();
-    auto ret = gEnv->gflagsManager()->registerGflags(configItems);
+    auto ret = gEnv->gflagsManager()->registerGflags(std::move(configItems));
     ASSERT_TRUE(ret.ok());
 
     // set/get without declaration

--- a/src/graph/test/ConfigTest.cpp
+++ b/src/graph/test/ConfigTest.cpp
@@ -29,55 +29,65 @@ protected:
     }
 };
 
-void mockRegisterGflags(meta::ClientBasedGflagsManager* cfgMan) {
+std::vector<meta::cpp2::ConfigItem>
+mockRegisterGflags() {
+    std::vector<meta::cpp2::ConfigItem> configItems;
     {
         auto module = meta::cpp2::ConfigModule::STORAGE;
         auto type = meta::cpp2::ConfigType::INT64;
         int64_t value = 0L;
-        cfgMan->registerConfig(module, "k0", type, meta::cpp2::ConfigMode::IMMUTABLE,
-                               meta::toThriftValueStr(type, value)).get();
-        cfgMan->registerConfig(module, "k1", type, meta::cpp2::ConfigMode::MUTABLE,
-                               meta::toThriftValueStr(type, value)).get();
+        configItems.emplace_back(meta::toThriftConfigItem(module, "k0", type,
+                                 meta::cpp2::ConfigMode::IMMUTABLE,
+                                 meta::toThriftValueStr(type, value)));
+        configItems.emplace_back(meta::toThriftConfigItem(module, "k1", type,
+                                 meta::cpp2::ConfigMode::MUTABLE,
+                                 meta::toThriftValueStr(type, value)));
     }
     {
         auto module = meta::cpp2::ConfigModule::STORAGE;
         auto type = meta::cpp2::ConfigType::BOOL;
         auto mode = meta::cpp2::ConfigMode::MUTABLE;
         bool value = false;
-        cfgMan->registerConfig(module, "k2", type, mode, meta::toThriftValueStr(type, value)).get();
+        configItems.emplace_back(meta::toThriftConfigItem(module, "k2", type, mode,
+                                 meta::toThriftValueStr(type, value)));
     }
     {
         auto module = meta::cpp2::ConfigModule::META;
         auto mode = meta::cpp2::ConfigMode::MUTABLE;
         auto type = meta::cpp2::ConfigType::DOUBLE;
         double value = 1.0;
-        cfgMan->registerConfig(module, "k1", type, mode, meta::toThriftValueStr(type, value)).get();
+        configItems.emplace_back(meta::toThriftConfigItem(module, "k1", type, mode,
+                                 meta::toThriftValueStr(type, value)));
     }
     {
         auto module = meta::cpp2::ConfigModule::META;
         auto mode = meta::cpp2::ConfigMode::MUTABLE;
         auto type = meta::cpp2::ConfigType::STRING;
         std::string value = "nebula";
-        cfgMan->registerConfig(module, "k2", type, mode, meta::toThriftValueStr(type, value)).get();
+        configItems.emplace_back(meta::toThriftConfigItem(module, "k2", type, mode,
+                                 meta::toThriftValueStr(type, value)));
     }
     {
         auto type = meta::cpp2::ConfigType::STRING;
         auto mode = meta::cpp2::ConfigMode::MUTABLE;
         std::string value = "nebula";
-        cfgMan->registerConfig(meta::cpp2::ConfigModule::GRAPH, "k3",
-                               type, mode, meta::toThriftValueStr(type, value)).get();
-        cfgMan->registerConfig(meta::cpp2::ConfigModule::META, "k3",
-                               type, mode, meta::toThriftValueStr(type, value)).get();
-        cfgMan->registerConfig(meta::cpp2::ConfigModule::STORAGE, "k3",
-                               type, mode, meta::toThriftValueStr(type, value)).get();
+        configItems.emplace_back(meta::toThriftConfigItem(meta::cpp2::ConfigModule::GRAPH, "k3",
+                                 type, mode, meta::toThriftValueStr(type, value)));
+        configItems.emplace_back(meta::toThriftConfigItem(meta::cpp2::ConfigModule::META, "k3",
+                                 type, mode, meta::toThriftValueStr(type, value)));
+        configItems.emplace_back(meta::toThriftConfigItem(meta::cpp2::ConfigModule::STORAGE, "k3",
+                                 type, mode, meta::toThriftValueStr(type, value)));
     }
+    return configItems;
 }
 
 TEST_F(ConfigTest, ConfigTest) {
     auto client = gEnv->getClient();
     ASSERT_NE(nullptr, client);
 
-    mockRegisterGflags(gEnv->gflagsManager());
+    auto configItems = mockRegisterGflags();
+    auto ret = gEnv->gflagsManager()->registerGflags(configItems);
+    ASSERT_TRUE(ret.ok());
 
     // set/get without declaration
     {

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -456,6 +456,7 @@ enum ConfigMode {
     IMMUTABLE   = 0x00,
     REBOOT      = 0x01,
     MUTABLE     = 0x02,
+    IGNORED     = 0x03,
 } (cpp.enum_strict)
 
 struct ConfigItem {

--- a/src/kvstore/plugins/hbase/test/CMakeLists.txt
+++ b/src/kvstore/plugins/hbase/test/CMakeLists.txt
@@ -17,6 +17,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:meta_client>
         $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
@@ -44,6 +45,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:meta_client>
         $<TARGET_OBJECTS:meta_thrift_obj>
         $<TARGET_OBJECTS:adHocSchema_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}

--- a/src/kvstore/test/CMakeLists.txt
+++ b/src/kvstore/test/CMakeLists.txt
@@ -13,6 +13,7 @@ set(KVSTORE_TEST_LIBS
     $<TARGET_OBJECTS:network_obj>
     $<TARGET_OBJECTS:thrift_obj>
     $<TARGET_OBJECTS:time_obj>
+    $<TARGET_OBJECTS:gflags_man_obj>
 )
 
 nebula_add_test(

--- a/src/meta/CMakeLists.txt
+++ b/src/meta/CMakeLists.txt
@@ -58,6 +58,10 @@ nebula_add_library(
     meta_client OBJECT
     client/MetaClient.cpp
 )
+add_dependencies(
+    meta_client
+    gflags_man_obj
+)
 
 add_library(
     gflags_man_obj OBJECT

--- a/src/meta/ClientBasedGflagsManager.h
+++ b/src/meta/ClientBasedGflagsManager.h
@@ -35,17 +35,9 @@ public:
     folly::Future<StatusOr<std::vector<cpp2::ConfigItem>>>
     listConfigs(const cpp2::ConfigModule& module) override;
 
-    folly::Future<StatusOr<bool>> registerConfig(const cpp2::ConfigModule& module,
-                                                 const std::string& name,
-                                                 const cpp2::ConfigType& type,
-                                                 const cpp2::ConfigMode& mode,
-                                                 const std::string& defaultValue) override;
-
-    Status init() override;
+    Status registerGflags(const std::vector<cpp2::ConfigItem>& items);
 
 private:
-    Status registerGflags();
-
     template<typename ValueType>
     folly::Future<StatusOr<bool>> set(const cpp2::ConfigModule& module, const std::string& name,
                                       const cpp2::ConfigType& type, const ValueType& value);

--- a/src/meta/ClientBasedGflagsManager.h
+++ b/src/meta/ClientBasedGflagsManager.h
@@ -8,7 +8,6 @@
 #define META_CLIENTBASEDGFLAGSMANAGER_H_
 
 #include "base/Base.h"
-#include <gtest/gtest_prod.h>
 #include "meta/GflagsManager.h"
 #include "meta/client/MetaClient.h"
 
@@ -16,9 +15,6 @@ namespace nebula {
 namespace meta {
 
 class ClientBasedGflagsManager : public GflagsManager {
-    FRIEND_TEST(ConfigManTest, MetaConfigManTest);
-    FRIEND_TEST(ConfigManTest, MockConfigTest);
-
 public:
     explicit ClientBasedGflagsManager(MetaClient *metaClient);
 

--- a/src/meta/GflagsManager.cpp
+++ b/src/meta/GflagsManager.cpp
@@ -34,9 +34,11 @@ std::unordered_map<std::string, cpp2::ConfigMode> GflagsManager::parseConfigJson
         LOG(ERROR) << "Load gflags json failed";
         return configModeMap;
     }
-    std::vector<std::string> keys = {"IMMUTABLE", "REBOOT", "MUTABLE", "IGNORED"};
-    std::vector<cpp2::ConfigMode> modes = {cpp2::ConfigMode::IMMUTABLE, cpp2::ConfigMode::REBOOT,
-                                           cpp2::ConfigMode::MUTABLE, cpp2::ConfigMode::IGNORED};
+    static std::vector<std::string> keys = {"IMMUTABLE", "REBOOT", "MUTABLE", "IGNORED"};
+    static std::vector<cpp2::ConfigMode> modes = {cpp2::ConfigMode::IMMUTABLE,
+                                                  cpp2::ConfigMode::REBOOT,
+                                                  cpp2::ConfigMode::MUTABLE,
+                                                  cpp2::ConfigMode::IGNORED};
     for (size_t i = 0; i < keys.size(); i++) {
         std::vector<std::string> values;
         if (!conf.fetchAsStringArray(keys[i].c_str(), values).ok()) {
@@ -67,8 +69,9 @@ std::vector<cpp2::ConfigItem> GflagsManager::declareGflags(const cpp2::ConfigMod
 
         // default config type would be immutable
         cpp2::ConfigMode mode = cpp2::ConfigMode::IMMUTABLE;
-        if (configModeMap.find(name) != configModeMap.end()) {
-            mode = configModeMap[name];
+        auto iter = configModeMap.find(name);
+        if (iter != configModeMap.end()) {
+            mode = iter->second;
         }
         // ignore some useless gflags
         if (mode == cpp2::ConfigMode::IGNORED) {

--- a/src/meta/GflagsManager.cpp
+++ b/src/meta/GflagsManager.cpp
@@ -8,9 +8,7 @@
 #include "base/Configuration.h"
 #include "fs/FileUtils.h"
 
-DEFINE_string(graphd_gflags_json, "share/resources/gflags.json", "gflags mode json for graph");
-DEFINE_string(metad_gflags_json, "share/resources/gflags.json", "gflags mode json for metad");
-DEFINE_string(storaged_gflags_json, "share/resources/gflags.json", "gflags mode json for storaged");
+DEFINE_string(gflags_mode_json, "share/resources/gflags.json", "gflags mode json for service");
 
 namespace nebula {
 namespace meta {
@@ -55,13 +53,12 @@ GflagsManager::parseConfigJson(const std::string& path) {
     return configModeMap;
 }
 
-std::vector<cpp2::ConfigItem> GflagsManager::declareGflags(const cpp2::ConfigModule& module,
-                                                           const std::string& jsonPath) {
+std::vector<cpp2::ConfigItem> GflagsManager::declareGflags(const cpp2::ConfigModule& module) {
     std::vector<cpp2::ConfigItem> configItems;
     if (module == cpp2::ConfigModule::UNKNOWN) {
         return configItems;
     }
-    auto configModeMap = parseConfigJson(jsonPath);
+    auto configModeMap = parseConfigJson(FLAGS_gflags_mode_json);
     std::vector<gflags::CommandLineFlagInfo> flags;
     gflags::GetAllFlags(&flags);
     for (auto& flag : flags) {
@@ -113,20 +110,17 @@ std::vector<cpp2::ConfigItem> GflagsManager::declareGflags(const cpp2::ConfigMod
     return configItems;
 }
 
-void GflagsManager::getGflagsModule(cpp2::ConfigModule& gflagsModule, std::string& jsonPath) {
+void GflagsManager::getGflagsModule(cpp2::ConfigModule& gflagsModule) {
     // get current process according to gflags pid_file
     gflags::CommandLineFlagInfo pid;
     if (gflags::GetCommandLineFlagInfo("pid_file", &pid)) {
         auto defaultPid = pid.default_value;
         if (defaultPid.find("nebula-graphd") != std::string::npos) {
             gflagsModule = cpp2::ConfigModule::GRAPH;
-            jsonPath = FLAGS_graphd_gflags_json;
         } else if (defaultPid.find("nebula-storaged") != std::string::npos) {
             gflagsModule = cpp2::ConfigModule::STORAGE;
-            jsonPath = FLAGS_storaged_gflags_json;
         } else if (defaultPid.find("nebula-metad") != std::string::npos) {
             gflagsModule = cpp2::ConfigModule::META;
-            jsonPath = FLAGS_metad_gflags_json;
         } else {
             LOG(ERROR) << "Should not reach here";
         }

--- a/src/meta/GflagsManager.cpp
+++ b/src/meta/GflagsManager.cpp
@@ -31,6 +31,7 @@ std::unordered_map<std::string, cpp2::ConfigMode> GflagsManager::parseConfigJson
     std::unordered_map<std::string, cpp2::ConfigMode> configModeMap;
     Configuration conf;
     if (!conf.parseFromFile(json).ok()) {
+        LOG(ERROR) << "Load gflags json failed";
         return configModeMap;
     }
     std::vector<std::string> keys = {"IMMUTABLE", "REBOOT", "MUTABLE", "IGNORED"};

--- a/src/meta/GflagsManager.cpp
+++ b/src/meta/GflagsManager.cpp
@@ -82,8 +82,8 @@ std::vector<cpp2::ConfigItem> GflagsManager::declareGflags(const cpp2::ConfigMod
             mode = cpp2::ConfigMode::IMMUTABLE;
         }
 
-        // TODO: all int32 and uint32 are converted to int64
-        if (type == "uint32" || type == "int32" || type == "int64") {
+        // TODO: all int32/uint32/uint64 gflags are converted to int64 for now
+        if (type == "uint32" || type == "int32" || type == "int64" || type == "uint64") {
             cType = cpp2::ConfigType::INT64;
             value = folly::to<int64_t>(flag.current_value);
             valueStr = gflagsValueToThriftValue<int64_t>(flag);

--- a/src/meta/GflagsManager.h
+++ b/src/meta/GflagsManager.h
@@ -34,6 +34,8 @@ public:
 protected:
     virtual ~GflagsManager() = default;
 
+    static std::unordered_map<std::string, cpp2::ConfigMode> parseConfigJson();
+
     template<typename ValueType>
     static std::string gflagsValueToThriftValue(const gflags::CommandLineFlagInfo& flag);
 };

--- a/src/meta/GflagsManager.h
+++ b/src/meta/GflagsManager.h
@@ -29,12 +29,16 @@ public:
     virtual folly::Future<StatusOr<std::vector<cpp2::ConfigItem>>>
     listConfigs(const cpp2::ConfigModule& module) = 0;
 
-    static std::vector<cpp2::ConfigItem> declareGflags(const cpp2::ConfigModule& module);
+    static void getGflagsModule(cpp2::ConfigModule& gflagsModule, std::string& jsonPath);
+
+    static std::vector<cpp2::ConfigItem> declareGflags(const cpp2::ConfigModule& module,
+                                                       const std::string& jsonPath);
 
 protected:
     virtual ~GflagsManager() = default;
 
-    static std::unordered_map<std::string, cpp2::ConfigMode> parseConfigJson();
+    static std::unordered_map<std::string, cpp2::ConfigMode>
+           parseConfigJson(const std::string& json);
 
     template<typename ValueType>
     static std::string gflagsValueToThriftValue(const gflags::CommandLineFlagInfo& flag);

--- a/src/meta/GflagsManager.h
+++ b/src/meta/GflagsManager.h
@@ -29,10 +29,9 @@ public:
     virtual folly::Future<StatusOr<std::vector<cpp2::ConfigItem>>>
     listConfigs(const cpp2::ConfigModule& module) = 0;
 
-    static void getGflagsModule(cpp2::ConfigModule& gflagsModule, std::string& jsonPath);
+    static void getGflagsModule(cpp2::ConfigModule& gflagsModule);
 
-    static std::vector<cpp2::ConfigItem> declareGflags(const cpp2::ConfigModule& module,
-                                                       const std::string& jsonPath);
+    static std::vector<cpp2::ConfigItem> declareGflags(const cpp2::ConfigModule& module);
 
 protected:
     virtual ~GflagsManager() = default;

--- a/src/meta/GflagsManager.h
+++ b/src/meta/GflagsManager.h
@@ -29,27 +29,18 @@ public:
     virtual folly::Future<StatusOr<std::vector<cpp2::ConfigItem>>>
     listConfigs(const cpp2::ConfigModule& module) = 0;
 
-    virtual folly::Future<StatusOr<bool>> registerConfig(const cpp2::ConfigModule& module,
-                                                         const std::string& name,
-                                                         const cpp2::ConfigType& type,
-                                                         const cpp2::ConfigMode& mode,
-                                                         const std::string& defaultValue) = 0;
-
-    virtual Status init() = 0;
+    static std::vector<cpp2::ConfigItem> declareGflags(const cpp2::ConfigModule& module);
 
 protected:
     virtual ~GflagsManager() = default;
 
-    void declareGflags();
-
     template<typename ValueType>
-    std::string gflagsValueToThriftValue(const gflags::CommandLineFlagInfo& flag);
-
-    cpp2::ConfigModule                  module_{cpp2::ConfigModule::UNKNOWN};
-    std::vector<cpp2::ConfigItem>       gflagsDeclared_;
+    static std::string gflagsValueToThriftValue(const gflags::CommandLineFlagInfo& flag);
 };
 
 std::string toThriftValueStr(const cpp2::ConfigType& type, const VariantType& value);
+
+cpp2::ConfigMode toThriftConfigMode(const std::string& key);
 
 cpp2::ConfigItem toThriftConfigItem(const cpp2::ConfigModule& module, const std::string& name,
                                     const cpp2::ConfigType& type, const cpp2::ConfigMode& mode,

--- a/src/meta/KVBasedGflagsManager.cpp
+++ b/src/meta/KVBasedGflagsManager.cpp
@@ -22,9 +22,8 @@ KVBasedGflagsManager::~KVBasedGflagsManager() {
 
 Status KVBasedGflagsManager::init() {
     auto gflagsModule = cpp2::ConfigModule::UNKNOWN;
-    std::string gflagsJsonPath;
-    getGflagsModule(gflagsModule, gflagsJsonPath);
-    gflagsDeclared_ = declareGflags(gflagsModule, gflagsJsonPath);
+    getGflagsModule(gflagsModule);
+    gflagsDeclared_ = declareGflags(gflagsModule);
     return registerGflags(gflagsDeclared_);
 }
 

--- a/src/meta/KVBasedGflagsManager.h
+++ b/src/meta/KVBasedGflagsManager.h
@@ -37,10 +37,6 @@ public:
 private:
     Status registerGflags(const std::vector<cpp2::ConfigItem>& gflagsDeclared);
 
-    void getGflagsModule();
-
-    cpp2::ConfigModule module_{cpp2::ConfigModule::UNKNOWN};
-
     std::vector<cpp2::ConfigItem> gflagsDeclared_;
 
     kvstore::NebulaStore* kvstore_ = nullptr;

--- a/src/meta/KVBasedGflagsManager.h
+++ b/src/meta/KVBasedGflagsManager.h
@@ -32,18 +32,16 @@ public:
     folly::Future<StatusOr<std::vector<cpp2::ConfigItem>>>
     listConfigs(const cpp2::ConfigModule& module) override;
 
-    folly::Future<StatusOr<bool>> registerConfig(const cpp2::ConfigModule& module,
-                                                 const std::string& name,
-                                                 const cpp2::ConfigType& type,
-                                                 const cpp2::ConfigMode& mode,
-                                                 const std::string& defaultValue) override;
-
-    Status init() override;
+    Status init();
 
 private:
-    Status registerGflags();
+    Status registerGflags(const std::vector<cpp2::ConfigItem>& gflagsDeclared);
 
     void getGflagsModule();
+
+    cpp2::ConfigModule module_{cpp2::ConfigModule::UNKNOWN};
+
+    std::vector<cpp2::ConfigItem> gflagsDeclared_;
 
     kvstore::NebulaStore* kvstore_ = nullptr;
 };

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -1157,6 +1157,9 @@ MetaClient::regConfig(const std::vector<cpp2::ConfigItem>& items) {
 
 folly::Future<StatusOr<std::vector<cpp2::ConfigItem>>>
 MetaClient::getConfig(const cpp2::ConfigModule& module, const std::string& name) {
+    if (!configReady_) {
+        registerCfg();
+    }
     cpp2::ConfigItem item;
     item.set_module(module);
     item.set_name(name);
@@ -1175,6 +1178,9 @@ MetaClient::getConfig(const cpp2::ConfigModule& module, const std::string& name)
 folly::Future<StatusOr<bool>>
 MetaClient::setConfig(const cpp2::ConfigModule& module, const std::string& name,
                       const cpp2::ConfigType& type, const std::string& value) {
+    if (!configReady_) {
+        registerCfg();
+    }
     cpp2::ConfigItem item;
     item.set_module(module);
     item.set_name(name);
@@ -1196,6 +1202,9 @@ MetaClient::setConfig(const cpp2::ConfigModule& module, const std::string& name,
 
 folly::Future<StatusOr<std::vector<cpp2::ConfigItem>>>
 MetaClient::listConfigs(const cpp2::ConfigModule& module) {
+    if (!configReady_) {
+        registerCfg();
+    }
     cpp2::ListConfigsReq req;
     req.set_module(module);
     folly::Promise<StatusOr<std::vector<cpp2::ConfigItem>>> promise;
@@ -1227,8 +1236,8 @@ void MetaClient::setGflagsModule(const cpp2::ConfigModule& module) {
         } else {
             LOG(ERROR) << "Should not reach here";
         }
+        gflagsDeclared_ = GflagsManager::declareGflags(gflagsModule_);
     }
-    gflagsDeclared_ = GflagsManager::declareGflags(gflagsModule_);
 }
 
 void MetaClient::loadCfgThreadFunc() {
@@ -1236,15 +1245,18 @@ void MetaClient::loadCfgThreadFunc() {
     addLoadCfgTask();
 }
 
+bool MetaClient::registerCfg() {
+    auto ret = regConfig(gflagsDeclared_).get();
+    if (ret.ok()) {
+        LOG(INFO) << "Register gflags ok " << gflagsDeclared_.size();
+        configReady_ = true;
+    }
+    return configReady_;
+}
+
 void MetaClient::loadCfg() {
-    if (!configReady_) {
-        auto ret = regConfig(gflagsDeclared_).get();
-        if (ret.ok()) {
-            LOG(INFO) << "Register gflags ok " << gflagsDeclared_.size();
-            configReady_ = true;
-        } else {
-            LOG(INFO) << "Register gflags failed: " << ret.status();
-        }
+    if (!configReady_ && !registerCfg()) {
+        return;
     }
     // only load current module's config is enough
     auto ret = listConfigs(gflagsModule_).get();

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -1242,6 +1242,8 @@ void MetaClient::loadCfg() {
         if (ret.ok()) {
             LOG(INFO) << "Register gflags ok " << gflagsDeclared_.size();
             configReady_ = true;
+        } else {
+            LOG(INFO) << "Register gflags failed: " << ret.status();
         }
     }
     // only load current module's config is enough

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -1158,7 +1158,7 @@ MetaClient::regConfig(const std::vector<cpp2::ConfigItem>& items) {
 folly::Future<StatusOr<std::vector<cpp2::ConfigItem>>>
 MetaClient::getConfig(const cpp2::ConfigModule& module, const std::string& name) {
     if (!configReady_) {
-        registerCfg();
+        return Status::Error("Not ready!");
     }
     cpp2::ConfigItem item;
     item.set_module(module);
@@ -1179,7 +1179,7 @@ folly::Future<StatusOr<bool>>
 MetaClient::setConfig(const cpp2::ConfigModule& module, const std::string& name,
                       const cpp2::ConfigType& type, const std::string& value) {
     if (!configReady_) {
-        registerCfg();
+        return Status::Error("Not ready!");
     }
     cpp2::ConfigItem item;
     item.set_module(module);
@@ -1203,7 +1203,7 @@ MetaClient::setConfig(const cpp2::ConfigModule& module, const std::string& name,
 folly::Future<StatusOr<std::vector<cpp2::ConfigItem>>>
 MetaClient::listConfigs(const cpp2::ConfigModule& module) {
     if (!configReady_) {
-        registerCfg();
+        return Status::Error("Not ready!");
     }
     cpp2::ListConfigsReq req;
     req.set_module(module);

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -16,9 +16,7 @@ DEFINE_int32(heartbeat_interval_secs, 10, "Heartbeat interval");
 DEFINE_int32(meta_client_retry_times, 3, "meta client retry times, 0 means no retry");
 DEFINE_int32(meta_client_retry_interval_secs, 1, "meta client sleep interval between retry");
 DEFINE_string(cluster_id_path, "cluster.id", "file path saved clusterId");
-DECLARE_string(graphd_gflags_json);
-DECLARE_string(metad_gflags_json);
-DECLARE_string(storaged_gflags_json);
+DECLARE_string(gflags_mode_json);
 
 namespace nebula {
 namespace meta {
@@ -68,8 +66,8 @@ bool MetaClient::isMetadReady() {
 
 bool MetaClient::waitForMetadReady(int count, int retryIntervalSecs) {
     std::string gflagsJsonPath;
-    GflagsManager::getGflagsModule(gflagsModule_, gflagsJsonPath);
-    gflagsDeclared_ = GflagsManager::declareGflags(gflagsModule_, gflagsJsonPath);
+    GflagsManager::getGflagsModule(gflagsModule_);
+    gflagsDeclared_ = GflagsManager::declareGflags(gflagsModule_);
     isRunning_ = true;
     int tryCount = count;
     while (!isMetadReady() && ((count == -1) || (tryCount > 0)) && isRunning_) {

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -10,12 +10,14 @@
 #include "base/Base.h"
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <folly/RWSpinLock.h>
+#include <gtest/gtest_prod.h>
 #include "gen-cpp2/MetaServiceAsyncClient.h"
 #include "base/Status.h"
 #include "base/StatusOr.h"
 #include "thread/GenericWorker.h"
 #include "thrift/ThriftClientManager.h"
 #include "meta/SchemaProviderIf.h"
+#include "meta/GflagsManager.h"
 
 DECLARE_int32(meta_client_retry_times);
 
@@ -85,6 +87,9 @@ public:
 };
 
 class MetaClient {
+    FRIEND_TEST(ConfigManTest, MetaConfigManTest);
+    FRIEND_TEST(ConfigManTest, MockConfigTest);
+
 public:
     explicit MetaClient(std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool,
                         std::vector<HostAddr> addrs,
@@ -215,10 +220,6 @@ public:
 
     folly::Future<StatusOr<std::vector<cpp2::ConfigItem>>>
     listConfigs(const cpp2::ConfigModule& module);
-
-    cpp2::ConfigModule& getGflagsModule() {return gflagsModule_;}
-
-    void setGflagsModule(const cpp2::ConfigModule& module = cpp2::ConfigModule::UNKNOWN);
 
     // Opeartions for cache.
     StatusOr<GraphSpaceID> getSpaceIdByNameFromCache(const std::string& name);

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -263,6 +263,7 @@ protected:
 
     void loadCfgThreadFunc();
     void loadCfg();
+    bool registerCfg();
     void addLoadCfgTask();
     void updateGflagsValue(const ConfigItem& item);
 

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -349,6 +349,8 @@ private:
     MetaConfigMap         metaConfigMap_;
     folly::RWSpinLock     configCacheLock_;
     cpp2::ConfigModule    gflagsModule_{cpp2::ConfigModule::UNKNOWN};
+    std::atomic_bool      configReady_{false};
+    std::vector<cpp2::ConfigItem> gflagsDeclared_;
 };
 
 }  // namespace meta

--- a/src/meta/test/CMakeLists.txt
+++ b/src/meta/test/CMakeLists.txt
@@ -42,6 +42,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:schema_obj>
         $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
@@ -72,6 +73,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:network_obj>
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
@@ -103,6 +105,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:network_obj>
         $<TARGET_OBJECTS:schema_obj>
         $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
@@ -165,6 +168,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:raftex_obj>
         $<TARGET_OBJECTS:raftex_thrift_obj>
         $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
@@ -192,7 +196,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:ws_obj>
         $<TARGET_OBJECTS:ws_common_obj>
         $<TARGET_OBJECTS:hdfs_helper_obj>
-         $<TARGET_OBJECTS:http_client_obj>
+        $<TARGET_OBJECTS:http_client_obj>
         $<TARGET_OBJECTS:base_obj>
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:time_obj>
@@ -201,6 +205,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:process_obj>
         $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         proxygenhttpserver
         proxygenlib
@@ -240,6 +245,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:process_obj>
         $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         proxygenhttpserver
         proxygenlib
@@ -279,6 +285,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:process_obj>
         $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         proxygenhttpserver
         proxygenlib
@@ -309,6 +316,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
@@ -342,6 +350,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
@@ -373,6 +382,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
@@ -403,6 +413,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:network_obj>
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
@@ -431,6 +442,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:network_obj>
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}

--- a/src/meta/test/ConfigManTest.cpp
+++ b/src/meta/test/ConfigManTest.cpp
@@ -395,6 +395,7 @@ TEST(ConfigManTest, MockConfigTest) {
 
     auto consoleClient = std::make_shared<MetaClient>(threadPool,
         std::vector<HostAddr>{HostAddr(localIp, sc->port_)});
+    consoleClient->waitForMetadReady();
     ClientBasedGflagsManager console(consoleClient.get());
     // update in console
     for (int i = 0; i < 5; i++) {

--- a/src/meta/test/ConfigManTest.cpp
+++ b/src/meta/test/ConfigManTest.cpp
@@ -7,6 +7,7 @@
 #include "base/Base.h"
 #include <gtest/gtest.h>
 #include <folly/String.h>
+#include "base/Configuration.h"
 #include "fs/TempDir.h"
 #include "meta/test/TestUtils.h"
 #include "meta/GflagsManager.h"
@@ -221,27 +222,27 @@ TEST(ConfigManTest, MetaConfigManTest) {
     client->setGflagsModule(module);
 
     ClientBasedGflagsManager cfgMan(client.get());
-    cfgMan.module_ = module;
     // mock some test gflags to meta
     {
         auto mode = meta::cpp2::ConfigMode::MUTABLE;
-        cfgMan.gflagsDeclared_.emplace_back(toThriftConfigItem(
+        std::vector<cpp2::ConfigItem> configItems;
+        configItems.emplace_back(toThriftConfigItem(
             module, "int64_key_immutable", cpp2::ConfigType::INT64, cpp2::ConfigMode::IMMUTABLE,
             toThriftValueStr(cpp2::ConfigType::INT64, 100L)));
-        cfgMan.gflagsDeclared_.emplace_back(toThriftConfigItem(
+        configItems.emplace_back(toThriftConfigItem(
             module, "int64_key", cpp2::ConfigType::INT64,
             mode, toThriftValueStr(cpp2::ConfigType::INT64, 101L)));
-        cfgMan.gflagsDeclared_.emplace_back(toThriftConfigItem(
+        configItems.emplace_back(toThriftConfigItem(
             module, "bool_key", cpp2::ConfigType::BOOL,
             mode, toThriftValueStr(cpp2::ConfigType::BOOL, false)));
-        cfgMan.gflagsDeclared_.emplace_back(toThriftConfigItem(
+        configItems.emplace_back(toThriftConfigItem(
             module, "double_key", cpp2::ConfigType::DOUBLE,
             mode, toThriftValueStr(cpp2::ConfigType::DOUBLE, 1.23)));
         std::string defaultValue = "something";
-        cfgMan.gflagsDeclared_.emplace_back(toThriftConfigItem(
+        configItems.emplace_back(toThriftConfigItem(
             module, "string_key", cpp2::ConfigType::STRING,
             mode, toThriftValueStr(cpp2::ConfigType::STRING, defaultValue)));
-        cfgMan.registerGflags();
+        cfgMan.registerGflags(configItems);
     }
 
     // try to set/get config not registered
@@ -383,15 +384,14 @@ TEST(ConfigManTest, MockConfigTest) {
     client->waitForMetadReady();
     client->setGflagsModule(module);
     ClientBasedGflagsManager clientCfgMan(client.get());
-    clientCfgMan.module_ = module;
 
+    std::vector<cpp2::ConfigItem> configItems;
     for (int i = 0; i < 5; i++) {
         std::string name = "test" + std::to_string(i);
         std::string value = "v" + std::to_string(i);
-        clientCfgMan.gflagsDeclared_.emplace_back(
-                toThriftConfigItem(module, name, type, mode, value));
+        configItems.emplace_back(toThriftConfigItem(module, name, type, mode, value));
     }
-    clientCfgMan.registerGflags();
+    clientCfgMan.registerGflags(configItems);
 
     auto consoleClient = std::make_shared<MetaClient>(threadPool,
         std::vector<HostAddr>{HostAddr(localIp, sc->port_)});

--- a/src/meta/test/ConfigManTest.cpp
+++ b/src/meta/test/ConfigManTest.cpp
@@ -219,7 +219,7 @@ TEST(ConfigManTest, MetaConfigManTest) {
     auto client = std::make_shared<MetaClient>(threadPool,
         std::vector<HostAddr>{HostAddr(localIp, sc->port_)});
     client->waitForMetadReady();
-    client->setGflagsModule(module);
+    client->gflagsModule_ = module;
 
     ClientBasedGflagsManager cfgMan(client.get());
     // mock some test gflags to meta
@@ -382,7 +382,7 @@ TEST(ConfigManTest, MockConfigTest) {
     auto client = std::make_shared<MetaClient>(threadPool,
         std::vector<HostAddr>{HostAddr(localIp, sc->port_)});
     client->waitForMetadReady();
-    client->setGflagsModule(module);
+    client->gflagsModule_ = module;
     ClientBasedGflagsManager clientCfgMan(client.get());
 
     std::vector<cpp2::ConfigItem> configItems;

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -107,7 +107,6 @@ bool StorageServer::start() {
     }
 
     gFlagsMan_ = std::make_unique<meta::ClientBasedGflagsManager>(metaClient_.get());
-    gFlagsMan_->init();
 
     LOG(INFO) << "Init schema manager";
     schemaMan_ = meta::SchemaManager::create();

--- a/src/storage/test/CMakeLists.txt
+++ b/src/storage/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(storage_test_deps
     $<TARGET_OBJECTS:time_obj>
     $<TARGET_OBJECTS:fs_obj>
     $<TARGET_OBJECTS:network_obj>
+    $<TARGET_OBJECTS:gflags_man_obj>
 )
 
 
@@ -221,6 +222,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:network_obj>
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}

--- a/src/tools/storage-perf/CMakeLists.txt
+++ b/src/tools/storage-perf/CMakeLists.txt
@@ -23,6 +23,7 @@ nebula_add_executable(
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}


### PR DESCRIPTION
1. Let meta client retry to register configs to meta server.
2. Add `gflags.json` to avoid hard code config mode, and all default config mode is `IMMUTABLE`.
3. Add related command in complete.json

close #780