### PR TITLE
Add docker image building workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: make
         run: |
           . /etc/profile.d/devtoolset-8-enable.sh
-          cd _build && make -j2
+          cd _build && make -j $(nproc)
         shell: bash
       - name: test
         run: |

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,11 +17,11 @@ jobs:
         with:
           fetch-depth: 1
       - name: build
+        env:
+          image_name: ${{ secrets.DOCKER_USERNAME }}/nebula-metad:nightly
         run: |
-          docker build -t vesoft/nebula-metad:${{ github.sha }} -f docker/Dockerfile.metad .
-          docker tag vesoft/nebula-metad:${{ github.sha }} vesoft/nebula-metad:nightly
-          docker push vesoft/nebula-metad:${{ github.sha }}
-          docker push vesoft/nebula-metad:nightly
+          docker build -t ${IMAGE_NAME} -f docker/Dockerfile.metad .
+          docker push ${IMAGE_NAME}
         shell: bash
 
   storaged:
@@ -36,11 +36,11 @@ jobs:
         with:
           fetch-depth: 1
       - name: build
+        env:
+          image_name: ${{ secrets.DOCKER_USERNAME }}/nebula-storaged:nightly
         run: |
-          docker build -t vesoft/nebula-storaged:${{ github.sha }} -f docker/Dockerfile.storaged .
-          docker tag vesoft/nebula-storaged:${{ github.sha }} vesoft/nebula-storaged:nightly
-          docker push vesoft/nebula-storaged:${{ github.sha }}
-          docker push vesoft/nebula-storaged:nightly
+          docker build -t ${IMAGE_NAME} -f docker/Dockerfile.storaged .
+          docker push ${IMAGE_NAME}
         shell: bash
 
   graphd:
@@ -55,11 +55,11 @@ jobs:
         with:
           fetch-depth: 1
       - name: build
+        env:
+          image_name: ${{ secrets.DOCKER_USERNAME }}/nebula-graphd:nightly
         run: |
-          docker build -t vesoft/nebula-graphd:${{ github.sha }} -f docker/Dockerfile.graphd .
-          docker tag vesoft/nebula-graphd:${{ github.sha }} vesoft/nebula-graphd:nightly
-          docker push vesoft/nebula-graphd:${{ github.sha }}
-          docker push vesoft/nebula-graphd:nightly
+          docker build -t ${IMAGE_NAME} -f docker/Dockerfile.graphd .
+          docker push ${IMAGE_NAME}
         shell: bash
 
   console:
@@ -74,11 +74,11 @@ jobs:
         with:
           fetch-depth: 1
       - name: build
+        env:
+          image_name: ${{ secrets.DOCKER_USERNAME }}/nebula-console:nightly
         run: |
-          docker build -t vesoft/nebula-console:${{ github.sha }} -f docker/Dockerfile.console .
-          docker tag vesoft/nebula-console:${{ github.sha }} vesoft/nebula-console:nightly
-          docker push vesoft/nebula-console:${{ github.sha }}
-          docker push vesoft/nebula-console:nightly
+          docker build -t ${IMAGE_NAME} -f docker/Dockerfile.console .
+          docker push ${IMAGE_NAME}
         shell: bash
 
   nebula_graph:
@@ -93,9 +93,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: build
+        env:
+          image_name: ${{ secrets.DOCKER_USERNAME }}/nebula-graph:nightly
         run: |
-          docker build -t vesoft/nebula-graph:${{ github.sha }} -f docker/Dockerfile .
-          docker tag vesoft/nebula-graph:${{ github.sha }} vesoft/nebula-graph:nightly
-          docker push vesoft/nebula-graph:${{ github.sha }}
-          docker push vesoft/nebula-graph:nightly
+          docker build -t ${IMAGE_NAME} -f docker/Dockerfile .
+          docker push ${IMAGE_NAME}
         shell: bash

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,86 @@
+name: Nebula Service Docker Image Building Workflow
+
+on:
+  schedule:
+    - cron:  '0 2 * * *'
+
+jobs:
+  metad:
+    name: metad
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: azure/container-actions/docker-login@master
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: clone
+        run: |
+          git clone --single-branch --branch master --depth 1 https://github.com/vesoft-inc/nebula-docker-compose.git
+      - name: build
+        run: |
+          cd nebula-docker-compose/
+          docker build -t vesoft/nebula-metad:${{ github.sha }} -f Dockerfile.metad .
+          docker tag vesoft/nebula-metad:${{ github.sha }} vesoft/nebula-metad:nightly
+          docker push vesoft/nebula-metad:${{ github.sha }}
+          docker push vesoft/nebula-metad:nightly
+        shell: bash
+
+  storaged:
+    name: storaged
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: azure/container-actions/docker-login@master
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: clone
+        run: |
+          git clone --single-branch --branch master --depth 1 https://github.com/vesoft-inc/nebula-docker-compose.git
+      - name: build
+        run: |
+          cd nebula-docker-compose/
+          docker build -t vesoft/nebula-storaged:${{ github.sha }} -f Dockerfile.storaged .
+          docker tag vesoft/nebula-storaged:${{ github.sha }} vesoft/nebula-storaged:nightly
+          docker push vesoft/nebula-storaged:${{ github.sha }}
+          docker push vesoft/nebula-storaged:nightly
+        shell: bash
+
+  graphd:
+    name: graphd
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: azure/container-actions/docker-login@master
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: clone
+        run: |
+          git clone --single-branch --branch master --depth 1 https://github.com/vesoft-inc/nebula-docker-compose.git
+      - name: build
+        run: |
+          cd nebula-docker-compose/
+          docker build -t vesoft/nebula-graphd:${{ github.sha }} -f Dockerfile.graphd .
+          docker tag vesoft/nebula-graphd:${{ github.sha }} vesoft/nebula-graphd:nightly
+          docker push vesoft/nebula-graphd:${{ github.sha }}
+          docker push vesoft/nebula-graphd:nightly
+        shell: bash
+
+  console:
+    name: console
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: azure/container-actions/docker-login@master
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: clone
+        run: |
+          git clone --single-branch --branch master --depth 1 https://github.com/vesoft-inc/nebula-docker-compose.git
+      - name: build
+        run: |
+          cd nebula-docker-compose/
+          docker build -t vesoft/nebula-console:${{ github.sha }} -f Dockerfile.console .
+          docker tag vesoft/nebula-console:${{ github.sha }} vesoft/nebula-console:nightly
+          docker push vesoft/nebula-console:${{ github.sha }}
+          docker push vesoft/nebula-console:nightly
+        shell: bash

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -13,13 +13,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: clone
-        run: |
-          git clone --single-branch --branch master --depth 1 https://github.com/vesoft-inc/nebula-docker-compose.git
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - name: build
         run: |
-          cd nebula-docker-compose/
-          docker build -t vesoft/nebula-metad:${{ github.sha }} -f Dockerfile.metad .
+          docker build -t vesoft/nebula-metad:${{ github.sha }} -f docker/Dockerfile.metad .
           docker tag vesoft/nebula-metad:${{ github.sha }} vesoft/nebula-metad:nightly
           docker push vesoft/nebula-metad:${{ github.sha }}
           docker push vesoft/nebula-metad:nightly
@@ -33,13 +32,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: clone
-        run: |
-          git clone --single-branch --branch master --depth 1 https://github.com/vesoft-inc/nebula-docker-compose.git
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - name: build
         run: |
-          cd nebula-docker-compose/
-          docker build -t vesoft/nebula-storaged:${{ github.sha }} -f Dockerfile.storaged .
+          docker build -t vesoft/nebula-storaged:${{ github.sha }} -f docker/Dockerfile.storaged .
           docker tag vesoft/nebula-storaged:${{ github.sha }} vesoft/nebula-storaged:nightly
           docker push vesoft/nebula-storaged:${{ github.sha }}
           docker push vesoft/nebula-storaged:nightly
@@ -53,13 +51,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: clone
-        run: |
-          git clone --single-branch --branch master --depth 1 https://github.com/vesoft-inc/nebula-docker-compose.git
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - name: build
         run: |
-          cd nebula-docker-compose/
-          docker build -t vesoft/nebula-graphd:${{ github.sha }} -f Dockerfile.graphd .
+          docker build -t vesoft/nebula-graphd:${{ github.sha }} -f docker/Dockerfile.graphd .
           docker tag vesoft/nebula-graphd:${{ github.sha }} vesoft/nebula-graphd:nightly
           docker push vesoft/nebula-graphd:${{ github.sha }}
           docker push vesoft/nebula-graphd:nightly
@@ -73,14 +70,32 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: clone
-        run: |
-          git clone --single-branch --branch master --depth 1 https://github.com/vesoft-inc/nebula-docker-compose.git
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
       - name: build
         run: |
-          cd nebula-docker-compose/
-          docker build -t vesoft/nebula-console:${{ github.sha }} -f Dockerfile.console .
+          docker build -t vesoft/nebula-console:${{ github.sha }} -f docker/Dockerfile.console .
           docker tag vesoft/nebula-console:${{ github.sha }} vesoft/nebula-console:nightly
           docker push vesoft/nebula-console:${{ github.sha }}
           docker push vesoft/nebula-console:nightly
+        shell: bash
+
+  nebula_graph:
+    name: nebula graph
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: azure/container-actions/docker-login@master
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: build
+        run: |
+          docker build -t vesoft/nebula-graph:${{ github.sha }} -f docker/Dockerfile .
+          docker tag vesoft/nebula-graph:${{ github.sha }} vesoft/nebula-graph:nightly
+          docker push vesoft/nebula-graph:${{ github.sha }}
+          docker push vesoft/nebula-graph:nightly
         shell: bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,5 @@
 FROM vesoft/nebula-dev:centos as builder
 
-LABEL maintainer "yee.yi@vesoft.com"
-
 COPY . /home/nebula/BUILD
 
 RUN cd /home/nebula/BUILD/package \

--- a/docker/Dockerfile.console
+++ b/docker/Dockerfile.console
@@ -1,0 +1,18 @@
+FROM vesoft/nebula-dev:centos as builder
+
+COPY . /home/nebula/BUILD
+
+RUN cd /home/nebula/BUILD/package \
+  && . /etc/profile.d/devtoolset-8-enable.sh \
+  && ./make_srpm.sh -v $(git rev-parse --short HEAD) -p /home/nebula console
+
+FROM centos:7
+
+COPY --from=builder /home/nebula/RPMS/x86_64/nebula-base-*.el7.x86_64.rpm /usr/local/nebula/nebula-base.rpm
+COPY --from=builder /home/nebula/RPMS/x86_64/nebula-console-*.el7.x86_64.rpm /usr/local/nebula/nebula-console.rpm
+
+WORKDIR /usr/local/nebula
+
+RUN rpm -ivh *.rpm \
+  && mkdir -p ./{logs,data,pids} \
+  && rm -rf *.rpm

--- a/docker/Dockerfile.graphd
+++ b/docker/Dockerfile.graphd
@@ -1,0 +1,22 @@
+FROM vesoft/nebula-dev:centos as builder
+
+COPY . /home/nebula/BUILD
+
+RUN cd /home/nebula/BUILD/package \
+  && . /etc/profile.d/devtoolset-8-enable.sh \
+  && ./make_srpm.sh -v $(git rev-parse --short HEAD) -p /home/nebula graphd
+
+FROM centos:7
+
+COPY --from=builder /home/nebula/RPMS/x86_64/nebula-base-*.el7.x86_64.rpm /usr/local/nebula/nebula-base.rpm
+COPY --from=builder /home/nebula/RPMS/x86_64/nebula-graphd-*.el7.x86_64.rpm /usr/local/nebula/nebula-graphd.rpm
+
+WORKDIR /usr/local/nebula
+
+RUN rpm -ivh *.rpm \
+  && mkdir -p ./{logs,data,pids} \
+  && rm -rf *.rpm
+
+EXPOSE 3369 13000 13002
+
+ENTRYPOINT ["./bin/nebula-graphd", "--flagfile=./etc/nebula-graphd.conf", "--daemonize=false"]

--- a/docker/Dockerfile.metad
+++ b/docker/Dockerfile.metad
@@ -1,0 +1,22 @@
+FROM vesoft/nebula-dev:centos as builder
+
+COPY . /home/nebula/BUILD
+
+RUN cd /home/nebula/BUILD/package \
+  && . /etc/profile.d/devtoolset-8-enable.sh \
+  && ./make_srpm.sh -v $(git rev-parse --short HEAD) -p /home/nebula metad
+
+FROM centos:7
+
+COPY --from=builder /home/nebula/RPMS/x86_64/nebula-base-*.el7.x86_64.rpm /usr/local/nebula/nebula-base.rpm
+COPY --from=builder /home/nebula/RPMS/x86_64/nebula-metad-*.el7.x86_64.rpm /usr/local/nebula/nebula-metad.rpm
+
+WORKDIR /usr/local/nebula
+
+RUN rpm -ivh *.rpm \
+  && mkdir -p ./{logs,data,pids} \
+  && rm -rf *.rpm
+
+EXPOSE 45500 45501 11000 11002
+
+ENTRYPOINT ["./bin/nebula-metad", "--flagfile=./etc/nebula-metad.conf", "--daemonize=false"]

--- a/docker/Dockerfile.storaged
+++ b/docker/Dockerfile.storaged
@@ -1,0 +1,22 @@
+FROM vesoft/nebula-dev:centos as builder
+
+COPY . /home/nebula/BUILD
+
+RUN cd /home/nebula/BUILD/package \
+  && . /etc/profile.d/devtoolset-8-enable.sh \
+  && ./make_srpm.sh -v $(git rev-parse --short HEAD) -p /home/nebula storaged
+
+FROM centos:7
+
+COPY --from=builder /home/nebula/RPMS/x86_64/nebula-base-*.el7.x86_64.rpm /usr/local/nebula/nebula-base.rpm
+COPY --from=builder /home/nebula/RPMS/x86_64/nebula-storaged-*.el7.x86_64.rpm /usr/local/nebula/nebula-storaged.rpm
+
+WORKDIR /usr/local/nebula
+
+RUN rpm -ivh *.rpm \
+  && mkdir -p ./{logs,data,pids} \
+  && rm -rf *.rpm
+
+EXPOSE 44500 44501 12000 12002
+
+ENTRYPOINT ["./bin/nebula-storaged", "--flagfile=./etc/nebula-storaged.conf", "--daemonize=false"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,27 @@
+# Dockerfiles for Nebula Graph Services
+
+**NOTE:** The `Dockerfile` is used to build docker image only for **testing** nebula graph in local machine.
+
+Following Dockerfiles are ready for production.
+
+- `Dockerfile.graphd`: nebula-graphd service
+- `Dockerfile.metad`: nebula-metad service
+- `Dockerfile.storaged`: nebula-storaged service
+- `Dockerfile.console`: nebula console client
+
+## docker-compose
+
+Use git to clone nebula project to your local directory and `cd` to `docker` folder in nebula root path.
+
+```shell
+$ cd /path/to/nebula/project/ # replace your real nebula clone path
+$ cd docker
+```
+
+Start all services with `docker-compose` and enter `console` container. Then enjoy nebula graph :)
+
+```shell
+$ docker-compose up -d
+$ docker-compose run console bash
+(user@172.28.1.3) [(none)]> SHOW HOSTS;
+```

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,75 @@
+version: '3.4'
+services:
+  metad:
+    image: vesoft/nebula-metad:nightly
+    environment:
+      USER: root
+    command: ["--meta_server_addrs=172.28.1.1:45500", "--local_ip=172.28.1.1", "--port=45500"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11000/status"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      nebula-net:
+        ipv4_address: 172.28.1.1
+
+  storaged:
+    image: vesoft/nebula-storaged:nightly
+    environment:
+      USER: root
+    command: ["--meta_server_addrs=172.28.1.1:45500", "--local_ip=172.28.1.2", "--port=44500"]
+    depends_on:
+      - metad
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:12000/status"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      nebula-net:
+        ipv4_address: 172.28.1.2
+
+  graphd:
+    image: vesoft/nebula-graphd:nightly
+    environment:
+      USER: root
+    command: ["--meta_server_addrs=172.28.1.1:45500", "--port=3699"]
+    depends_on:
+      - metad
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:13000/status"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      nebula-net:
+        ipv4_address: 172.28.1.3
+
+  console:
+    image: vesoft/nebula-console:nightly
+    environment:
+      USER: root
+    entrypoint:
+      - ./bin/nebula
+      - -u
+      - user
+      - -p
+      - password
+      - --addr=172.28.1.3
+      - --port=3699
+    depends_on:
+      - graphd
+    networks:
+      nebula-net:
+        ipv4_address: 172.28.1.4
+
+networks:
+  nebula-net:
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.28.0.0/16


### PR DESCRIPTION
- Use github actions to build nebula service docker images and push them to docker hub at 2am every day night
- Fix docker-compose yaml and usage in readme
- Store nebula Dockerfiles in `docker` subdirectory rather than `vesoft-inc/nebula-docker-compose` repo
