### PR TITLE
Show space name in leader/part distribution of show hosts

### DIFF
--- a/docs/manual-EN/statement-syntax/data-definition-statements/show-syntax.md
+++ b/docs/manual-EN/statement-syntax/data-definition-statements/show-syntax.md
@@ -7,7 +7,7 @@ SHOW VARIABLES [graph|meta|storage]
 
 `SHOW TAGS` and `SHOW EDGES` return the defined tags and edge types in the space, respectively. 
 
-`SHOW HOSTS` is to list storage hosts registered by the meta server.
+`SHOW HOSTS` is to list storage hosts registered by the meta server. There are 6 columns: ip, port, status (online/offline), leader partitions count in all spaces, leader partitions count in each space, total partitions count in all spaces.
 
 For more information about `SHOW VARIABLES [graph|meta|storage]`, please refer to [variable syntax](../data-administration-statements/configuration-statements/variables-syntax.md).
 

--- a/src/graph/ShowExecutor.cpp
+++ b/src/graph/ShowExecutor.cpp
@@ -94,7 +94,7 @@ void ShowExecutor::showHosts() {
             if (a.get_status() == b.get_status()) {
                 return a.hostAddr.ip < b.hostAddr.ip;
             }
-            return a.status < b.status;
+            return a.get_status() < b.get_status();
         });
 
         for (auto& item : hostItems) {

--- a/src/graph/ShowExecutor.cpp
+++ b/src/graph/ShowExecutor.cpp
@@ -109,7 +109,7 @@ void ShowExecutor::showHosts() {
             std::string leaders;
             for (auto& spaceEntry : item.get_leader_parts()) {
                 leaderCount += spaceEntry.second.size();
-                leaders += "space " + folly::to<std::string>(spaceEntry.first) + ": " +
+                leaders += spaceEntry.first + ": " +
                            folly::to<std::string>(spaceEntry.second.size()) + ", ";
             }
             if (!leaders.empty()) {
@@ -121,8 +121,8 @@ void ShowExecutor::showHosts() {
 
             std::string parts;
             for (auto& spaceEntry : item.get_all_parts()) {
-                parts += "space " + folly::to<std::string>(spaceEntry.first) + ": " +
-                           folly::to<std::string>(spaceEntry.second.size()) + ", ";
+                parts += spaceEntry.first + ": " +
+                         folly::to<std::string>(spaceEntry.second.size()) + ", ";
             }
             if (!parts.empty()) {
                 parts.resize(parts.size() - 2);

--- a/src/graph/ShowExecutor.cpp
+++ b/src/graph/ShowExecutor.cpp
@@ -74,6 +74,7 @@ void ShowExecutor::execute() {
 void ShowExecutor::showHosts() {
     auto future = ectx()->getMetaClient()->listHosts();
     auto *runner = ectx()->rctx()->runner();
+    constexpr static char kNoValidPart[] = "No valid partition";
 
     auto cb = [this] (auto &&resp) {
         if (!resp.ok()) {
@@ -134,8 +135,8 @@ void ShowExecutor::showHosts() {
                 parts.resize(parts.size() - 2);
             } else {
                 // if there is no valid parition on a host at all
-                leaders = "No valid partition";
-                parts = "No valid partition";
+                leaders = kNoValidPart;
+                parts = kNoValidPart;
             }
             row[4].set_str(leaders);
             row[5].set_str(parts);

--- a/src/graph/test/SchemaTest.cpp
+++ b/src/graph/test/SchemaTest.cpp
@@ -54,7 +54,8 @@ TEST_F(SchemaTest, metaCommunication) {
         client->execute(query, resp);
         std::vector<std::tuple<std::string, std::string, std::string,
                                int, std::string, std::string>> expected {
-            {"127.0.0.1", std::to_string(gEnv->storageServerPort()), "online", 0, "", ""},
+            {"127.0.0.1", std::to_string(gEnv->storageServerPort()), "online", 0,
+             "No valid partition", "No valid partition"},
         };
         ASSERT_TRUE(verifyResult(resp, expected));
     }
@@ -667,7 +668,8 @@ TEST_F(SchemaTest, TTLtest) {
         client->execute(query, resp);
         std::vector<std::tuple<std::string, std::string, std::string,
                                int, std::string, std::string>> expected {
-            {"127.0.0.1", std::to_string(gEnv->storageServerPort()), "online", 0, "", ""},
+            {"127.0.0.1", std::to_string(gEnv->storageServerPort()), "online", 0,
+             "No valid partition", "No valid partition"},
         };
         ASSERT_TRUE(verifyResult(resp, expected));
     }

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -122,8 +122,8 @@ enum HostStatus {
 struct HostItem {
     1: common.HostAddr      hostAddr,
     2: HostStatus           status,
-    3: map<common.GraphSpaceID, list<common.PartitionID>> (cpp.template = "std::unordered_map") leader_parts,
-    4: map<common.GraphSpaceID, list<common.PartitionID>> (cpp.template = "std::unordered_map") all_parts,
+    3: map<string, list<common.PartitionID>> (cpp.template = "std::unordered_map") leader_parts,
+    4: map<string, list<common.PartitionID>> (cpp.template = "std::unordered_map") all_parts,
 }
 
 struct UserItem {

--- a/src/meta/processors/admin/AdminClient.cpp
+++ b/src/meta/processors/admin/AdminClient.cpp
@@ -251,7 +251,7 @@ folly::Future<Status> AdminClient::getResponse(
     folly::via(evb, [evb, pro = std::move(pro), host, req = std::move(req),
                      remoteFunc = std::move(remoteFunc), respGen = std::move(respGen),
                      this] () mutable {
-        auto client = clientsMan_->client(host, evb, false, FLAGS_admin_rpc_timeout_ms);
+        auto client = clientsMan_->client(host, evb);
         remoteFunc(client, std::move(req))
             .then(evb, [p = std::move(pro), respGen = std::move(respGen)](
                            folly::Try<storage::cpp2::AdminExecResp>&& t) mutable {
@@ -283,7 +283,7 @@ void AdminClient::getResponse(
     folly::via(evb, [evb, hosts = std::move(hosts), index, req = std::move(req),
                      remoteFunc = std::move(remoteFunc), retry, pro = std::move(pro),
                      retryLimit, this] () mutable {
-        auto client = clientsMan_->client(hosts[index], evb, false, FLAGS_admin_rpc_timeout_ms);
+        auto client = clientsMan_->client(hosts[index], evb);
         remoteFunc(client, req)
             .then(evb, [p = std::move(pro), hosts = std::move(hosts), index, req = std::move(req),
                         remoteFunc = std::move(remoteFunc), retry, retryLimit,
@@ -431,7 +431,7 @@ folly::Future<Status> AdminClient::getLeaderDist(HostLeaderMap* result) {
         auto* evb = ioThreadPool_->getEventBase();
         folly::via(evb, [pro = std::move(pro), host, evb, result, this] () mutable {
             storage::cpp2::GetLeaderReq req;
-            auto client = clientsMan_->client(host, evb, false, FLAGS_admin_rpc_timeout_ms);
+            auto client = clientsMan_->client(host, evb);
             client->future_getLeaderPart(std::move(req))
                 .then(evb, [p = std::move(pro), host,
                             result] (folly::Try<storage::cpp2::GetLeaderResp>&& t) mutable {

--- a/src/meta/processors/admin/AdminClient.cpp
+++ b/src/meta/processors/admin/AdminClient.cpp
@@ -251,7 +251,7 @@ folly::Future<Status> AdminClient::getResponse(
     folly::via(evb, [evb, pro = std::move(pro), host, req = std::move(req),
                      remoteFunc = std::move(remoteFunc), respGen = std::move(respGen),
                      this] () mutable {
-        auto client = clientsMan_->client(host, evb);
+        auto client = clientsMan_->client(host, evb, false, FLAGS_admin_rpc_timeout_ms);
         remoteFunc(client, std::move(req))
             .then(evb, [p = std::move(pro), respGen = std::move(respGen)](
                            folly::Try<storage::cpp2::AdminExecResp>&& t) mutable {
@@ -283,7 +283,7 @@ void AdminClient::getResponse(
     folly::via(evb, [evb, hosts = std::move(hosts), index, req = std::move(req),
                      remoteFunc = std::move(remoteFunc), retry, pro = std::move(pro),
                      retryLimit, this] () mutable {
-        auto client = clientsMan_->client(hosts[index], evb);
+        auto client = clientsMan_->client(hosts[index], evb, false, FLAGS_admin_rpc_timeout_ms);
         remoteFunc(client, req)
             .then(evb, [p = std::move(pro), hosts = std::move(hosts), index, req = std::move(req),
                         remoteFunc = std::move(remoteFunc), retry, retryLimit,
@@ -431,7 +431,7 @@ folly::Future<Status> AdminClient::getLeaderDist(HostLeaderMap* result) {
         auto* evb = ioThreadPool_->getEventBase();
         folly::via(evb, [pro = std::move(pro), host, evb, result, this] () mutable {
             storage::cpp2::GetLeaderReq req;
-            auto client = clientsMan_->client(host, evb);
+            auto client = clientsMan_->client(host, evb, false, FLAGS_admin_rpc_timeout_ms);
             client->future_getLeaderPart(std::move(req))
                 .then(evb, [p = std::move(pro), host,
                             result] (folly::Try<storage::cpp2::GetLeaderResp>&& t) mutable {

--- a/src/meta/processors/admin/Balancer.cpp
+++ b/src/meta/processors/admin/Balancer.cpp
@@ -377,7 +377,7 @@ cpp2::ErrorCode Balancer::leaderBalance() {
         hostLeaderMap_.reset(new HostLeaderMap);
         auto status = client_->getLeaderDist(hostLeaderMap_.get()).get();
 
-        if (!status.ok()) {
+        if (!status.ok() || hostLeaderMap_->empty()) {
             inLeaderBalance_ = false;
             return cpp2::ErrorCode::E_RPC_FAILURE;
         }

--- a/src/meta/processors/partsMan/ListHostsProcessor.cpp
+++ b/src/meta/processors/partsMan/ListHostsProcessor.cpp
@@ -79,11 +79,7 @@ StatusOr<std::vector<cpp2::HostItem>> ListHostsProcessor::allHostsWithStatus(
                        std::unordered_map<std::string, std::vector<PartitionID>>> allParts;
     for (const auto& spaceId : spaces) {
         // get space name by space id
-        auto it = spaceIdNameMap.find(spaceId);
-        if (it == spaceIdNameMap.end()) {
-            continue;
-        }
-        auto spaceName = it->second;
+        auto spaceName = spaceIdNameMap[spaceId];
 
         std::unordered_map<HostAddr, std::vector<PartitionID>> hostParts;
         const auto& partPrefix = MetaServiceUtils::partPrefix(spaceId);

--- a/src/meta/processors/partsMan/ListHostsProcessor.h
+++ b/src/meta/processors/partsMan/ListHostsProcessor.h
@@ -28,9 +28,16 @@ private:
             , adminClient_(adminClient) {}
 
     /**
-     * Get all hosts with online/offline status.
+     * Get all hosts with online/offline status and partition distribution.
      * */
-    StatusOr<std::vector<cpp2::HostItem>> allHostsWithStatus();
+    StatusOr<std::vector<cpp2::HostItem>>
+    allHostsWithStatus(std::unordered_map<GraphSpaceID, std::string>& spaceIdName);
+
+    /**
+     * Get all hosts with storage leader distribution.
+     * */
+    void getLeaderDist(std::vector<cpp2::HostItem>& hostItems,
+                       std::unordered_map<GraphSpaceID, std::string>& spaceIdName);
 
     AdminClient* adminClient_;
 };

--- a/src/meta/processors/partsMan/ListHostsProcessor.h
+++ b/src/meta/processors/partsMan/ListHostsProcessor.h
@@ -31,13 +31,13 @@ private:
      * Get all hosts with online/offline status and partition distribution.
      * */
     StatusOr<std::vector<cpp2::HostItem>>
-    allHostsWithStatus(std::unordered_map<GraphSpaceID, std::string>& spaceIdName);
+    allHostsWithStatus(std::unordered_map<GraphSpaceID, std::string>& spaceIdNameMap);
 
     /**
      * Get all hosts with storage leader distribution.
      * */
     void getLeaderDist(std::vector<cpp2::HostItem>& hostItems,
-                       std::unordered_map<GraphSpaceID, std::string>& spaceIdName);
+                       std::unordered_map<GraphSpaceID, std::string>& spaceIdNameMap);
 
     AdminClient* adminClient_;
 };


### PR DESCRIPTION
Show space name instead of space id in leader/partition distribution of `show hosts`. The screenshot of `show hosts` looks as follows:
![image](https://user-images.githubusercontent.com/13706157/64581009-1a979e80-d3bb-11e9-9939-e9a46a67b993.png)

close #909 
close #925 