### PR TITLE
Fixed compile warnings about name shadowing

### DIFF
--- a/src/common/base/NebulaKeyUtils.cpp
+++ b/src/common/base/NebulaKeyUtils.cpp
@@ -13,7 +13,7 @@ std::string NebulaKeyUtils::vertexKey(PartitionID partId, VertexID vId,
                                       TagID tagId, TagVersion tv) {
     constexpr uint32_t tagMask = 0xBFFFFFFF;
     tagId &= tagMask;
-    int32_t item = (partId << 8) | (NebulaKeyType::kData);
+    int32_t item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kData);
 
     std::string key;
     key.reserve(kVertexLen);
@@ -33,7 +33,7 @@ std::string NebulaKeyUtils::edgeKey(PartitionID partId,
                                     EdgeVersion ev) {
     constexpr uint32_t edgeMask = 0x40000000;
     type |= edgeMask;
-    int32_t item = (partId << 8) | (NebulaKeyType::kData);
+    int32_t item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kData);
 
     std::string key;
     key.reserve(kEdgeLen);
@@ -48,8 +48,8 @@ std::string NebulaKeyUtils::edgeKey(PartitionID partId,
 
 // static
 std::string NebulaKeyUtils::systemCommitKey(PartitionID partId) {
-    int32_t item = (partId << 8) | (NebulaKeyType::kSystem);
-    uint32_t type = NebulaSystemKeyType::kSystemCommit;
+    int32_t item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kSystem);
+    uint32_t type = static_cast<uint32_t>(NebulaSystemKeyType::kSystemCommit);
     std::string key;
     key.reserve(kSystemLen);
     key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
@@ -59,8 +59,8 @@ std::string NebulaKeyUtils::systemCommitKey(PartitionID partId) {
 
 // static
 std::string NebulaKeyUtils::systemPartKey(PartitionID partId) {
-    uint32_t item = (partId << 8) | (NebulaKeyType::kSystem);
-    uint32_t type = NebulaSystemKeyType::kSystemPart;
+    uint32_t item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kSystem);
+    uint32_t type = static_cast<uint32_t>(NebulaSystemKeyType::kSystemPart);
     std::string key;
     key.reserve(kSystemLen);
     key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
@@ -72,7 +72,7 @@ std::string NebulaKeyUtils::systemPartKey(PartitionID partId) {
 std::string NebulaKeyUtils::uuidKey(PartitionID partId, const folly::StringPiece& name) {
     std::string key;
     key.reserve(sizeof(PartitionID) + name.size());
-    int32_t item = (partId << 8) | (NebulaKeyType::kUUID);
+    int32_t item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kUUID);
     key.append(reinterpret_cast<const char*>(&item), sizeof(int32_t))
        .append(name.data(), name.size());
     return key;
@@ -82,7 +82,7 @@ std::string NebulaKeyUtils::uuidKey(PartitionID partId, const folly::StringPiece
 std::string NebulaKeyUtils::vertexPrefix(PartitionID partId, VertexID vId, TagID tagId) {
     constexpr uint32_t tagMask = 0xBFFFFFFF;
     tagId &= tagMask;
-    PartitionID item = (partId << 8) | (NebulaKeyType::kData);
+    PartitionID item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kData);
 
     std::string key;
     key.reserve(kVertexLen);
@@ -96,7 +96,7 @@ std::string NebulaKeyUtils::vertexPrefix(PartitionID partId, VertexID vId, TagID
 std::string NebulaKeyUtils::edgePrefix(PartitionID partId, VertexID srcId, EdgeType type) {
     constexpr uint32_t edgeMask = 0x40000000;
     type |= edgeMask;
-    PartitionID item = (partId << 8) | (NebulaKeyType::kData);
+    PartitionID item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kData);
 
     std::string key;
     key.reserve(sizeof(PartitionID) + sizeof(VertexID) + sizeof(EdgeType));
@@ -108,7 +108,7 @@ std::string NebulaKeyUtils::edgePrefix(PartitionID partId, VertexID srcId, EdgeT
 
 // static
 std::string NebulaKeyUtils::prefix(PartitionID partId) {
-    PartitionID item = (partId << 8) | (NebulaKeyType::kData);
+    PartitionID item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kData);
     std::string key;
     key.reserve(sizeof(PartitionID));
     key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID));
@@ -117,7 +117,7 @@ std::string NebulaKeyUtils::prefix(PartitionID partId) {
 
 // static
 std::string NebulaKeyUtils::vertexPrefix(PartitionID partId, VertexID vId) {
-    PartitionID item = (partId << 8) | (NebulaKeyType::kData);
+    PartitionID item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kData);
     std::string key;
     key.reserve(sizeof(PartitionID) + sizeof(VertexID));
     key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
@@ -127,7 +127,7 @@ std::string NebulaKeyUtils::vertexPrefix(PartitionID partId, VertexID vId) {
 
 // static
 std::string NebulaKeyUtils::edgePrefix(PartitionID partId, VertexID vId) {
-    PartitionID item = (partId << 8) | (NebulaKeyType::kData);
+    PartitionID item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kData);
     std::string key;
     key.reserve(sizeof(PartitionID) + sizeof(VertexID));
     key.append(reinterpret_cast<const char*>(&item), sizeof(PartitionID))
@@ -137,7 +137,7 @@ std::string NebulaKeyUtils::edgePrefix(PartitionID partId, VertexID vId) {
 
 // static
 std::string NebulaKeyUtils::systemPrefix() {
-    int8_t type = NebulaKeyType::kSystem;
+    int8_t type = static_cast<uint32_t>(NebulaKeyType::kSystem);
     std::string key;
     key.reserve(sizeof(int8_t));
     key.append(reinterpret_cast<const char*>(&type), sizeof(int8_t));
@@ -149,7 +149,7 @@ std::string NebulaKeyUtils::prefix(PartitionID partId, VertexID src, EdgeType ty
                                    EdgeRanking ranking, VertexID dst) {
     constexpr uint32_t edgeMask = 0x40000000;
     type |= edgeMask;
-    PartitionID item = (partId << 8) | (NebulaKeyType::kData);
+    PartitionID item = (partId << 8) | static_cast<uint32_t>(NebulaKeyType::kData);
 
     std::string key;
     key.reserve(sizeof(PartitionID) + sizeof(VertexID) + sizeof(EdgeType)

--- a/src/common/base/NebulaKeyUtils.h
+++ b/src/common/base/NebulaKeyUtils.h
@@ -20,14 +20,14 @@ namespace nebula {
  *
  * */
 
-enum NebulaKeyType : uint32_t {
+enum class NebulaKeyType : uint32_t {
     kData              = 0x00000001,
     kIndex             = 0x00000002,
     kUUID              = 0x00000003,
     kSystem            = 0x00000004,
 };
 
-enum NebulaSystemKeyType : uint32_t {
+enum class NebulaSystemKeyType : uint32_t {
     kSystemCommit      = 0x00000001,
     kSystemPart        = 0x00000002,
 };
@@ -82,7 +82,8 @@ public:
         constexpr uint32_t tagMask  = 0x40000000;
         constexpr uint32_t typeMask = 0x000000FF;
         constexpr int32_t len = static_cast<int32_t>(sizeof(NebulaKeyType));
-        if (NebulaKeyType::kData != (readInt<int32_t>(rawKey.data(), len) & typeMask)) {
+        auto type = readInt<uint32_t>(rawKey.data(), len) & typeMask;
+        if (static_cast<uint32_t>(NebulaKeyType::kData) != type) {
             return false;
         }
         auto offset = sizeof(PartitionID) + sizeof(VertexID);
@@ -100,12 +101,13 @@ public:
         constexpr uint32_t edgeMask = 0x40000000;
         constexpr uint32_t typeMask = 0x000000FF;
         constexpr int32_t len = static_cast<int32_t>(sizeof(NebulaKeyType));
-        if (NebulaKeyType::kData != (readInt<int32_t>(rawKey.data(), len) & typeMask)) {
+        auto type = readInt<uint32_t>(rawKey.data(), len) & typeMask;
+        if (static_cast<uint32_t>(NebulaKeyType::kData) != type) {
             return false;
         }
         auto offset = sizeof(PartitionID) + sizeof(VertexID);
-        EdgeType type = readInt<EdgeType>(rawKey.data() + offset, sizeof(EdgeType));
-        return type & edgeMask;
+        EdgeType etype = readInt<EdgeType>(rawKey.data() + offset, sizeof(EdgeType));
+        return etype & edgeMask;
     }
 
     static bool isSystemCommit(const folly::StringPiece& rawKey) {
@@ -114,7 +116,8 @@ public:
         }
         auto position = rawKey.data() + sizeof(PartitionID);
         auto len = sizeof(NebulaSystemKeyType);
-        return NebulaSystemKeyType::kSystemCommit == readInt<uint32_t>(position, len);
+        auto type = readInt<uint32_t>(position, len);
+        return static_cast<uint32_t>(NebulaSystemKeyType::kSystemCommit) == type;
     }
 
     static bool isSystemPart(const folly::StringPiece& rawKey) {
@@ -123,7 +126,8 @@ public:
         }
         auto position = rawKey.data() + sizeof(PartitionID);
         auto len = sizeof(NebulaSystemKeyType);
-        return NebulaSystemKeyType::kSystemPart == readInt<uint32_t>(position, len);
+        auto type = readInt<uint32_t>(position, len);
+        return static_cast<uint32_t>(NebulaSystemKeyType::kSystemPart) == type;
     }
 
     static VertexID getSrcId(const folly::StringPiece& rawKey) {
@@ -162,18 +166,21 @@ public:
     static bool isDataKey(const folly::StringPiece& key) {
         constexpr uint32_t typeMask = 0x000000FF;
         constexpr int32_t len = static_cast<int32_t>(sizeof(NebulaKeyType));
-        return NebulaKeyType::kData == (readInt<int32_t>(key.data(), len) & typeMask);
+        auto type = readInt<int32_t>(key.data(), len) & typeMask;
+        return static_cast<uint32_t>(NebulaKeyType::kData) == type;
     }
 
     static bool isIndexKey(const folly::StringPiece& key) {
         constexpr uint32_t typeMask = 0x000000FF;
         constexpr int32_t len = static_cast<int32_t>(sizeof(NebulaKeyType));
-        return NebulaKeyType::kIndex == (readInt<int32_t>(key.data(), len) & typeMask);
+        auto type = readInt<int32_t>(key.data(), len) & typeMask;
+        return static_cast<uint32_t>(NebulaKeyType::kIndex) == type;
     }
 
     static bool isUUIDKey(const folly::StringPiece& key) {
         constexpr uint32_t typeMask = 0x000000FF;
-        return NebulaKeyType::kUUID == (readInt<int32_t>(key.data(), sizeof(int32_t)) & typeMask);
+        auto type = readInt<int32_t>(key.data(), sizeof(int32_t)) & typeMask;
+        return static_cast<uint32_t>(NebulaKeyType::kUUID) == type;
     }
 
     static folly::StringPiece keyWithNoVersion(const folly::StringPiece& rawKey) {


### PR DESCRIPTION
`Expression::kUUID` shadows `NebulaKeyType::kUUID`.