### PR TITLE
Added support for local commands in console

### DIFF
--- a/share/resources/completion.json
+++ b/share/resources/completion.json
@@ -108,6 +108,16 @@
             "sub_keywords": [
                 "YIELD", "COUNT", "COUNT_DISTINCT", "SUM", "AVG", "MAX", "MIN", "STD", "BIT_AND", "BIT_OR", "BIT_XOR"
             ]
+        },
+        ":exit": {
+        },
+        ":quit": {
+        },
+        ":sh": {
+        },
+        ":bash": {
+        },
+        ":history": {
         }
     },
     "typenames": [

--- a/src/console/CMakeLists.txt
+++ b/src/console/CMakeLists.txt
@@ -18,6 +18,7 @@ nebula_add_executable(
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:process_obj>
     LIBRARIES
         ${THRIFT_LIBRARIES}
         wangle

--- a/src/console/CliManager.cpp
+++ b/src/console/CliManager.cpp
@@ -383,10 +383,15 @@ bool isStartOfStatement(std::string &primaryKeyword) {
         return true;
     }
 
+    // If this is an upcoming local command
+    if (piece == ":") {
+        return true;
+    }
+
     // If the inputs are terminated with ';' or '|', i.e. complete statements
     // Additionally, there is an incomplete primary keyword for the next statement
     {
-        static const std::regex pattern(R"((\s*\w+[^;|]*[;|]\s*)*(\w+)?)");
+        static const std::regex pattern(R"((\s*:?\w+[^;|]*[;|]\s*)*(:?\w+)?)");
         std::smatch result;
 
         if (std::regex_match(line, result, pattern)) {
@@ -397,7 +402,7 @@ bool isStartOfStatement(std::string &primaryKeyword) {
     // The same to the occasion above, except that the primary keyword is complete
     // This is where sub keywords shall be completed
     {
-        static const std::regex pattern(R"((\s*\w+[^;|]*[;|]\s*)*(\w+)[^;|]+)");
+        static const std::regex pattern(R"((\s*:?\w+[^;|]*[;|]\s*)*(:?\w+)[^;|]+)");
         std::smatch result;
 
         if (std::regex_match(line, result, pattern)) {


### PR DESCRIPTION
All user inputs prefixed with ":" are considered as local commands, which won't be sent on wire to the remote server.

In this PR, I added:
  * `:exit`, `:quit` to quit from console
  * `:sh`, `:bash` to execute any command in a sub-shell
  * `:history` to display the input history

It is worth to mention that, with `:sh sleep N`, we are able to do schema manipulation(e.g. create tag) in a batch mode.