### PR TITLE
Fix crash problem when create space in multiple replica meta env

### DIFF
--- a/src/meta/processors/BaseProcessor.h
+++ b/src/meta/processors/BaseProcessor.h
@@ -172,7 +172,7 @@ protected:
     /**
      * Get one auto-increment Id.
      * */
-    int32_t autoIncrementId();
+    ErrorOr<cpp2::ErrorCode, int32_t> autoIncrementId();
 
     /**
      * Check spaceId exist or not.

--- a/src/meta/processors/BaseProcessor.inl
+++ b/src/meta/processors/BaseProcessor.inl
@@ -139,14 +139,16 @@ StatusOr<std::vector<nebula::cpp2::HostAddr>> BaseProcessor<RESP>::allHosts() {
 
 
 template<typename RESP>
-int32_t BaseProcessor<RESP>::autoIncrementId() {
+ErrorOr<cpp2::ErrorCode, int32_t> BaseProcessor<RESP>::autoIncrementId() {
     folly::SharedMutex::WriteHolder holder(LockUtils::idLock());
     static const std::string kIdKey = "__id__";
     int32_t id;
     std::string val;
     auto ret = kvstore_->get(kDefaultSpaceId, kDefaultPartId, kIdKey, &val);
     if (ret != kvstore::ResultCode::SUCCEEDED) {
-        CHECK_EQ(kvstore::ResultCode::ERR_KEY_NOT_FOUND, ret);
+        if (ret != kvstore::ResultCode::ERR_KEY_NOT_FOUND) {
+            return to(ret);
+        }
         id = 1;
     } else {
         id = *reinterpret_cast<const int32_t*>(val.c_str()) + 1;
@@ -155,13 +157,20 @@ int32_t BaseProcessor<RESP>::autoIncrementId() {
     std::vector<kvstore::KV> data;
     data.emplace_back(kIdKey,
                       std::string(reinterpret_cast<const char*>(&id), sizeof(id)));
+    folly::Baton<true, std::atomic> baton;
     kvstore_->asyncMultiPut(kDefaultSpaceId,
                             kDefaultPartId,
                             std::move(data),
-                            [] (kvstore::ResultCode code) {
-        CHECK_EQ(code, kvstore::ResultCode::SUCCEEDED);
+                            [&] (kvstore::ResultCode code) {
+        ret = code;
+        baton.post();
     });
-    return id;
+    baton.wait();
+    if (ret != kvstore::ResultCode::SUCCEEDED) {
+        return to(ret);
+    } else {
+        return id;
+    }
 }
 
 

--- a/src/meta/processors/partsMan/CreateSpaceProcessor.cpp
+++ b/src/meta/processors/partsMan/CreateSpaceProcessor.cpp
@@ -34,7 +34,14 @@ void CreateSpaceProcessor::process(const cpp2::CreateSpaceReq& req) {
         return;
     }
 
-    auto spaceId = autoIncrementId();
+    auto idRet = autoIncrementId();
+    if (!nebula::ok(idRet)) {
+        LOG(ERROR) << "Create Space Failed : Get space id failed";
+        resp_.set_code(nebula::error(idRet));
+        onFinished();
+        return;
+    }
+    auto spaceId = nebula::value(idRet);
     auto spaceName = properties.get_space_name();
     auto partitionNum = properties.get_partition_num();
     auto replicaFactor = properties.get_replica_factor();

--- a/src/meta/processors/schemaMan/CreateEdgeProcessor.cpp
+++ b/src/meta/processors/schemaMan/CreateEdgeProcessor.cpp
@@ -35,8 +35,15 @@ void CreateEdgeProcessor::process(const cpp2::CreateEdgeReq& req) {
         return;
     }
 
+    auto edgeTypeRet = autoIncrementId();
+    if (!nebula::ok(edgeTypeRet)) {
+        LOG(ERROR) << "Create edge failed : Get edge type id failed";
+        resp_.set_code(nebula::error(edgeTypeRet));
+        onFinished();
+        return;
+    }
+    auto edgeType = nebula::value(edgeTypeRet);
     std::vector<kvstore::KV> data;
-    EdgeType edgeType = autoIncrementId();
     data.emplace_back(MetaServiceUtils::indexEdgeKey(req.get_space_id(), req.get_edge_name()),
                       std::string(reinterpret_cast<const char*>(&edgeType), sizeof(edgeType)));
     data.emplace_back(MetaServiceUtils::schemaEdgeKey(req.get_space_id(), edgeType, 0),

--- a/src/meta/processors/schemaMan/CreateTagProcessor.cpp
+++ b/src/meta/processors/schemaMan/CreateTagProcessor.cpp
@@ -36,7 +36,14 @@ void CreateTagProcessor::process(const cpp2::CreateTagReq& req) {
         return;
     }
 
-    TagID tagId = autoIncrementId();
+    auto tagRet = autoIncrementId();
+    if (!nebula::ok(tagRet)) {
+        LOG(ERROR) << "Create tag failed : Get tag id failed";
+        resp_.set_code(nebula::error(tagRet));
+        onFinished();
+        return;
+    }
+    auto tagId = nebula::value(tagRet);
     std::vector<kvstore::KV> data;
     data.emplace_back(MetaServiceUtils::indexTagKey(req.get_space_id(), req.get_tag_name()),
                       std::string(reinterpret_cast<const char*>(&tagId), sizeof(tagId)));

--- a/src/meta/processors/usersMan/AuthenticationProcessor.cpp
+++ b/src/meta/processors/usersMan/AuthenticationProcessor.cpp
@@ -25,7 +25,14 @@ void CreateUserProcessor::process(const cpp2::CreateUserReq& req) {
         return;
     }
 
-    UserID userId = autoIncrementId();
+    auto userRet = autoIncrementId();
+    if (!nebula::ok(userRet)) {
+        LOG(ERROR) << "Create User Failed : Get user id failed";
+        resp_.set_code(nebula::error(userRet));
+        onFinished();
+        return;
+    }
+    auto userId = nebula::value(userRet);
     std::vector<kvstore::KV> data;
     data.emplace_back(MetaServiceUtils::indexUserKey(user.get_account()),
                       std::string(reinterpret_cast<const char*>(&userId), sizeof(userId)));


### PR DESCRIPTION
For now, since we support multiple replica of meta server, we may fail when write into kvstore with error code `E_LEADER_CHANGED`. Instead of crash, we check and return corresponding error code.

close #817 