### PR TITLE
Do implicit type casting in relational expression.

### DIFF
--- a/src/common/filter/Expressions.h
+++ b/src/common/filter/Expressions.h
@@ -891,6 +891,7 @@ private:
 
     const char* decode(const char *pos, const char *end) override;
 
+    Status implicitCasting(VariantType &lhs, VariantType &rhs) const;
 
 private:
     Operator                                    op_;

--- a/src/common/filter/test/ExpressionTest.cpp
+++ b/src/common/filter/test/ExpressionTest.cpp
@@ -293,6 +293,49 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
     TEST_EXPR(-1 <= -2, false);
     TEST_EXPR(-2 <= -1, true);
 
+    TEST_EXPR(0.5 == 1, false);
+    TEST_EXPR(1.0 == 1, true);
+    TEST_EXPR(0.5 != 1, true);
+    TEST_EXPR(1.0 != 1, false);
+    TEST_EXPR(0.5 > 1, false);
+    TEST_EXPR(0.5 >= 1, false);
+    TEST_EXPR(0.5 < 1, true);
+    TEST_EXPR(0.5 <= 1, true);
+
+    TEST_EXPR(true == 1, true);
+    TEST_EXPR(true == 2, false);
+    TEST_EXPR(true != 1, false);
+    TEST_EXPR(true != 2, true);
+    TEST_EXPR(true > 1, false);
+    TEST_EXPR(true >= 1, true);
+    TEST_EXPR(true < 1, false);
+    TEST_EXPR(true <= 1, true);
+    TEST_EXPR(false == 0, true);
+    TEST_EXPR(false == 1, false);
+    TEST_EXPR(false != 0, false);
+    TEST_EXPR(false != 1, true);
+    TEST_EXPR(false > 0, false);
+    TEST_EXPR(false >= 0, true);
+    TEST_EXPR(false < 0, false);
+    TEST_EXPR(false <= 0, true);
+
+    TEST_EXPR(true == 1.0, true);
+    TEST_EXPR(true == 2.0, false);
+    TEST_EXPR(true != 1.0, false);
+    TEST_EXPR(true != 2.0, true);
+    TEST_EXPR(true > 1.0, false);
+    TEST_EXPR(true >= 1.0, true);
+    TEST_EXPR(true < 1.0, false);
+    TEST_EXPR(true <= 1.0, true);
+    TEST_EXPR(false == 0.0, true);
+    TEST_EXPR(false == 1.0, false);
+    TEST_EXPR(false != 0.0, false);
+    TEST_EXPR(false != 1.0, true);
+    TEST_EXPR(false > 0.0, false);
+    TEST_EXPR(false >= 0.0, true);
+    TEST_EXPR(false < 0.0, false);
+    TEST_EXPR(false <= 0.0, true);
+
     TEST_EXPR(8 % 2 + 1 == 1, true);
     TEST_EXPR(8 % 2 + 1 != 1, false);
     TEST_EXPR(8 % 3 + 1 == 3, true);
@@ -732,6 +775,12 @@ TEST_F(ExpressionTest, InvalidExpressionTest) {
     TEST_EXPR(1.0 % "a");
     TEST_EXPR(-"A");
     TEST_EXPR(TRUE + FALSE);
+    TEST_EXPR("123" > 123);
+    TEST_EXPR("123" < 123);
+    TEST_EXPR("123" >= 123);
+    TEST_EXPR("123" <= 123);
+    TEST_EXPR("123" == 123);
+    TEST_EXPR("123" != 123);
 #undef TEST_EXPR
 }
 


### PR DESCRIPTION
Close #530.
The **boost::variant** will not compare the content if the type do not match. So we should do implicit type casting.