### PR TITLE
Use manual configuration when generate go source code.

### DIFF
--- a/cmake/ThriftGenerate.cmake
+++ b/cmake/ThriftGenerate.cmake
@@ -84,7 +84,7 @@ add_custom_command(
     --gen "mstch_cpp2:include_prefix=${include_prefix},process_in_event_base,stack_arguments"
     --gen "py"
     --gen "java:hashcode"
-    --gen "go"
+    --gen "go:thrift_import=github.com/facebook/fbthrift/thrift/lib/go/thrift"
     -o "." "${file_path}/${file_name}.thrift"
   DEPENDS "${file_path}/${file_name}.thrift"
   COMMENT "Generating thrift files for ${file_name}"


### PR DESCRIPTION
The default configuration of _**thrift_import**_ is out of date. It would not work well. So I replace it with a manual configuration.