### PR TITLE
Issue #796 export the statistics of RocksDB.

### DIFF
--- a/src/graph/ShowExecutor.h
+++ b/src/graph/ShowExecutor.h
@@ -31,6 +31,7 @@ public:
     void showCreateSpace();
     void showCreateTag();
     void showCreateEdge();
+    void showEngineStatus();
 
     void setupResponse(cpp2::ExecutionResponse &resp) override;
 

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -169,6 +169,19 @@ struct AdminExecResp {
     2: common.HostAddr  leader,
 }
 
+
+struct StatisticsData {
+     1: common.GraphSpaceID  space_id,
+     2: string               path,
+     3: string               status,
+}
+
+struct StatisticsResp {
+    1: required ResponseCommon result,
+    2: common.HostAddr         host,
+    3: list<StatisticsData>    data,
+}
+
 struct AddPartReq {
     1: common.GraphSpaceID space_id,
     2: common.PartitionID  part_id,
@@ -203,7 +216,6 @@ struct CatchUpDataReq {
     3: common.HostAddr     target,
 }
 
-
 service StorageService {
     QueryResponse getOutBound(1: GetNeighborsRequest req)
     QueryResponse getInBound(1: GetNeighborsRequest req)
@@ -225,5 +237,7 @@ service StorageService {
     AdminExecResp waitingForCatchUpData(1: CatchUpDataReq req);
     AdminExecResp removePart(1: RemovePartReq req);
     AdminExecResp memberChange(1: MemberChangeReq req);
-}
 
+    //storage status
+    StatisticsResp statistics(1: common.HostAddr h);
+}

--- a/src/kvstore/KVEngine.h
+++ b/src/kvstore/KVEngine.h
@@ -107,6 +107,8 @@ public:
 
     virtual ResultCode flush() = 0;
 
+    virtual std::string statistics() = 0;
+
 protected:
     GraphSpaceID spaceId_;
 };
@@ -114,4 +116,3 @@ protected:
 }  // namespace kvstore
 }  // namespace nebula
 #endif  // KVSTORE_KVENGINE_H_
-

--- a/src/kvstore/KVStore.h
+++ b/src/kvstore/KVStore.h
@@ -145,6 +145,8 @@ public:
 
     virtual ResultCode flush(GraphSpaceID spaceId) = 0;
 
+    virtual std::vector<std::tuple<GraphSpaceID, std::string, std::string>> statistics() = 0;
+
 protected:
     KVStore() = default;
 };
@@ -152,4 +154,3 @@ protected:
 }  // namespace kvstore
 }  // namespace nebula
 #endif  // KVSTORE_KVSTORE_H_
-

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -536,6 +536,16 @@ ErrorOr<ResultCode, std::shared_ptr<SpacePartInfo>> NebulaStore::space(GraphSpac
     return it->second;
 }
 
+std::vector<std::tuple<GraphSpaceID, std::string, std::string>> NebulaStore::statistics() {
+    std::vector<std::tuple<GraphSpaceID, std::string, std::string>> v;
+    v.reserve(spaces_.size());
+    for (auto& space : spaces_) {
+        for (auto& p : space.second->engines_) {
+            v.emplace_back(space.first, p->getDataRoot(), p->statistics());
+        }
+    }
+    return v;
+}
+
 }  // namespace kvstore
 }  // namespace nebula
-

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -158,6 +158,8 @@ public:
 
     bool isLeader(GraphSpaceID spaceId, PartitionID partId);
 
+    std::vector<std::tuple<GraphSpaceID, std::string, std::string>> statistics() override;
+
 private:
     /**
      * Implement four interfaces in Handler.
@@ -199,4 +201,3 @@ private:
 }  // namespace kvstore
 }  // namespace nebula
 #endif  // KVSTORE_NEBULASTORE_H_
-

--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -107,6 +107,8 @@ RocksEngine::RocksEngine(GraphSpaceID spaceId,
 
     rocksdb::Options options;
     rocksdb::DB* db = nullptr;
+    stats_ = rocksdb::CreateDBStatistics();
+    options.statistics = stats_;
     rocksdb::Status status = initRocksdbOptions(options);
     CHECK(status.ok());
     if (mergeOp != nullptr) {
@@ -423,6 +425,8 @@ ResultCode RocksEngine::flush() {
         return ResultCode::ERR_UNKNOWN;
     }
 }
+
+std::string RocksEngine::statistics() { return stats_->ToString(); }
 
 }  // namespace kvstore
 }  // namespace nebula

--- a/src/kvstore/RocksEngine.h
+++ b/src/kvstore/RocksEngine.h
@@ -165,11 +165,14 @@ public:
 
     ResultCode flush() override;
 
+    std::string statistics() override;
+
 private:
     std::string partKey(PartitionID partId);
 
 private:
     std::string  dataPath_;
+    std::shared_ptr<rocksdb::Statistics> stats_{nullptr};
     std::unique_ptr<rocksdb::DB> db_{nullptr};
     int32_t partsNum_ = -1;
 };
@@ -177,4 +180,3 @@ private:
 }  // namespace kvstore
 }  // namespace nebula
 #endif  // KVSTORE_ROCKSENGINE_H_
-

--- a/src/kvstore/RocksEngineConfig.h
+++ b/src/kvstore/RocksEngineConfig.h
@@ -35,6 +35,8 @@ DECLARE_int32(rocksdb_batch_size);
 
 DECLARE_string(part_man_type);
 
+DECLARE_int32(rocksdb_stats_level);
+DECLARE_int32(rocksdb_stats_dump_period_sec);
 
 namespace nebula {
 namespace kvstore {
@@ -44,4 +46,3 @@ rocksdb::Status initRocksdbOptions(rocksdb::Options &baseOpts);
 }  // namespace kvstore
 }  // namespace nebula
 #endif  // KVSTORE_ROCKSENGINECONFIG_H_
-

--- a/src/kvstore/plugins/hbase/HBaseStore.h
+++ b/src/kvstore/plugins/hbase/HBaseStore.h
@@ -141,6 +141,11 @@ public:
         return ResultCode::ERR_UNSUPPORTED;
     }
 
+    std::vector<std::tuple<GraphSpaceID, std::string, std::string>> statistics() override {
+        std::vector<std::tuple<GraphSpaceID, std::string, std::string>> v;
+        return v;
+    }
+
 private:
     std::string getRowKey(const std::string& key) {
         return key.substr(sizeof(PartitionID), key.size() - sizeof(PartitionID));
@@ -183,4 +188,3 @@ private:
 }  // namespace kvstore
 }  // namespace nebula
 #endif  // KVSTORE_PLUGINS_HBASE_HBASESTORE_H_
-

--- a/src/kvstore/test/RocksEngineConfigTest.cpp
+++ b/src/kvstore/test/RocksEngineConfigTest.cpp
@@ -84,6 +84,19 @@ TEST(RocksEngineConfigTest, createOptionsTest) {
     FLAGS_rocksdb_db_options = "";
 }
 
+TEST(RocksEngineConfigTest, statisticsOptionsTest) {
+    rocksdb::Options options;
+
+    FLAGS_rocksdb_stats_level = 2;
+    FLAGS_rocksdb_stats_dump_period_sec = 100;
+    auto s = initRocksdbOptions(options);
+    ASSERT_EQ(true, s.ok());
+
+
+    // Clean up
+    FLAGS_rocksdb_db_options = "";
+}
+
 }  // namespace kvstore
 }  // namespace nebula
 

--- a/src/kvstore/test/RocksEngineTest.cpp
+++ b/src/kvstore/test/RocksEngineTest.cpp
@@ -198,6 +198,22 @@ TEST(RocksEngineTest, CompactTest) {
     EXPECT_EQ(ResultCode::SUCCEEDED, engine->compact());
 }
 
+TEST(RocksEngineTest, StatisticTest) {
+    fs::TempDir rootPath("/tmp/rocksdb_engine_CompactTest.XXXXXX");
+    auto engine = std::make_unique<RocksEngine>(0, rootPath.path());
+    std::vector<KV> data;
+    for (int32_t i = 2; i < 100;  i++) {
+        data.emplace_back(folly::stringPrintf("key_%d", i),
+                          folly::stringPrintf("value_%d", i));
+    }
+    EXPECT_EQ(ResultCode::SUCCEEDED, engine->multiPut(std::move(data)));
+    auto s = engine->statistics();
+
+    std::regex regex("(.*) : (.*)", std::regex::extended);
+    std::smatch m;
+    EXPECT_EQ(std::regex_search(s, m, regex), true);
+}
+
 }  // namespace kvstore
 }  // namespace nebula
 
@@ -209,4 +225,3 @@ int main(int argc, char** argv) {
 
     return RUN_ALL_TESTS();
 }
-

--- a/src/parser/AdminSentences.cpp
+++ b/src/parser/AdminSentences.cpp
@@ -30,6 +30,8 @@ std::string ShowSentence::toString() const {
             return folly::stringPrintf("SHOW CREATE TAG %s", name_.get()->c_str());
         case ShowType::kShowCreateEdge:
             return folly::stringPrintf("SHOW CREATE EDGE %s", name_.get()->c_str());
+        case ShowType::kShowEngineStatus:
+            return folly::stringPrintf("SHOW ENGINE STATUS");
         case ShowType::kUnknown:
         default:
             FLOG_FATAL("Type illegal");

--- a/src/parser/AdminSentences.h
+++ b/src/parser/AdminSentences.h
@@ -29,7 +29,8 @@ public:
         kShowRoles,
         kShowCreateSpace,
         kShowCreateTag,
-        kShowCreateEdge
+        kShowCreateEdge,
+        kShowEngineStatus
     };
 
     explicit ShowSentence(ShowType sType) {

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -104,6 +104,7 @@ class GraphScanner;
 %token KW_ORDER KW_ASC
 %token KW_FETCH KW_PROP
 %token KW_DISTINCT KW_ALL
+%token KW_ENGINE KW_STATUS
 /* symbols */
 %token L_PAREN R_PAREN L_BRACKET R_BRACKET L_BRACE R_BRACE COMMA
 %token PIPE OR AND LT LE GT GE EQ NE PLUS MINUS MUL DIV MOD NOT NEG ASSIGN
@@ -1227,6 +1228,9 @@ show_sentence
     }
     | KW_SHOW KW_CREATE KW_EDGE name_label {
         $$ = new ShowSentence(ShowSentence::ShowType::kShowCreateEdge, $4);
+    }
+    | KW_SHOW KW_ENGINE KW_STATUS {
+        $$ = new ShowSentence(ShowSentence::ShowType::kShowEngineStatus);
     }
     ;
 

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -113,6 +113,8 @@ STORAGE                     ([Ss][Tt][Oo][Rr][Aa][Gg][Ee])
 FETCH                       ([Ff][Ee][Tt][Cc][Hh])
 PROP                        ([Pp][Rr][Oo][Pp])
 ALL                         ([Aa][Ll][Ll])
+ENGINE                      ([Ee][Nn][Gg][Ii][Nn][Ee])
+STATUS                      ([Ss][Tt][Aa][Tt][Uu][Ss])
 
 LABEL                       ([a-zA-Z][_a-zA-Z0-9]*)
 DEC                         ([0-9])
@@ -215,6 +217,8 @@ IP_OCTET                    ([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])
 {FETCH}                     { return TokenType::KW_FETCH; }
 {PROP}                      { return TokenType::KW_PROP; }
 {ALL}                       { return TokenType::KW_ALL; }
+{ENGINE}                    { return TokenType::KW_ENGINE; }
+{STATUS}                    { return TokenType::KW_STATUS; }
 
 "."                         { return TokenType::DOT; }
 ","                         { return TokenType::COMMA; }

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -789,6 +789,12 @@ TEST(Parser, AdminOperation) {
         auto result = parser.parse(query);
         ASSERT_TRUE(result.ok()) << result.status();
     }
+    {
+        GQLParser parser;
+        std::string query = "SHOW ENGINE STATUS";
+        auto result = parser.parse(query);
+        ASSERT_TRUE(result.ok()) << result.status();
+    }
 }
 
 TEST(Parser, UserOperation) {

--- a/src/storage/StorageServiceHandler.cpp
+++ b/src/storage/StorageServiceHandler.cpp
@@ -114,6 +114,13 @@ StorageServiceHandler::future_memberChange(const cpp2::MemberChangeReq& req) {
     RETURN_FUTURE(processor);
 }
 
+folly::Future<cpp2::StatisticsResp> StorageServiceHandler::future_statistics(
+    const nebula::cpp2::HostAddr &h) {
+    auto* processor = StatisticsProcessor::instance(kvstore_);
+    auto f = processor->getFuture();
+    processor->process(h);
+    return f;
+}
+
 }  // namespace storage
 }  // namespace nebula
-

--- a/src/storage/StorageServiceHandler.h
+++ b/src/storage/StorageServiceHandler.h
@@ -68,6 +68,8 @@ public:
     folly::Future<cpp2::AdminExecResp>
     future_memberChange(const cpp2::MemberChangeReq& req) override;
 
+    folly::Future<cpp2::StatisticsResp> future_statistics(const nebula::cpp2::HostAddr& h) override;
+
 private:
     kvstore::KVStore* kvstore_ = nullptr;
     meta::SchemaManager* schemaMan_;

--- a/src/storage/client/StorageClient.cpp
+++ b/src/storage/client/StorageClient.cpp
@@ -234,6 +234,16 @@ folly::SemiFuture<StorageRpcResponse<cpp2::EdgePropResponse>> StorageClient::get
         });
 }
 
+folly::SemiFuture<StorageRpcResponse<storage::cpp2::StatisticsResp>> StorageClient::getStatistics(
+    const std::vector<HostAddr> hosts, folly::EventBase* evb) {
+    return collectStatusResponse(evb, hosts,
+                           [](cpp2::StorageServiceAsyncClient* client, const HostAddr& h) {
+                               nebula::cpp2::HostAddr host;
+                               host.set_ip(h.first);
+                               host.set_port(h.second);
+                               return client->future_statistics(host);
+                           });
+}
 
 PartitionID StorageClient::partId(GraphSpaceID spaceId, int64_t id) const {
     auto parts = partsNum(spaceId);

--- a/src/storage/client/StorageClient.h
+++ b/src/storage/client/StorageClient.h
@@ -127,6 +127,9 @@ public:
         std::vector<storage::cpp2::PropDef> returnCols,
         folly::EventBase* evb = nullptr);
 
+    folly::SemiFuture<StorageRpcResponse<storage::cpp2::StatisticsResp>> getStatistics(
+        const std::vector<HostAddr> hosts, folly::EventBase* evb = nullptr);
+
 protected:
     // Calculate the partition id for the given vertex id
     PartitionID partId(GraphSpaceID spaceId, int64_t id) const;
@@ -169,6 +172,11 @@ protected:
         std::unordered_map<HostAddr, Request> requests,
         RemoteFunc&& remoteFunc);
 
+    template <class RemoteFunc,
+              class Response = typename std::result_of<RemoteFunc(
+                  storage::cpp2::StorageServiceAsyncClient*, const HostAddr&)>::type::value_type>
+    folly::SemiFuture<StorageRpcResponse<Response>> collectStatusResponse(
+        folly::EventBase* evb, std::vector<HostAddr> hosts, RemoteFunc&& remoteFunc);
     // Cluster given ids into the host they belong to
     // The method returns a map
     //  host_addr (A host, but in most case, the leader will be chosen)
@@ -220,4 +228,3 @@ private:
 #include "storage/client/StorageClient.inl"
 
 #endif  // STORAGE_CLIENT_STORAGECLIENT_H_
-


### PR DESCRIPTION
Summary:

1. Provide new syntax to export the statistics for all storage nodes.
     show engine status;
2. It will output five columns(Ip, Port, SpaceId, Path, EngineStatus).
3. Added two configuration options(rocksdb_stats_level and rocksdb_stats_dump_period_sec).