### PR TITLE
fsync upon closing WAL files

### DIFF
--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -279,6 +279,7 @@ void FileBasedWal::closeCurrFile() {
         return;
     }
 
+    CHECK_EQ(fsync(currFd_), 0);
     // Close the file
     CHECK_EQ(close(currFd_), 0);
     currFd_ = -1;


### PR DESCRIPTION
Or there will be possible data loss / corruption depending on the exact way how data is interpreted and handled. `close` doesn't mean automatic `fsync`.