### PR TITLE
Cleanup load config interval secs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,16 @@
 *.swp
 *.so
+*.DS_Store
 
 build
 _build
 _build.log
 _install
 install_manifest.txt
+
+# ccls
+.ccls
+compile_commands.json
 
 src/common/base/Base.h.gch
 gen-*

--- a/docs/deploy-cluster.md
+++ b/docs/deploy-cluster.md
@@ -20,7 +20,7 @@ For `Ubuntu` :
 dpkg -i nebula-{VERSION}.{SYSTEM_VERSION}.amd64.deb
 ```
 
-By default, the config files are under `/usr/local/nebula/etc`, you should modify the `meta_server_addrs` to set the Meta Server's address. 
+By default, the config files are under `/usr/local/nebula/etc`, you should modify the `meta_server_addrs` to set the Meta Server's address.
 
 In order to enable multi copy Meta service, you should set the meta addresses split by comma into `meta_server_addrs`.
 
@@ -63,7 +63,7 @@ Property Name               | Default Value            | Description
 `daemonize`                 | true                     | Whether run as a daemon process.
 `cluster_id`                | 0                        | A unique id for each cluster.
 `putTryNum`                 | 10                       | Number of attempts to generate cluster ID.
-`load_config_interval_secs` | 2 * 60                   | Load config interval.
+`load_data_interval_secs`   | 2 * 60                   | Load data interval.
 `meta_ingest_thread_num`    | 3.                       | Meta daemon's ingest thread number.
 
 **Storage Service** supports the following config properties.
@@ -145,5 +145,3 @@ Property Name            | Default Value | Description
 `p`                      | ""            | Password used to authenticate.
 `enable_history`         | false         | Whether to force saving the command history.
 `server_conn_timeout_ms` | 1000          | Connection timeout in milliseconds.
-
-

--- a/docs/manual-CN/statement-syntax/data-administration-statements/configuration-statements/variables-syntax.md
+++ b/docs/manual-CN/statement-syntax/data-administration-statements/configuration-statements/variables-syntax.md
@@ -28,23 +28,26 @@ GET VARIABLES [graph|meta|storage :] var
 
 例如
 ```
-nebula> GET VARIABLES storage:load_config_interval_secs
+nebula> GET VARIABLES storage:load_data_interval_secs
 =================================================================
 | module  | name                      | type  | mode    | value |
 =================================================================
-| STORAGE | load_config_interval_secs | INT64 | MUTABLE | 120   |
+| STORAGE | load_data_interval_secs   | INT64 | MUTABLE | 120   |
 -----------------------------------------------------------------
 ```
 
 ```
-nebula> GET VARIABLES load_config_interval_secs
-===================================================================
-| module  | name                      | type  | mode      | value |
-===================================================================
-| META    | load_config_interval_secs | INT64 | IMMUTABLE | 120   |
--------------------------------------------------------------------
-| STORAGE | load_config_interval_secs | INT64 | MUTABLE   | 1     |
--------------------------------------------------------------------
+nebula> GET VARIABLES load_data_interval_secs
+=================================================================
+| module  | name                    | type  | mode      | value |
+=================================================================
+| GRAPH   | load_data_interval_secs | INT64 | MUTABLE   | 120   |
+-----------------------------------------------------------------
+| META    | load_data_interval_secs | INT64 | IMMUTABLE | 120   |
+-----------------------------------------------------------------
+| STORAGE | load_data_interval_secs | INT64 | MUTABLE   | 120   |
+-----------------------------------------------------------------
+Got 3 rows (Time spent: 1449/2339 us)
 ```
 
 ### 更新变量
@@ -56,12 +59,13 @@ UPDATE VARIABLES [graph|meta|storage :] var = value
 
 例如
 ```
-nebula> UPDATE VARIABLES storage:load_config_interval_secs=1
+nebula> UPDATE VARIABLES storage:load_data_interval_secs=1
 Execution succeeded (Time spent: 1750/2484 us)
-nebula> GET VARIABLES storage:load_config_interval_secs
-=================================================================
-| module  | name                      | type  | mode    | value |
-=================================================================
-| STORAGE | load_config_interval_secs | INT64 | MUTABLE | 1     |
------------------------------------------------------------------
+nebula> GET VARIABLES storage:load_data_interval_secs
+===============================================================
+| module  | name                    | type  | mode    | value |
+===============================================================
+| STORAGE | load_data_interval_secs | INT64 | MUTABLE | 1     |
+---------------------------------------------------------------
+Got 1 rows (Time spent: 1678/3420 us)
 ```

--- a/docs/manual-EN/statement-syntax/data-administration-statements/configuration-statements/variables-syntax.md
+++ b/docs/manual-EN/statement-syntax/data-administration-statements/configuration-statements/variables-syntax.md
@@ -29,23 +29,26 @@ GET VARIABLES [graph|meta|storage :] var
 
 For example
 ```
-nebula> GET VARIABLES storage:load_config_interval_secs
+nebula> GET VARIABLES storage:load_data_interval_secs
 =================================================================
 | module  | name                      | type  | mode    | value |
 =================================================================
-| STORAGE | load_config_interval_secs | INT64 | MUTABLE | 120   |
+| STORAGE | load_data_interval_secs   | INT64 | MUTABLE | 120   |
 -----------------------------------------------------------------
 ```
 
 ```
-nebula> GET VARIABLES load_config_interval_secs
-===================================================================
-| module  | name                      | type  | mode      | value |
-=================================================================== 
-| META    | load_config_interval_secs | INT64 | IMMUTABLE | 120   |
--------------------------------------------------------------------
-| STORAGE | load_config_interval_secs | INT64 | MUTABLE   | 1     |
-------------------------------------------------------------------- 
+nebula> GET VARIABLES load_data_interval_secs
+=================================================================
+| module  | name                    | type  | mode      | value |
+=================================================================
+| GRAPH   | load_data_interval_secs | INT64 | MUTABLE   | 120   |
+-----------------------------------------------------------------
+| META    | load_data_interval_secs | INT64 | IMMUTABLE | 120   |
+-----------------------------------------------------------------
+| STORAGE | load_data_interval_secs | INT64 | MUTABLE   | 120   |
+-----------------------------------------------------------------
+Got 3 rows (Time spent: 1449/2339 us)
 ```
 
 ### Update variables
@@ -57,12 +60,13 @@ UPDATE VARIABLES [graph|meta|storage :] var = value
 
 For example
 ```
-nebula> UPDATE VARIABLES storage:load_config_interval_secs=1
+nebula> UPDATE VARIABLES storage:load_data_interval_secs=1
 Execution succeeded (Time spent: 1750/2484 us)
-nebula> GET VARIABLES storage:load_config_interval_secs
-=================================================================
-| module  | name                      | type  | mode    | value |
-=================================================================
-| STORAGE | load_config_interval_secs | INT64 | MUTABLE | 1     |
------------------------------------------------------------------
+nebula> GET VARIABLES storage:load_data_interval_secs
+===============================================================
+| module  | name                    | type  | mode    | value |
+===============================================================
+| STORAGE | load_data_interval_secs | INT64 | MUTABLE | 1     |
+---------------------------------------------------------------
+Got 1 rows (Time spent: 1678/3420 us)
 ```

--- a/src/graph/test/ConfigTest.cpp
+++ b/src/graph/test/ConfigTest.cpp
@@ -6,18 +6,17 @@
  */
 
 #include "base/Base.h"
-#include "graph/test/TestEnv.h"
 #include "graph/test/TestBase.h"
-#include "meta/test/TestUtils.h"
+#include "graph/test/TestEnv.h"
 #include "meta/ClientBasedGflagsManager.h"
+#include "meta/test/TestUtils.h"
 
 DECLARE_int32(load_data_interval_secs);
-DECLARE_int32(load_config_interval_secs);
 
 namespace nebula {
 namespace graph {
 
-class ConfigTest: public TestBase {
+class ConfigTest : public TestBase {
 protected:
     void SetUp() override {
         TestBase::SetUp();

--- a/src/meta/GflagsManager.cpp
+++ b/src/meta/GflagsManager.cpp
@@ -9,7 +9,7 @@
 namespace nebula {
 namespace meta {
 
-template<typename ValueType>
+template <typename ValueType>
 std::string GflagsManager::gflagsValueToThriftValue(const gflags::CommandLineFlagInfo& flag) {
     std::string ret;
     auto value = folly::to<ValueType>(flag.current_value);
@@ -17,7 +17,7 @@ std::string GflagsManager::gflagsValueToThriftValue(const gflags::CommandLineFla
     return ret;
 }
 
-template<>
+template <>
 std::string GflagsManager::gflagsValueToThriftValue<std::string>(
         const gflags::CommandLineFlagInfo& flag) {
     return flag.current_value;
@@ -57,7 +57,7 @@ void GflagsManager::declareGflags() {
             continue;
         }
 
-        if (name == "load_data_interval_secs" || name == "load_config_interval_secs") {
+        if (name == "load_data_interval_secs") {
             mode = cpp2::ConfigMode::MUTABLE;
         }
         if (module_ == cpp2::ConfigModule::META) {
@@ -109,6 +109,5 @@ cpp2::ConfigItem toThriftConfigItem(const cpp2::ConfigModule& module,
     return item;
 }
 
-}  // namespace meta
-}  // namespace nebula
-
+}   // namespace meta
+}   // namespace nebula

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -4,8 +4,8 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#include "base/Base.h"
 #include <gtest/gtest.h>
+#include "base/Base.h"
 #include "parser/GQLParser.h"
 
 // TODO(dutor) Inspect the internal structures to check on the syntax and semantics
@@ -884,7 +884,6 @@ TEST(Parser, UserOperation) {
     }
 }
 
-
 TEST(Parser, UnreservedKeywords) {
     {
         GQLParser parser;
@@ -921,7 +920,6 @@ TEST(Parser, UnreservedKeywords) {
         ASSERT_TRUE(result.ok()) << result.status();
     }
 }
-
 
 TEST(Parser, Annotation) {
     {
@@ -1136,13 +1134,13 @@ TEST(Parser, ConfigOperation) {
     }
     {
         GQLParser parser;
-        std::string query = "UPDATE VARIABLES load_config_interval_secs=120";
+        std::string query = "UPDATE VARIABLES load_data_interval_secs=120";
         auto result = parser.parse(query);
         ASSERT_TRUE(result.ok()) << result.status();
     }
     {
         GQLParser parser;
-        std::string query = "GET VARIABLES load_config_interval_secs";
+        std::string query = "GET VARIABLES load_data_interval_secs";
         auto result = parser.parse(query);
         ASSERT_TRUE(result.ok()) << result.status();
     }


### PR DESCRIPTION
- Fix variables syntax document. close #845 
- Replace `load_config_interval_secs` with `load_data_interval_secs` in Test
- Cleanup gflags declaration about `load_config_interval_secs`
- Ignore [ccls](https://github.com/MaskRay/ccls) configuration files