### PR TITLE
update KVVerifyTool, support get/put kv pairs from multiple storage instance

### DIFF
--- a/package/nebula.spec
+++ b/package/nebula.spec
@@ -73,6 +73,11 @@ Summary: tool for storage
 Group: Applications/Databases
 %description storage_perf
 
+%package simple_kv_verify
+Summary: tool for storage
+Group: Applications/Databases
+%description simple_kv_verify
+
 
 # the files include exe, config file, scripts
 # base rpm include files
@@ -129,6 +134,10 @@ fi
 # storage_perf rpm
 %files storage_perf
 %attr(0755,root,root) %{_bindir}/storage_perf
+
+# simple_kv_verify rpm
+%files simple_kv_verify
+%attr(0755,root,root) %{_bindir}/simple_kv_verify
 
 %debug_package
 

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -404,11 +404,16 @@ void RaftPart::commitTransLeader(const HostAddr& target) {
     LOG(INFO) << idStr_ << "Commit transfer leader to " << target;
     switch (role_) {
         case Role::LEADER: {
-            if (target != addr_) {
-                lastMsgRecvDur_.reset();
-                role_ = Role::FOLLOWER;
-                leader_ = HostAddr(0, 0);
-                LOG(INFO) << idStr_ << "Give up my leadership!";
+            if (target != addr_ && !hosts_.empty()) {
+                auto iter = std::find_if(hosts_.begin(), hosts_.end(), [] (const auto& h) {
+                    return !h->isLearner();
+                });
+                if (iter != hosts_.end()) {
+                    lastMsgRecvDur_.reset();
+                    role_ = Role::FOLLOWER;
+                    leader_ = HostAddr(0, 0);
+                    LOG(INFO) << idStr_ << "Give up my leadership!";
+                }
             } else {
                 LOG(INFO) << idStr_ << "I am already the leader!";
             }

--- a/src/storage/client/StorageClient.inl
+++ b/src/storage/client/StorageClient.inl
@@ -125,6 +125,8 @@ folly::SemiFuture<StorageRpcResponse<Response>> StorageClient::collectResponse(
                                              code.get_part_id(),
                                              HostAddr(leader->get_ip(), leader->get_port()));
                             }
+                        } else if (code.get_code() == storage::cpp2::ErrorCode::E_PART_NOT_FOUND) {
+                            invalidLeader(spaceId, code.get_part_id());
                         } else {
                             // Simply keep the result
                             context->resp.failedParts().emplace(code.get_part_id(),
@@ -195,6 +197,8 @@ folly::Future<StatusOr<Response>> StorageClient::getResponse(
                         updateLeader(spaceId, code.get_part_id(),
                                      HostAddr(leader->get_ip(), leader->get_port()));
                     }
+                } else if (code.get_code() == storage::cpp2::ErrorCode::E_PART_NOT_FOUND) {
+                    invalidLeader(spaceId, code.get_part_id());
                 }
             }
             p.setValue(std::move(resp));


### PR DESCRIPTION
1. We only handle response from one host previously. Actually, we need to check key-value pairs from responses of all hosts.
2. During balance data, sometimes the partition is not on a hosts anymore, we need to invalidate leader info in client.