### PR TITLE
Make balance works

### DIFF
--- a/src/common/base/Status.h
+++ b/src/common/base/Status.h
@@ -114,6 +114,7 @@ public:
     STATUS_GENERATOR(CfgErrorType);
     STATUS_GENERATOR(CfgImmutable);
     STATUS_GENERATOR(LeaderChanged);
+    STATUS_GENERATOR(Balanced);
 
 #undef STATUS_GENERATOR
 
@@ -147,6 +148,7 @@ public:
         kCfgErrorType           = 411,
         kCfgImmutable           = 412,
         kLeaderChanged          = 413,
+        kBalanced               = 414,
     };
 
     Code code() const {

--- a/src/graph/BalanceExecutor.cpp
+++ b/src/graph/BalanceExecutor.cpp
@@ -24,6 +24,12 @@ void BalanceExecutor::execute() {
         case BalanceSentence::SubType::kLeader:
             balanceLeader();
             break;
+        case BalanceSentence::SubType::kData:
+            balanceData();
+            break;
+        case BalanceSentence::SubType::kShowBalancePlan:
+            showBalancePlan();
+            break;
         case BalanceSentence::SubType::kUnknown:
             onError_(Status::Error("Type unknown"));
             break;
@@ -58,6 +64,106 @@ void BalanceExecutor::balanceLeader() {
     };
 
     std::move(future).via(runner).thenValue(cb).thenError(error);
+}
+
+void BalanceExecutor::balanceData() {
+    auto future = ectx()->getMetaClient()->balance();
+    auto *runner = ectx()->rctx()->runner();
+
+    auto cb = [this] (auto &&resp) {
+        if (!resp.ok()) {
+            DCHECK(onError_);
+            onError_(std::move(resp).status());
+            return;
+        }
+        auto balanceId = std::move(resp).value();
+        resp_ = std::make_unique<cpp2::ExecutionResponse>();
+        std::vector<std::string> header{"ID"};
+        resp_->set_column_names(std::move(header));
+
+        std::vector<cpp2::RowValue> rows;
+        std::vector<cpp2::ColumnValue> row;
+        row.resize(1);
+        row[0].set_integer(balanceId);
+        rows.emplace_back();
+
+        rows.back().set_columns(std::move(row));
+
+        resp_->set_rows(std::move(rows));
+
+        DCHECK(onFinish_);
+        onFinish_();
+    };
+
+    auto error = [this] (auto &&e) {
+        LOG(ERROR) << "Exception caught: " << e.what();
+        DCHECK(onError_);
+        onError_(Status::Error("Internal error"));
+        return;
+    };
+
+    std::move(future).via(runner).thenValue(cb).thenError(error);
+}
+
+void BalanceExecutor::showBalancePlan() {
+    auto id = sentence_->balanceId();
+    auto future = ectx()->getMetaClient()->showBalance(id);
+    auto *runner = ectx()->rctx()->runner();
+    auto cb = [this] (auto &&resp) {
+        if (!resp.ok()) {
+            DCHECK(onError_);
+            onError_(std::move(resp).status());
+            return;
+        }
+        auto tasks = std::move(resp).value();
+        resp_ = std::make_unique<cpp2::ExecutionResponse>();
+        std::vector<std::string> header{"balanceId, spaceId:partId, src->dst", "status"};
+        resp_->set_column_names(std::move(header));
+
+        std::vector<cpp2::RowValue> rows;
+        rows.reserve(tasks.size());
+        for (auto& task : tasks) {
+            std::vector<cpp2::ColumnValue> row;
+            row.resize(2);
+            row[0].set_str(std::move(task.get_id()));
+            switch (task.get_result()) {
+                case meta::cpp2::TaskResult::SUCCEEDED:
+                    row[1].set_str("succeeded");
+                    break;
+                case meta::cpp2::TaskResult::FAILED:
+                    row[1].set_str("failed");
+                    break;
+                case meta::cpp2::TaskResult::IN_PROGRESS:
+                    row[1].set_str("in progress");
+                    break;
+                case meta::cpp2::TaskResult::INVALID:
+                    row[1].set_str("invalid");
+                    break;
+            }
+            rows.emplace_back();
+            rows.back().set_columns(std::move(row));
+        }
+        resp_->set_rows(std::move(rows));
+        DCHECK(onFinish_);
+        onFinish_();
+    };
+
+    auto error = [this] (auto &&e) {
+        LOG(ERROR) << "Exception caught: " << e.what();
+        DCHECK(onError_);
+        onError_(Status::Error("Internal error"));
+        return;
+    };
+
+    std::move(future).via(runner).thenValue(cb).thenError(error);
+}
+
+void BalanceExecutor::setupResponse(cpp2::ExecutionResponse &resp) {
+    if (resp_) {
+        resp = std::move(*resp_);
+    } else {
+        Executor::setupResponse(resp);
+    }
 }
 
 }   // namespace graph

--- a/src/graph/BalanceExecutor.h
+++ b/src/graph/BalanceExecutor.h
@@ -27,6 +27,12 @@ public:
 
     void balanceLeader();
 
+    void balanceData();
+
+    void showBalancePlan();
+
+    void setupResponse(cpp2::ExecutionResponse &resp) override;
+
 private:
     BalanceSentence                          *sentence_{nullptr};
     std::unique_ptr<cpp2::ExecutionResponse>  resp_;

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -32,9 +32,10 @@ enum ErrorCode {
     E_CONFLICT         = -29,
     E_WRONGCLUSTER     = -30,
 
-    // KV Failure
     E_STORE_FAILURE          = -31,
     E_STORE_SEGMENT_ILLEGAL  = -32,
+    E_BAD_BALANCE_PLAN     = -33,
+    E_BALANCED             = -34,
 
     E_INVALID_PASSWORD       = -41,
     E_INPROPER_ROLE          = -42,
@@ -432,11 +433,25 @@ struct BalanceReq {
     2: optional i64 id,
 }
 
+enum TaskResult {
+    SUCCEEDED  = 0x00,
+    FAILED = 0x01,
+    IN_PROGRESS = 0x02,
+    INVALID = 0x03,
+} (cpp.enum_strict)
+
+
+struct BalanceTask {
+    1: string id,
+    2: TaskResult result,
+}
+
 struct BalanceResp {
     1: ErrorCode        code,
     2: i64              id,
     // Valid if code equals E_LEADER_CHANGED.
     3: common.HostAddr  leader,
+    4: list<BalanceTask> tasks,
 }
 
 struct LeaderBalanceReq {

--- a/src/interface/raftex.thrift
+++ b/src/interface/raftex.thrift
@@ -33,6 +33,8 @@ enum ErrorCode {
     E_TOO_MANY_REQUESTS = -15;
     E_PERSIST_SNAPSHOT_FAILED = -16;
 
+    E_BAD_ROLE = -17,
+
     E_EXCEPTION = -20;          // An thrift internal exception was thrown
 }
 

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -35,6 +35,8 @@ enum ErrorCode {
     E_INVALID_UPDATER = -32,
     E_INVALID_STORE = -33,
     E_INVALID_PEER  = -34,
+    // meta client failed
+    E_LOAD_META_FAILED = -41,
     E_UNKNOWN = -100,
 } (cpp.enum_strict)
 

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -23,6 +23,7 @@ enum ErrorCode {
     E_KEY_HAS_EXISTS = -12,
     E_SPACE_NOT_FOUND = -13,
     E_PART_NOT_FOUND = -14,
+    E_CONSENSUS_ERROR = -15,
 
     // meta failures
     E_EDGE_PROP_NOT_FOUND = -21,

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -32,6 +32,8 @@ enum ErrorCode {
     // Invalid request
     E_INVALID_FILTER = -31,
     E_INVALID_UPDATER = -32,
+    E_INVALID_STORE = -33,
+    E_INVALID_PEER  = -34,
     E_UNKNOWN = -100,
 } (cpp.enum_strict)
 
@@ -221,6 +223,9 @@ struct RemovePartReq {
 struct MemberChangeReq {
     1: common.GraphSpaceID space_id,
     2: common.PartitionID  part_id,
+    3: common.HostAddr     peer,
+    // true means add a peer, false means remove a peer.
+    4: bool                add,
 }
 
 struct TransLeaderReq {

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -35,6 +35,8 @@ enum ErrorCode {
     E_INVALID_UPDATER = -32,
     E_INVALID_STORE = -33,
     E_INVALID_PEER  = -34,
+    E_RETRY_EXHAUSTED = -35,
+
     // meta client failed
     E_LOAD_META_FAILED = -41,
     E_UNKNOWN = -100,

--- a/src/kvstore/LogEncoder.cpp
+++ b/src/kvstore/LogEncoder.cpp
@@ -164,59 +164,29 @@ std::vector<folly::StringPiece> decodeMultiValues(folly::StringPiece encoded) {
     return values;
 }
 
-std::string encodeLearner(const HostAddr& learner) {
+std::string encodeHost(LogType type, const HostAddr& host) {
     std::string encoded;
-    encoded.reserve(kHeadLen + sizeof(HostAddr));
+    encoded.reserve(sizeof(int64_t) + 1 + sizeof(HostAddr));
     // Timestamp (8 bytes)
     int64_t ts = time::WallClock::fastNowInMilliSec();
     encoded.append(reinterpret_cast<char*>(&ts), sizeof(int64_t));
     // Log type
-    auto type = LogType::OP_ADD_LEARNER;
     encoded.append(reinterpret_cast<char*>(&type), 1);
-    // Value length
-    uint32_t len = static_cast<uint32_t>(sizeof(HostAddr));
-    encoded.append(reinterpret_cast<char*>(&len), sizeof(len));
-    // Learner addr
-    encoded.append(reinterpret_cast<const char*>(&learner), sizeof(HostAddr));
+    encoded.append(reinterpret_cast<const char*>(&host), sizeof(HostAddr));
     return encoded;
 }
 
-HostAddr decodeLearner(const std::string& encoded) {
+HostAddr decodeHost(LogType type, folly::StringPiece encoded) {
     HostAddr addr;
-    CHECK_EQ(kHeadLen + sizeof(HostAddr), encoded.size());
-    memcpy(&addr.first, encoded.data() + kHeadLen, sizeof(addr.first));
+    CHECK_EQ(sizeof(int64_t) + 1 + sizeof(HostAddr), encoded.size());
+    CHECK(encoded[sizeof(int64_t)] == type);
+    memcpy(&addr.first, encoded.begin() + sizeof(int64_t) + 1, sizeof(addr.first));
     memcpy(&addr.second,
-           encoded.data() + kHeadLen + sizeof(addr.first),
+           encoded.begin() + sizeof(int64_t) + 1 + sizeof(addr.first),
            sizeof(addr.second));
     return addr;
 }
 
-std::string encodeTransLeader(const HostAddr& targetAddr) {
-    std::string encoded;
-    encoded.reserve(kHeadLen + sizeof(HostAddr));
-    // Timestamp (8 bytes)
-    int64_t ts = time::WallClock::fastNowInMilliSec();
-    encoded.append(reinterpret_cast<char*>(&ts), sizeof(int64_t));
-    // Log type
-    auto type = LogType::OP_TRANS_LEADER;
-    encoded.append(reinterpret_cast<char*>(&type), 1);
-    // Value length
-    uint32_t len = static_cast<uint32_t>(sizeof(HostAddr));
-    encoded.append(reinterpret_cast<char*>(&len), sizeof(len));
-    // Target addr
-    encoded.append(reinterpret_cast<const char*>(&targetAddr), sizeof(HostAddr));
-    return encoded;
-}
-
-HostAddr decodeTransLeader(folly::StringPiece encoded) {
-    HostAddr addr;
-    CHECK_EQ(kHeadLen + sizeof(HostAddr), encoded.size());
-    memcpy(&addr.first, encoded.begin() + kHeadLen, sizeof(addr.first));
-    memcpy(&addr.second,
-           encoded.begin() + kHeadLen + sizeof(addr.first),
-           sizeof(addr.second));
-    return addr;
-}
 }  // namespace kvstore
 }  // namespace nebula
 

--- a/src/kvstore/LogEncoder.cpp
+++ b/src/kvstore/LogEncoder.cpp
@@ -176,7 +176,7 @@ std::string encodeHost(LogType type, const HostAddr& host) {
     return encoded;
 }
 
-HostAddr decodeHost(LogType type, folly::StringPiece encoded) {
+HostAddr decodeHost(LogType type, const folly::StringPiece& encoded) {
     HostAddr addr;
     CHECK_EQ(sizeof(int64_t) + 1 + sizeof(HostAddr), encoded.size());
     CHECK(encoded[sizeof(int64_t)] == type);

--- a/src/kvstore/LogEncoder.h
+++ b/src/kvstore/LogEncoder.h
@@ -42,7 +42,7 @@ std::vector<folly::StringPiece> decodeMultiValues(folly::StringPiece encoded);
 
 
 std::string encodeHost(LogType type, const HostAddr& learner);
-HostAddr decodeHost(LogType type, folly::StringPiece encoded);
+HostAddr decodeHost(LogType type, const folly::StringPiece& encoded);
 
 }  // namespace kvstore
 }  // namespace nebula

--- a/src/kvstore/LogEncoder.h
+++ b/src/kvstore/LogEncoder.h
@@ -21,6 +21,8 @@ enum LogType : char {
     OP_REMOVE_RANGE   = 0x6,
     OP_ADD_LEARNER    = 0x07,
     OP_TRANS_LEADER   = 0x08,
+    OP_ADD_PEER       = 0x09,
+    OP_REMOVE_PEER    = 0x10,
 };
 
 std::string encodeKV(const folly::StringPiece& key,
@@ -38,11 +40,10 @@ std::string encodeMultiValues(LogType type,
                               folly::StringPiece v2);
 std::vector<folly::StringPiece> decodeMultiValues(folly::StringPiece encoded);
 
-std::string encodeLearner(const HostAddr& learner);
-HostAddr decodeLearner(const std::string& encoded);
 
-std::string encodeTransLeader(const HostAddr& targetAddr);
-HostAddr decodeTransLeader(folly::StringPiece encoded);
+std::string encodeHost(LogType type, const HostAddr& learner);
+HostAddr decodeHost(LogType type, folly::StringPiece encoded);
+
 }  // namespace kvstore
 }  // namespace nebula
 #endif  // KVSTORE_LOGENCODER_H_

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -252,6 +252,7 @@ void NebulaStore::removePart(GraphSpaceID spaceId, PartitionID partId) {
             auto* e = partIt->second->engine();
             CHECK_NOTNULL(e);
             raftService_->removePartition(partIt->second);
+            partIt->second->reset();
             spaceIt->second->parts_.erase(partId);
             e->removePart(partId);
         }

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -177,6 +177,8 @@ public:
 
     void removePart(GraphSpaceID spaceId, PartitionID partId) override;
 
+    ErrorOr<ResultCode, std::shared_ptr<SpacePartInfo>> space(GraphSpaceID spaceId);
+
 private:
     std::unique_ptr<KVEngine> newEngine(GraphSpaceID spaceId, const std::string& path);
 
@@ -186,8 +188,6 @@ private:
                                   bool asLearner);
 
     ErrorOr<ResultCode, KVEngine*> engine(GraphSpaceID spaceId, PartitionID partId);
-
-    ErrorOr<ResultCode, std::shared_ptr<SpacePartInfo>> space(GraphSpaceID spaceId);
 
 private:
     // The lock used to protect spaces_

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -166,23 +166,24 @@ public:
 
     bool isLeader(GraphSpaceID spaceId, PartitionID partId);
 
-private:
     /**
      * Implement four interfaces in Handler.
      * */
     void addSpace(GraphSpaceID spaceId) override;
 
-    void addPart(GraphSpaceID spaceId, PartitionID partId) override;
+    void addPart(GraphSpaceID spaceId, PartitionID partId, bool asLearner) override;
 
     void removeSpace(GraphSpaceID spaceId) override;
 
     void removePart(GraphSpaceID spaceId, PartitionID partId) override;
 
+private:
     std::unique_ptr<KVEngine> newEngine(GraphSpaceID spaceId, const std::string& path);
 
     std::shared_ptr<Part> newPart(GraphSpaceID spaceId,
                                   PartitionID partId,
-                                  KVEngine* engine);
+                                  KVEngine* engine,
+                                  bool asLearner);
 
     ErrorOr<ResultCode, KVEngine*> engine(GraphSpaceID spaceId, PartitionID partId);
 

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -143,7 +143,7 @@ void Part::asyncAtomicOp(raftex::AtomicOp op, KVCallback cb) {
 }
 
 void Part::asyncAddLearner(const HostAddr& learner, KVCallback cb) {
-    std::string log = encodeLearner(learner);
+    std::string log = encodeHost(OP_ADD_LEARNER, learner);
     sendCommandAsync(std::move(log))
         .then([callback = std::move(cb)] (AppendLogResult res) mutable {
         callback(toResultCode(res));
@@ -151,7 +151,23 @@ void Part::asyncAddLearner(const HostAddr& learner, KVCallback cb) {
 }
 
 void Part::asyncTransferLeader(const HostAddr& target, KVCallback cb) {
-    std::string log = encodeTransLeader(target);
+    std::string log = encodeHost(OP_TRANS_LEADER, target);
+    sendCommandAsync(std::move(log))
+        .then([callback = std::move(cb)] (AppendLogResult res) mutable {
+        callback(toResultCode(res));
+    });
+}
+
+void Part::asyncAddPeer(const HostAddr& peer, KVCallback cb) {
+    std::string log = encodeHost(OP_ADD_PEER, peer);
+    sendCommandAsync(std::move(log))
+        .then([callback = std::move(cb)] (AppendLogResult res) mutable {
+        callback(toResultCode(res));
+    });
+}
+
+void Part::asyncRemovePeer(const HostAddr& peer, KVCallback cb) {
+    std::string log = encodeHost(OP_REMOVE_PEER, peer);
     sendCommandAsync(std::move(log))
         .then([callback = std::move(cb)] (AppendLogResult res) mutable {
         callback(toResultCode(res));
@@ -246,13 +262,18 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
             }
             break;
         }
+        case OP_ADD_PEER:
         case OP_ADD_LEARNER: {
             break;
         }
         case OP_TRANS_LEADER: {
-            auto newLeader = decodeTransLeader(log);
+            auto newLeader = decodeHost(OP_TRANS_LEADER, log);
             commitTransLeader(newLeader);
-            LOG(INFO) << idStr_ << "Transfer leader to " << newLeader;
+            break;
+        }
+        case OP_REMOVE_PEER: {
+            auto peer = decodeHost(OP_REMOVE_PEER, log);
+            commitRemovePeer(peer);
             break;
         }
         default: {
@@ -320,15 +341,23 @@ bool Part::preProcessLog(LogID logId,
     if (!log.empty()) {
         switch (log[sizeof(int64_t)]) {
             case OP_ADD_LEARNER: {
-                auto learner = decodeLearner(log);
+                auto learner = decodeHost(OP_ADD_LEARNER, log);
                 addLearner(learner);
-                LOG(INFO) << idStr_ << "Preprocess add learner " << learner;
                 break;
             }
             case OP_TRANS_LEADER: {
-                auto newLeader = decodeTransLeader(log);
+                auto newLeader = decodeHost(OP_TRANS_LEADER, log);
                 preProcessTransLeader(newLeader);
-                LOG(INFO) << idStr_ << "Preprocess transfer leader to " << newLeader;
+                break;
+            }
+            case OP_ADD_PEER: {
+                auto peer = decodeHost(OP_ADD_PEER, log);
+                addPeer(peer);
+                break;
+            }
+            case OP_REMOVE_PEER: {
+                auto peer = decodeHost(OP_REMOVE_PEER, log);
+                preProcessRemovePeer(peer);
                 break;
             }
             default: {

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -136,6 +136,13 @@ void Part::asyncRemoveRange(folly::StringPiece start,
         });
 }
 
+void Part::sync(KVCallback cb) {
+    sendCommandAsync("")
+        .then([callback = std::move(cb)] (AppendLogResult res) mutable {
+        callback(toResultCode(res));
+    });
+}
+
 void Part::asyncAtomicOp(raftex::AtomicOp op, KVCallback cb) {
     atomicOpAsync(std::move(op)).then([callback = std::move(cb)] (AppendLogResult res) mutable {
         callback(toResultCode(res));

--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -58,6 +58,9 @@ public:
 
     void asyncRemovePeer(const HostAddr& peer, KVCallback cb);
 
+    // Sync the information committed on follower.
+    void sync(KVCallback cb);
+
     void registerNewLeaderCb(NewLeaderCallback cb) {
         newLeaderCb_ = std::move(cb);
     }

--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -54,6 +54,10 @@ public:
 
     void asyncTransferLeader(const HostAddr& target, KVCallback cb);
 
+    void asyncAddPeer(const HostAddr& peer, KVCallback cb);
+
+    void asyncRemovePeer(const HostAddr& peer, KVCallback cb);
+
     void registerNewLeaderCb(NewLeaderCallback cb) {
         newLeaderCb_ = std::move(cb);
     }

--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -12,6 +12,7 @@
 #include "kvstore/Common.h"
 #include "kvstore/KVEngine.h"
 #include "kvstore/raftex/SnapshotManager.h"
+#include "kvstore/wal/FileBasedWal.h"
 
 namespace nebula {
 namespace kvstore {
@@ -67,6 +68,12 @@ public:
 
     void unRegisterNewLeaderCb() {
         newLeaderCb_ = nullptr;
+    }
+
+    // clean up all data about this part.
+    void reset() {
+        LOG(INFO) << idStr_ << "Clean up all wals";
+        wal()->reset();
     }
 
 private:

--- a/src/kvstore/PartManager.cpp
+++ b/src/kvstore/PartManager.cpp
@@ -85,7 +85,7 @@ void MetaServerBasedPartManager::onSpaceRemoved(GraphSpaceID spaceId) {
 
 void MetaServerBasedPartManager::onPartAdded(const PartMeta& partMeta) {
     if (handler_ != nullptr) {
-        handler_->addPart(partMeta.spaceId_, partMeta.partId_);
+        handler_->addPart(partMeta.spaceId_, partMeta.partId_, false);
     } else {
         VLOG(1) << "handler_ is nullptr!";
     }

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -18,7 +18,7 @@ namespace kvstore {
 class Handler {
 public:
     virtual void addSpace(GraphSpaceID spaceId) = 0;
-    virtual void addPart(GraphSpaceID spaceId, PartitionID partId) = 0;
+    virtual void addPart(GraphSpaceID spaceId, PartitionID partId, bool asLearner) = 0;
     virtual void removeSpace(GraphSpaceID spaceId) = 0;
     virtual void removePart(GraphSpaceID spaceId, PartitionID partId) = 0;
 };
@@ -96,7 +96,7 @@ public:
             handler_->addSpace(spaceId);
         }
         if (noPart && handler_) {
-            handler_->addPart(spaceId, partId);
+            handler_->addPart(spaceId, partId, false);
         }
      }
 

--- a/src/kvstore/SnapshotManagerImpl.cpp
+++ b/src/kvstore/SnapshotManagerImpl.cpp
@@ -38,9 +38,7 @@ void SnapshotManagerImpl::accessAllRowsInSnapshot(GraphSpaceID spaceId,
         totalCount++;
         iter->next();
     }
-    if (data.size() > 0) {
-        cb(std::move(data), totalCount, totalSize, true);
-    }
+    cb(std::move(data), totalCount, totalSize, true);
 }
 }  // namespace kvstore
 }  // namespace nebula

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -24,6 +24,7 @@ namespace raftex {
 class RaftPart;
 
 class Host final : public std::enable_shared_from_this<Host> {
+    friend class RaftPart;
 public:
     Host(const HostAddr& addr, std::shared_ptr<RaftPart> part, bool isLearner = false);
 
@@ -56,6 +57,10 @@ public:
 
     bool isLearner() const {
         return isLearner_;
+    }
+
+    void setLearner(bool isLearner) {
+        isLearner_ = isLearner;
     }
 
     folly::Future<cpp2::AskForVoteResponse> askForVote(

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -420,7 +420,7 @@ void RaftPart::commitTransLeader(const HostAddr& target) {
             break;
         }
         case Role::LEARNER: {
-            CHECK(target != addr_) << idStr_ << "I am learner, not in the raft group";
+            LOG(INFO) << idStr_ << "I am learner, not in the raft group, skip the log";
             break;
         }
     }

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -469,7 +469,11 @@ void RaftPart::removePeer(const HostAddr& peer) {
     if (it == hosts_.end()) {
         LOG(INFO) << idStr_ << "The peer " << peer << " not exist!";
     } else {
-        CHECK(!(*it)->isLearner()) << idStr_ << "Peer " << peer << " should not be learner!";
+        if ((*it)->isLearner()) {
+            LOG(INFO) << idStr_ << "The peer is learner, remove it directly!";
+            hosts_.erase(it);
+            return;
+        }
         hosts_.erase(it);
         updateQuorum();
         LOG(INFO) << idStr_ << "Remove peer " << peer;

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -42,6 +42,7 @@ enum class AppendLogResult {
     E_TERM_OUT_OF_DATE = -7,
     E_SENDING_SNAPSHOT = -8,
     E_INVALID_PEER = -9,
+    E_NOT_ENOUGH_ACKS = -10,
 };
 
 enum class LogType {

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -298,8 +298,7 @@ private:
      ***************************************************/
     const char* roleStr(Role role) const;
 
-    cpp2::ErrorCode verifyLeader(const cpp2::AppendLogRequest& req,
-                                 std::lock_guard<std::mutex>& lck);
+    cpp2::ErrorCode verifyLeader(const cpp2::AppendLogRequest& req);
 
     /*****************************************************************
      * Asynchronously send a heartbeat (An empty log entry)

--- a/src/kvstore/raftex/test/CMakeLists.txt
+++ b/src/kvstore/raftex/test/CMakeLists.txt
@@ -70,3 +70,11 @@ nebula_add_test(
     OBJECTS ${RAFTEX_TEST_LIBS}
     LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
 )
+
+nebula_add_test(
+    NAME member_change_test
+    SOURCES MemberChangeTest.cpp RaftexTestBase.cpp TestShard.cpp
+    OBJECTS ${RAFTEX_TEST_LIBS}
+    LIBRARIES ${THRIFT_LIBRARIES} wangle gtest
+)
+

--- a/src/kvstore/raftex/test/MemberChangeTest.cpp
+++ b/src/kvstore/raftex/test/MemberChangeTest.cpp
@@ -72,7 +72,7 @@ TEST(MemberChangeTest, AddRemovePeerTest) {
         for (size_t i = 0; i < copies.size() - 1; i++) {
             CHECK_EQ(2, copies[i]->hosts_.size());
         }
-        CHECK(copies[3]->isStopped());
+//        CHECK(copies[3]->isStopped());
     }
     finishRaft(services, copies, workers, leader);
 }
@@ -100,7 +100,8 @@ TEST(MemberChangeTest, RemoveLeaderTest) {
         auto f = copies[leaderIndex]->sendCommandAsync(
                         test::encodeRemovePeer(allHosts[leaderIndex]));
         f.wait();
-        CHECK(copies[leaderIndex]->isStopped());
+        copies[leaderIndex]->stop();
+//        CHECK(copies[leaderIndex]->isStopped());
         for (size_t i = 0; i < copies.size(); i++) {
             if (static_cast<int>(i) != leaderIndex) {
                 CHECK_EQ(2, copies[i]->hosts_.size());

--- a/src/kvstore/raftex/test/MemberChangeTest.cpp
+++ b/src/kvstore/raftex/test/MemberChangeTest.cpp
@@ -1,0 +1,140 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/Base.h"
+#include <gtest/gtest.h>
+#include <folly/String.h>
+#include "fs/TempDir.h"
+#include "fs/FileUtils.h"
+#include "thread/GenericThreadPool.h"
+#include "network/NetworkUtils.h"
+#include "kvstore/raftex/RaftexService.h"
+#include "kvstore/raftex/test/RaftexTestBase.h"
+#include "kvstore/raftex/test/TestShard.h"
+
+DECLARE_uint32(raft_heartbeat_interval_secs);
+
+
+namespace nebula {
+namespace raftex {
+
+TEST(MemberChangeTest, AddRemovePeerTest) {
+    fs::TempDir walRoot("/tmp/member_change.XXXXXX");
+    std::shared_ptr<thread::GenericThreadPool> workers;
+    std::vector<std::string> wals;
+    std::vector<HostAddr> allHosts;
+    std::vector<std::shared_ptr<RaftexService>> services;
+    std::vector<std::shared_ptr<test::TestShard>> copies;
+
+    std::shared_ptr<test::TestShard> leader;
+    std::vector<bool> isLearner = {false, false, false, true};
+    setupRaft(4, walRoot, workers, wals, allHosts, services, copies, leader, isLearner);
+
+    // Check all hosts agree on the same leader
+    checkLeadership(copies, leader);
+
+    CHECK_EQ(2, leader->hosts_.size());
+
+    {
+        auto f = leader->sendCommandAsync(test::encodeAddPeer(allHosts[3]));
+        f.wait();
+
+        for (auto& c : copies) {
+            CHECK_EQ(3, c->hosts_.size());
+        }
+    }
+    std::vector<std::string> msgs;
+    LogID id = -1;
+    appendLogs(0, 99, leader, msgs, id);
+    // Sleep a while to make sure the last log has been committed on
+    // followers
+    sleep(FLAGS_raft_heartbeat_interval_secs);
+
+    checkConsensus(copies, 0, 99, msgs);
+
+    {
+        LOG(INFO) << "Add the same peer again!";
+        auto f = leader->sendCommandAsync(test::encodeAddPeer(allHosts[3]));
+        f.wait();
+
+        for (auto& c : copies) {
+            CHECK_EQ(3, c->hosts_.size());
+        }
+    }
+    {
+        LOG(INFO) << "Remove the peer added!";
+        auto f = leader->sendCommandAsync(test::encodeRemovePeer(allHosts[3]));
+        f.wait();
+
+        for (size_t i = 0; i < copies.size() - 1; i++) {
+            CHECK_EQ(2, copies[i]->hosts_.size());
+        }
+        CHECK(copies[3]->isStopped());
+    }
+    finishRaft(services, copies, workers, leader);
+}
+
+TEST(MemberChangeTest, RemoveLeaderTest) {
+    fs::TempDir walRoot("/tmp/member_change.XXXXXX");
+    std::shared_ptr<thread::GenericThreadPool> workers;
+    std::vector<std::string> wals;
+    std::vector<HostAddr> allHosts;
+    std::vector<std::shared_ptr<RaftexService>> services;
+    std::vector<std::shared_ptr<test::TestShard>> copies;
+
+    std::shared_ptr<test::TestShard> leader;
+    std::vector<bool> isLearner = {false, false, false, false};
+    setupRaft(4, walRoot, workers, wals, allHosts, services, copies, leader, isLearner);
+
+    // Check all hosts agree on the same leader
+    auto leaderIndex = checkLeadership(copies, leader);
+
+    CHECK_EQ(3, leader->hosts_.size());
+
+    {
+        LOG(INFO) << "Send remove peer request, remove " << allHosts[leaderIndex];
+        leader.reset();
+        auto f = copies[leaderIndex]->sendCommandAsync(
+                        test::encodeRemovePeer(allHosts[leaderIndex]));
+        f.wait();
+        CHECK(copies[leaderIndex]->isStopped());
+        for (size_t i = 0; i < copies.size(); i++) {
+            if (static_cast<int>(i) != leaderIndex) {
+                CHECK_EQ(2, copies[i]->hosts_.size());
+            }
+        }
+    }
+
+    waitUntilLeaderElected(copies, leader);
+
+    auto nLeaderIndex = checkLeadership(copies, leader);
+    CHECK(leaderIndex != nLeaderIndex);
+
+    std::vector<std::string> msgs;
+    LogID id = -1;
+    appendLogs(0, 99, leader, msgs, id);
+    // Sleep a while to make sure the last log has been committed on
+    // followers
+    sleep(FLAGS_raft_heartbeat_interval_secs);
+
+    checkConsensus(copies, 0, 99, msgs);
+
+    finishRaft(services, copies, workers, leader);
+}
+
+}  // namespace raftex
+}  // namespace nebula
+
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    folly::init(&argc, &argv, true);
+    google::SetStderrLogging(google::INFO);
+
+    return RUN_ALL_TESTS();
+}
+
+

--- a/src/kvstore/raftex/test/RaftCase.cpp
+++ b/src/kvstore/raftex/test/RaftCase.cpp
@@ -205,7 +205,7 @@ TEST_F(FiveRaftTest, DISABLED_Figure8) {
 
         if (alive < quorum) {
             size_t idx = folly::Random::rand32(size_);
-            if (!copies_[idx]->isRunning_) {
+            if (!copies_[idx]->isRunning()) {
                 rebootOneCopy(services_, copies_, allHosts_, idx);
                 ++alive;
             }
@@ -214,7 +214,7 @@ TEST_F(FiveRaftTest, DISABLED_Figure8) {
 
     LOG(INFO) << "=====> Now let's reboot all copy and check consensus";
     for (int32_t i = 0; i < size_; i++) {
-        if (!copies_[i]->isRunning_) {
+        if (!copies_[i]->isRunning()) {
             rebootOneCopy(services_, copies_, allHosts_, i);
         }
     }

--- a/src/kvstore/raftex/test/SnapshotTest.cpp
+++ b/src/kvstore/raftex/test/SnapshotTest.cpp
@@ -27,9 +27,9 @@ namespace raftex {
 
 TEST(SnapshotTest, LearnerCatchUpDataTest) {
     fs::TempDir walRoot("/tmp/catch_up_data.XXXXXX");
-    FLAGS_wal_file_size = 128;
-    FLAGS_wal_buffer_size = 64;
-    FLAGS_wal_buffer_num = 1000;
+    FLAGS_wal_file_size = 1024;
+    FLAGS_wal_buffer_size = 512;
+    FLAGS_wal_buffer_num = 30;
     FLAGS_raft_rpc_timeout_ms = 2000;
     std::shared_ptr<thread::GenericThreadPool> workers;
     std::vector<std::string> wals;

--- a/src/kvstore/test/LogEncoderTest.cpp
+++ b/src/kvstore/test/LogEncoderTest.cpp
@@ -121,6 +121,12 @@ TEST(LogEncoderTest, KVTest) {
     ASSERT_EQ("KV_val", decoded.second);
 }
 
+TEST(LogEncoderTest, HostTest) {
+    auto encoded = encodeHost(OP_ADD_LEARNER, HostAddr(1, 1));
+    auto decoded = decodeHost(OP_ADD_LEARNER, encoded);
+    ASSERT_EQ(HostAddr(1, 1), decoded);
+}
+
 }  // namespace kvstore
 }  // namespace nebula
 

--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -443,7 +443,10 @@ bool FileBasedWal::appendLogInternal(LogID id,
     }
 
     ssize_t bytesWritten = write(currFd_, strBuf.data(), strBuf.size());
-    CHECK_EQ(bytesWritten, strBuf.size());
+    if (bytesWritten != (ssize_t)strBuf.size()) {
+        LOG(FATAL) << idStr_ << "bytesWritten:" << bytesWritten << ", expected:" << strBuf.size()
+                   << ", error:" << strerror(errno);
+    }
     currInfo_->setSize(currInfo_->size() + strBuf.size());
     currInfo_->setLastId(id);
     currInfo_->setLastTerm(term);

--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -277,9 +277,9 @@ void FileBasedWal::closeCurrFile() {
         return;
     }
 
-    CHECK_EQ(fsync(currFd_), 0);
+    CHECK_EQ(fsync(currFd_), 0) << strerror(errno);
     // Close the file
-    CHECK_EQ(close(currFd_), 0);
+    CHECK_EQ(close(currFd_), 0) << strerror(errno);
     currFd_ = -1;
 
     auto now = time::WallClock::fastNowInSec();

--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -284,8 +284,8 @@ void FileBasedWal::closeCurrFile() {
 
     auto now = time::WallClock::fastNowInSec();
     currInfo_->setMTime(now);
-    DCHECK_EQ(currInfo_->size(), FileUtils::fileSize(currInfo_->path()))
-        << currInfo_->path() << " size does not match";
+//    DCHECK_EQ(currInfo_->size(), FileUtils::fileSize(currInfo_->path()))
+//        << currInfo_->path() << " size does not match";
     struct utimbuf timebuf;
     timebuf.modtime = currInfo_->mtime();
     timebuf.actime = currInfo_->mtime();

--- a/src/meta/ActiveHostsMan.cpp
+++ b/src/meta/ActiveHostsMan.cpp
@@ -54,5 +54,10 @@ std::vector<HostAddr> ActiveHostsMan::getActiveHosts(kvstore::KVStore* kv, int32
     return hosts;
 }
 
+bool ActiveHostsMan::isLived(kvstore::KVStore* kv, const HostAddr& host) {
+    auto activeHosts = getActiveHosts(kv);
+    return std::find(activeHosts.begin(), activeHosts.end(), host) != activeHosts.end();
+}
+
 }  // namespace meta
 }  // namespace nebula

--- a/src/meta/ActiveHostsMan.h
+++ b/src/meta/ActiveHostsMan.h
@@ -53,6 +53,8 @@ public:
 
     static std::vector<HostAddr> getActiveHosts(kvstore::KVStore* kv, int32_t expiredTTL = 0);
 
+    static bool isLived(kvstore::KVStore* kv, const HostAddr& host);
+
 protected:
     ActiveHostsMan() = default;
 };

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -268,9 +268,13 @@ public:
 
     const std::vector<HostAddr>& getAddresses();
 
+    Status refreshCache();
+
 protected:
     void loadDataThreadFunc();
-    void loadData();
+    // Return true if load succeeded.
+    bool loadData();
+
     void addLoadDataTask();
 
     void heartBeatThreadFunc();

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -211,6 +211,9 @@ public:
     folly::Future<StatusOr<int64_t>>
     balance();
 
+    folly::Future<StatusOr<std::vector<cpp2::BalanceTask>>>
+    showBalance(int64_t balanceId);
+
     folly::Future<StatusOr<bool>> balanceLeader();
 
     // Operations for config

--- a/src/meta/processors/admin/AdminClient.cpp
+++ b/src/meta/processors/admin/AdminClient.cpp
@@ -118,7 +118,7 @@ folly::Future<Status> AdminClient::waitingForCatchUpData(GraphSpaceID spaceId,
     auto f = pro.getFuture();
     getResponse(ret.value(), 0, std::move(req), [] (auto client, auto request) {
         return client->future_waitingForCatchUpData(request);
-    }, 0, std::move(pro), FLAGS_max_retry_times_admin_op);
+    }, 0, std::move(pro), 3);
     return f;
 }
 

--- a/src/meta/processors/admin/AdminClient.cpp
+++ b/src/meta/processors/admin/AdminClient.cpp
@@ -159,7 +159,12 @@ folly::Future<Status> AdminClient::updateMeta(GraphSpaceID spaceId,
     }
     auto peers = std::move(ret).value();
     auto it = std::find(peers.begin(), peers.end(), src);
-    CHECK(it != peers.end());
+    if (it == peers.end()) {
+        LOG(INFO) << "src " << src << " has been removed in [" << spaceId << ", " << partId << "]";
+        // In this case, the dst should be existed in peers.
+        CHECK(std::find(peers.begin(), peers.end(), dst) != peers.end());
+        return Status::OK();
+    }
     peers.erase(it);
     peers.emplace_back(dst);
     std::vector<nebula::cpp2::HostAddr> thriftPeers;

--- a/src/meta/processors/admin/AdminClient.h
+++ b/src/meta/processors/admin/AdminClient.h
@@ -64,11 +64,22 @@ public:
                                   const HostAddr& host,
                                   bool asLearner);
 
-    folly::Future<Status> addLearner(GraphSpaceID spaceId, PartitionID partId);
+    folly::Future<Status> addLearner(GraphSpaceID spaceId,
+                                     PartitionID partId,
+                                     const HostAddr& learner);
 
-    folly::Future<Status> waitingForCatchUpData(GraphSpaceID spaceId, PartitionID partId);
+    folly::Future<Status> waitingForCatchUpData(GraphSpaceID spaceId,
+                                                PartitionID partId,
+                                                const HostAddr& target);
 
-    folly::Future<Status> memberChange(GraphSpaceID spaceId, PartitionID partId);
+    /**
+     * Add/Remove one peer for raft group (spaceId, partId).
+     * "added" should be true if we want to add one peer, otherwise it is false.
+     * */
+    folly::Future<Status> memberChange(GraphSpaceID spaceId,
+                                       PartitionID partId,
+                                       const HostAddr& peer,
+                                       bool added);
 
     folly::Future<Status> updateMeta(GraphSpaceID spaceId,
                                      PartitionID partId,
@@ -105,7 +116,7 @@ private:
 
     Status handleResponse(const storage::cpp2::AdminExecResp& resp);
 
-    nebula::cpp2::HostAddr to(const HostAddr& addr);
+    nebula::cpp2::HostAddr toThriftHost(const HostAddr& addr);
 
     StatusOr<std::vector<HostAddr>> getPeers(GraphSpaceID spaceId, PartitionID partId);
 

--- a/src/meta/processors/admin/BalancePlan.cpp
+++ b/src/meta/processors/admin/BalancePlan.cpp
@@ -7,6 +7,7 @@
 #include "meta/processors/admin/BalancePlan.h"
 #include <folly/synchronization/Baton.h>
 #include "meta/processors/Common.h"
+#include "meta/ActiveHostsMan.h"
 
 DEFINE_uint32(task_concurrency, 10, "The tasks number could be invoked simultaneously");
 
@@ -130,7 +131,7 @@ bool BalancePlan::saveInStore(bool onlyPlan) {
     return true;
 }
 
-bool BalancePlan::recovery() {
+bool BalancePlan::recovery(bool resume) {
     if (kv_) {
         const auto& prefix = BalanceTask::prefix(id_);
         std::unique_ptr<kvstore::KVIterator> iter;
@@ -150,18 +151,28 @@ bool BalancePlan::recovery() {
                 task.partId_ = std::get<2>(tup);
                 task.src_ = std::get<3>(tup);
                 task.dst_ = std::get<4>(tup);
+                task.taskIdStr_ = task.buildTaskId();
             }
             {
                 auto tup = BalanceTask::parseVal(iter->val());
                 task.status_ = std::get<0>(tup);
                 task.ret_ = std::get<1>(tup);
-                if (task.ret_ == BalanceTask::Result::FAILED) {
-                    // Resume the failed task.
-                    task.ret_ = BalanceTask::Result::IN_PROGRESS;
-                }
                 task.srcLived_ = std::get<2>(tup);
                 task.startTimeMs_ = std::get<3>(tup);
                 task.endTimeMs_ = std::get<4>(tup);
+                if (resume && task.ret_ != BalanceTask::Result::SUCCEEDED) {
+                    // Resume the failed task.
+                    task.ret_ = BalanceTask::Result::IN_PROGRESS;
+                    task.status_ = BalanceTask::Status::START;
+                    if (ActiveHostsMan::isLived(kv_, task.src_)) {
+                        task.srcLived_ = true;
+                    } else {
+                        task.srcLived_ = false;
+                    }
+                    if (!ActiveHostsMan::isLived(kv_, task.dst_)) {
+                        task.ret_ = BalanceTask::Result::INVALID;
+                    }
+                }
             }
             tasks_.emplace_back(std::move(task));
             iter->next();

--- a/src/meta/processors/admin/BalancePlan.cpp
+++ b/src/meta/processors/admin/BalancePlan.cpp
@@ -54,6 +54,7 @@ void BalancePlan::invoke() {
                         finished = true;
                         if (status_ == Status::IN_PROGRESS) {
                             status_ = Status::SUCCEEDED;
+                            LOG(INFO) << "Balance " << id_ << " succeeded!";
                         }
                     }
                 }
@@ -76,6 +77,7 @@ void BalancePlan::invoke() {
                     status_ = Status::FAILED;
                     if (finishedTaskNum_ == tasks_.size()) {
                         finished = true;
+                        LOG(INFO) << "Balance " << id_ << " failed!";
                     }
                 }
                 if (finished) {
@@ -157,8 +159,9 @@ bool BalancePlan::recovery() {
                     // Resume the failed task.
                     task.ret_ = BalanceTask::Result::IN_PROGRESS;
                 }
-                task.startTimeMs_ = std::get<2>(tup);
-                task.endTimeMs_ = std::get<3>(tup);
+                task.srcLived_ = std::get<2>(tup);
+                task.startTimeMs_ = std::get<3>(tup);
+                task.endTimeMs_ = std::get<4>(tup);
             }
             tasks_.emplace_back(std::move(task));
             iter->next();

--- a/src/meta/processors/admin/BalancePlan.h
+++ b/src/meta/processors/admin/BalancePlan.h
@@ -53,6 +53,10 @@ public:
      * */
     void rollback() {}
 
+    Status status() {
+        return status_;
+    }
+
     bool saveInStore(bool onlyPlan = false);
 
     BalanceID id() const {

--- a/src/meta/processors/admin/BalancePlan.h
+++ b/src/meta/processors/admin/BalancePlan.h
@@ -39,6 +39,14 @@ public:
         , kv_(kv)
         , client_(client) {}
 
+    BalancePlan(const BalancePlan& plan)
+        : id_(plan.id_)
+        , kv_(plan.kv_)
+        , client_(plan.client_)
+        , tasks_(plan.tasks_)
+        , finishedTaskNum_(plan.finishedTaskNum_)
+        , status_(plan.status_) {}
+
     void addTask(BalanceTask task) {
         tasks_.emplace_back(std::move(task));
     }
@@ -63,8 +71,12 @@ public:
         return id_;
     }
 
+    const std::vector<BalanceTask>& tasks() const {
+        return tasks_;
+    }
+
 private:
-    bool recovery();
+    bool recovery(bool resume = true);
 
     std::string planKey() const;
 

--- a/src/meta/processors/admin/BalanceProcessor.cpp
+++ b/src/meta/processors/admin/BalanceProcessor.cpp
@@ -19,8 +19,35 @@ void BalanceProcessor::process(const cpp2::BalanceReq& req) {
         return;
     }
     if (req.get_id() != nullptr) {
-        LOG(ERROR) << "Unsupport show status for specific balance plan, id=" << *req.get_id();
-        resp_.set_code(cpp2::ErrorCode::E_UNSUPPORTED);
+        auto ret = Balancer::instance(kvstore_)->show(*req.get_id());
+        if (!ret.ok()) {
+            resp_.set_code(cpp2::ErrorCode::E_BAD_BALANCE_PLAN);
+            onFinished();
+            return;
+        }
+        resp_.set_code(cpp2::ErrorCode::SUCCEEDED);
+        const auto& plan = ret.value();
+        std::vector<cpp2::BalanceTask> thriftTasks;
+        for (auto& task : plan.tasks()) {
+            cpp2::BalanceTask t;
+            t.set_id(task.taskIdStr());
+            switch (task.result()) {
+                case BalanceTask::Result::SUCCEEDED:
+                    t.set_result(cpp2::TaskResult::SUCCEEDED);
+                    break;
+                case BalanceTask::Result::FAILED:
+                    t.set_result(cpp2::TaskResult::FAILED);
+                    break;
+                case BalanceTask::Result::IN_PROGRESS:
+                    t.set_result(cpp2::TaskResult::IN_PROGRESS);
+                    break;
+                case BalanceTask::Result::INVALID:
+                    t.set_result(cpp2::TaskResult::INVALID);
+                    break;
+            }
+            thriftTasks.emplace_back(std::move(t));
+        }
+        resp_.set_tasks(std::move(thriftTasks));
         onFinished();
         return;
     }
@@ -33,8 +60,11 @@ void BalanceProcessor::process(const cpp2::BalanceReq& req) {
     }
     auto ret = Balancer::instance(kvstore_)->balance();
     if (!ret.ok()) {
-        LOG(INFO) << "The balancer is running.";
-        resp_.set_code(cpp2::ErrorCode::E_BALANCER_RUNNING);
+        if (ret.status() == Status::Balanced()) {
+            resp_.set_code(cpp2::ErrorCode::E_BALANCED);
+        } else {
+            resp_.set_code(cpp2::ErrorCode::E_BALANCER_RUNNING);
+        }
         onFinished();
         return;
     }

--- a/src/meta/processors/admin/BalanceTask.cpp
+++ b/src/meta/processors/admin/BalanceTask.cpp
@@ -22,6 +22,13 @@ const std::string kBalanceTaskTable = "__b_task__"; // NOLINT
 
 void BalanceTask::invoke() {
     CHECK_NOTNULL(client_);
+    if (ret_ == Result::INVALID) {
+        endTimeMs_ = time::WallClock::fastNowInMilliSec();
+        saveInStore();
+        LOG(ERROR) << taskIdStr_ << "Task invalid!";
+        onFinished_();
+        return;
+    }
     if (ret_ == Result::FAILED) {
         endTimeMs_ = time::WallClock::fastNowInMilliSec();
         saveInStore();

--- a/src/meta/processors/admin/BalanceTask.cpp
+++ b/src/meta/processors/admin/BalanceTask.cpp
@@ -25,6 +25,7 @@ void BalanceTask::invoke() {
     if (ret_ == Result::FAILED) {
         endTimeMs_ = time::WallClock::fastNowInMilliSec();
         saveInStore();
+        LOG(ERROR) << taskIdStr_ << "Task failed, status_ " << static_cast<int32_t>(status_);
         onError_();
         return;
     }
@@ -38,15 +39,20 @@ void BalanceTask::invoke() {
         case Status::CHANGE_LEADER: {
             LOG(INFO) << taskIdStr_ << "Ask the src to give up the leadership.";
             SAVE_STATE();
-            client_->transLeader(spaceId_, partId_, src_).thenValue([this](auto&& resp) {
-                if (!resp.ok()) {
-                    ret_ = Result::FAILED;
-                } else {
-                    status_ = Status::ADD_PART_ON_DST;
-                }
-                invoke();
-            });
-            break;
+            if (srcLived_) {
+                client_->transLeader(spaceId_, partId_, src_).thenValue([this](auto&& resp) {
+                    if (!resp.ok()) {
+                        ret_ = Result::FAILED;
+                    } else {
+                        status_ = Status::ADD_PART_ON_DST;
+                    }
+                    invoke();
+                });
+                break;
+            } else {
+                LOG(INFO) << taskIdStr_ << "Src host has been lost, so no need to transfer leader";
+                status_ = Status::ADD_PART_ON_DST;
+            }
         }
         case Status::ADD_PART_ON_DST: {
             LOG(INFO) << taskIdStr_ << "Open the part as learner on dst.";
@@ -105,7 +111,8 @@ void BalanceTask::invoke() {
             LOG(INFO) << taskIdStr_ << "Send member change request to the leader"
                       << ", it will remove the old member on src host";
             SAVE_STATE();
-            client_->memberChange(spaceId_, partId_, src_, false).thenValue([this](auto&& resp) {
+            client_->memberChange(spaceId_, partId_, src_, false).thenValue(
+                    [this] (auto&& resp) {
                 if (!resp.ok()) {
                     ret_ = Result::FAILED;
                 } else {
@@ -118,7 +125,11 @@ void BalanceTask::invoke() {
         case Status::UPDATE_PART_META: {
             LOG(INFO) << taskIdStr_ << "Update meta for part.";
             SAVE_STATE();
-            client_->updateMeta(spaceId_, partId_, src_, dst_).thenValue([this](auto&& resp) {
+            client_->updateMeta(spaceId_, partId_, src_, dst_).thenValue(
+                        [this] (auto&& resp) {
+                // The callback will be called inside raft set value. So don't call invoke directly
+                // here.
+                LOG(INFO) << "Update meta succeeded!";
                 if (!resp.ok()) {
                     ret_ = Result::FAILED;
                 } else {
@@ -129,18 +140,24 @@ void BalanceTask::invoke() {
             break;
         }
         case Status::REMOVE_PART_ON_SRC: {
-            LOG(INFO) << taskIdStr_ << "Close part on src host.";
+            LOG(INFO) << taskIdStr_ << "Close part on src host, srcLived " << srcLived_;
             SAVE_STATE();
-            client_->removePart(spaceId_, partId_, src_).thenValue([this](auto&& resp) {
-                if (!resp.ok()) {
-                    ret_ = Result::FAILED;
-                } else {
-                    ret_ = Result::SUCCEEDED;
-                    status_ = Status::END;
-                }
-                invoke();
-            });
-            break;
+            if (srcLived_) {
+                client_->removePart(spaceId_, partId_, src_).thenValue([this](auto&& resp) {
+                    if (!resp.ok()) {
+                        ret_ = Result::FAILED;
+                    } else {
+                        ret_ = Result::SUCCEEDED;
+                        status_ = Status::END;
+                    }
+                    invoke();
+                });
+                break;
+            } else {
+                LOG(INFO) << taskIdStr_ << "Don't remove part on src " << src_;
+                ret_ = Result::SUCCEEDED;
+                status_ = Status::END;
+            }
         }
         case Status::END: {
             LOG(INFO) << taskIdStr_ <<  "Part has been moved successfully!";
@@ -201,6 +218,7 @@ std::string BalanceTask::taskVal() {
     str.reserve(32);
     str.append(reinterpret_cast<const char*>(&status_), sizeof(status_));
     str.append(reinterpret_cast<const char*>(&ret_), sizeof(ret_));
+    str.append(reinterpret_cast<const char*>(&srcLived_), sizeof(srcLived_));
     str.append(reinterpret_cast<const char*>(&startTimeMs_), sizeof(startTimeMs_));
     str.append(reinterpret_cast<const char*>(&endTimeMs_), sizeof(endTimeMs_));
     return str;
@@ -229,17 +247,19 @@ BalanceTask::parseKey(const folly::StringPiece& rawKey) {
     return std::make_tuple(balanceId, spaceId, partId, src, dst);
 }
 
-std::tuple<BalanceTask::Status, BalanceTask::Result, int64_t, int64_t>
+std::tuple<BalanceTask::Status, BalanceTask::Result, bool, int64_t, int64_t>
 BalanceTask::parseVal(const folly::StringPiece& rawVal) {
     int32_t offset = 0;
     auto status = *reinterpret_cast<const BalanceTask::Status*>(rawVal.begin() + offset);
     offset += sizeof(BalanceTask::Status);
     auto ret = *reinterpret_cast<const BalanceTask::Result*>(rawVal.begin() + offset);
     offset += sizeof(BalanceTask::Result);
+    auto srcLived = *reinterpret_cast<const bool*>(rawVal.begin() + offset);
+    offset += sizeof(bool);
     auto start = *reinterpret_cast<const int64_t*>(rawVal.begin() + offset);
     offset += sizeof(int64_t);
     auto end = *reinterpret_cast<const int64_t*>(rawVal.begin() + offset);
-    return std::make_tuple(status, ret, start, end);
+    return std::make_tuple(status, ret, srcLived, start, end);
 }
 
 }  // namespace meta

--- a/src/meta/processors/admin/BalanceTask.h
+++ b/src/meta/processors/admin/BalanceTask.h
@@ -32,6 +32,7 @@ public:
                 PartitionID partId,
                 const HostAddr& src,
                 const HostAddr& dst,
+                bool srcLived,
                 kvstore::KVStore* kv,
                 AdminClient* client)
         : balanceId_(balanceId)
@@ -39,6 +40,7 @@ public:
         , partId_(partId)
         , src_(src)
         , dst_(dst)
+        , srcLived_(srcLived)
         , taskIdStr_(folly::stringPrintf(
                                       "[%ld, %d, %s:%d->%s:%d] ",
                                       balanceId,
@@ -89,7 +91,7 @@ private:
     static std::tuple<BalanceID, GraphSpaceID, PartitionID, HostAddr, HostAddr>
     parseKey(const folly::StringPiece& rawKey);
 
-    static std::tuple<BalanceTask::Status, BalanceTask::Result, int64_t, int64_t>
+    static std::tuple<BalanceTask::Status, BalanceTask::Result, bool, int64_t, int64_t>
     parseVal(const folly::StringPiece& rawVal);
 
 private:
@@ -98,6 +100,7 @@ private:
     PartitionID  partId_;
     HostAddr     src_;
     HostAddr     dst_;
+    bool         srcLived_ = true;  // false means the src host have been lost.
     std::string  taskIdStr_;
     kvstore::KVStore* kv_ = nullptr;
     AdminClient* client_ = nullptr;

--- a/src/meta/processors/admin/BalanceTask.h
+++ b/src/meta/processors/admin/BalanceTask.h
@@ -60,15 +60,16 @@ public:
 
 private:
     enum class Status : uint8_t {
-        START               = 0x01,
-        CHANGE_LEADER       = 0x02,
-        ADD_PART_ON_DST     = 0x03,
-        ADD_LEARNER         = 0x04,
-        CATCH_UP_DATA       = 0x05,
-        MEMBER_CHANGE       = 0x06,
-        UPDATE_PART_META    = 0x07,  // After this state, we can't rollback anymore.
-        REMOVE_PART_ON_SRC  = 0x08,
-        END                 = 0xFF,
+        START                   = 0x01,
+        CHANGE_LEADER           = 0x02,
+        ADD_PART_ON_DST         = 0x03,
+        ADD_LEARNER             = 0x04,
+        CATCH_UP_DATA           = 0x05,
+        MEMBER_CHANGE_ADD       = 0x06,
+        MEMBER_CHANGE_REMOVE    = 0x07,
+        UPDATE_PART_META        = 0x08,  // After this state, we can't rollback anymore.
+        REMOVE_PART_ON_SRC      = 0x09,
+        END                     = 0xFF,
     };
 
     enum class Result : uint8_t {

--- a/src/meta/processors/admin/Balancer.cpp
+++ b/src/meta/processors/admin/Balancer.cpp
@@ -311,14 +311,12 @@ void Balancer::calDiff(const std::unordered_map<HostAddr, std::vector<PartitionI
     for (auto it = hostParts.begin(); it != hostParts.end(); it++) {
         VLOG(1) << "Original Host " << it->first << ", parts " << it->second.size();
         if (std::find(activeHosts.begin(), activeHosts.end(), it->first) == activeHosts.end()) {
-            LOG(INFO) << "Lost host " << it->first;
             lost.emplace_back(it->first);
         }
     }
     for (auto& h : activeHosts) {
         VLOG(1) << "Active host " << h;
         if (hostParts.find(h) == hostParts.end()) {
-            LOG(INFO) << "New Host " << h;
             newlyAdded.emplace_back(h);
         }
     }

--- a/src/meta/processors/admin/Balancer.h
+++ b/src/meta/processors/admin/Balancer.h
@@ -66,22 +66,16 @@ public:
      * */
     StatusOr<BalanceID> balance();
 
-    bool isRunning() {
-        return running_;
-    }
+    /**
+     * Show balance plan id status.
+     * */
+    StatusOr<BalancePlan> show(BalanceID id) const;
 
     /**
-     * TODO(heng): Rollback some specific balance id
+     * TODO(heng): rollback some balance plan.
      */
     Status rollback(BalanceID id) {
         return Status::Error("unplemented, %ld", id);
-    }
-
-    /**
-     * TODO(heng): Only generate balance plan for our users.
-     * */
-    const BalancePlan* preview() {
-        return plan_.get();
     }
 
     /**
@@ -101,6 +95,10 @@ public:
     }
 
     cpp2::ErrorCode leaderBalance();
+
+    bool isRunning() {
+        return running_;
+    }
 
 private:
     Balancer(kvstore::KVStore* kv, std::unique_ptr<AdminClient> client)

--- a/src/meta/processors/admin/Balancer.h
+++ b/src/meta/processors/admin/Balancer.h
@@ -50,6 +50,7 @@ class Balancer {
     FRIEND_TEST(BalanceTest, LeaderBalanceTest);
     FRIEND_TEST(BalanceTest, ManyHostsLeaderBalancePlanTest);
     FRIEND_TEST(BalanceIntegrationTest, LeaderBalanceTest);
+    FRIEND_TEST(BalanceIntegrationTest, BalanceTest);
 
 public:
     static Balancer* instance(kvstore::KVStore* kv) {
@@ -64,6 +65,10 @@ public:
      * Return Error if reject the balance request, otherwise return balance id.
      * */
     StatusOr<BalanceID> balance();
+
+    bool isRunning() {
+        return running_;
+    }
 
     /**
      * TODO(heng): Rollback some specific balance id
@@ -123,6 +128,10 @@ private:
                  const std::vector<HostAddr>& activeHosts,
                  std::vector<HostAddr>& newlyAdded,
                  std::vector<HostAddr>& lost);
+
+    StatusOr<HostAddr> hostWithPart(
+                        const std::unordered_map<HostAddr, std::vector<PartitionID>>& hostParts,
+                        PartitionID partId);
 
     StatusOr<HostAddr> hostWithMinimalParts(
                         const std::unordered_map<HostAddr, std::vector<PartitionID>>& hostParts,

--- a/src/meta/test/AdminClientTest.cpp
+++ b/src/meta/test/AdminClientTest.cpp
@@ -115,8 +115,8 @@ TEST(AdminClientTest, SimpleTest) {
     {
         LOG(INFO) << "Test transLeader...";
         folly::Baton<true, std::atomic> baton;
-        client->transLeader(0, 0, {localIp, sc->port_}).then([&baton](auto&& st) {
-            CHECK(st.ok());
+        client->transLeader(0, 0, {localIp, sc->port_}, HostAddr(1, 1)).then([&baton](auto&& st) {
+            CHECK(st.ok()) << st.toString();
             baton.post();
         });
         baton.wait();
@@ -188,7 +188,7 @@ TEST(AdminClientTest, RetryTest) {
     {
         LOG(INFO) << "Test transLeader, return ok if target is not leader";
         folly::Baton<true, std::atomic> baton;
-        client->transLeader(0, 1, {localIp, sc2->port_}).then([&baton](auto&& st) {
+        client->transLeader(0, 1, {localIp, sc2->port_}, HostAddr(1, 1)).then([&baton](auto&& st) {
             CHECK(st.ok());
             baton.post();
         });

--- a/src/meta/test/AdminClientTest.cpp
+++ b/src/meta/test/AdminClientTest.cpp
@@ -197,7 +197,7 @@ TEST(AdminClientTest, RetryTest) {
     {
         LOG(INFO) << "Test member change...";
         folly::Baton<true, std::atomic> baton;
-        client->memberChange(0, 1).then([&baton](auto&& st) {
+        client->memberChange(0, 1, HostAddr(0, 0), true).then([&baton](auto&& st) {
             CHECK(st.ok());
             baton.post();
         });
@@ -206,7 +206,7 @@ TEST(AdminClientTest, RetryTest) {
     {
         LOG(INFO) << "Test add learner...";
         folly::Baton<true, std::atomic> baton;
-        client->addLearner(0, 1).then([&baton](auto&& st) {
+        client->addLearner(0, 1, HostAddr(0, 0)).then([&baton](auto&& st) {
             CHECK(st.ok());
             baton.post();
         });
@@ -215,7 +215,7 @@ TEST(AdminClientTest, RetryTest) {
     {
         LOG(INFO) << "Test waitingForCatchUpData...";
         folly::Baton<true, std::atomic> baton;
-        client->waitingForCatchUpData(0, 1).then([&baton](auto&& st) {
+        client->waitingForCatchUpData(0, 1, HostAddr(0, 0)).then([&baton](auto&& st) {
             CHECK(st.ok());
             baton.post();
         });
@@ -225,7 +225,7 @@ TEST(AdminClientTest, RetryTest) {
     {
         LOG(INFO) << "Test member change...";
         folly::Baton<true, std::atomic> baton;
-        client->memberChange(0, 1).then([&baton](auto&& st) {
+        client->memberChange(0, 1, HostAddr(0, 0), true).then([&baton](auto&& st) {
             CHECK(!st.ok());
             CHECK_EQ("Leader changed!", st.toString());
             baton.post();

--- a/src/meta/test/BalanceIntegrationTest.cpp
+++ b/src/meta/test/BalanceIntegrationTest.cpp
@@ -146,10 +146,7 @@ TEST(BalanceIntegrationTest, BalanceTest) {
         for (int32_t vId = 0; vId < 10000; vId++) {
             vIds.emplace_back(vId);
         }
-        retCols.emplace_back(
-            storage::TestUtils::propDef(storage::cpp2::PropOwner::SOURCE,
-                                        "c",
-                                        tagId));
+        retCols.emplace_back(storage::TestUtils::vetexPropDef("c", tagId));
         auto f = sClient->getVertexProps(spaceId, std::move(vIds), std::move(retCols));
         auto resp = std::move(f).get();
         if (!resp.succeeded()) {
@@ -165,8 +162,8 @@ TEST(BalanceIntegrationTest, BalanceTest) {
         auto& results = resp.responses();
         ASSERT_EQ(partition, results.size());
         EXPECT_EQ(0, results[0].result.failed_codes.size());
-        EXPECT_EQ(1, results[0].vertex_schema.columns.size());
-        auto tagProvider = std::make_shared<ResultSchemaProvider>(results[0].vertex_schema);
+        EXPECT_EQ(1, results[0].vertex_schema[tagId].columns.size());
+        auto tagProvider = std::make_shared<ResultSchemaProvider>(results[0].vertex_schema[tagId]);
         EXPECT_EQ(10000, results[0].vertices.size());
     }
     LOG(INFO) << "Let's open a new storage service";

--- a/src/meta/test/BalanceIntegrationTest.cpp
+++ b/src/meta/test/BalanceIntegrationTest.cpp
@@ -11,19 +11,240 @@
 #include "meta/test/TestUtils.h"
 #include "storage/test/TestUtils.h"
 #include "fs/TempDir.h"
+#include "storage/client/StorageClient.h"
+#include "storage/test/TestUtils.h"
+#include "dataman/RowWriter.h"
 
 DECLARE_int32(load_data_interval_secs);
 DECLARE_int32(heartbeat_interval_secs);
 DECLARE_uint32(raft_heartbeat_interval_secs);
+DECLARE_int32(expired_threshold_sec);
 
 namespace nebula {
 namespace meta {
 
-TEST(BalanceIntegrationTest, SimpleTest) {
-    auto sc = std::make_unique<test::ServerContext>();
-    auto handler = std::make_shared<nebula::storage::StorageServiceHandler>(nullptr, nullptr);
-    sc->mockCommon("storage", 0, handler);
-    LOG(INFO) << "Start storage server on " << sc->port_;
+TEST(BalanceIntegrationTest, BalanceTest) {
+    FLAGS_load_data_interval_secs = 1;
+    FLAGS_heartbeat_interval_secs = 1;
+    FLAGS_raft_heartbeat_interval_secs = 1;
+    FLAGS_expired_threshold_sec = 3;
+    fs::TempDir rootPath("/tmp/balance_integration_test.XXXXXX");
+    IPv4 localIp;
+    network::NetworkUtils::ipv4ToInt("127.0.0.1", localIp);
+    const nebula::ClusterID kClusterId = 10;
+
+    uint32_t localMetaPort = network::NetworkUtils::getAvailablePort();
+    LOG(INFO) << "Start meta server....";
+    std::string metaPath = folly::stringPrintf("%s/meta", rootPath.path());
+    auto metaServerContext = meta::TestUtils::mockMetaServer(localMetaPort, metaPath.c_str(),
+                                                             kClusterId);
+    localMetaPort = metaServerContext->port_;
+
+    auto adminClient = std::make_unique<AdminClient>(metaServerContext->kvStore_.get());
+    Balancer balancer(metaServerContext->kvStore_.get(), std::move(adminClient));
+
+    auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(10);
+    std::vector<HostAddr> metaAddr = {HostAddr(localIp, localMetaPort)};
+
+    LOG(INFO) << "Create meta client...";
+    uint32_t tempDataPort = network::NetworkUtils::getAvailablePort();
+    HostAddr tempDataAddr(localIp, tempDataPort);
+    auto mClient = std::make_unique<meta::MetaClient>(threadPool, metaAddr, tempDataAddr,
+                                                      kClusterId, false);
+
+    mClient->waitForMetadReady();
+
+    int partition = 1;
+    int replica = 3;
+    LOG(INFO) << "Start " << replica << " storage services, partition number " << partition;
+    std::vector<HostAddr> peers;
+    std::vector<uint32_t> storagePorts;
+    std::vector<std::shared_ptr<meta::MetaClient>> metaClients;
+    std::vector<std::unique_ptr<test::ServerContext>> serverContexts;
+    for (int i = 0; i < replica; i++) {
+        uint32_t storagePort = network::NetworkUtils::getAvailablePort();
+        HostAddr storageAddr(localIp, storagePort);
+        storagePorts.emplace_back(storagePort);
+        peers.emplace_back(storageAddr);
+
+        VLOG(1) << "The storage server has been added to the meta service";
+
+        auto metaClient = std::make_shared<meta::MetaClient>(threadPool, metaAddr, storageAddr,
+                                                             kClusterId, true);
+        metaClient->waitForMetadReady();
+        metaClients.emplace_back(metaClient);
+    }
+
+    for (int i = 0; i < replica; i++) {
+        std::string dataPath = folly::stringPrintf("%s/%d/data", rootPath.path(), i);
+        auto sc = storage::TestUtils::mockStorageServer(metaClients[i].get(),
+                                                        dataPath.c_str(),
+                                                        localIp,
+                                                        storagePorts[i],
+                                                        true);
+        serverContexts.emplace_back(std::move(sc));
+    }
+
+    LOG(INFO) << "Create space and schema";
+    auto ret = mClient->createSpace("storage", partition, replica).get();
+    ASSERT_TRUE(ret.ok());
+    auto spaceId = ret.value();
+    std::vector<nebula::cpp2::ColumnDef> columns;
+    columns.emplace_back(FRAGILE,
+                         "c",
+                         nebula::cpp2::ValueType(FRAGILE,
+                                                 SupportedType::STRING,
+                                                 nullptr,
+                                                 nullptr));
+    nebula::cpp2::Schema schema;
+    schema.set_columns(std::move(columns));
+    auto tagRet = mClient->createTagSchema(spaceId, "tag", std::move(schema)).get();
+    ASSERT_TRUE(tagRet.ok());
+    auto tagId = tagRet.value();
+    sleep(FLAGS_load_data_interval_secs + FLAGS_raft_heartbeat_interval_secs + 3);
+
+    LOG(INFO) << "Let's write some data";
+    auto sClient = std::make_unique<storage::StorageClient>(threadPool, mClient.get());
+    {
+        std::vector<storage::cpp2::Vertex> vertices;
+        for (int32_t vId = 0; vId < 10000; vId++) {
+            storage::cpp2::Vertex v;
+            v.set_id(vId);
+            decltype(v.tags) tags;
+            storage::cpp2::Tag t;
+            t.set_tag_id(tagId);
+            // Generate some tag props.
+            RowWriter writer;
+            writer << std::string(1024, 'A');
+            t.set_props(writer.encode());
+            tags.emplace_back(std::move(t));
+            v.set_tags(std::move(tags));
+            vertices.emplace_back(std::move(v));
+        }
+        int retry = 10;
+        while (retry-- > 0) {
+            auto f = sClient->addVertices(spaceId, vertices, true);
+            LOG(INFO) << "Waiting for the response...";
+            auto resp = std::move(f).get();
+            if (resp.completeness() == 100) {
+                LOG(INFO) << "All requests has been processed!";
+                break;
+            }
+            if (!resp.succeeded()) {
+                for (auto& err : resp.failedParts()) {
+                    LOG(ERROR) << "Partition " << err.first
+                               << " failed: " << static_cast<int32_t>(err.second);
+                }
+            }
+            LOG(INFO) << "Failed, the remaining retry times " << retry;
+        }
+    }
+    {
+        LOG(INFO) << "Check data...";
+        std::vector<VertexID> vIds;
+        std::vector<storage::cpp2::PropDef> retCols;
+        for (int32_t vId = 0; vId < 10000; vId++) {
+            vIds.emplace_back(vId);
+        }
+        retCols.emplace_back(
+            storage::TestUtils::propDef(storage::cpp2::PropOwner::SOURCE,
+                                        "c",
+                                        tagId));
+        auto f = sClient->getVertexProps(spaceId, std::move(vIds), std::move(retCols));
+        auto resp = std::move(f).get();
+        if (!resp.succeeded()) {
+            std::stringstream ss;
+            for (auto& p : resp.failedParts()) {
+                ss << "Part " << p.first
+                   << ": " << static_cast<int32_t>(p.second)
+                   << "; ";
+            }
+            VLOG(2) << "Failed partitions:: " << ss.str();
+        }
+        ASSERT_TRUE(resp.succeeded());
+        auto& results = resp.responses();
+        ASSERT_EQ(partition, results.size());
+        EXPECT_EQ(0, results[0].result.failed_codes.size());
+        EXPECT_EQ(1, results[0].vertex_schema.columns.size());
+        auto tagProvider = std::make_shared<ResultSchemaProvider>(results[0].vertex_schema);
+        EXPECT_EQ(10000, results[0].vertices.size());
+    }
+    LOG(INFO) << "Let's open a new storage service";
+    std::unique_ptr<test::ServerContext> newServer;
+    std::unique_ptr<meta::MetaClient> newMetaClient;
+    uint32_t storagePort = network::NetworkUtils::getAvailablePort();
+    HostAddr storageAddr(localIp, storagePort);
+    {
+        newMetaClient = std::make_unique<meta::MetaClient>(threadPool, metaAddr, storageAddr,
+                                                           kClusterId, true);
+        newMetaClient->waitForMetadReady();
+        std::string dataPath = folly::stringPrintf("%s/%d/data", rootPath.path(), replica + 1);
+        newServer = storage::TestUtils::mockStorageServer(newMetaClient.get(),
+                                                          dataPath.c_str(),
+                                                          localIp,
+                                                          storagePort,
+                                                          true);
+        LOG(INFO) << "Start a new storage server on " << storageAddr;
+    }
+    LOG(INFO) << "Let's stop the last storage servcie " << storagePorts.back();
+    {
+        metaClients.back()->stop();
+        serverContexts.back().reset();
+        // Wait for the host be expired on meta.
+        sleep(FLAGS_expired_threshold_sec + 1);
+    }
+
+    LOG(INFO) << "Let's balance";
+    auto bIdRet = balancer.balance();
+    CHECK(bIdRet.ok()) << bIdRet.status();
+    while (balancer.isRunning()) {
+        sleep(1);
+    }
+
+    // Sleep enough time until the data committed on newly added server
+    sleep(FLAGS_raft_heartbeat_interval_secs + 5);
+    {
+        LOG(INFO) << "Balance Finished, check the newly added server";
+        std::unique_ptr<kvstore::KVIterator> iter;
+        auto prefix = NebulaKeyUtils::prefix(1);
+        ASSERT_EQ(kvstore::ResultCode::SUCCEEDED, newServer->kvStore_->prefix(spaceId,
+                                                                              1,
+                                                                              prefix,
+                                                                              &iter));
+        int num = 0;
+        std::string lastKey = "";
+        while (iter->valid()) {
+            // filter the multipule versions for data.
+            auto key = NebulaKeyUtils::keyWithNoVersion(iter->key());
+            if (lastKey == key) {
+                iter->next();
+                continue;
+            }
+            lastKey = key.str();
+            iter->next();
+            num++;
+        }
+        ASSERT_EQ(10000, num);
+    }
+    {
+        LOG(INFO) << "Check meta";
+        auto paRet = mClient->getPartsAlloc(spaceId).get();
+        ASSERT_TRUE(paRet.ok()) << paRet.status();
+        ASSERT_EQ(1, paRet.value().size());
+        for (auto it = paRet.value().begin(); it != paRet.value().end(); it++) {
+            ASSERT_EQ(3, it->second.size());
+            ASSERT_TRUE(std::find(it->second.begin(), it->second.end(), storageAddr)
+                                    != it->second.end());
+        }
+    }
+    for (auto& c : metaClients) {
+        c->stop();
+    }
+    serverContexts.clear();
+    metaClients.clear();
+    newMetaClient->stop();
+    newServer.reset();
+    newMetaClient.reset();
 }
 
 TEST(BalanceIntegrationTest, LeaderBalanceTest) {
@@ -100,6 +321,11 @@ TEST(BalanceIntegrationTest, LeaderBalanceTest) {
         std::unordered_map<GraphSpaceID, std::vector<PartitionID>> leaderIds;
         EXPECT_EQ(3, serverContexts[i]->kvStore_->allLeader(leaderIds));
     }
+    for (auto& c : metaClients) {
+        c->stop();
+    }
+    serverContexts.clear();
+    metaClients.clear();
 }
 
 }  // namespace meta

--- a/src/meta/test/BalancerTest.cpp
+++ b/src/meta/test/BalancerTest.cpp
@@ -32,7 +32,9 @@ public:
     folly::Future<Status> response(int index) {
         folly::Promise<Status> pro;
         auto f = pro.getFuture();
+        LOG(INFO) << "Response " << index;
         executor_->add([this, p = std::move(pro), index]() mutable {
+            LOG(INFO) << "Call callback";
             p.setValue(this->statusArray_[index]);
         });
         return f;
@@ -87,7 +89,7 @@ TEST(BalanceTaskTest, SimpleTest) {
         std::vector<Status> sts(7, Status::OK());
         std::unique_ptr<FaultInjector> injector(new TestFaultInjector(std::move(sts)));
         auto client = std::make_unique<AdminClient>(std::move(injector));
-        BalanceTask task(0, 0, 0, HostAddr(0, 0), HostAddr(1, 1), nullptr, nullptr);
+        BalanceTask task(0, 0, 0, HostAddr(0, 0), HostAddr(1, 1), true, nullptr, nullptr);
         folly::Baton<true, std::atomic> b;
         task.onFinished_ = [&]() {
             LOG(INFO) << "Task finished!";
@@ -112,7 +114,7 @@ TEST(BalanceTaskTest, SimpleTest) {
                                 Status::OK()};
         std::unique_ptr<FaultInjector> injector(new TestFaultInjector(std::move(sts)));
         auto client = std::make_unique<AdminClient>(std::move(injector));
-        BalanceTask task(0, 0, 0, HostAddr(0, 0), HostAddr(1, 1), nullptr, nullptr);
+        BalanceTask task(0, 0, 0, HostAddr(0, 0), HostAddr(1, 1), true, nullptr, nullptr);
         folly::Baton<true, std::atomic> b;
         task.onFinished_ = []() {
             LOG(FATAL) << "We should not reach here!";
@@ -254,7 +256,7 @@ TEST(BalanceTest, DispatchTasksTest) {
         FLAGS_task_concurrency = 10;
         BalancePlan plan(0L, nullptr, nullptr);
         for (int i = 0; i < 20; i++) {
-            BalanceTask task(0, 0, 0, HostAddr(i, 0), HostAddr(i, 1), nullptr, nullptr);
+            BalanceTask task(0, 0, 0, HostAddr(i, 0), HostAddr(i, 1), true, nullptr, nullptr);
             plan.addTask(std::move(task));
         }
         plan.dispatchTasks();
@@ -267,7 +269,7 @@ TEST(BalanceTest, DispatchTasksTest) {
         FLAGS_task_concurrency = 10;
         BalancePlan plan(0L, nullptr, nullptr);
         for (int i = 0; i < 5; i++) {
-            BalanceTask task(0, 0, i, HostAddr(i, 0), HostAddr(i, 1), nullptr, nullptr);
+            BalanceTask task(0, 0, i, HostAddr(i, 0), HostAddr(i, 1), true, nullptr, nullptr);
             plan.addTask(std::move(task));
         }
         plan.dispatchTasks();
@@ -280,11 +282,11 @@ TEST(BalanceTest, DispatchTasksTest) {
         FLAGS_task_concurrency = 20;
         BalancePlan plan(0L, nullptr, nullptr);
         for (int i = 0; i < 5; i++) {
-            BalanceTask task(0, 0, i, HostAddr(i, 0), HostAddr(i, 1), nullptr, nullptr);
+            BalanceTask task(0, 0, i, HostAddr(i, 0), HostAddr(i, 1), true, nullptr, nullptr);
             plan.addTask(std::move(task));
         }
         for (int i = 0; i < 10; i++) {
-            BalanceTask task(0, 0, i, HostAddr(i, 2), HostAddr(i, 3), nullptr, nullptr);
+            BalanceTask task(0, 0, i, HostAddr(i, 2), HostAddr(i, 3), true, nullptr, nullptr);
             plan.addTask(std::move(task));
         }
         plan.dispatchTasks();
@@ -308,7 +310,7 @@ TEST(BalanceTest, BalancePlanTest) {
         auto client = std::make_unique<AdminClient>(std::move(injector));
 
         for (int i = 0; i < 10; i++) {
-            BalanceTask task(0, 0, 0, HostAddr(i, 0), HostAddr(i, 1), nullptr, nullptr);
+            BalanceTask task(0, 0, 0, HostAddr(i, 0), HostAddr(i, 1), true, nullptr, nullptr);
             task.client_ = client.get();
             plan.addTask(std::move(task));
         }
@@ -333,7 +335,7 @@ TEST(BalanceTest, BalancePlanTest) {
         auto client = std::make_unique<AdminClient>(std::move(injector));
 
         for (int i = 0; i < 10; i++) {
-            BalanceTask task(0, 0, i, HostAddr(i, 0), HostAddr(i, 1), nullptr, nullptr);
+            BalanceTask task(0, 0, i, HostAddr(i, 0), HostAddr(i, 1), true, nullptr, nullptr);
             task.client_ = client.get();
             plan.addTask(std::move(task));
         }
@@ -361,7 +363,7 @@ TEST(BalanceTest, BalancePlanTest) {
             std::unique_ptr<FaultInjector> injector(new TestFaultInjector(std::move(sts)));
             client1 = std::make_unique<AdminClient>(std::move(injector));
             for (int i = 0; i < 9; i++) {
-                BalanceTask task(0, 0, i, HostAddr(i, 0), HostAddr(i, 1), nullptr, nullptr);
+                BalanceTask task(0, 0, i, HostAddr(i, 0), HostAddr(i, 1), true, nullptr, nullptr);
                 task.client_ = client1.get();
                 plan.addTask(std::move(task));
             }
@@ -377,7 +379,7 @@ TEST(BalanceTest, BalancePlanTest) {
                                 Status::OK()};
             std::unique_ptr<FaultInjector> injector(new TestFaultInjector(std::move(sts)));
             client2 = std::make_unique<AdminClient>(std::move(injector));
-            BalanceTask task(0, 0, 0, HostAddr(10, 0), HostAddr(10, 1), nullptr, nullptr);
+            BalanceTask task(0, 0, 0, HostAddr(10, 0), HostAddr(10, 1), true, nullptr, nullptr);
             task.client_ = client2.get();
             plan.addTask(std::move(task));
         }
@@ -465,9 +467,11 @@ TEST(BalanceTest, NormalTest) {
                 ASSERT_EQ(BalanceTask::Status::END, task.status_);
                 task.ret_ = std::get<1>(tup);
                 ASSERT_EQ(BalanceTask::Result::SUCCEEDED, task.ret_);
-                task.startTimeMs_ = std::get<2>(tup);
+                task.srcLived_ = std::get<2>(tup);
+                ASSERT_FALSE(task.srcLived_);
+                task.startTimeMs_ = std::get<3>(tup);
                 ASSERT_GT(task.startTimeMs_, 0);
-                task.endTimeMs_ = std::get<3>(tup);
+                task.endTimeMs_ = std::get<4>(tup);
                 ASSERT_GT(task.endTimeMs_, 0);
             }
             num++;
@@ -555,9 +559,11 @@ TEST(BalanceTest, RecoveryTest) {
                 ASSERT_EQ(BalanceTask::Status::CATCH_UP_DATA, task.status_);
                 task.ret_ = std::get<1>(tup);
                 ASSERT_EQ(BalanceTask::Result::FAILED, task.ret_);
-                task.startTimeMs_ = std::get<2>(tup);
+                task.srcLived_ = std::get<2>(tup);
+                ASSERT_FALSE(task.srcLived_);
+                task.startTimeMs_ = std::get<3>(tup);
                 ASSERT_GT(task.startTimeMs_, 0);
-                task.endTimeMs_ = std::get<3>(tup);
+                task.endTimeMs_ = std::get<4>(tup);
                 ASSERT_GT(task.endTimeMs_, 0);
             }
             num++;
@@ -611,9 +617,11 @@ TEST(BalanceTest, RecoveryTest) {
                 ASSERT_EQ(BalanceTask::Status::END, task.status_);
                 task.ret_ = std::get<1>(tup);
                 ASSERT_EQ(BalanceTask::Result::SUCCEEDED, task.ret_);
-                task.startTimeMs_ = std::get<2>(tup);
+                task.srcLived_ = std::get<2>(tup);
+                ASSERT_FALSE(task.srcLived_);
+                task.startTimeMs_ = std::get<3>(tup);
                 ASSERT_GT(task.startTimeMs_, 0);
-                task.endTimeMs_ = std::get<3>(tup);
+                task.endTimeMs_ = std::get<4>(tup);
                 ASSERT_GT(task.endTimeMs_, 0);
             }
             num++;

--- a/src/meta/test/BalancerTest.cpp
+++ b/src/meta/test/BalancerTest.cpp
@@ -418,7 +418,7 @@ TEST(BalanceTest, NormalTest) {
     auto client = std::make_unique<AdminClient>(std::move(injector));
     Balancer balancer(kv.get(), std::move(client));
     auto ret = balancer.balance();
-    CHECK_EQ(Status::Error("No tasks"), ret.status());
+    CHECK_EQ(Status::Balanced(), ret.status());
 
     sleep(1);
     LOG(INFO) << "Now, we lost host " << HostAddr(3, 3);
@@ -614,9 +614,8 @@ TEST(BalanceTest, RecoveryTest) {
             {
                 auto tup = BalanceTask::parseVal(iter->val());
                 task.status_ = std::get<0>(tup);
-                ASSERT_EQ(BalanceTask::Status::END, task.status_);
                 task.ret_ = std::get<1>(tup);
-                ASSERT_EQ(BalanceTask::Result::SUCCEEDED, task.ret_);
+                ASSERT_EQ(BalanceTask::Result::INVALID, task.ret_);
                 task.srcLived_ = std::get<2>(tup);
                 ASSERT_FALSE(task.srcLived_);
                 task.startTimeMs_ = std::get<3>(tup);

--- a/src/meta/test/CMakeLists.txt
+++ b/src/meta/test/CMakeLists.txt
@@ -334,6 +334,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:schema_obj>
         $<TARGET_OBJECTS:meta_client>
         $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:storage_client>
         $<TARGET_OBJECTS:storage_service_handler>
         $<TARGET_OBJECTS:kvstore_obj>
         $<TARGET_OBJECTS:storage_thrift_obj>

--- a/src/meta/test/MetaClientTest.cpp
+++ b/src/meta/test/MetaClientTest.cpp
@@ -324,7 +324,8 @@ TEST(MetaClientTest, TagTest) {
         columns.emplace_back(FRAGILE, "column_s",
                              ValueType(FRAGILE, SupportedType::STRING, nullptr, nullptr));
         nebula::cpp2::Schema schema;
-        auto result = client->createTagSchema(spaceId, "test_tag", schema).get();
+        schema.set_columns(std::move(columns));
+        auto result = client->createTagSchema(spaceId, "test_tag", std::move(schema)).get();
         ASSERT_TRUE(result.ok());
         id = result.value();
     }
@@ -342,6 +343,7 @@ TEST(MetaClientTest, TagTest) {
         ASSERT_TRUE(result1.ok());
         auto result2 = client->getTagSchema(spaceId, "test_tag").get();
         ASSERT_TRUE(result2.ok());
+        ASSERT_EQ(3, result2.value().columns.size());
         ASSERT_EQ(result1.value().columns.size(), result2.value().columns.size());
         for (auto i = 0u; i < result1.value().columns.size(); i++) {
             ASSERT_EQ(result1.value().columns[i].name, result2.value().columns[i].name);

--- a/src/meta/test/MetaHttpDownloadHandlerTest.cpp
+++ b/src/meta/test/MetaHttpDownloadHandlerTest.cpp
@@ -16,6 +16,7 @@
 
 DECLARE_int32(load_data_interval_secs);
 DECLARE_string(pid_file);
+DECLARE_int32(ws_storage_http_port);
 
 namespace nebula {
 namespace meta {
@@ -25,7 +26,8 @@ std::unique_ptr<hdfs::HdfsHelper> helper = std::make_unique<meta::MockHdfsOKHelp
 class MetaHttpDownloadHandlerTestEnv : public ::testing::Environment {
 public:
     void SetUp() override {
-        FLAGS_ws_http_port = 12000;
+        FLAGS_ws_http_port = 12100;
+        FLAGS_ws_storage_http_port = 12100;
         FLAGS_ws_h2_port = 0;
         VLOG(1) << "Starting web service...";
 
@@ -33,6 +35,14 @@ public:
         kv_ = TestUtils::initKV(rootPath_->path());
         TestUtils::createSomeHosts(kv_.get());
         TestUtils::assembleSpace(kv_.get(), 1, 2);
+
+        // Because we reuse the kvstore for storage handler, let's add part manually.
+        auto* partMan = static_cast<kvstore::MemPartManager*>(kv_->partManager());
+        partMan->addPart(1, 1);
+        partMan->addPart(1, 2);
+
+        // wait for the leader election
+        sleep(3);
 
         pool_ = std::make_unique<nebula::thread::GenericThreadPool>();
         pool_->start(3);

--- a/src/meta/test/MetaHttpIngestHandlerTest.cpp
+++ b/src/meta/test/MetaHttpIngestHandlerTest.cpp
@@ -15,13 +15,16 @@
 #include <rocksdb/sst_file_writer.h>
 #include "thread/GenericThreadPool.h"
 
+DECLARE_int32(ws_storage_http_port);
+
 namespace nebula {
 namespace meta {
 
 class MetaHttpIngestHandlerTestEnv : public ::testing::Environment {
 public:
     void SetUp() override {
-        FLAGS_ws_http_port = 12000;
+        FLAGS_ws_http_port = 12100;
+        FLAGS_ws_storage_http_port = 12100;
         FLAGS_ws_h2_port = 0;
         VLOG(1) << "Starting web service...";
 

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -44,9 +44,6 @@ public:
         // 0 => {0}
         auto& partsMap = partMan->partsMap();
         partsMap[0][0] = PartMeta();
-        // 1 => {1,2}
-        partsMap[1][1] = PartMeta();
-        partsMap[1][2] = PartMeta();
 
         std::vector<std::string> paths;
         paths.emplace_back(folly::stringPrintf("%s/disk1", rootPath));

--- a/src/parser/AdminSentences.h
+++ b/src/parser/AdminSentences.h
@@ -359,6 +359,8 @@ public:
     enum class SubType : uint32_t {
         kUnknown,
         kLeader,
+        kData,
+        kShowBalancePlan,
     };
 
     // TODO: add more subtype for balance
@@ -367,14 +369,25 @@ public:
         subType_ = std::move(subType);
     }
 
+    explicit BalanceSentence(int64_t id) {
+        kind_ = Kind::kBalance;
+        subType_ = SubType::kShowBalancePlan;
+        balanceId_ = id;
+    }
+
     std::string toString() const override;
 
     SubType subType() const {
         return subType_;
     }
 
+    int64_t balanceId() const {
+        return balanceId_;
+    }
+
 private:
     SubType                         subType_{SubType::kUnknown};
+    int64_t                         balanceId_{0};
 };
 
 }   // namespace nebula

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -107,7 +107,8 @@ class GraphScanner;
 %token KW_ORDER KW_ASC
 %token KW_FETCH KW_PROP KW_UPDATE KW_UPSERT KW_WHEN
 %token KW_DISTINCT KW_ALL KW_OF
-%token KW_BALANCE KW_LEADER
+%token KW_BALANCE KW_LEADER KW_DATA
+
 /* symbols */
 %token L_PAREN R_PAREN L_BRACKET R_BRACKET L_BRACE R_BRACE COMMA
 %token PIPE OR AND XOR LT LE GT GE EQ NE PLUS MINUS MUL DIV MOD NOT NEG ASSIGN
@@ -1564,6 +1565,12 @@ set_config_sentence
 balance_sentence
     : KW_BALANCE KW_LEADER {
         $$ = new BalanceSentence(BalanceSentence::SubType::kLeader);
+    }
+    | KW_BALANCE KW_DATA {
+        $$ = new BalanceSentence(BalanceSentence::SubType::kData);
+    }
+    | KW_BALANCE KW_DATA INTEGER {
+        $$ = new BalanceSentence($3);
     }
     ;
 

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -120,6 +120,7 @@ ALL                         ([Aa][Ll][Ll])
 BALANCE                     ([Bb][Aa][Ll][Aa][Nn][Cc][Ee])
 LEADER                      ([Ll][Ee][Aa][Dd][Ee][Rr])
 OF                          ([Oo][Ff])
+DATA                        ([Dd][Aa][Tt][Aa])
 
 LABEL                       ([a-zA-Z][_a-zA-Z0-9]*)
 DEC                         ([0-9])
@@ -229,6 +230,7 @@ IP_OCTET                    ([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])
 {ALL}                       { return TokenType::KW_ALL; }
 {BALANCE}                   { return TokenType::KW_BALANCE; }
 {LEADER}                    { return TokenType::KW_LEADER; }
+{DATA}                      { return TokenType::KW_DATA; }
 
 "."                         { return TokenType::DOT; }
 ","                         { return TokenType::COMMA; }

--- a/src/storage/AdminProcessor.h
+++ b/src/storage/AdminProcessor.h
@@ -8,9 +8,10 @@
 #define STORAGE_TRANSLEADERPROCESSOR_H_
 
 #include "base/Base.h"
-#include "storage/BaseProcessor.h"
 #include "kvstore/NebulaStore.h"
 #include "kvstore/Part.h"
+#include "storage/StorageFlags.h"
+#include "storage/BaseProcessor.h"
 
 namespace nebula {
 namespace storage {
@@ -23,13 +24,15 @@ public:
 
     void process(const cpp2::TransLeaderReq& req) {
         CHECK_NOTNULL(kvstore_);
+        LOG(INFO) << "Receive transfer leader for space "
+                  << req.get_space_id() << ", part " << req.get_part_id()
+                  << ", to [" << req.get_new_leader().get_ip()
+                  << ", " << req.get_new_leader().get_port() << "]";
         auto spaceId = req.get_space_id();
         auto partId = req.get_part_id();
         auto ret = kvstore_->part(spaceId, partId);
         if (!ok(ret)) {
-            resp_.set_code(to(error(ret)));
-            promise_.setValue(std::move(resp_));
-            delete this;
+            onFinished(to(error(ret)));
             return;
         }
         auto part = nebula::value(ret);
@@ -48,9 +51,7 @@ public:
                     resp_.set_leader(toThriftHost(leader));
                 }
             }
-            resp_.set_code(to(code));
-            promise_.setValue(std::move(resp_));
-            delete this;
+            onFinished(to(code));
         });
     }
 
@@ -66,7 +67,16 @@ public:
     }
 
     void process(const cpp2::AddPartReq& req) {
-        UNUSED(req);
+        if (FLAGS_store_type != "nebula") {
+            onFinished(cpp2::ErrorCode::E_INVALID_STORE);
+            return;
+        }
+
+        LOG(INFO) << "Receive add part for space "
+                  << req.get_space_id() << ", part " << req.get_part_id();
+        auto* store = static_cast<kvstore::NebulaStore*>(kvstore_);
+        store->addPart(req.get_space_id(), req.get_part_id(), req.get_as_learner());
+        onFinished(cpp2::ErrorCode::SUCCEEDED);
     }
 
 private:
@@ -81,7 +91,13 @@ public:
     }
 
     void process(const cpp2::RemovePartReq& req) {
-        UNUSED(req);
+        if (FLAGS_store_type != "nebula") {
+            onFinished(cpp2::ErrorCode::E_INVALID_STORE);
+            return;
+        }
+        auto* store = static_cast<kvstore::NebulaStore*>(kvstore_);
+        store->removePart(req.get_space_id(), req.get_part_id());
+        onFinished(cpp2::ErrorCode::SUCCEEDED);
     }
 
 private:
@@ -96,7 +112,36 @@ public:
     }
 
     void process(const cpp2::MemberChangeReq& req) {
-        UNUSED(req);
+        CHECK_NOTNULL(kvstore_);
+        auto spaceId = req.get_space_id();
+        auto partId = req.get_part_id();
+        LOG(INFO) << "Receive member change for space "
+                  << spaceId << ", part " << partId
+                  << ", add/remove " << (req.get_add() ? "add" : "remove");
+        auto ret = kvstore_->part(spaceId, partId);
+        if (!ok(ret)) {
+            onFinished(to(error(ret)));
+            return;
+        }
+        auto part = nebula::value(ret);
+        auto peer = kvstore::NebulaStore::getRaftAddr(HostAddr(req.get_peer().get_ip(),
+                                                               req.get_peer().get_port()));
+        auto cb = [this, spaceId, partId] (kvstore::ResultCode code) {
+            auto leaderRet = kvstore_->partLeader(spaceId, partId);
+            CHECK(ok(leaderRet));
+            if (code == kvstore::ResultCode::ERR_LEADER_CHANGED) {
+                auto leader = value(std::move(leaderRet));
+                resp_.set_leader(toThriftHost(leader));
+            }
+            onFinished(to(code));
+        };
+        if (req.get_add()) {
+            LOG(INFO) << "Add peer " << peer;
+            part->asyncAddPeer(peer, cb);
+        } else {
+            LOG(INFO) << "Remove peer " << peer;
+            part->asyncRemovePeer(peer, cb);
+        }
     }
 
 private:
@@ -111,7 +156,27 @@ public:
     }
 
     void process(const cpp2::AddLearnerReq& req) {
-        UNUSED(req);
+        auto spaceId = req.get_space_id();
+        auto partId = req.get_part_id();
+        LOG(INFO) << "Receive add learner for space "
+                  << spaceId << ", part " << partId;
+        auto ret = kvstore_->part(spaceId, partId);
+        if (!ok(ret)) {
+            onFinished(to(error(ret)));
+            return;
+        }
+        auto part = nebula::value(ret);
+        auto learner = kvstore::NebulaStore::getRaftAddr(HostAddr(req.get_learner().get_ip(),
+                                                                  req.get_learner().get_port()));
+        part->asyncAddLearner(learner, [this, spaceId, partId] (kvstore::ResultCode code) {
+            auto leaderRet = kvstore_->partLeader(spaceId, partId);
+            CHECK(ok(leaderRet));
+            if (code == kvstore::ResultCode::ERR_LEADER_CHANGED) {
+                auto leader = value(std::move(leaderRet));
+                resp_.set_leader(toThriftHost(leader));
+            }
+            onFinished(to(code));
+        });
     }
 
 private:
@@ -125,13 +190,61 @@ public:
         return new WaitingForCatchUpDataProcessor(kvstore);
     }
 
+    ~WaitingForCatchUpDataProcessor() {
+        if (bgThread_) {
+            bgThread_->join();
+        }
+    }
+
     void process(const cpp2::CatchUpDataReq& req) {
-        UNUSED(req);
+        auto spaceId = req.get_space_id();
+        auto partId = req.get_part_id();
+        LOG(INFO) << "Received waiting for catching up data for space "
+                  << spaceId << ", part " << partId;
+        auto ret = kvstore_->part(spaceId, partId);
+        if (!ok(ret)) {
+            onFinished(to(error(ret)));
+            return;
+        }
+        auto part = nebula::value(ret);
+        auto peer = kvstore::NebulaStore::getRaftAddr(HostAddr(req.get_target().get_ip(),
+                                                               req.get_target().get_port()));
+        bgThread_ = std::make_unique<std::thread>([this, part, peer, spaceId, partId] {
+            int retry = FLAGS_waiting_catch_up_retry_times;
+            while (retry-- > 0) {
+                LOG(INFO) << "Waiting for catching up data, peer " << peer
+                          << ", try " << retry << " times";
+                auto res = part->isCatchedUp(peer);
+                switch (res) {
+                    case raftex::AppendLogResult::SUCCEEDED:
+                        onFinished(cpp2::ErrorCode::SUCCEEDED);
+                        return;
+                    case raftex::AppendLogResult::E_INVALID_PEER:
+                        onFinished(cpp2::ErrorCode::E_INVALID_PEER);
+                        return;
+                    case raftex::AppendLogResult::E_NOT_A_LEADER: {
+                        auto leaderRet = kvstore_->partLeader(spaceId, partId);
+                        CHECK(ok(leaderRet));
+                        auto leader = value(std::move(leaderRet));
+                        resp_.set_leader(toThriftHost(leader));
+                        onFinished(cpp2::ErrorCode::E_LEADER_CHANGED);
+                        return;
+                    }
+                    default:
+                        onFinished(cpp2::ErrorCode::E_UNKNOWN);
+                        return;
+                }
+                sleep(FLAGS_waiting_catch_up_interval_in_secs);
+            }
+        });
     }
 
 private:
     explicit WaitingForCatchUpDataProcessor(kvstore::KVStore* kvstore)
             : BaseProcessor<cpp2::AdminExecResp>(kvstore, nullptr) {}
+
+private:
+    std::unique_ptr<std::thread> bgThread_;
 };
 
 class GetLeaderProcessor : public BaseProcessor<cpp2::GetLeaderResp> {

--- a/src/storage/AdminProcessor.h
+++ b/src/storage/AdminProcessor.h
@@ -229,9 +229,12 @@ public:
                         onFinished(cpp2::ErrorCode::E_LEADER_CHANGED);
                         return;
                     }
+                    case raftex::AppendLogResult::E_SENDING_SNAPSHOT:
+                        LOG(INFO) << "Still sending snapshot, please wait...";
+                        break;
                     default:
-                        onFinished(cpp2::ErrorCode::E_UNKNOWN);
-                        return;
+                        LOG(INFO) << "Unknown error " << static_cast<int32_t>(res);
+                        break;
                 }
                 sleep(FLAGS_waiting_catch_up_interval_in_secs);
             }

--- a/src/storage/AdminProcessor.h
+++ b/src/storage/AdminProcessor.h
@@ -247,6 +247,7 @@ public:
                 }
                 sleep(FLAGS_waiting_catch_up_interval_in_secs);
             }
+            onFinished(cpp2::ErrorCode::E_RETRY_EXHAUSTED);
         });
     }
 

--- a/src/storage/BaseProcessor.h
+++ b/src/storage/BaseProcessor.h
@@ -48,6 +48,14 @@ protected:
         delete this;
     }
 
+    // This method will be used for single part request processor.
+    // Currently, it is used in AdminProcessor
+    void onFinished(cpp2::ErrorCode code) {
+        resp_.set_code(code);
+        promise_.setValue(std::move(resp_));
+        delete this;
+    }
+
     void doPut(GraphSpaceID spaceId, PartitionID partId, std::vector<kvstore::KV> data);
 
     void doRemove(GraphSpaceID spaceId, PartitionID partId, std::vector<std::string> keys);

--- a/src/storage/BaseProcessor.inl
+++ b/src/storage/BaseProcessor.inl
@@ -21,6 +21,8 @@ cpp2::ErrorCode BaseProcessor<RESP>::to(kvstore::ResultCode code) {
         return cpp2::ErrorCode::E_SPACE_NOT_FOUND;
     case kvstore::ResultCode::ERR_PART_NOT_FOUND:
         return cpp2::ErrorCode::E_PART_NOT_FOUND;
+    case kvstore::ResultCode::ERR_CONSENSUS_ERROR:
+        return cpp2::ErrorCode::E_CONSENSUS_ERROR;
     default:
         return cpp2::ErrorCode::E_UNKNOWN;
     }

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -1,6 +1,7 @@
 nebula_add_library(
     storage_service_handler OBJECT
     StorageServiceHandler.cpp
+    StorageFlags.cpp
     QueryBaseProcessor.cpp
     AddVerticesProcessor.cpp
     AddEdgesProcessor.cpp

--- a/src/storage/StorageFlags.cpp
+++ b/src/storage/StorageFlags.cpp
@@ -1,0 +1,15 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/Base.h"
+#include "storage/StorageFlags.h"
+
+DEFINE_string(store_type, "nebula",
+              "Which type of KVStore to be used by the storage daemon."
+              " Options can be \"nebula\", \"hbase\", etc.");
+DEFINE_int32(waiting_catch_up_retry_times, 30, "retry times when waiting for catching up data");
+DEFINE_int32(waiting_catch_up_interval_in_secs, 30,
+             "interval between two requests for catching up state");

--- a/src/storage/StorageFlags.h
+++ b/src/storage/StorageFlags.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef STORAGE_STORAGEFLAGS_H_
+#define STORAGE_STORAGEFLAGS_H_
+
+#include "base/Base.h"
+
+DECLARE_string(store_type);
+
+DECLARE_int32(waiting_catch_up_retry_times);
+
+DECLARE_int32(waiting_catch_up_interval_in_secs);
+
+#endif  // STORAGE_STORAGEFLAGS_H_

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -122,7 +122,9 @@ bool StorageServer::start() {
         return false;
     }
 
-    auto handler = std::make_shared<StorageServiceHandler>(kvstore_.get(), schemaMan_.get());
+    auto handler = std::make_shared<StorageServiceHandler>(kvstore_.get(),
+                                                           schemaMan_.get(),
+                                                           metaClient_.get());
     try {
         LOG(INFO) << "The storage deamon start on " << localHost_;
         tfServer_ = std::make_unique<apache::thrift::ThriftServer>();

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -6,6 +6,7 @@
 
 #include "storage/StorageServer.h"
 #include "network/NetworkUtils.h"
+#include "storage/StorageFlags.h"
 #include "storage/StorageServiceHandler.h"
 #include "storage/StorageHttpStatusHandler.h"
 #include "storage/StorageHttpDownloadHandler.h"
@@ -21,9 +22,6 @@
 
 DEFINE_int32(port, 44500, "Storage daemon listening port");
 DEFINE_bool(reuse_port, true, "Whether to turn on the SO_REUSEPORT option");
-DEFINE_string(store_type, "nebula",
-              "Which type of KVStore to be used by the storage daemon."
-              " Options can be \"nebula\", \"hbase\", etc.");
 DEFINE_int32(num_io_threads, 16, "Number of IO threads");
 DEFINE_int32(num_worker_threads, 32, "Number of workers");
 DEFINE_int32(storage_http_thread_num, 3, "Number of storage daemon's http thread");

--- a/src/storage/StorageServiceHandler.cpp
+++ b/src/storage/StorageServiceHandler.cpp
@@ -103,7 +103,7 @@ StorageServiceHandler::future_transLeader(const cpp2::TransLeaderReq& req) {
 
 folly::Future<cpp2::AdminExecResp>
 StorageServiceHandler::future_addPart(const cpp2::AddPartReq& req) {
-    auto* processor = AddPartProcessor::instance(kvstore_);
+    auto* processor = AddPartProcessor::instance(kvstore_, metaClient_);
     RETURN_FUTURE(processor);
 }
 

--- a/src/storage/StorageServiceHandler.h
+++ b/src/storage/StorageServiceHandler.h
@@ -21,9 +21,11 @@ class StorageServiceHandler final : public cpp2::StorageServiceSvIf {
 
 public:
     StorageServiceHandler(kvstore::KVStore* kvstore,
-                          meta::SchemaManager* schemaMan)
+                          meta::SchemaManager* schemaMan,
+                          meta::MetaClient* client)
         : kvstore_(kvstore)
-        , schemaMan_(schemaMan) {}
+        , schemaMan_(schemaMan)
+        , metaClient_(client) {}
 
     folly::Future<cpp2::QueryResponse>
     future_getBound(const cpp2::GetNeighborsRequest& req) override;
@@ -82,7 +84,8 @@ public:
 
 private:
     kvstore::KVStore* kvstore_ = nullptr;
-    meta::SchemaManager* schemaMan_;
+    meta::SchemaManager* schemaMan_ = nullptr;
+    meta::MetaClient* metaClient_ = nullptr;
 };
 
 }  // namespace storage

--- a/src/storage/test/StorageServiceHandlerTest.cpp
+++ b/src/storage/test/StorageServiceHandlerTest.cpp
@@ -27,7 +27,9 @@ TEST(StorageServiceHandlerTest, FutureAddVerticesTest) {
     LOG(INFO) << "Test FutureAddVerticesTest...";
     std::unique_ptr<kvstore::KVStore> kvstore = TestUtils::initKV(rootPath.path());
 
-    auto storageServiceHandler = std::make_unique<StorageServiceHandler>(kvstore.get(), nullptr);
+    auto storageServiceHandler = std::make_unique<StorageServiceHandler>(kvstore.get(),
+                                                                         nullptr,
+                                                                         nullptr);
     auto resp = storageServiceHandler->future_addVertices(req).get();
     EXPECT_EQ(typeid(cpp2::ExecResponse).name() , typeid(resp).name());
 

--- a/src/storage/test/TestUtils.h
+++ b/src/storage/test/TestUtils.h
@@ -210,7 +210,7 @@ public:
         }
 
         auto handler = std::make_shared<nebula::storage::StorageServiceHandler>(
-            sc->kvStore_.get(), sc->schemaMan_.get());
+            sc->kvStore_.get(), sc->schemaMan_.get(), mClient);
         sc->mockCommon("storage", port, handler);
         auto ptr = dynamic_cast<kvstore::MetaServerBasedPartManager*>(
             sc->kvStore_->partManager());

--- a/src/tools/storage-perf/StoragePerfTool.cpp
+++ b/src/tools/storage-perf/StoragePerfTool.cpp
@@ -235,13 +235,16 @@ private:
         auto f = client_->addVertices(spaceId_, genVertices(), true)
                     .via(evb).then([this](auto&& resps) {
                         if (!resps.succeeded()) {
-                            LOG(ERROR) << "Request failed!";
+                            for (auto& entry : resps.failedParts()) {
+                                LOG(ERROR) << "Request failed, part " << entry.first
+                                           << ", error " << static_cast<int32_t>(entry.second);
+                            }
                         } else {
                             VLOG(3) << "request successed!";
                         }
                         this->finishedRequests_++;
-                     }).onError([](folly::FutureException&) {
-                        LOG(ERROR) << "Request failed!";
+                     }).onError([](folly::FutureException& e) {
+                        LOG(ERROR) << "Request failed, e = " << e.what();
                      });
     }
 


### PR DESCRIPTION
subtask of #182 
Main changes:
1.  Support raft member change.  To be simple,  we just add/remove one peer each time. 
2.  Make balance works.  
3.  Show specified balance plan in detail.
4.  Fix some problems when recovery.

**Show the usage with an example:**
Originally,  the cluster have 7 hosts with 3 parts, 3 replica.  
Let's scale the cluster to 9 hosts (one part one host). 

1.  Start two new hosts directly. (192.168.8.210:44920,   192.168.8.210:44930)

2.  We could show our parts allocation with "show hosts" (3 parts, 3 replica, 7 hosts,  2 new hosts)
```
(user@127.0.0.1) [(none)]> show hosts
=================================================================================================
| Ip            | Port  | Status  | Leader count | Leader distribution | Partition distribution |
=================================================================================================
| 192.168.8.210 | 34600 | online  | 0            |                     | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 34900 | online  | 1            | space 1: 1          | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 35940 | online  | 0            |                     | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 34920 | online  | 0            |                     | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 44920 | online  | 0            |                     |                        |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 44930 | online  | 0            |                     |                        |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 34700 | online  | 1            | space 1: 1          | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 34500 | online  | 0            |                     | space 1: 2             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 34800 | online  | 1            | space 1: 1          | space 1: 2             |
-------------------------------------------------------------------------------------------------
```


3. Now, we could use balance as follows, balance id will be showed in table.

```
(user@127.0.0.1) [(none)]> balance data
==============
| ID         |
==============
| 1568100011 |
--------------
Got 1 rows (Time spent: 3483/4713 us)
```

4. The balance has been runned in the backend.  Now, we could use "balance data $id" to show the detail of the plan. 

```
(user@127.0.0.1) [(none)]> balance data 1568100011
==============================================================================
| balanceId, spaceId:partId, src->dst                          | status      |
==============================================================================
| [1568100011, 1:1, 192.168.8.210:34800->192.168.8.210:44930]  | in progress |
------------------------------------------------------------------------------
| [1568100011, 1:2, 192.168.8.210:34500->192.168.8.210:44920]  | in progress |
------------------------------------------------------------------------------
Got 2 rows (Time spent: 1273/2097 us)
```

5. After finishing the balance plan,  we could check the status with "show hosts"

```
(user@127.0.0.1) [(none)]> show hosts
=================================================================================================
| Ip            | Port  | Status  | Leader count | Leader distribution | Partition distribution |
=================================================================================================
| 192.168.8.210 | 34600 | online  | 0            |                     | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 34900 | online  | 1            | space 1: 1          | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 35940 | online  | 0            |                     | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 34920 | online  | 1            | space 1: 1          | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 44920 | online  | 0            |                     | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 44930 | online  | 0            |                     | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 34700 | online  | 1            | space 1: 1          | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 34500 | online  | 0            |                     | space 1: 1             |
-------------------------------------------------------------------------------------------------
| 192.168.8.210 | 34800 | online  | 0            |                     | space 1: 1             |
-------------------------------------------------------------------------------------------------
```

