### PR TITLE
fix a bug in DeleteVertexExecutor

### DIFF
--- a/src/graph/DeleteVertexExecutor.cpp
+++ b/src/graph/DeleteVertexExecutor.cpp
@@ -33,7 +33,7 @@ Status DeleteVertexExecutor::prepare() {
 }
 
 void DeleteVertexExecutor::execute() {
-    // TODO(zlcook) Get edgeKes of a vertex by Go
+    // TODO(zlcook) Get edgeKeys of a vertex by Go
     auto future = ectx()->getStorageClient()->getEdgeKeys(spaceId_, vid_);
     auto *runner = ectx()->rctx()->runner();
     auto cb = [this] (auto &&resp) {
@@ -53,7 +53,11 @@ void DeleteVertexExecutor::execute() {
             allEdges.emplace_back(std::move(edge));
             allEdges.emplace_back(std::move(reverseEdge));
         }
-        deleteEdges(&allEdges);
+        if (allEdges.size() > 0) {
+            deleteEdges(&allEdges);
+        } else {
+            deleteVertex();
+        }
         return;
     };
 

--- a/src/graph/test/DeleteVertexTest.cpp
+++ b/src/graph/test/DeleteVertexTest.cpp
@@ -163,6 +163,40 @@ TEST_F(DeleteVertexTest, base) {
         };
         ASSERT_TRUE(verifyResult(resp, expected));
     }
+
+    // Delete non-existing vertex
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "DELETE VERTEX uuid(\"Non-existing Vertex\")";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+
+    // Delete a vertex without edges
+    {
+        // Insert a vertex without edges
+        cpp2::ExecutionResponse resp;
+        auto query = "INSERT VERTEX player(name, age) "
+                     "VALUES uuid(\"A Loner\"): (\"A Loner\", 0)";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "DELETE VERTEX uuid(\"A Loner\")";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "FETCH PROP ON player uuid(\"A Loner\") "
+                     "YIELD player.name, player.age";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<std::string, int64_t>> expected = {
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
 }
 
 }  // namespace graph


### PR DESCRIPTION
* before: deleting a vertex without edges will cause the following exception
```
#0  0x0000000001a28d47 in nebula::storage::StorageRpcResponse<nebula::storage::cpp2::ExecResponse>::completeness (this=0x7f390db69148) at /export/nebula/src/storage/client/StorageClient.h:53
53	        return (totalReqsSent_ - failedReqs_) * 100 / totalReqsSent_;
```
