### PR TITLE
Recompile the new third-party library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ set(THRIFT_LIBRARIES
     thrift-core
 )
 
+set(ROCKSDB_LIBRARIES ${Rocksdb_LIBRARY})
 
 # All compression libraries
 set(COMPRESSION_LIBRARIES bz2 snappy zstd z)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ if(NOT ${NEBULA_OTHER_ROOT} STREQUAL "")
         list(INSERT CMAKE_LIBRARY_PATH 0 ${DIR}/lib)
         list(INSERT CMAKE_PROGRAM_PATH 0 ${DIR}/bin)
         include_directories(SYSTEM ${DIR}/include)
-        link_directories(${DIR}/lib64)
+        link_directories(${DIR}/lib)
     endforeach()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,19 +8,10 @@
 #
 #   CMAKE_C_COMPILER               -- Specify the compiler for C language
 #   CMAKE_CXX_COMPILER             -- Specify the compiler for C++ language
-
-#   NEBULA_GPERF_BIN_DIR           -- Specify the full path to the directory
-#                                      containing gperf binary
-#   NEBULA_FLEX_ROOT               -- Specify the root directory for flex
-#   NEBULA_BISON_ROOT              -- Specify the root directory for bison
-#   NEBULA_READLINE_ROOT           -- Specify the root directory for readline
-#   NEBULA_NCURSES_ROOT            -- Specify the root directory for ncurses
-#   NEBULA_KRB5_ROOT               -- Specify the root directory for KRB5
-#   NEBULA_LIBUNWIND_ROOT          -- Specify the root directory for libunwind
-#   NEBULA_OPENSSL_ROOT            -- Specify the root directory for openssl
-#   NEBULA_BOOST_ROOT              -- Specify the root directory for boost
-
-#   NEBULA_THIRDPARTY_ROOT          -- Specify the root directory for third-party
+#
+#   NEBULA_THIRDPARTY_ROOT         -- Specify the root directory for third-party
+#   NEBULA_OTHER_ROOT              -- Specify the root directory for user build
+#                                  -- Split with ":", exp: DIR:DIR
 #
 #   SKIP_JAVA_CLIENT               -- Skip building the java client
 #   ENABLE_JEMALLOC                -- Link jemalloc into all executables
@@ -129,61 +120,6 @@ endif()
 # To include customized FindXXX.cmake modules
 set(CMAKE_MODULE_PATH "${NEBULA_HOME}/cmake" ${CMAKE_MODULE_PATH})
 
-if(NOT ${NEBULA_KRB5_ROOT} STREQUAL "")
-    message(STATUS "Specified NEBULA_KRB5_ROOT: " ${NEBULA_KRB5_ROOT})
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_KRB5_ROOT}/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_KRB5_ROOT}/lib)
-    list(INSERT CMAKE_PROGRAM_PATH 0 ${NEBULA_KRB5_ROOT}/bin)
-endif()
-
-if(NOT ${NEBULA_LIBUNWIND_ROOT} STREQUAL "")
-    message(STATUS "Specified NEBULA_LIBUNWIND_ROOT: " ${NEBULA_LIBUNWIND_ROOT})
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_LIBUNWIND_ROOT}/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_LIBUNWIND_ROOT}/lib)
-endif()
-
-if(NOT ${NEBULA_OPENSSL_ROOT} STREQUAL "")
-    message(STATUS "Specified NEBULA_OPENSSL_ROOT: " ${NEBULA_OPENSSL_ROOT})
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_OPENSSL_ROOT}/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_OPENSSL_ROOT}/lib)
-endif()
-
-if(NOT ${NEBULA_BOOST_ROOT} STREQUAL "")
-    message(STATUS "Specified NEBULA_BOOST_ROOT: " ${NEBULA_BOOST_ROOT})
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_BOOST_ROOT}/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_BOOST_ROOT}/lib)
-endif()
-
-if(NOT ${NEBULA_READLINE_ROOT} STREQUAL "")
-    message(STATUS "Specified NEBULA_READLINE_ROOT: " ${NEBULA_READLINE_ROOT})
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_READLINE_ROOT}/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_READLINE_ROOT}/lib)
-endif()
-
-if(NOT ${NEBULA_NCURSES_ROOT} STREQUAL "")
-    message(STATUS "Specified NEBULA_NCURSES_ROOT: " ${NEBULA_NCURSES_ROOT})
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_NCURSES_ROOT}/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_NCURSES_ROOT}/lib)
-endif()
-
-if(NOT ${NEBULA_FLEX_ROOT} STREQUAL "")
-    message(STATUS "Specified NEBULA_FLEX_ROOT: " ${NEBULA_FLEX_ROOT})
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_FLEX_ROOT}/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_FLEX_ROOT}/lib)
-    list(INSERT CMAKE_PROGRAM_PATH 0 ${NEBULA_FLEX_ROOT}/bin)
-endif()
-
-if(NOT ${NEBULA_BISON_ROOT} STREQUAL "")
-    message(STATUS "Specified NEBULA_BISON_ROOT: " ${NEBULA_BISON_ROOT})
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_BISON_ROOT}/lib)
-    list(INSERT CMAKE_PROGRAM_PATH 0 ${NEBULA_BISON_ROOT}/bin)
-endif()
-
-if(NOT ${NEBULA_GPERF_BIN_DIR} STREQUAL "")
-    message(STATUS "Specified NEBULA_GPERF_BIN_DIR: " ${NEBULA_GPERF_BIN_DIR})
-    list(INSERT CMAKE_PROGRAM_PATH 0 ${NEBULA_GPERF_BIN_DIR})
-endif()
-
 # When NEBULA_THIRDPARTY_ROOT is null, set default value as /opt/nebula/third-party
 if("${NEBULA_THIRDPARTY_ROOT}" STREQUAL "")
     SET(NEBULA_THIRDPARTY_ROOT "/opt/nebula/third-party")
@@ -192,80 +128,27 @@ endif()
 # third-party
 if(NOT ${NEBULA_THIRDPARTY_ROOT} STREQUAL "")
     message(STATUS "Specified NEBULA_THIRDPARTY_ROOT: " ${NEBULA_THIRDPARTY_ROOT})
-    # bzip2
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/bzip2/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/bzip2/lib)
-    list(INSERT CMAKE_PROGRAM_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/bzip2/bin)
+    list(APPEND CMAKE_INCLUDE_PATH ${NEBULA_THIRDPARTY_ROOT}/include)
+    list(APPEND CMAKE_LIBRARY_PATH ${NEBULA_THIRDPARTY_ROOT}/lib)
+    list(APPEND CMAKE_LIBRARY_PATH ${NEBULA_THIRDPARTY_ROOT}/lib64)
+    list(APPEND CMAKE_PROGRAM_PATH ${NEBULA_THIRDPARTY_ROOT}/bin)
+    include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/include)
+    link_directories(
+        ${NEBULA_THIRDPARTY_ROOT}/lib
+        ${NEBULA_THIRDPARTY_ROOT}/lib64
+    )
+endif()
 
-    # double-conversion
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/double-conversion/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/double-conversion/lib)
-
-    # fatal
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/fatal/include)
-
-    # fbthrift
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/fbthrift/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/fbthrift/lib)
-    list(INSERT CMAKE_PROGRAM_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/fbthrift/bin)
-
-    # folly
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/folly/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/folly/lib)
-
-    # gflags
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/gflags/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/gflags/lib)
-    list(INSERT CMAKE_PROGRAM_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/gflags/bin)
-
-    # glog
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/glog/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/glog/lib)
-
-    # googletest
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/googletest/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/googletest/lib)
-
-    # jemalloc
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/jemalloc/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/jemalloc/lib)
-    list(INSERT CMAKE_PROGRAM_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/jemalloc/bin)
-
-    # libevent
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/libevent/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/libevent/lib)
-    list(INSERT CMAKE_PROGRAM_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/libevent/bin)
-
-    # mstch
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/mstch/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/mstch/lib)
-
-    # proxygen
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/proxygen/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/proxygen/lib)
-
-    # rocksdb
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/rocksdb/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/rocksdb/lib)
-    set(ROCKSDB_LIBRARIES ${NEBULA_ROCKSDB_ROOT}/lib/librocksdb.a)
-
-    # snappy
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/snappy/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/snappy/lib)
-
-    # wangle
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/wangle/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/wangle/lib)
-
-    # zlib
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/zlib/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/zlib/lib)
-
-    # zstd
-    list(INSERT CMAKE_INCLUDE_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/zstd/include)
-    list(INSERT CMAKE_LIBRARY_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/zstd/lib)
-    list(INSERT CMAKE_PROGRAM_PATH 0 ${NEBULA_THIRDPARTY_ROOT}/zstd/bin)
-
+if(NOT ${NEBULA_OTHER_ROOT} STREQUAL "")
+    string(REPLACE ":" ";" DIR_LIST ${NEBULA_OTHER_ROOT})
+    list(LENGTH DIR_LIST len)
+    foreach(DIR IN LISTS DIR_LIST )
+        list(INSERT CMAKE_INCLUDE_PATH 0 ${DIR}/include)
+        list(INSERT CMAKE_LIBRARY_PATH 0 ${DIR}/lib)
+        list(INSERT CMAKE_PROGRAM_PATH 0 ${DIR}/bin)
+        include_directories(SYSTEM ${DIR}/include)
+        link_directories(${DIR}/lib64)
+    endforeach()
 endif()
 
 string(REPLACE ";" ":" INCLUDE_PATH_STR "${CMAKE_INCLUDE_PATH}")
@@ -424,29 +307,6 @@ macro(nebula_add_library name type)
     )
 endmacro()
 
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/bzip2/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/double-conversion/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/fatal/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/fbthrift/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/folly/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/gflags/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/glog/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/googletest/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/jemalloc/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/libevent/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/mstch/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/proxygen/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/rocksdb/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/snappy/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/wangle/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/zlib/include)
-include_directories(SYSTEM ${NEBULA_THIRDPARTY_ROOT}/zstd/include)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-include_directories(SYSTEM ${OPENSSL_INCLUDE_DIR})
-include_directories(SYSTEM ${KRB5_INCLUDE_DIRS})
-include_directories(SYSTEM ${FLEX_INCLUDE_DIRS})
-include_directories(SYSTEM ${NCURSES_INCLUDE_DIR})
-include_directories(SYSTEM ${Readline_INCLUDE_DIR})
 include_directories(AFTER ${NEBULA_HOME}/src)
 include_directories(AFTER src/common)
 include_directories(AFTER src/interface)
@@ -455,28 +315,6 @@ include_directories(AFTER ${CMAKE_CURRENT_BINARY_DIR}/src/interface)
 include_directories(AFTER ${CMAKE_CURRENT_BINARY_DIR}/src/kvstore/plugins)
 include_directories(AFTER ${CMAKE_CURRENT_BINARY_DIR}/src/kvstore/plugins/hbase)
 include_directories(AFTER ${CMAKE_CURRENT_BINARY_DIR}/src/parser)
-
-link_directories(
-    ${NEBULA_THIRDPARTY_ROOT}/bzip2/lib
-    ${NEBULA_THIRDPARTY_ROOT}/double-conversion/lib
-    ${NEBULA_THIRDPARTY_ROOT}/fatal/lib
-    ${NEBULA_THIRDPARTY_ROOT}/fbthrift/lib
-    ${NEBULA_THIRDPARTY_ROOT}/folly/lib
-    ${NEBULA_THIRDPARTY_ROOT}/gflags/lib
-    ${NEBULA_THIRDPARTY_ROOT}/glog/lib
-    ${NEBULA_THIRDPARTY_ROOT}/googletest/lib
-    ${NEBULA_THIRDPARTY_ROOT}/jemalloc/lib
-    ${NEBULA_THIRDPARTY_ROOT}/libevent/lib
-    ${NEBULA_THIRDPARTY_ROOT}/mstch/lib
-    ${NEBULA_THIRDPARTY_ROOT}/proxygen/lib
-    ${NEBULA_THIRDPARTY_ROOT}/rocksdb/lib
-    ${NEBULA_THIRDPARTY_ROOT}/snappy/lib
-    ${NEBULA_THIRDPARTY_ROOT}/wangle/lib
-    ${NEBULA_THIRDPARTY_ROOT}/zlib/lib
-    ${NEBULA_THIRDPARTY_ROOT}/zstd/lib
-    ${Boost_LIBRARY_DIRS}
-    ${KRB5_LIBRARY_DIRS}
-)
 
 # All thrift libraries
 set(THRIFT_LIBRARIES
@@ -492,7 +330,6 @@ set(THRIFT_LIBRARIES
     thrift-core
 )
 
-set(ROCKSDB_LIBRARIES ${Rocksdb_LIBRARY})
 
 # All compression libraries
 set(COMPRESSION_LIBRARIES bz2 snappy zstd z)

--- a/build_dep.sh
+++ b/build_dep.sh
@@ -13,144 +13,83 @@ DIR=/tmp/download
 mkdir $DIR
 trap "rm -fr $DIR" EXIT
 
-url_addr=https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb
+url_addr=https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party
 no_deps=0
 if [[ $1 != C ]] && [[ $1 != U ]] && [[ $1 != N ]]; then
     echo "Usage: ${0} <C|U|N>  # C: the user in China, U: the user in US, N: no need packages"
     exit -1
 fi
 
-[[ $1 == U ]] && url_addr=https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/
+[[ $1 == U ]] && url_addr=https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party
 
 [[ $1 == N ]] && no_deps=1
 
-# fedora
-function fedora_install {
-    echo "###### start install dep in fedora ######"
-    sudo yum -y install autoconf \
-        autoconf-archive \
-        automake \
-        bison \
-        bzip2-devel \
-        cmake \
-        curl \
-        gcc \
-        gcc-c++ \
-        java-1.8.0-openjdk \
-        java-1.8.0-openjdk-devel \
-        libstdc++-static \
-        libstdc++-devel \
-        libtool \
+function yum_install {
+    # clean the installed third-party
+    result=`rpm -qa | grep vs-nebula-3rdparty | wc -l`
+    if [[ $result -ne 0 ]]; then
+        echo "#### vs-nebula-3rdparty have been installed, uninstall it firstly ####"
+        sudo rpm -e vs-nebula-3rdparty
+    fi
+
+    sudo yum -y install wget \
         make \
-        maven \
-        ncurses \
-        ncurses-devel \
-        perl \
-        perl-WWW-Curl \
-        python \
-        readline \
-        readline-devel \
-        unzip \
-        xz-devel \
-        wget
-
-    installPackage $1
-
-    echo "alias cmake='cmake -DNEBULA_GPERF_BIN_DIR=/opt/nebula/gperf/bin -DNEBULA_FLEX_ROOT=/opt/nebula/flex -DNEBULA_BOOST_ROOT=/opt/nebula/boost -DNEBULA_OPENSSL_ROOT=/opt/nebula/openssl -DNEBULA_KRB5_ROOT=/opt/nebula/krb5 -DNEBULA_LIBUNWIND_ROOT=/opt/nebula/libunwind'" >> ~/.bashrc
-    return 0
-}
-
-# centos6
-function centos6_install {
-    echo "###### start install dep in centos6.5 ######"
-    sudo yum -y install wget \
-        libtool \
-        autoconf \
-        autoconf-archive \
-        automake \
-        perl-WWW-Curl \
-        perl-YAML \
-        perl-CGI \
-        perl-DBI \
-        perl-Pod-Simple \
         glibc-devel \
-        ncurses-devel \
-        readline-devel \
-        maven \
-        java-1.8.0-openjdk \
-        unzip
-
-    installPackage $1
-
-    echo "export PATH=/opt/nebula/autoconf/bin:/opt/nebula/automake/bin:/opt/nebula/libtool/bin:/opt/nebula/gettext/bin:/opt/nebula/flex/bin:/opt/nebula/binutils/bin:\$PATH" >> ~/.bashrc
-    echo "export ACLOCAL_PATH=/opt/nebula/automake/share/aclocal-1.15:/opt/nebula/libtool/share/aclocal:/opt/nebula/autoconf-archive/share/aclocal" >> ~/.bashrc
-    return 0
-}
-
-# centos7
-function centos7_install {
-    echo "###### start install dep in centos7.5 ######"
-    sudo yum -y install wget \
-        libtool \
-        autoconf \
-        autoconf-archive \
-        automake \
-        ncurses-devel \
-        readline-devel \
+        m4 \
         perl-WWW-Curl \
+        ncurses-devel \
+        readline-devel \
         maven \
         java-1.8.0-openjdk \
         unzip
 
-    installPackage $1
+    # feroda and centos7 has it
+    if [[ $1 == 1 || $1 == 2 ]]; then
+        sudo yum -y install perl-Data-Dumper
+    fi
 
+    if [[ $1 == 3 ]]; then
+        sudo yum -y install perl-YAML \
+            perl-CGI \
+            perl-DBI \
+            perl-Pod-Simple
+    fi
+
+    installPackage $1
+    addAlias $1
     return 0
 }
 
-# ubuntu1604
-function ubuntu16_install {
-    echo "###### start install dep in ubuntu16 ######"
-    sudo apt-get -y install gcc-multilib \
-        libtool \
-        autoconf \
-        autoconf-archive \
-        automake \
+function aptget_install {
+    # clean the installed third-party
+    result=`dpkg -l | grep vs-nebula-3rdparty | wc -l`
+    if [[ $result -ne 0 ]]; then
+        echo "#### vs-nebula-3rdparty have been installed, uninstall it firstly ####"
+        sudo dpkg -P vs-nebula-3rdparty
+    fi
+
+    sudo apt-get -y install wget \
+        make \
+        gcc-multilib \
+        m4 \
         libncurses5-dev \
         libreadline-dev \
         python \
         maven \
-        openjdk-8-jdk unzip
+        openjdk-8-jdk \
+        unzip
 
     installPackage $1
-
-    echo "export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:\$LIBRARY_PATH" >> ~/.bashrc
-    return 0
-}
-
-# ubuntu1804
-function ubuntu18_install {
-    echo "###### start install dep in ubuntu18 ######"
-    sudo apt-get -y install gcc-multilib \
-        libtool \
-        autoconf \
-        autoconf-archive \
-        automake \
-        libncurses5-dev \
-        libreadline-dev \
-        python \
-        maven \
-        openjdk-8-jdk unzip
-
-    installPackage $1
-
-    echo "export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:\$LIBRARY_PATH" >> ~/.bashrc
+    addAlias $1
     return 0
 }
 
 function installPackage {
     versions=(empty fedora29 centos7.5 centos6.5 ubuntu18 ubuntu16)
     package_name=${versions[$1]}
+    echo "###### start install dep in $package_name ######"
     [[ $package_name = empty ]] && return 0
+    [[ ! -n $package_name ]] && return 0
     if [[ no_deps -eq 0 ]]; then
         echo "###### There is no need to rely on packages ######"
         cd $DIR
@@ -163,32 +102,27 @@ function installPackage {
 }
 
 function addAlias {
-    echo "alias cmake='/opt/nebula/cmake/bin/cmake -DCMAKE_C_COMPILER=/opt/nebula/gcc/bin/gcc -DCMAKE_CXX_COMPILER=/opt/nebula/gcc/bin/g++ -DNEBULA_GPERF_BIN_DIR=/opt/nebula/gperf/bin -DNEBULA_FLEX_ROOT=/opt/nebula/flex -DNEBULA_BOOST_ROOT=/opt/nebula/boost -DNEBULA_OPENSSL_ROOT=/opt/nebula/openssl -DNEBULA_KRB5_ROOT=/opt/nebula/krb5 -DNEBULA_LIBUNWIND_ROOT=/opt/nebula/libunwind -DNEBULA_BISON_ROOT=/opt/nebula/bison'" >> ~/.bashrc
-    echo "alias ctest='/opt/nebula/cmake/bin/ctest'" >> ~/.bashrc
+    echo "export PATH=/opt/nebula/third-party/bin:\$PATH" >> ~/.bashrc
+    echo "export ACLOCAL_PATH=/opt/nebula/third-party/share/aclocal-1.15:/opt/nebula/third-party/share/aclocal" >> ~/.bashrc
+    echo "alias cmake='/opt/nebula/third-party/bin/cmake -DCMAKE_C_COMPILER=/opt/nebula/third-party/bin/gcc -DCMAKE_CXX_COMPILER=/opt/nebula/third-party/bin/g++'" >> ~/.bashrc
+    echo "alias ctest='/opt/nebula/third-party/bin/ctest'" >> ~/.bashrc
+    if [[ $1 == 4 || $1 == 5 ]]; then
+        echo "export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:\$LIBRARY_PATH" >> ~/.bashrc
+    fi
     return 0
 }
 
 # fedora29:1, centos7.5:2, centos6.5:3, ubuntu18:4, ubuntu16:5
 function getSystemVer {
-    result=`cat /proc/version|grep fc`
-    if [[ -n $result ]]; then
-        return 1
+    if [[ -e /etc/redhat-release ]]; then
+        [[ -n `cat /etc/redhat-release|grep Fedora` ]] && return 1
+        [[ -n `cat /etc/redhat-release|grep "release 7."` ]] && return 2
+        [[ -n `cat /etc/redhat-release|grep "release 6."` ]] && return 3
     fi
-    result=`cat /proc/version|grep el7`
-    if [[ -n $result ]]; then
-        return 2
-    fi
-    result=`cat /proc/version|grep el6`
-    if [[ -n $result ]]; then
-        return 3
-    fi
-    result=`cat /proc/version|grep ubuntu1~18`
-    if [[ -n $result ]]; then
-        return 4
-    fi
-    result=`cat /proc/version|grep ubuntu1~16`
-    if [[ -n $result ]]; then
-        return 5
+    if [[ -e /etc/issue ]]; then
+        result=`cat /etc/issue|cut -d " " -f 2 |cut -d "." -f 1`
+        [[ result -eq 18 ]] && return 4
+        [[ result -eq 16 ]] && return 5
     fi
     return 0
 }
@@ -200,24 +134,14 @@ version=$?
 set -e
 
 case $version in
-    1)
-        fedora_install $version
-        ;;
-    2)
-        centos7_install $version
-        addAlias
-        ;;
-    3)
-        centos6_install $version
-        addAlias
+    1|2|3)
+        yum_install $version
         ;;
     4)
-        ubuntu18_install $version
-        addAlias
+        aptget_install $version
         ;;
     5)
-        ubuntu16_install $version
-        addAlias
+        aptget_install $version
         ;;
     *)
         echo "unknown system"
@@ -227,3 +151,4 @@ esac
 
 echo "###### install succeed ######"
 exit 0
+

--- a/build_dep.sh
+++ b/build_dep.sh
@@ -118,6 +118,7 @@ function getSystemVer {
         [[ -n `cat /etc/redhat-release|grep Fedora` ]] && return 1
         [[ -n `cat /etc/redhat-release|grep "release 7."` ]] && return 2
         [[ -n `cat /etc/redhat-release|grep "release 6."` ]] && return 3
+        return 0
     fi
     if [[ -e /etc/issue ]]; then
         result=`cat /etc/issue|cut -d " " -f 2 |cut -d "." -f 1`
@@ -137,10 +138,7 @@ case $version in
     1|2|3)
         yum_install $version
         ;;
-    4)
-        aptget_install $version
-        ;;
-    5)
+    4|5)
         aptget_install $version
         ;;
     *)

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -38,36 +38,36 @@ bash> git clone https://github.com/vesoft-inc/nebula.git
 - user's environment cannot download oss packages directly
 
     Step 1:
+    Install others through local sources
+
+    ```
+    bash> cd nebula && ./build_dep.sh N
+    ```
+
+    Step 2:
     Download the corresponding version of the dependency package
 
     **user in China**
-    - [Fedora29/30](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/fedora29.tar.gz)
-    - [Centos7.0~7.6](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos7.5.tar.gz)
-    - [Centos6.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos6.5.tar.gz)
-    - [Ubuntu1604](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu16.tar.gz)
-    - [Ubuntu1804](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu18.tar.gz)
+    - [Fedora29/30](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/fedora29.tar.gz)
+    - [Centos7.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/centos7.5.tar.gz)
+    - [Centos6.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/centos6.5.tar.gz)
+    - [Ubuntu1604](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/ubuntu16.tar.gz)
+    - [Ubuntu1804](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/ubuntu18.tar.gz)
 
     **user in US**
 
-    - [Fedora29/30](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/fedora29.tar.gz)
-    - [Centos7.0~7.6](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos7.5.tar.gz)
-    - [Centos6.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos6.5.tar.gz)
-    - [Ubuntu1604](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu16.tar.gz)
-    - [Ubuntu1804](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu18.tar.gz)
+    - [Fedora29/30](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/fedora29.tar.gz)
+    - [Centos7.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/centos7.5.tar.gz)
+    - [Centos6.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/centos6.5.tar.gz)
+    - [Ubuntu1604](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/ubuntu16.tar.gz)
+    - [Ubuntu1804](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/ubuntu18.tar.gz)
 
-    Step 2:
+    Step 3:
     Install the package
 
     ```
     tar xf ${package_name}.tar.gz
     cd ${package_name} && ./install.sh
-    ```
-
-    Step 3:
-    Install others through local sources
-
-    ```
-    bash> cd nebula && ./build_dep.sh N
     ```
 
 #### Step 3: update **~/.bashrc**

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -41,19 +41,19 @@ bash> git clone https://github.com/vesoft-inc/nebula.git
     Download the corresponding version of the dependency package
 
     **user in China**
-    - [Fedora29/30](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/fedora29.tar.gz)
-    - [Centos7.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/centos7.5.tar.gz)
-    - [Centos6.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/centos6.5.tar.gz)
-    - [Ubuntu1604](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/ubuntu16.tar.gz)
-    - [Ubuntu1804](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/ubuntu18.tar.gz)
+    - [Fedora29/30](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/fedora29.tar.gz)
+    - [Centos7.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos7.5.tar.gz)
+    - [Centos6.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos6.5.tar.gz)
+    - [Ubuntu1604](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu16.tar.gz)
+    - [Ubuntu1804](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu18.tar.gz)
 
     **user in US**
 
-    - [Fedora29/30](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/fedora29.tar.gz)
-    - [Centos7.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/centos7.5.tar.gz)
-    - [Centos6.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/centos6.5.tar.gz)
-    - [Ubuntu1604](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/ubuntu16.tar.gz)
-    - [Ubuntu1804](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/ubuntu18.tar.gz)
+    - [Fedora29/30](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/fedora29.tar.gz)
+    - [Centos7.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos7.5.tar.gz)
+    - [Centos6.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos6.5.tar.gz)
+    - [Ubuntu1604](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu16.tar.gz)
+    - [Ubuntu1804](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu18.tar.gz)
 
     Step 2:
     Install the package

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -8,7 +8,7 @@ Nebula is developed based C++14, so it requires a compiler supporting C++14 feat
 
 ### Supported system version
 - Fedora29, 30
-- Centos6.5, 7.5
+- Centos6.5, Centos7.0~7.6
 - Ubuntu16.04, 18.04
 
 ### Required storage
@@ -42,7 +42,7 @@ bash> git clone https://github.com/vesoft-inc/nebula.git
 
     **user in China**
     - [Fedora29/30](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/fedora29.tar.gz)
-    - [Centos7.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos7.5.tar.gz)
+    - [Centos7.0~7.6](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos7.5.tar.gz)
     - [Centos6.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos6.5.tar.gz)
     - [Ubuntu1604](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu16.tar.gz)
     - [Ubuntu1804](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu18.tar.gz)
@@ -50,7 +50,7 @@ bash> git clone https://github.com/vesoft-inc/nebula.git
     **user in US**
 
     - [Fedora29/30](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/fedora29.tar.gz)
-    - [Centos7.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos7.5.tar.gz)
+    - [Centos7.0~7.6](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos7.5.tar.gz)
     - [Centos6.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos6.5.tar.gz)
     - [Ubuntu1604](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu16.tar.gz)
     - [Ubuntu1804](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu18.tar.gz)
@@ -76,24 +76,13 @@ bash> git clone https://github.com/vesoft-inc/nebula.git
 bash> source ~/.bashrc
 ```
 #### Step 4: build
-- without java client
 
-    ```
-    bash> mkdir build && cd build
-    bash> cmake ..
-    bash> make
-    bash> sudo make install
-    ```
-- with java client
-
-    ```
-    bash> mvn install:install-file -Dfile=/opt/nebula/third-party/fbthrift/thrift-1.0-SNAPSHOT.jar -DgroupId="com.facebook" -DartifactId="thrift" -Dversion="1.0-SNAPSHOT" -Dpackaging=jar
-    bash> mkdir build && cd build
-    bash> cmake -DSKIP_JAVA_CLIENT=OFF ..
-    bash> make
-    bash> sudo make install
-    ```
-
+```
+bash> mkdir build && cd build
+bash> cmake ..
+bash> make
+bash> sudo make install
+```
 #### **Building completed**
 - If no errors are shown
 
@@ -211,3 +200,22 @@ nebula> SHOW HOSTS;
     sudo update-alternatives --config java
     ```
     and select the java-1.8.0-openjdk/java-8-openjdk
+
+- **Error info**: `internal error`
+
+    **resolve**
+
+    You need to compile the third-party by yourself, the installation path is **/opt/nebula/third-party**
+
+    ```
+    bash> wget https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/nebula-3rdparty.tar.gz
+    bash> tar xf nebula-3rdparty.tar.gz && cd nebula-3rdparty
+    bash> ./install_deps.sh
+    bash> sudo make
+    bash> cd nebula && ./build_dep.sh N
+    bash> source ~/.bashrc
+    bash> mkdir build && cd build
+    bash> cmake ..
+    bash> make
+    bash> sudo make install
+    ```

--- a/docs/manual-CN/how-to-build.md
+++ b/docs/manual-CN/how-to-build.md
@@ -4,7 +4,7 @@ Nebula 基于 C++14 开发，因此它需要一个支持 C++14 的编译器。
 
 ### 支持系统版本
 - Fedora29, 30
-- Centos6.5, 7.5
+- Centos6.5, Centos7.0~7.6
 - Ubuntu16.04, 18.04
 
 ### 需要的存储空间
@@ -38,7 +38,7 @@ bash> git clone https://github.com/vesoft-inc/nebula.git
 
     **中国用户**
     - [Fedora29/30](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/fedora29.tar.gz)
-    - [Centos7.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos7.5.tar.gz)
+    - [Centos7.0~7.6](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos7.5.tar.gz)
     - [Centos6.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos6.5.tar.gz)
     - [Ubuntu1604](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu16.tar.gz)
     - [Ubuntu1804](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu18.tar.gz)
@@ -46,7 +46,7 @@ bash> git clone https://github.com/vesoft-inc/nebula.git
     **美国用户**
 
     - [Fedora29/30](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/fedora29.tar.gz)
-    - [Centos7.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos7.5.tar.gz)
+    - [Centos7.0~7.6](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos7.5.tar.gz)
     - [Centos6.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos6.5.tar.gz)
     - [Ubuntu1604](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu16.tar.gz)
     - [Ubuntu1804](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu18.tar.gz)
@@ -73,23 +73,12 @@ bash> source ~/.bashrc
 ```
 #### 步骤 4: 构建
 
-- 不编译 java client
-
-    ```
-    bash> mkdir build && cd build
-    bash> cmake ..
-    bash> make
-    bash> sudo make install
-    ```
-- 编译 java client
-
-    ```
-    bash> mvn install:install-file -Dfile=/opt/nebula/third-party/fbthrift/thrift-1.0-SNAPSHOT.jar -DgroupId="com.facebook" -DartifactId="thrift" -Dversion="1.0-SNAPSHOT" -Dpackaging=jar
-    bash> mkdir build && cd build
-    bash> cmake -DSKIP_JAVA_CLIENT=OFF ..
-    bash> make
-    bash> sudo make install
-    ```
+```
+bash> mkdir build && cd build
+bash> cmake ..
+bash> make
+bash> sudo make install
+```
 
 #### **构建完成**
 - 如果没有任何错误信息
@@ -215,4 +204,23 @@ nebula> SHOW HOSTS;
     export JRE_HOME=$JAVA_HOME/jre
     export CLASSPATH=$JAVA_HOME/lib:$JRE_HOME/lib:$CLASSPATH
     export PATH=$JAVA_HOME/bin:$JRE_HOME/bin:$PATH
+    ```
+
+- **错误信息**: `internal error`
+
+    **解决方案**:
+
+    你需要自己编译第三方库，第三方库的安装路径为 **/opt/nebula/third-party**
+
+    ```
+    bash> wget https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/nebula-3rdparty.tar.gz
+    bash> tar xf nebula-3rdparty.tar.gz && cd nebula-3rdparty
+    bash> ./install_deps.sh
+    bash> sudo make
+    bash> cd nebula && ./build_dep.sh N
+    bash> source ~/.bashrc
+    bash> mkdir build && cd build
+    bash> cmake ..
+    bash> make
+    bash> sudo make install
     ```

--- a/docs/manual-CN/how-to-build.md
+++ b/docs/manual-CN/how-to-build.md
@@ -34,36 +34,36 @@ bash> git clone https://github.com/vesoft-inc/nebula.git
 - 环境不能直接下载oss包的用户
 
     步骤 1:
+    从本地源下载依赖和进行配置
+
+    ```
+    bash> cd nebula && ./build_dep.sh N
+    ```
+
+    步骤 2:
     从下面链接中下载对应版本的压缩包
 
     **中国用户**
-    - [Fedora29/30](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/fedora29.tar.gz)
-    - [Centos7.0~7.6](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos7.5.tar.gz)
-    - [Centos6.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos6.5.tar.gz)
-    - [Ubuntu1604](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu16.tar.gz)
-    - [Ubuntu1804](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu18.tar.gz)
+    - [Fedora29/30](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/fedora29.tar.gz)
+    - [Centos7.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/centos7.5.tar.gz)
+    - [Centos6.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/centos6.5.tar.gz)
+    - [Ubuntu1604](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/ubuntu16.tar.gz)
+    - [Ubuntu1804](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/ubuntu18.tar.gz)
 
     **美国用户**
 
-    - [Fedora29/30](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/fedora29.tar.gz)
-    - [Centos7.0~7.6](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos7.5.tar.gz)
-    - [Centos6.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos6.5.tar.gz)
-    - [Ubuntu1604](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu16.tar.gz)
-    - [Ubuntu1804](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu18.tar.gz)
+    - [Fedora29/30](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/fedora29.tar.gz)
+    - [Centos7.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/centos7.5.tar.gz)
+    - [Centos6.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/centos6.5.tar.gz)
+    - [Ubuntu1604](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/ubuntu16.tar.gz)
+    - [Ubuntu1804](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/ubuntu18.tar.gz)
 
-    步骤 2:
+    步骤 3:
     安装下载好的压缩包
 
     ```
     tar xf ${package_name}.tar.gz
     cd ${package_name} && ./install.sh
-    ```
-
-    Step 3:
-    从本地源下载依赖和进行配置
-
-    ```
-    bash> cd nebula && ./build_dep.sh N
     ```
 
 #### 步骤 3: 应用 **~/.bashrc** 修改

--- a/docs/manual-CN/how-to-build.md
+++ b/docs/manual-CN/how-to-build.md
@@ -37,19 +37,19 @@ bash> git clone https://github.com/vesoft-inc/nebula.git
     从下面链接中下载对应版本的压缩包
 
     **中国用户**
-    - [Fedora29/30](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/fedora29.tar.gz)
-    - [Centos7.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/centos7.5.tar.gz)
-    - [Centos6.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/centos6.5.tar.gz)
-    - [Ubuntu1604](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/ubuntu16.tar.gz)
-    - [Ubuntu1804](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/build-deb/ubuntu18.tar.gz)
+    - [Fedora29/30](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/fedora29.tar.gz)
+    - [Centos7.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos7.5.tar.gz)
+    - [Centos6.5](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/centos6.5.tar.gz)
+    - [Ubuntu1604](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu16.tar.gz)
+    - [Ubuntu1804](https://nebula-graph.oss-cn-hangzhou.aliyuncs.com/third-party/ubuntu18.tar.gz)
 
     **美国用户**
 
-    - [Fedora29/30](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/fedora29.tar.gz)
-    - [Centos7.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/centos7.5.tar.gz)
-    - [Centos6.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/centos6.5.tar.gz)
-    - [Ubuntu1604](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/ubuntu16.tar.gz)
-    - [Ubuntu1804](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/build-deb/ubuntu18.tar.gz)
+    - [Fedora29/30](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/fedora29.tar.gz)
+    - [Centos7.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos7.5.tar.gz)
+    - [Centos6.5](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/centos6.5.tar.gz)
+    - [Ubuntu1604](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu16.tar.gz)
+    - [Ubuntu1804](https://nebula-graph-us.oss-us-west-1.aliyuncs.com/third-party/ubuntu18.tar.gz)
 
     步骤 2:
     安装下载好的压缩包


### PR DESCRIPTION
Now the third-party includes the build tools, such as gcc cmake automake ……
We package them into a rpm/deb file. Users only execute the /nebula/build_dep.sh, the dependencies will auto-download and install, and the user can easy to build! Please read the detailed procedures [how_to_build](https://github.com/vesoft-inc/nebula/blob/master/docs/how-to-build.md)

- The supported system
	- Fedora29, 30
	- Centos6.5, Centos7.0~7.6
	- Ubuntu16.04, 18.04

- If you want to change the rocksdb, you can use it

```
cmake -DNEBULA_OTHER_ROOT=$YOUR_ROCKSDB_ROOT ..
```

close #976