### PR TITLE
Use smart pointer make function to construct objects

### DIFF
--- a/src/kvstore/CompactionFilter.h
+++ b/src/kvstore/CompactionFilter.h
@@ -62,15 +62,13 @@ public:
         if (context.is_full_compaction) {
             LOG(INFO) << "Do full compaction!";
             lastRunCustomFilterTimeSec_ = now;
-            return std::unique_ptr<rocksdb::CompactionFilter>(
-                            new KVCompactionFilter(spaceId_, createKVFilter()));
+            return std::make_unique<KVCompactionFilter>(spaceId_, createKVFilter());
         } else {
             if (customFilterIntervalSecs_ >= 0
                     && now - lastRunCustomFilterTimeSec_ > customFilterIntervalSecs_) {
                 LOG(INFO) << "Do custom minor compaction!";
                 lastRunCustomFilterTimeSec_ = now;
-                return std::unique_ptr<rocksdb::CompactionFilter>(
-                            new KVCompactionFilter(spaceId_, createKVFilter()));
+                return std::make_unique<KVCompactionFilter>(spaceId_, createKVFilter());
             }
             LOG(INFO) << "Do default minor compaction!";
             return std::unique_ptr<rocksdb::CompactionFilter>(nullptr);
@@ -91,8 +89,6 @@ private:
     int32_t lastRunCustomFilterTimeSec_ = 0;
 };
 
-
-}  // namespace kvstore
-}  // namespace nebula
-#endif  // KVSTORE_COMPACTIONFILTER_H_
-
+}   // namespace kvstore
+}   // namespace nebula
+#endif   // KVSTORE_COMPACTIONFILTER_H_

--- a/src/kvstore/plugins/hbase/test/TestUtils.h
+++ b/src/kvstore/plugins/hbase/test/TestUtils.h
@@ -49,8 +49,7 @@ private:
             column.type.type = nebula::cpp2::SupportedType::STRING;
             schema.columns.emplace_back(std::move(column));
         }
-        return std::shared_ptr<meta::SchemaProviderIf>(
-            new ResultSchemaProvider(std::move(schema)));
+        return std::make_shared<ResultSchemaProvider>(std::move(schema));
     }
 
 
@@ -72,11 +71,9 @@ private:
             column.type.type = nebula::cpp2::SupportedType::STRING;
             schema.columns.emplace_back(std::move(column));
         }
-        return std::shared_ptr<meta::SchemaProviderIf>(
-            new ResultSchemaProvider(std::move(schema)));
+        return std::make_shared<ResultSchemaProvider>(std::move(schema));
     }
 };
 
 }  // namespace kvstore
 }  // namespace nebula
-

--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -485,10 +485,7 @@ bool FileBasedWal::appendLogs(LogIterator& iter) {
 
 std::unique_ptr<LogIterator> FileBasedWal::iterator(LogID firstLogId,
                                                     LogID lastLogId) {
-    return std::unique_ptr<LogIterator>(
-        new FileBasedWalIterator(shared_from_this(),
-                                 firstLogId,
-                                 lastLogId));
+    return std::make_unique<FileBasedWalIterator>(shared_from_this(), firstLogId, lastLogId);
 }
 
 
@@ -645,4 +642,3 @@ size_t FileBasedWal::accessAllBuffers(std::function<bool(BufferPtr buffer)> fn) 
 
 }  // namespace wal
 }  // namespace nebula
-

--- a/src/meta/SchemaManager.cpp
+++ b/src/meta/SchemaManager.cpp
@@ -12,10 +12,8 @@ namespace nebula {
 namespace meta {
 
 std::unique_ptr<SchemaManager> SchemaManager::create() {
-    auto sm = std::unique_ptr<SchemaManager>(new ServerBasedSchemaManager());
-    return sm;
+    return std::make_unique<ServerBasedSchemaManager>();
 }
 
-}  // namespace meta
-}  // namespace nebula
-
+}   // namespace meta
+}   // namespace nebula

--- a/src/storage/CompactionFilter.h
+++ b/src/storage/CompactionFilter.h
@@ -100,14 +100,13 @@ public:
         : schemaMan_(schemaMan) {}
 
     std::unique_ptr<kvstore::KVFilter> createKVFilter() override {
-        return std::unique_ptr<kvstore::KVFilter>(new NebulaCompactionFilter(schemaMan_));
+        return std::make_unique<NebulaCompactionFilter>(schemaMan_);
     }
 
 private:
     meta::SchemaManager* schemaMan_ = nullptr;
 };
 
-}  // namespace storage
-}  // namespace nebula
-#endif  // STORAGE_COMPACTIONFILTER_H_
-
+}   // namespace storage
+}   // namespace nebula
+#endif   // STORAGE_COMPACTIONFILTER_H_

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -37,8 +37,7 @@ std::unique_ptr<kvstore::KVStore> StorageServer::getStoreInstance() {
     options.partMan_ = std::make_unique<kvstore::MetaServerBasedPartManager>(
                                                 localHost_,
                                                 metaClient_.get());
-    options.cfFactory_ = std::shared_ptr<kvstore::KVCompactionFilterFactory>(
-                                new storage::NebulaCompactionFilterFactory(schemaMan_.get()));
+    options.cfFactory_ = std::make_shared<NebulaCompactionFilterFactory>(schemaMan_.get());
     if (FLAGS_store_type == "nebula") {
         auto nbStore = std::make_unique<kvstore::NebulaStore>(std::move(options),
                                                               ioThreadPool_,
@@ -166,6 +165,5 @@ void StorageServer::stop() {
     }
 }
 
-}  // namespace storage
-}  // namespace nebula
-
+}   // namespace storage
+}   // namespace nebula

--- a/src/storage/test/TestUtils.h
+++ b/src/storage/test/TestUtils.h
@@ -133,8 +133,7 @@ public:
             column.type.type = nebula::cpp2::SupportedType::STRING;
             schema.columns.emplace_back(std::move(column));
         }
-        return std::shared_ptr<meta::SchemaProviderIf>(
-            new ResultSchemaProvider(std::move(schema)));
+        return std::make_shared<ResultSchemaProvider>(std::move(schema));
     }
 
 
@@ -158,8 +157,7 @@ public:
             column.type.type = nebula::cpp2::SupportedType::STRING;
             schema.columns.emplace_back(std::move(column));
         }
-        return std::shared_ptr<meta::SchemaProviderIf>(
-            new ResultSchemaProvider(std::move(schema)));
+        return std::make_shared<ResultSchemaProvider>(std::move(schema));
     }
 
 


### PR DESCRIPTION
Construct objects with smart pointer **make** function rather than `new` way.

references:
- [Quick Q: Differences between std::make_unique and std::unique_ptr with new](https://isocpp.org/blog/2019/06/quick-q-differences-between-stdmake-unique-and-stdunique-ptr-with-new)