### PR TITLE
Support comparison function in().

### DIFF
--- a/src/common/filter/Expressions.h
+++ b/src/common/filter/Expressions.h
@@ -701,6 +701,18 @@ public:
         }
     }
 
+    FunctionCallExpression(Expression *expr,
+                           std::string *name,
+                           ArgumentList *args) {
+        kind_ = kFunctionCall;
+        expr_.reset(expr);
+        name_.reset(name);
+        if (args != nullptr) {
+            args_ = args->args();
+            delete args;
+        }
+    }
+
     std::string toString() const override;
 
     OptVariantType eval() const override;
@@ -709,6 +721,9 @@ public:
 
     void setContext(ExpressionContext *ctx) override {
         context_ = ctx;
+        if (expr_ != nullptr) {
+            expr_->setContext(ctx);
+        }
         for (auto &arg : args_) {
             arg->setContext(ctx);
         }
@@ -722,6 +737,7 @@ private:
 private:
     std::unique_ptr<std::string>                name_;
     std::vector<std::unique_ptr<Expression>>    args_;
+    std::unique_ptr<Expression>                 expr_;
     std::function<VariantType(const std::vector<VariantType>&)> function_;
 };
 

--- a/src/common/filter/FunctionManager.cpp
+++ b/src/common/filter/FunctionManager.cpp
@@ -409,24 +409,75 @@ FunctionManager::FunctionManager() {
         attr.maxArity_ = 1;
         attr.body_ = [] (const auto &args) {
             switch (args[0].which()) {
-                case 0: {
+                case VAR_INT64: {
                     auto v = Expression::asInt(args[0]);
                     return static_cast<int64_t>(std::hash<int64_t>()(v));
                 }
-                case 1: {
+                case VAR_DOUBLE: {
                     auto v = Expression::asDouble(args[0]);
                     return static_cast<int64_t>(std::hash<double>()(v));
                 }
-                case 2: {
+                case VAR_BOOL: {
                     auto v = Expression::asBool(args[0]);
                     return static_cast<int64_t>(std::hash<bool>()(v));
                 }
-                case 3: {
+                case VAR_STR: {
                     auto &v = Expression::asString(args[0]);
                     return static_cast<int64_t>(std::hash<std::string>()(v));
                 }
                 default:
+                    LOG(ERROR) << "Unkown type: " << args[0].which();
                     return INT64_MIN;
+            }
+        };
+    }
+    {
+        auto &attr = functions_["in"];
+        attr.minArity_ = 2;
+        attr.maxArity_ = INT64_MAX;
+        attr.body_ = [] (const auto &args) {
+            VariantType cmp = args.back();
+            LOG(INFO) << cmp;
+            switch (cmp.which()) {
+                case VAR_INT64: {
+                    auto v = Expression::asInt(cmp);
+                    std::unordered_set<uint64_t> vals;
+                    for (auto iter = args.begin(); iter < (args.end() - 1); ++iter) {
+                        vals.emplace(Expression::toInt(*iter));
+                    }
+                    auto ret = vals.emplace(v);
+                    return !ret.second;
+                }
+                case VAR_DOUBLE: {
+                    auto v = Expression::asDouble(cmp);
+                    std::unordered_set<double> vals;
+                    for (auto iter = args.begin(); iter < (args.end() - 1); ++iter) {
+                        vals.emplace(Expression::toDouble(*iter));
+                    }
+                    auto ret = vals.emplace(v);
+                    return !ret.second;
+                }
+                case VAR_BOOL: {
+                    auto v = Expression::asBool(cmp);
+                    std::unordered_set<bool> vals;
+                    for (auto iter = args.begin(); iter < (args.end() - 1); ++iter) {
+                        vals.emplace(Expression::toBool(*iter));
+                    }
+                    auto ret = vals.emplace(v);
+                    return !ret.second;
+                }
+                case VAR_STR: {
+                    auto v = Expression::asString(cmp);
+                    std::unordered_set<std::string> vals;
+                    for (auto iter = args.begin(); iter < (args.end() - 1); ++iter) {
+                        vals.emplace(Expression::toString(*iter));
+                    }
+                    auto ret = vals.emplace(v);
+                    return !ret.second;
+                }
+                default:
+                    LOG(ERROR) << "Unkown type: " << cmp.which();
+                    return false;
             }
         };
     }
@@ -435,8 +486,12 @@ FunctionManager::FunctionManager() {
 
 // static
 StatusOr<FunctionManager::Function>
-FunctionManager::get(const std::string &func, size_t arity) {
-    return instance().getInternal(func, arity);
+FunctionManager::get(const std::string &func, size_t arity, bool isExprSet) {
+    if ((func != "in" && isExprSet)
+            || (func == "in" && !isExprSet)) {
+        return Status::SyntaxError("syntax error near %s", func.c_str());
+    }
+    return instance().getInternal(func, (arity + (isExprSet ? 1 : 0)));
 }
 
 

--- a/src/common/filter/FunctionManager.h
+++ b/src/common/filter/FunctionManager.h
@@ -29,7 +29,7 @@ public:
     /**
      * To obtain a function named `func', with the actual arity.
      */
-    static StatusOr<Function> get(const std::string &func, size_t arity);
+    static StatusOr<Function> get(const std::string &func, size_t arity, bool isExprSet);
 
     /**
      * To load a set of functions from a shared object dynamically.

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -626,5 +626,69 @@ TEST_F(GoTest, NotExistTagProp) {
         ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, code);
     }
 }
+
+TEST_F(GoTest, inCall) {
+    {
+        cpp2::ExecutionResponse resp;
+        auto &player = players_["Boris Diaw"];
+        auto *fmt = "GO FROM %ld OVER serve "
+                    "WHERE $$.team.name in (\"Hawks\", \"Suns\") "
+                    "YIELD $^.player.name, serve.start_year, serve.end_year, $$.team.name";
+        auto query = folly::stringPrintf(fmt, player.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code) << *resp.get_error_msg();
+
+        std::vector<std::string> expectedColNames{
+            {"$^.player.name"}, {"serve.start_year"}, {"serve.end_year"}, {"$$.team.name"}
+        };
+        ASSERT_TRUE(verifyColNames(resp, expectedColNames));
+
+        std::vector<std::tuple<std::string, int64_t, int64_t, std::string>> expected = {
+            {player.name(), 2003, 2005, "Hawks"},
+            {player.name(), 2005, 2008, "Suns"},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "GO FROM %ld OVER like YIELD like._dst AS id"
+                    "| GO FROM $-.id OVER serve WHERE $-.id in(%ld, 123)";
+        auto query = folly::stringPrintf(fmt,
+                players_["Tim Duncan"].vid(), players_["Tony Parker"].vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+
+        std::vector<std::string> expectedColNames{
+            {"serve._dst"}
+        };
+        ASSERT_TRUE(verifyColNames(resp, expectedColNames));
+
+        std::vector<std::tuple<int64_t>> expected = {
+            {teams_["Spurs"].vid()},
+            {teams_["Hornets"].vid()},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "GO FROM %ld OVER like YIELD like._dst AS id"
+                    "| GO FROM $-.id OVER serve WHERE $-.id in(%ld, 123) && 1 == 1";
+        auto query = folly::stringPrintf(fmt,
+                players_["Tim Duncan"].vid(), players_["Tony Parker"].vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+
+        std::vector<std::string> expectedColNames{
+            {"serve._dst"}
+        };
+        ASSERT_TRUE(verifyColNames(resp, expectedColNames));
+
+        std::vector<std::tuple<int64_t>> expected = {
+            {teams_["Spurs"].vid()},
+            {teams_["Hornets"].vid()},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+}
 }   // namespace graph
 }   // namespace nebula

--- a/src/graph/test/YieldTest.cpp
+++ b/src/graph/test/YieldTest.cpp
@@ -203,5 +203,24 @@ TEST_F(YieldTest, Logic) {
         ASSERT_TRUE(verifyResult(resp, expected));
     }
 }
+
+TEST_F(YieldTest, inCall) {
+    auto client = gEnv->getClient();
+    ASSERT_NE(nullptr, client);
+    {
+        cpp2::ExecutionResponse resp;
+        std::string query = "YIELD 1 in(0,1,2), 123";
+        auto code = client->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code) << *resp.get_error_msg();
+        std::vector<std::string> expectedColNames{
+            {"1 in(0,1,2)"}, {"123"}
+        };
+        ASSERT_TRUE(verifyColNames(resp, expectedColNames));
+        std::vector<std::tuple<bool, uint64_t>> expected{
+            {true, 123}
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+}
 }   // namespace graph
 }   // namespace nebula

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -234,6 +234,7 @@ unreserved_keyword
      | KW_GOD                { $$ = new std::string("god"); }
      | KW_ADMIN              { $$ = new std::string("admin"); }
      | KW_GUEST              { $$ = new std::string("guest"); }
+     | KW_IN                 { $$ = new std::string("in"); }
      ;
 
 primary_expression
@@ -327,8 +328,11 @@ alias_ref_expression
     ;
 
 function_call_expression
-    : LABEL L_PAREN opt_argument_list R_PAREN {
-        $$ = new FunctionCallExpression($1, $3);
+    : name_label L_PAREN opt_argument_list R_PAREN {
+        $$ = new FunctionCallExpression(nullptr, $1, $3);
+    }
+    | primary_expression name_label L_PAREN opt_argument_list R_PAREN {
+        $$ = new FunctionCallExpression($1, $2, $4);
     }
     ;
 


### PR DESCRIPTION
I notice that _**in()**_ is a comparison function in Mysql. So I learn from the design and implement it with a function.
The syntax would looks like:
```
YIELD 1 in(1,2,3);
```

Or you may reference it in filter:
```
WHERE 1 in(1,2,3)
```

Definitely, you can reference the input , src and dest ref:
```
WHERE $-.id in(1,2,3)
WHERE $$.team.name in("Spurs","Suns")
WHERE $^.player.name in("Tim Duncan", "Tony Parker")
```

close #1040 