### PR TITLE
Try to introduce concurrency to unit testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,5 +29,5 @@ jobs:
       - name: test
         run: |
           . /etc/profile.d/devtoolset-8-enable.sh
-          cd _build && ctest --output-on-failure
+          cd _build && ctest -j $(nproc) --output-on-failure
         shell: bash

--- a/src/common/network/NetworkUtils.cpp
+++ b/src/common/network/NetworkUtils.cpp
@@ -114,13 +114,56 @@ bool NetworkUtils::getDynamicPortRange(uint16_t& low, uint16_t& high) {
 
 std::unordered_set<uint16_t> NetworkUtils::getPortsInUse() {
     static const std::regex regex("[^:]+:[^:]+:([0-9A-F]+).+");
-    fs::FileUtils::FileLineIterator iter("/proc/net/tcp", &regex);
     std::unordered_set<uint16_t> inUse;
-    while (iter.valid()) {
-        auto &sm = iter.matched();
-        inUse.emplace(std::stoul(sm[1].str(), NULL, 16));
-        ++iter;
+    {
+        fs::FileUtils::FileLineIterator iter("/proc/net/tcp", &regex);
+        while (iter.valid()) {
+            auto &sm = iter.matched();
+            inUse.emplace(std::stoul(sm[1].str(), NULL, 16));
+            ++iter;
+        }
     }
+    {
+        fs::FileUtils::FileLineIterator iter("/proc/net/tcp6", &regex);
+        while (iter.valid()) {
+            auto &sm = iter.matched();
+            inUse.emplace(std::stoul(sm[1].str(), NULL, 16));
+            ++iter;
+        }
+    }
+    {
+        fs::FileUtils::FileLineIterator iter("/proc/net/udp", &regex);
+        while (iter.valid()) {
+            auto &sm = iter.matched();
+            inUse.emplace(std::stoul(sm[1].str(), NULL, 16));
+            ++iter;
+        }
+    }
+    {
+        fs::FileUtils::FileLineIterator iter("/proc/net/udp6", &regex);
+        while (iter.valid()) {
+            auto &sm = iter.matched();
+            inUse.emplace(std::stoul(sm[1].str(), NULL, 16));
+            ++iter;
+        }
+    }
+    {
+        fs::FileUtils::FileLineIterator iter("/proc/net/raw", &regex);
+        while (iter.valid()) {
+            auto &sm = iter.matched();
+            inUse.emplace(std::stoul(sm[1].str(), NULL, 16));
+            ++iter;
+        }
+    }
+    {
+        fs::FileUtils::FileLineIterator iter("/proc/net/raw6", &regex);
+        while (iter.valid()) {
+            auto &sm = iter.matched();
+            inUse.emplace(std::stoul(sm[1].str(), NULL, 16));
+            ++iter;
+        }
+    }
+
     return inUse;
 }
 
@@ -135,9 +178,15 @@ uint16_t NetworkUtils::getAvailablePort() {
 
     std::unordered_set<uint16_t> portsInUse = getPortsInUse();
     uint16_t port = 0;
-    do {
-        port = folly::Random::rand32(low, static_cast<int32_t>(high) + 1);
-    } while (portsInUse.find(port) != portsInUse.end());
+    while (true) {
+        port = folly::Random::rand32(1025, low);
+        if (portsInUse.find(port) != portsInUse.end()) {
+            continue;
+        }
+        if (portsInUse.find(port + 1) == portsInUse.end()) {
+            break;
+        }
+    }
 
     return port;
 }

--- a/src/common/network/NetworkUtils.cpp
+++ b/src/common/network/NetworkUtils.cpp
@@ -179,6 +179,9 @@ uint16_t NetworkUtils::getAvailablePort() {
     std::unordered_set<uint16_t> portsInUse = getPortsInUse();
     uint16_t port = 0;
     while (true) {
+        // NOTE
+        // The availablity of port number *outside* the ephemeral port range is
+        // relatively stable for the binding purpose.
         port = folly::Random::rand32(1025, low);
         if (portsInUse.find(port) != portsInUse.end()) {
             continue;

--- a/src/common/network/NetworkUtils.h
+++ b/src/common/network/NetworkUtils.h
@@ -30,7 +30,11 @@ public:
     static bool getDynamicPortRange(uint16_t& low, uint16_t& high);
     // Get all ports that are currently in use
     static std::unordered_set<uint16_t> getPortsInUse();
-    // Get a dynamic port that is not in use
+    // To get a port number which is available to bind on.
+    // The availability is not guaranteed, e.g. in the parallel case.
+    //
+    // Note that this function is to be used for testing purpose.
+    // So don't use it in production code.
     static uint16_t getAvailablePort();
 
     // Convert the given IP (must be in the form of "xx.xx.xx.xx") and Port to a HostAddr

--- a/src/common/stats/test/CMakeLists.txt
+++ b/src/common/stats/test/CMakeLists.txt
@@ -12,6 +12,34 @@ nebula_add_test(
         gtest
 )
 
+nebula_add_test(
+    NAME
+        stats_manager_rate_test
+    SOURCES
+        StatsManagerRateTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+    LIBRARIES
+        gtest
+)
+
+nebula_add_test(
+    NAME
+        stats_manager_cross_leveLtest
+    SOURCES
+        StatsManagerCrossLevelTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_obj>
+    LIBRARIES
+        gtest
+)
+
 
 nebula_add_executable(
     NAME

--- a/src/common/stats/test/CMakeLists.txt
+++ b/src/common/stats/test/CMakeLists.txt
@@ -28,7 +28,7 @@ nebula_add_test(
 
 nebula_add_test(
     NAME
-        stats_manager_cross_leveLtest
+        stats_manager_cross_level_test
     SOURCES
         StatsManagerCrossLevelTest.cpp
     OBJECTS

--- a/src/common/stats/test/StatsManagerCrossLevelTest.cpp
+++ b/src/common/stats/test/StatsManagerCrossLevelTest.cpp
@@ -1,0 +1,53 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/Base.h"
+#include <gtest/gtest.h>
+#include "stats/StatsManager.h"
+#include "thread/GenericWorker.h"
+
+namespace nebula {
+namespace stats {
+
+TEST(StatsManager, CrossLevelTest) {
+    auto statId = StatsManager::registerHisto("stat03", 1, 1, 100);
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 10; i++) {
+        threads.emplace_back([statId, i] () {
+            for (int k = i * 10 + 10; k >= i * 10 + 1; k--) {
+                StatsManager::addValue(statId, k);
+                if (k > i * 10 + 1) {
+                    sleep(7);
+                }
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    // The first number of each thread should be moved to the next level
+    EXPECT_EQ(4500, StatsManager::readValue("stat03.sum.60"));
+    EXPECT_EQ(5050, StatsManager::readValue("stat03.SUM.600"));
+    EXPECT_EQ(90, StatsManager::readValue("stat03.count.60"));
+    EXPECT_EQ(100, StatsManager::readValue("stat03.COUNT.600"));
+    EXPECT_EQ(99, StatsManager::readValue("stat03.p99.60"));
+    EXPECT_EQ(100, StatsManager::readValue("stat03.P99.600"));
+}
+
+}   // namespace stats
+}   // namespace nebula
+
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    folly::init(&argc, &argv, true);
+    google::SetStderrLogging(google::INFO);
+
+    return RUN_ALL_TESTS();
+}
+

--- a/src/common/stats/test/StatsManagerRateTest.cpp
+++ b/src/common/stats/test/StatsManagerRateTest.cpp
@@ -1,0 +1,49 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/Base.h"
+#include <gtest/gtest.h>
+#include "stats/StatsManager.h"
+#include "thread/GenericWorker.h"
+
+namespace nebula {
+namespace stats {
+
+TEST(StatsManager, RateTest) {
+    auto statId = StatsManager::registerStats("ratetest");
+    auto thread = std::make_unique<thread::GenericWorker>();
+    ASSERT_TRUE(thread->start());
+
+    auto task = [=] () {
+        StatsManager::addValue(statId);
+    };
+    constexpr auto qps = 100L;
+    thread->addRepeatTask(1 * 1000 / qps, task);
+
+    ::usleep(60 * 1000 * 1000);
+
+    auto actual = StatsManager::readValue("ratetest.rate.60");
+
+    ASSERT_LT(std::max(qps, actual) - std::min(qps, actual), 10L) << "expected: " << qps
+                                                                  << ", actual: " << actual;
+
+    thread->stop();
+    thread->wait();
+    thread.reset();
+}
+
+}   // namespace stats
+}   // namespace nebula
+
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    folly::init(&argc, &argv, true);
+    google::SetStderrLogging(google::INFO);
+
+    return RUN_ALL_TESTS();
+}
+

--- a/src/meta/test/MetaHttpDownloadHandlerTest.cpp
+++ b/src/meta/test/MetaHttpDownloadHandlerTest.cpp
@@ -26,8 +26,7 @@ std::unique_ptr<hdfs::HdfsHelper> helper = std::make_unique<meta::MockHdfsOKHelp
 class MetaHttpDownloadHandlerTestEnv : public ::testing::Environment {
 public:
     void SetUp() override {
-        FLAGS_ws_http_port = 12100;
-        FLAGS_ws_storage_http_port = 12100;
+        FLAGS_ws_http_port = 0;
         FLAGS_ws_h2_port = 0;
         VLOG(1) << "Starting web service...";
 
@@ -59,6 +58,7 @@ public:
             return handler;
         });
         auto status = WebService::start();
+        FLAGS_ws_storage_http_port = FLAGS_ws_http_port;
         ASSERT_TRUE(status.ok()) << status;
     }
 

--- a/src/meta/test/MetaHttpIngestHandlerTest.cpp
+++ b/src/meta/test/MetaHttpIngestHandlerTest.cpp
@@ -23,8 +23,7 @@ namespace meta {
 class MetaHttpIngestHandlerTestEnv : public ::testing::Environment {
 public:
     void SetUp() override {
-        FLAGS_ws_http_port = 12100;
-        FLAGS_ws_storage_http_port = 12100;
+        FLAGS_ws_http_port = 0;
         FLAGS_ws_h2_port = 0;
         VLOG(1) << "Starting web service...";
 
@@ -46,6 +45,7 @@ public:
             return handler;
         });
         auto status = WebService::start();
+        FLAGS_ws_storage_http_port = FLAGS_ws_http_port;
         ASSERT_TRUE(status.ok()) << status;
     }
 

--- a/src/storage/AdminProcessor.h
+++ b/src/storage/AdminProcessor.h
@@ -40,7 +40,7 @@ public:
         auto host = kvstore::NebulaStore::getRaftAddr(HostAddr(req.get_new_leader().get_ip(),
                                                                req.get_new_leader().get_port()));
         part->asyncTransferLeader(host,
-                                  [this, spaceId, partId, host] (kvstore::ResultCode code) {
+                                  [this, spaceId, partId] (kvstore::ResultCode code) {
             auto leaderRet = kvstore_->partLeader(spaceId, partId);
             CHECK(ok(leaderRet));
             if (code == kvstore::ResultCode::ERR_LEADER_CHANGED) {


### PR DESCRIPTION
This patch reduces the chances of listen port conflicts, so that we can run unit tests concurrently, i.e `ctest --output-on-failure -jN`. By doing this, the duration of unit testing could be reduced to 2 minutes from 12.