### PR TITLE
Check if empty in Cord before serializing

### DIFF
--- a/src/common/base/Cord.cpp
+++ b/src/common/base/Cord.cpp
@@ -76,6 +76,10 @@ void Cord::clear() {
 
 
 bool Cord::applyTo(std::function<bool(const char*, int32_t)> visitor) const {
+    if (empty()) {
+        return true;
+    }
+
     char* next = head_;
     while (next != tail_) {
         if (!visitor(next, blockContentSize_)) {
@@ -94,6 +98,10 @@ bool Cord::applyTo(std::function<bool(const char*, int32_t)> visitor) const {
 
 
 size_t Cord::appendTo(std::string& str) const {
+    if (empty()) {
+        return 0;
+    }
+
     char* next = head_;
     while (next != tail_) {
         str.append(next, blockContentSize_);
@@ -112,11 +120,7 @@ size_t Cord::appendTo(std::string& str) const {
 
 std::string Cord::str() const {
     std::string buf;
-    if (len_ == 0) {
-        return buf;
-    }
     buf.reserve(len_);
-
     appendTo(buf);
 
     return buf;

--- a/src/common/base/test/CordTest.cpp
+++ b/src/common/base/test/CordTest.cpp
@@ -10,6 +10,21 @@
 
 namespace nebula {
 
+TEST(Cord, Empty) {
+    {
+        Cord cord;
+        auto empty = cord.str();
+        ASSERT_TRUE(empty.empty()) << "size: " << empty.size();
+    }
+    {
+        Cord cord;
+        std::string empty;
+        cord.appendTo(empty);
+        ASSERT_TRUE(empty.empty()) << "size: " << empty.size();
+    }
+}
+
+
 TEST(Cord, write) {
     Cord cord;
 


### PR DESCRIPTION
FYI. There seems a bug in STL, that `std::string::append(nullptr, 1024)` won't crash if it doesn't have enough capacity, instead the string will be expanded(like resize). But if we use the old CXX ABI, the program will crash.