### PR TITLE
Improved build concurrency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,9 +380,6 @@ macro(nebula_add_test)
     endif()
 endmacro()
 
-macro(nebula_build_after_base obj_name)
-endmacro()
-
 # All ordinary libraries shall depend on the compile-time generated files,
 # including the precompiled header, a.k.a Base.h.gch, and thrift headers.
 macro(nebula_add_library name type)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,9 @@ macro(nebula_add_library name type)
         graph_thrift_headers
         storage_thrift_headers
         meta_thrift_headers
+        raftex_thrift_headers
         hbase_thrift_headers
+        parser_target
     )
 endmacro()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,12 +381,21 @@ macro(nebula_add_test)
 endmacro()
 
 macro(nebula_build_after_base obj_name)
-    add_dependencies(${obj_name} base_obj)
 endmacro()
 
+# All ordinary libraries shall depend on the compile-time generated files,
+# including the precompiled header, a.k.a Base.h.gch, and thrift headers.
 macro(nebula_add_library name type)
     add_library(${name} ${type} ${ARGN})
-    nebula_build_after_base(${name})
+    add_dependencies(
+        ${name}
+        base_obj_gch
+        common_thrift_headers
+        graph_thrift_headers
+        storage_thrift_headers
+        meta_thrift_headers
+        hbase_thrift_headers
+    )
 endmacro()
 
 include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/bzip2/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,13 +380,18 @@ macro(nebula_add_test)
     endif()
 endmacro()
 
-# All ordinary libraries shall depend on the compile-time generated files,
+# For simplicity, we make all ordinary libraries depend on the compile-time generated files,
 # including the precompiled header, a.k.a Base.h.gch, and thrift headers.
 macro(nebula_add_library name type)
     add_library(${name} ${type} ${ARGN})
+    if (PCHSupport_FOUND)
+        add_dependencies(
+            ${name}
+            base_obj_gch
+        )
+    endif()
     add_dependencies(
         ${name}
-        base_obj_gch
         common_thrift_headers
         graph_thrift_headers
         storage_thrift_headers

--- a/cmake/FindPCHSupport.cmake
+++ b/cmake/FindPCHSupport.cmake
@@ -30,7 +30,7 @@ ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 
 
 
-MACRO(ADD_PRECOMPILED_HEADER _targetName _input _dep)
+MACRO(ADD_PRECOMPILED_HEADER _targetName _input)
 
     GET_FILENAME_COMPONENT(_name ${_input} NAME)
     SET(_source "${CMAKE_CURRENT_SOURCE_DIR}/${_input}")
@@ -77,7 +77,6 @@ MACRO(ADD_PRECOMPILED_HEADER _targetName _input _dep)
 				-o ${_output} ${_source}
         MAIN_DEPENDENCY ${_source})
     ADD_CUSTOM_TARGET(${_targetName}_gch DEPENDS ${_output})
-    ADD_DEPENDENCIES(${_targetName}_gch ${_dep})
     ADD_DEPENDENCIES(${_targetName} ${_targetName}_gch)
 
 ENDMACRO(ADD_PRECOMPILED_HEADER)

--- a/cmake/ThriftGenerate.cmake
+++ b/cmake/ThriftGenerate.cmake
@@ -96,10 +96,11 @@ add_library(
   OBJECT
   ${${file_name}-cpp2-SOURCES}
 )
+add_custom_target(${file_name}_thrift_headers DEPENDS ${${file_name}-cpp2-HEADERS})
 if(NOT "${file_name}" STREQUAL "common")
 add_dependencies(
   "${file_name}_thrift_obj"
-  "common_thrift_obj"
+  common_thrift_headers
 )
 endif()
 endmacro()

--- a/src/common/base/CMakeLists.txt
+++ b/src/common/base/CMakeLists.txt
@@ -9,9 +9,8 @@ add_library(
     NebulaKeyUtils.cpp
 )
 
-add_dependencies(base_obj common_thrift_obj graph_thrift_obj raftex_thrift_obj storage_thrift_obj meta_thrift_obj hbase_thrift_obj)
 IF(${PCHSupport_FOUND})
-    add_precompiled_header(base_obj Base.h common_thrift_obj graph_thrift_obj raftex_thrift_obj storage_thrift_obj meta_thrift_obj hbase_thrift_obj)
+    add_precompiled_header(base_obj Base.h)
 ENDIF(${PCHSupport_FOUND})
 
 add_custom_target(

--- a/src/common/http/CMakeLists.txt
+++ b/src/common/http/CMakeLists.txt
@@ -1,5 +1,3 @@
-add_library(http_client_obj OBJECT HttpClient.cpp)
-
-add_dependencies(http_client_obj process_obj base_obj)
+nebula_add_library(http_client_obj OBJECT HttpClient.cpp)
 
 nebula_add_subdirectory(test)

--- a/src/graph/CMakeLists.txt
+++ b/src/graph/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(
+nebula_add_library(
     graph_obj OBJECT
     GraphFlags.cpp
     GraphService.cpp
@@ -49,26 +49,10 @@ add_library(
     MatchExecutor.cpp
     DeleteVertexExecutor.cpp
 )
-add_dependencies(
-    graph_obj
-    parser_obj
-    graph_thrift_obj
-    meta_thrift_obj
-    meta_client
-    gflags_man_obj
-    schema_obj
-    stats_obj
-    process_obj
-    base_obj
-)
 
-add_library(
+nebula_add_library(
     graph_http_handler OBJECT
     GraphHttpHandler.cpp
-)
-add_dependencies(
-    graph_http_handler
-    base_obj
 )
 
 nebula_add_subdirectory(test)

--- a/src/meta/CMakeLists.txt
+++ b/src/meta/CMakeLists.txt
@@ -59,43 +59,20 @@ nebula_add_library(
     meta_client OBJECT
     client/MetaClient.cpp
 )
-add_dependencies(
-    meta_client
-    gflags_man_obj
-)
 
-add_library(
+nebula_add_library(
     gflags_man_obj OBJECT
     GflagsManager.cpp
 )
-add_dependencies(
-    gflags_man_obj
-    base_obj
-)
 
-add_library(
+nebula_add_library(
     meta_gflags_man_obj OBJECT
     ClientBasedGflagsManager.cpp
 )
-add_dependencies(
-    meta_gflags_man_obj
-    gflags_man_obj
-    meta_service_handler
-    base_obj
-    meta_client
-    meta_thrift_obj
-)
 
-add_library(
+nebula_add_library(
     kv_gflags_man_obj OBJECT
     KVBasedGflagsManager.cpp
-)
-add_dependencies(
-    kv_gflags_man_obj
-    gflags_man_obj
-    meta_service_handler
-    base_obj
-    kvstore_obj
 )
 
 nebula_add_subdirectory(test)

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -4,6 +4,8 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 bison_target(Parser parser.yy ${CMAKE_CURRENT_BINARY_DIR}/GraphParser.cpp COMPILE_FLAGS "-Werror")
 flex_target(Scanner scanner.lex ${CMAKE_CURRENT_BINARY_DIR}/GraphScanner.cpp)
 
+add_custom_target(parser_target DEPENDS ${FLEX_Scanner_OUTPUTS} ${BISON_Parser_OUTPUTS})
+
 add_flex_bison_dependency(Scanner Parser)
 
 add_compile_options(-Wno-error=sign-compare)


### PR DESCRIPTION
At compile time, we actually depend on the _**codegen**_ of the thrift files, but no need to _**compile**_ the generated files first.
With this PR, the overall build time could be reduced by nearly 30% in a 56 processors environment.