### PR TITLE
Support balance stop

### DIFF
--- a/src/common/thrift/ReconnectingRequestChannel.cpp
+++ b/src/common/thrift/ReconnectingRequestChannel.cpp
@@ -54,6 +54,8 @@ class ReconnectingRequestChannel::RequestCallback
                  apache::thrift::transport::TTransportException>()) {
       return;
     }
+    // qwer
+    LOG(INFO) << "Reset connection !!!";
     if (channel_.impl_ != impl_) {
       return;
     }

--- a/src/common/thrift/ReconnectingRequestChannel.cpp
+++ b/src/common/thrift/ReconnectingRequestChannel.cpp
@@ -54,8 +54,6 @@ class ReconnectingRequestChannel::RequestCallback
                  apache::thrift::transport::TTransportException>()) {
       return;
     }
-    // qwer
-    LOG(INFO) << "Reset connection !!!";
     if (channel_.impl_ != impl_) {
       return;
     }

--- a/src/graph/BalanceExecutor.cpp
+++ b/src/graph/BalanceExecutor.cpp
@@ -27,6 +27,9 @@ void BalanceExecutor::execute() {
         case BalanceSentence::SubType::kData:
             balanceData();
             break;
+        case BalanceSentence::SubType::kDataStop:
+            balanceData(true);
+            break;
         case BalanceSentence::SubType::kShowBalancePlan:
             showBalancePlan();
             break;
@@ -66,8 +69,8 @@ void BalanceExecutor::balanceLeader() {
     std::move(future).via(runner).thenValue(cb).thenError(error);
 }
 
-void BalanceExecutor::balanceData() {
-    auto future = ectx()->getMetaClient()->balance();
+void BalanceExecutor::balanceData(bool isStop) {
+    auto future = ectx()->getMetaClient()->balance(isStop);
     auto *runner = ectx()->rctx()->runner();
 
     auto cb = [this] (auto &&resp) {

--- a/src/graph/BalanceExecutor.h
+++ b/src/graph/BalanceExecutor.h
@@ -27,7 +27,9 @@ public:
 
     void balanceLeader();
 
-    void balanceData();
+    void balanceData(bool isStop = false);
+
+    void stopBalanceData();
 
     void showBalancePlan();
 

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -36,6 +36,7 @@ enum ErrorCode {
     E_STORE_SEGMENT_ILLEGAL  = -32,
     E_BAD_BALANCE_PLAN     = -33,
     E_BALANCED             = -34,
+    E_NO_RUNNING_BALANCE_PLAN = -35,
 
     E_INVALID_PASSWORD       = -41,
     E_INPROPER_ROLE          = -42,
@@ -443,6 +444,7 @@ struct BalanceReq {
     1: optional common.GraphSpaceID space_id,
     // Specify the balance id to check the status of the related balance plan
     2: optional i64 id,
+    3: optional bool stop,
 }
 
 enum TaskResult {

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -582,7 +582,6 @@ int32_t NebulaStore::allLeader(std::unordered_map<GraphSpaceID,
         int32_t leaderCount = 0;
         int32_t followerCount = 0;
         int32_t learnerCount = 0;
-        bool flag = false;
 
         auto spaceId = spaceIt.first;
         for (const auto& partIt : spaceIt.second->parts_) {
@@ -594,13 +593,12 @@ int32_t NebulaStore::allLeader(std::unordered_map<GraphSpaceID,
             } else if (partIt.second->isFollower()) {
                 followerCount++;
             } else if (partIt.second->isLearner()) {
-                if (!flag) {
-                    flag = false;
-                    LOG(INFO) << "rewq " << partId;
-                }
+                // qwer
+                LOG(INFO) << "rewq " << partId;
                 learnerCount++;
             }
         }
+        // qwer
         LOG(INFO) << " !!! Space " << spaceId
                   << " Leader: " << leaderCount
                   << " Follower : " << followerCount

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -579,14 +579,32 @@ int32_t NebulaStore::allLeader(std::unordered_map<GraphSpaceID,
     folly::RWSpinLock::ReadHolder rh(&lock_);
     int32_t count = 0;
     for (const auto& spaceIt : spaces_) {
+        int32_t leaderCount = 0;
+        int32_t followerCount = 0;
+        int32_t learnerCount = 0;
+        bool flag = false;
+
         auto spaceId = spaceIt.first;
         for (const auto& partIt : spaceIt.second->parts_) {
             auto partId = partIt.first;
             if (partIt.second->isLeader()) {
                 leaderIds[spaceId].emplace_back(partId);
+                leaderCount++;
                 ++count;
+            } else if (partIt.second->isFollower()) {
+                followerCount++;
+            } else if (partIt.second->isLearner()) {
+                if (!flag) {
+                    flag = false;
+                    LOG(INFO) << "rewq " << partId;
+                }
+                learnerCount++;
             }
         }
+        LOG(INFO) << " !!! Space " << spaceId
+                  << " Leader: " << leaderCount
+                  << " Follower : " << followerCount
+                  << " Learner: " << learnerCount;
     }
     return count;
 }

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -579,30 +579,14 @@ int32_t NebulaStore::allLeader(std::unordered_map<GraphSpaceID,
     folly::RWSpinLock::ReadHolder rh(&lock_);
     int32_t count = 0;
     for (const auto& spaceIt : spaces_) {
-        int32_t leaderCount = 0;
-        int32_t followerCount = 0;
-        int32_t learnerCount = 0;
-
         auto spaceId = spaceIt.first;
         for (const auto& partIt : spaceIt.second->parts_) {
             auto partId = partIt.first;
             if (partIt.second->isLeader()) {
                 leaderIds[spaceId].emplace_back(partId);
-                leaderCount++;
                 ++count;
-            } else if (partIt.second->isFollower()) {
-                followerCount++;
-            } else if (partIt.second->isLearner()) {
-                // qwer
-                LOG(INFO) << "rewq " << partId;
-                learnerCount++;
             }
         }
-        // qwer
-        LOG(INFO) << " !!! Space " << spaceId
-                  << " Leader: " << leaderCount
-                  << " Follower : " << followerCount
-                  << " Learner: " << learnerCount;
     }
     return count;
 }

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -152,7 +152,9 @@ void Part::asyncAtomicOp(raftex::AtomicOp op, KVCallback cb) {
 void Part::asyncAddLearner(const HostAddr& learner, KVCallback cb) {
     std::string log = encodeHost(OP_ADD_LEARNER, learner);
     sendCommandAsync(std::move(log))
-        .thenValue([callback = std::move(cb)] (AppendLogResult res) mutable {
+        .thenValue([callback = std::move(cb), learner, this] (AppendLogResult res) mutable {
+        LOG(INFO) << idStr_ << "[xxx] add learner " << learner
+                  << ", result: " << static_cast<int32_t>(toResultCode(res));
         callback(toResultCode(res));
     });
 }
@@ -160,7 +162,9 @@ void Part::asyncAddLearner(const HostAddr& learner, KVCallback cb) {
 void Part::asyncTransferLeader(const HostAddr& target, KVCallback cb) {
     std::string log = encodeHost(OP_TRANS_LEADER, target);
     sendCommandAsync(std::move(log))
-        .thenValue([callback = std::move(cb)] (AppendLogResult res) mutable {
+        .thenValue([callback = std::move(cb), target, this] (AppendLogResult res) mutable {
+        LOG(INFO) << idStr_ << "[xxx] transfer leader to " << target
+                  << ", result: " << static_cast<int32_t>(toResultCode(res));
         callback(toResultCode(res));
     });
 }
@@ -168,7 +172,9 @@ void Part::asyncTransferLeader(const HostAddr& target, KVCallback cb) {
 void Part::asyncAddPeer(const HostAddr& peer, KVCallback cb) {
     std::string log = encodeHost(OP_ADD_PEER, peer);
     sendCommandAsync(std::move(log))
-        .thenValue([callback = std::move(cb)] (AppendLogResult res) mutable {
+        .thenValue([callback = std::move(cb), peer, this] (AppendLogResult res) mutable {
+        LOG(INFO) << idStr_ << "[xxx] add peer " << peer
+                  << ", result: " << static_cast<int32_t>(toResultCode(res));
         callback(toResultCode(res));
     });
 }
@@ -176,7 +182,9 @@ void Part::asyncAddPeer(const HostAddr& peer, KVCallback cb) {
 void Part::asyncRemovePeer(const HostAddr& peer, KVCallback cb) {
     std::string log = encodeHost(OP_REMOVE_PEER, peer);
     sendCommandAsync(std::move(log))
-        .thenValue([callback = std::move(cb)] (AppendLogResult res) mutable {
+        .thenValue([callback = std::move(cb), peer, this] (AppendLogResult res) mutable {
+        LOG(INFO) << idStr_ << "[xxx] remove peer " << peer
+                  << ", result: " << static_cast<int32_t>(toResultCode(res));
         callback(toResultCode(res));
     });
 }
@@ -360,6 +368,7 @@ bool Part::preProcessLog(LogID logId,
                 auto learner = decodeHost(OP_ADD_LEARNER, log);
                 auto ts = getTimestamp(log);
                 if (ts > startTimeMs_) {
+                    LOG(INFO) << idStr_ << "qwer add learner " << learner;
                     addLearner(learner);
                 } else {
                     LOG(INFO) << idStr_ << "Skip stale add learner " << learner;
@@ -370,6 +379,7 @@ bool Part::preProcessLog(LogID logId,
                 auto newLeader = decodeHost(OP_TRANS_LEADER, log);
                 auto ts = getTimestamp(log);
                 if (ts > startTimeMs_) {
+                    LOG(INFO) << idStr_ << "qwer trans leader " << newLeader;
                     preProcessTransLeader(newLeader);
                 } else {
                     LOG(INFO) << idStr_ << "Skip stale transfer leader " << newLeader;
@@ -380,6 +390,8 @@ bool Part::preProcessLog(LogID logId,
                 auto peer = decodeHost(OP_ADD_PEER, log);
                 auto ts = getTimestamp(log);
                 if (ts > startTimeMs_) {
+                    LOG(INFO) << idStr_ << "qwer add peer " << peer
+                              << " " << static_cast<int32_t>(role_);
                     addPeer(peer);
                 } else {
                     LOG(INFO) << idStr_ << "Skip stale add peer " << peer;
@@ -390,6 +402,7 @@ bool Part::preProcessLog(LogID logId,
                 auto peer = decodeHost(OP_REMOVE_PEER, log);
                 auto ts = getTimestamp(log);
                 if (ts > startTimeMs_) {
+                    LOG(INFO) << idStr_ << "qwer remove peer " << peer;
                     preProcessRemovePeer(peer);
                 } else {
                     LOG(INFO) << idStr_ << "Skip stale remove peer " << peer;

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -153,7 +153,7 @@ void Part::asyncAddLearner(const HostAddr& learner, KVCallback cb) {
     std::string log = encodeHost(OP_ADD_LEARNER, learner);
     sendCommandAsync(std::move(log))
         .thenValue([callback = std::move(cb), learner, this] (AppendLogResult res) mutable {
-        LOG(INFO) << idStr_ << "[xxx] add learner " << learner
+        LOG(INFO) << idStr_ << "add learner " << learner
                   << ", result: " << static_cast<int32_t>(toResultCode(res));
         callback(toResultCode(res));
     });
@@ -163,7 +163,7 @@ void Part::asyncTransferLeader(const HostAddr& target, KVCallback cb) {
     std::string log = encodeHost(OP_TRANS_LEADER, target);
     sendCommandAsync(std::move(log))
         .thenValue([callback = std::move(cb), target, this] (AppendLogResult res) mutable {
-        LOG(INFO) << idStr_ << "[xxx] transfer leader to " << target
+        LOG(INFO) << idStr_ << "ansfer leader to " << target
                   << ", result: " << static_cast<int32_t>(toResultCode(res));
         callback(toResultCode(res));
     });
@@ -173,7 +173,7 @@ void Part::asyncAddPeer(const HostAddr& peer, KVCallback cb) {
     std::string log = encodeHost(OP_ADD_PEER, peer);
     sendCommandAsync(std::move(log))
         .thenValue([callback = std::move(cb), peer, this] (AppendLogResult res) mutable {
-        LOG(INFO) << idStr_ << "[xxx] add peer " << peer
+        LOG(INFO) << idStr_ << "add peer " << peer
                   << ", result: " << static_cast<int32_t>(toResultCode(res));
         callback(toResultCode(res));
     });
@@ -183,7 +183,7 @@ void Part::asyncRemovePeer(const HostAddr& peer, KVCallback cb) {
     std::string log = encodeHost(OP_REMOVE_PEER, peer);
     sendCommandAsync(std::move(log))
         .thenValue([callback = std::move(cb), peer, this] (AppendLogResult res) mutable {
-        LOG(INFO) << idStr_ << "[xxx] remove peer " << peer
+        LOG(INFO) << idStr_ << "remove peer " << peer
                   << ", result: " << static_cast<int32_t>(toResultCode(res));
         callback(toResultCode(res));
     });
@@ -368,7 +368,7 @@ bool Part::preProcessLog(LogID logId,
                 auto learner = decodeHost(OP_ADD_LEARNER, log);
                 auto ts = getTimestamp(log);
                 if (ts > startTimeMs_) {
-                    LOG(INFO) << idStr_ << "qwer add learner " << learner;
+                    LOG(INFO) << idStr_ << "Preprocess add learner " << learner;
                     addLearner(learner);
                 } else {
                     LOG(INFO) << idStr_ << "Skip stale add learner " << learner;
@@ -379,7 +379,7 @@ bool Part::preProcessLog(LogID logId,
                 auto newLeader = decodeHost(OP_TRANS_LEADER, log);
                 auto ts = getTimestamp(log);
                 if (ts > startTimeMs_) {
-                    LOG(INFO) << idStr_ << "qwer trans leader " << newLeader;
+                    LOG(INFO) << idStr_ << "Preprocess trans leader " << newLeader;
                     preProcessTransLeader(newLeader);
                 } else {
                     LOG(INFO) << idStr_ << "Skip stale transfer leader " << newLeader;
@@ -390,8 +390,7 @@ bool Part::preProcessLog(LogID logId,
                 auto peer = decodeHost(OP_ADD_PEER, log);
                 auto ts = getTimestamp(log);
                 if (ts > startTimeMs_) {
-                    LOG(INFO) << idStr_ << "qwer add peer " << peer
-                              << " " << static_cast<int32_t>(role_);
+                    LOG(INFO) << idStr_ << "Preprocess add peer " << peer;
                     addPeer(peer);
                 } else {
                     LOG(INFO) << idStr_ << "Skip stale add peer " << peer;
@@ -402,7 +401,7 @@ bool Part::preProcessLog(LogID logId,
                 auto peer = decodeHost(OP_REMOVE_PEER, log);
                 auto ts = getTimestamp(log);
                 if (ts > startTimeMs_) {
-                    LOG(INFO) << idStr_ << "qwer remove peer " << peer;
+                    LOG(INFO) << idStr_ << "Preprocess remove peer " << peer;
                     preProcessRemovePeer(peer);
                 } else {
                     LOG(INFO) << idStr_ << "Skip stale remove peer " << peer;

--- a/src/kvstore/raftex/Host.cpp
+++ b/src/kvstore/raftex/Host.cpp
@@ -192,10 +192,6 @@ void Host::appendLogsInternal(folly::EventBase* eb,
                 self->setResponse(r);
                 self->lastLogIdSent_ = self->logIdToSend_;
                 self->hasException_ = true;
-                // qwer
-                if (self->isLearner_) {
-                    LOG(INFO) << self->idStr_ << "Exception !!! " << t.exception().what();
-                }
             }
             self->noMoreRequestCV_.notify_all();
             return;
@@ -452,16 +448,8 @@ folly::Future<cpp2::AppendLogResponse> Host::sendAppendLogRequest(
               << ", last_log_term_sent" << req->get_last_log_term_sent()
               << ", last_log_id_sent " << req->get_last_log_id_sent();
     // Get client connection
-    // qwer
     auto client = tcManager().client(addr_, eb, false, FLAGS_raft_rpc_timeout_ms);
     return client->future_appendLog(*req);
-    /*
-    return folly::via(eb, [this, eb, req] () mutable {
-        // Get client connection
-        auto client = tcManager().client(addr_, eb, false, FLAGS_raft_rpc_timeout_ms);
-        return client->future_appendLog(*req);
-    });
-    */
 }
 
 bool Host::noRequest() const {

--- a/src/kvstore/raftex/Host.cpp
+++ b/src/kvstore/raftex/Host.cpp
@@ -191,10 +191,16 @@ void Host::appendLogsInternal(folly::EventBase* eb,
                 std::lock_guard<std::mutex> g(self->lock_);
                 self->setResponse(r);
                 self->lastLogIdSent_ = self->logIdToSend_;
+                self->hasException_ = true;
+                // qwer
+                if (self->isLearner_) {
+                    LOG(INFO) << self->idStr_ << "Exception !!! " << t.exception().what();
+                }
             }
             self->noMoreRequestCV_.notify_all();
             return;
         }
+        self->hasException_ = false;
 
         cpp2::AppendLogResponse resp = std::move(t).value();
         VLOG(3) << self->idStr_ << "AppendLogResponse "
@@ -446,8 +452,16 @@ folly::Future<cpp2::AppendLogResponse> Host::sendAppendLogRequest(
               << ", last_log_term_sent" << req->get_last_log_term_sent()
               << ", last_log_id_sent " << req->get_last_log_id_sent();
     // Get client connection
+    // qwer
     auto client = tcManager().client(addr_, eb, false, FLAGS_raft_rpc_timeout_ms);
     return client->future_appendLog(*req);
+    /*
+    return folly::via(eb, [this, eb, req] () mutable {
+        // Get client connection
+        auto client = tcManager().client(addr_, eb, false, FLAGS_raft_rpc_timeout_ms);
+        return client->future_appendLog(*req);
+    });
+    */
 }
 
 bool Host::noRequest() const {

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -132,6 +132,7 @@ private:
 
     LogID committedLogId_{0};
     std::atomic_bool sendingSnapshot_{false};
+    std::atomic_bool hasException_{false};
 };
 
 }  // namespace raftex

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -130,9 +130,11 @@ private:
     LogID lastLogIdSent_{0};
     TermID lastLogTermSent_{0};
 
+    // CommittedLogId of follower
+    LogID followerCommittedLogId_{0};
+
     LogID committedLogId_{0};
     std::atomic_bool sendingSnapshot_{false};
-    std::atomic_bool hasException_{false};
 };
 
 }  // namespace raftex

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -350,7 +350,7 @@ AppendLogResult RaftPart::canAppendLogs() {
         return AppendLogResult::E_STOPPED;
     }
     if (role_ != Role::LEADER) {
-        LOG(ERROR) << idStr_ << "The partition is not a leader";
+        VLOG(2) << idStr_ << "The partition is not a leader";
         return AppendLogResult::E_NOT_A_LEADER;
     }
 
@@ -448,10 +448,6 @@ void RaftPart::updateQuorum() {
 
 void RaftPart::addPeer(const HostAddr& peer) {
     CHECK(!raftLock_.try_lock());
-    // qwer
-    for (const auto& h : hosts_) {
-        LOG(INFO) << idStr_ << "wwww " << h->address();
-    }
     if (peer == addr_) {
         if (role_ == Role::LEARNER) {
             LOG(INFO) << idStr_ << "I am learner, promote myself to be follower";
@@ -491,10 +487,6 @@ void RaftPart::removePeer(const HostAddr& peer) {
     auto it = std::find_if(hosts_.begin(), hosts_.end(), [&peer] (const auto& h) {
                   return h->address() == peer;
               });
-    // qwer
-    for (const auto& h : hosts_) {
-        LOG(INFO) << idStr_ << "qqqq " << h->address();
-    }
     if (it == hosts_.end()) {
         LOG(INFO) << idStr_ << "The peer " << peer << " not exist!";
     } else {
@@ -1732,6 +1724,12 @@ AppendLogResult RaftPart::isCatchedUp(const HostAddr& peer) {
     }
     for (auto& host : hosts_) {
         if (host->addr_ == peer) {
+            if (host->hasException_) {
+                // qwer
+                LOG(INFO) << idStr_ << "wtf wtf Connection between " << peer << " has exception";
+                return AppendLogResult::E_RPC_EXCEPTION;
+            }
+            // qwer
             LOG(INFO) << idStr_ << "wtf " << host->sendingSnapshot_;
             return host->sendingSnapshot_ ? AppendLogResult::E_SENDING_SNAPSHOT
                                           : AppendLogResult::SUCCEEDED;

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -1725,12 +1725,9 @@ AppendLogResult RaftPart::isCatchedUp(const HostAddr& peer) {
     for (auto& host : hosts_) {
         if (host->addr_ == peer) {
             if (host->hasException_) {
-                // qwer
-                LOG(INFO) << idStr_ << "wtf wtf Connection between " << peer << " has exception";
+                LOG(INFO) << idStr_ << "Connection between " << peer << " has exception";
                 return AppendLogResult::E_RPC_EXCEPTION;
             }
-            // qwer
-            LOG(INFO) << idStr_ << "wtf " << host->sendingSnapshot_;
             return host->sendingSnapshot_ ? AppendLogResult::E_SENDING_SNAPSHOT
                                           : AppendLogResult::SUCCEEDED;
         }

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -1724,9 +1724,11 @@ AppendLogResult RaftPart::isCatchedUp(const HostAddr& peer) {
     }
     for (auto& host : hosts_) {
         if (host->addr_ == peer) {
-            if (host->hasException_) {
-                LOG(INFO) << idStr_ << "Connection between " << peer << " has exception";
-                return AppendLogResult::E_RPC_EXCEPTION;
+            if (host->followerCommittedLogId_ < wal_->firstLogId()) {
+                LOG(INFO) << idStr_ << "The committed log id of peer is "
+                          << host->followerCommittedLogId_
+                          << ", which is invalid or less than my first wal log id";
+                return AppendLogResult::E_SENDING_SNAPSHOT;
             }
             return host->sendingSnapshot_ ? AppendLogResult::E_SENDING_SNAPSHOT
                                           : AppendLogResult::SUCCEEDED;

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -43,6 +43,7 @@ enum class AppendLogResult {
     E_SENDING_SNAPSHOT = -8,
     E_INVALID_PEER = -9,
     E_NOT_ENOUGH_ACKS = -10,
+    E_RPC_EXCEPTION = -11,
 };
 
 enum class LogType {

--- a/src/kvstore/wal/FileBasedWal.h
+++ b/src/kvstore/wal/FileBasedWal.h
@@ -25,7 +25,7 @@ struct FileBasedWalPolicy {
     int32_t ttl = 86400;
     // The maximum size of each log message file (in byte). When the existing
     // log file reaches this size, a new file will be created
-    size_t fileSize = 128 * 1024L * 1024L;
+    size_t fileSize = 16 * 1024L * 1024L;
 
     // Size of each buffer (in byte)
     size_t bufferSize = 8 * 1024L * 1024L;

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -416,6 +416,8 @@ Status MetaClient::handleResponse(const RESP& resp) {
             return Status::Error("The balancer is running!");
         case cpp2::ErrorCode::E_BAD_BALANCE_PLAN:
             return Status::Error("Bad balance plan!");
+        case cpp2::ErrorCode::E_NO_RUNNING_BALANCE_PLAN:
+            return Status::Error("No running balance plan!");
         }
         default:
             return Status::Error("Unknown code %d", static_cast<int32_t>(resp.get_code()));
@@ -1199,8 +1201,11 @@ folly::Future<StatusOr<bool>> MetaClient::heartbeat() {
     return future;
 }
 
-folly::Future<StatusOr<int64_t>> MetaClient::balance() {
+folly::Future<StatusOr<int64_t>> MetaClient::balance(bool isStop) {
     cpp2::BalanceReq req;
+    if (isStop) {
+        req.set_stop(isStop);
+    }
     folly::Promise<StatusOr<int64_t>> promise;
     auto future = promise.getFuture();
     getResponse(std::move(req), [] (auto client, auto request) {

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -217,7 +217,7 @@ public:
 
     // Operations for admin
     folly::Future<StatusOr<int64_t>>
-    balance();
+    balance(bool isStop = false);
 
     folly::Future<StatusOr<std::vector<cpp2::BalanceTask>>>
     showBalance(int64_t balanceId);

--- a/src/meta/processors/admin/AdminClient.cpp
+++ b/src/meta/processors/admin/AdminClient.cpp
@@ -11,6 +11,7 @@
 #include "kvstore/Part.h"
 
 DEFINE_int32(max_retry_times_admin_op, 30, "max retry times for admin request!");
+DECLARE_uint32(raft_heartbeat_interval_secs);
 
 namespace nebula {
 namespace meta {
@@ -106,6 +107,7 @@ folly::Future<Status> AdminClient::waitingForCatchUpData(GraphSpaceID spaceId,
     if (injector_) {
         return injector_->waitingForCatchUpData();
     }
+    sleep(FLAGS_raft_heartbeat_interval_secs);
     storage::cpp2::CatchUpDataReq req;
     req.set_space_id(spaceId);
     req.set_part_id(partId);
@@ -137,10 +139,6 @@ folly::Future<Status> AdminClient::memberChange(GraphSpaceID spaceId,
     auto ret = getPeers(spaceId, partId);
     if (!ret.ok()) {
         return ret.status();
-    }
-    // qwer
-    for (const auto& h : ret.value()) {
-        LOG(INFO) << "[AdminClient] send member change to " << h << " " << partId;
     }
     folly::Promise<Status> pro;
     auto f = pro.getFuture();

--- a/src/meta/processors/admin/AdminClient.cpp
+++ b/src/meta/processors/admin/AdminClient.cpp
@@ -262,7 +262,6 @@ void AdminClient::getResponse(const HostAddr& host,
                               int32_t retryLimit) {
     auto* evb = ioThreadPool_->getEventBase();
     auto partId = req.get_part_id();
-    LOG(INFO) << "!!! " << retry;
     folly::via(evb, [evb, pro = std::move(pro), host, req = std::move(req), partId,
                      remoteFunc = std::move(remoteFunc), respGen = std::move(respGen),
                      retry, retryLimit, this] () mutable {
@@ -274,6 +273,7 @@ void AdminClient::getResponse(const HostAddr& host,
                 // exception occurred during RPC
                 if (t.hasException()) {
                     if (retry < retryLimit) {
+                        usleep(1000 * 50);
                         getResponse(host, std::move(req), std::move(remoteFunc), std::move(respGen),
                                     std::move(pro), retry + 1, retryLimit);
                         return;
@@ -290,6 +290,7 @@ void AdminClient::getResponse(const HostAddr& host,
                     pro.setValue(respGen(resultCode));
                 } else {
                     if (retry < retryLimit) {
+                        usleep(1000 * 50);
                         getResponse(host, std::move(req), std::move(remoteFunc), std::move(respGen),
                                     std::move(pro), retry + 1, retryLimit);
                         return;

--- a/src/meta/processors/admin/AdminClient.h
+++ b/src/meta/processors/admin/AdminClient.h
@@ -50,7 +50,9 @@ public:
     }
 
     explicit AdminClient(std::unique_ptr<FaultInjector> injector)
-        : injector_(std::move(injector)) {}
+        : injector_(std::move(injector)) {
+        ioThreadPool_ = std::make_unique<folly::IOThreadPoolExecutor>(10);
+    }
 
     ~AdminClient() = default;
 
@@ -94,6 +96,10 @@ public:
 
     FaultInjector* faultInjector() {
         return injector_.get();
+    }
+
+    folly::IOThreadPoolExecutor* ioThreadPool() {
+        return ioThreadPool_.get();
     }
 
 private:

--- a/src/meta/processors/admin/AdminClient.h
+++ b/src/meta/processors/admin/AdminClient.h
@@ -51,7 +51,6 @@ public:
 
     explicit AdminClient(std::unique_ptr<FaultInjector> injector)
         : injector_(std::move(injector)) {
-        ioThreadPool_ = std::make_unique<folly::IOThreadPoolExecutor>(10);
     }
 
     ~AdminClient() = default;
@@ -96,10 +95,6 @@ public:
 
     FaultInjector* faultInjector() {
         return injector_.get();
-    }
-
-    folly::IOThreadPoolExecutor* ioThreadPool() {
-        return ioThreadPool_.get();
     }
 
 private:

--- a/src/meta/processors/admin/AdminClient.h
+++ b/src/meta/processors/admin/AdminClient.h
@@ -106,10 +106,13 @@ private:
     template<class Request,
              class RemoteFunc,
              class RespGenerator>
-    folly::Future<Status> getResponse(const HostAddr& host,
-                                      Request req,
-                                      RemoteFunc remoteFunc,
-                                      RespGenerator respGen);
+    void getResponse(const HostAddr& host,
+                     Request req,
+                     RemoteFunc remoteFunc,
+                     RespGenerator respGen,
+                     folly::Promise<Status> pro,
+                     int32_t retry,
+                     int32_t retryLimit);
 
     template<typename Request, typename RemoteFunc>
     void getResponse(std::vector<HostAddr> hosts,

--- a/src/meta/processors/admin/BalanceProcessor.cpp
+++ b/src/meta/processors/admin/BalanceProcessor.cpp
@@ -18,6 +18,20 @@ void BalanceProcessor::process(const cpp2::BalanceReq& req) {
         onFinished();
         return;
     }
+    if (req.get_stop() != nullptr) {
+        if (!(*req.get_stop())) {
+            resp_.set_code(cpp2::ErrorCode::E_UNKNOWN);
+            onFinished();
+            return;
+        }
+        auto ret = Balancer::instance(kvstore_)->stop();
+        if (!ret.ok()) {
+            resp_.set_code(cpp2::ErrorCode::E_NO_RUNNING_BALANCE_PLAN);
+        }
+        resp_.set_id(ret.value());
+        onFinished();
+        return;
+    }
     if (req.get_id() != nullptr) {
         auto ret = Balancer::instance(kvstore_)->show(*req.get_id());
         if (!ret.ok()) {
@@ -30,8 +44,8 @@ void BalanceProcessor::process(const cpp2::BalanceReq& req) {
         std::vector<cpp2::BalanceTask> thriftTasks;
         for (auto& task : plan.tasks()) {
             cpp2::BalanceTask t;
-            t.set_id(task.taskIdStr());
-            switch (task.result()) {
+            t.set_id(task->taskIdStr());
+            switch (task->result()) {
                 case BalanceTask::Result::SUCCEEDED:
                     t.set_result(cpp2::TaskResult::SUCCEEDED);
                     break;

--- a/src/meta/processors/admin/BalanceTask.cpp
+++ b/src/meta/processors/admin/BalanceTask.cpp
@@ -10,7 +10,6 @@
 
 DEFINE_int32(wait_time_after_open_part_ms, 3000,
              "The wait time after open part, zero means no wait");
-DECLARE_uint32(raft_heartbeat_interval_secs);
 
 namespace nebula {
 namespace meta {
@@ -118,7 +117,6 @@ void BalanceTask::invoke() {
                         status_ = Status::MEMBER_CHANGE_ADD;
                     }
                 }
-                sleep(FLAGS_raft_heartbeat_interval_secs);
                 invoke();
             });
             break;
@@ -131,12 +129,8 @@ void BalanceTask::invoke() {
                 {
                     std::lock_guard<std::mutex> lg(lock_);
                     if (!resp.ok()) {
-                        // qwer
-                        LOG(INFO) << "eeee " << partId_;
                         ret_ = Result::FAILED;
                     } else {
-                        // qwer
-                        LOG(INFO) << "rrrr " << partId_;
                         status_ = Status::MEMBER_CHANGE_REMOVE;
                     }
                 }

--- a/src/meta/processors/admin/Balancer.h
+++ b/src/meta/processors/admin/Balancer.h
@@ -44,6 +44,7 @@ class Balancer {
     FRIEND_TEST(BalanceTest, BalancePartsTest);
     FRIEND_TEST(BalanceTest, NormalTest);
     FRIEND_TEST(BalanceTest, RecoveryTest);
+    FRIEND_TEST(BalanceTest, StopBalanceDataTest);
     FRIEND_TEST(BalanceTest, LeaderBalancePlanTest);
     FRIEND_TEST(BalanceTest, SimpleLeaderBalancePlanTest);
     FRIEND_TEST(BalanceTest, IntersectHostsLeaderBalancePlanTest);
@@ -70,6 +71,11 @@ public:
      * Show balance plan id status.
      * */
     StatusOr<BalancePlan> show(BalanceID id) const;
+
+    /**
+     * Stop balance plan by canceling all waiting balance task.
+     * */
+    StatusOr<BalanceID> stop();
 
     /**
      * TODO(heng): rollback some balance plan.
@@ -116,7 +122,7 @@ private:
      * */
     Status buildBalancePlan();
 
-    std::vector<BalanceTask> genTasks(GraphSpaceID spaceId);
+    std::vector<std::unique_ptr<BalanceTask>> genTasks(GraphSpaceID spaceId);
 
     void getHostParts(GraphSpaceID spaceId,
                       std::unordered_map<HostAddr, std::vector<PartitionID>>& hostParts,
@@ -139,7 +145,7 @@ private:
                       GraphSpaceID spaceId,
                       std::unordered_map<HostAddr, std::vector<PartitionID>>& newHostParts,
                       int32_t totalParts,
-                      std::vector<BalanceTask>& tasks);
+                      std::vector<std::unique_ptr<BalanceTask>>& tasks);
 
 
     std::vector<std::pair<HostAddr, int32_t>>
@@ -171,14 +177,15 @@ private:
                           GraphSpaceID spaceId);
 
 private:
-    std::atomic_bool  running_{false};
+    bool running_{false};
     kvstore::KVStore* kv_ = nullptr;
     std::unique_ptr<AdminClient> client_{nullptr};
     // Current running plan.
     std::unique_ptr<BalancePlan> plan_{nullptr};
     std::unique_ptr<folly::Executor> executor_;
-    std::atomic_bool  inLeaderBalance_{false};
+    std::atomic_bool inLeaderBalance_{false};
     std::unique_ptr<HostLeaderMap> hostLeaderMap_;
+    std::mutex lock_;
 };
 
 }  // namespace meta

--- a/src/meta/test/BalancerTest.cpp
+++ b/src/meta/test/BalancerTest.cpp
@@ -985,19 +985,6 @@ TEST(BalanceTest, LeaderBalanceTest) {
     ASSERT_EQ(ret, cpp2::ErrorCode::SUCCEEDED);
 }
 
-class Wtf {
-public:
-    Wtf() = default;
-private:
-    std::mutex lock;
-};
-
-TEST(BalanceTest, WtfTest) {
-    std::vector<std::unique_ptr<Wtf>> vec;
-    auto wtf = std::make_unique<Wtf>();
-    vec.emplace_back(std::move(wtf));
-}
-
 }  // namespace meta
 }  // namespace nebula
 

--- a/src/meta/test/ConfigManTest.cpp
+++ b/src/meta/test/ConfigManTest.cpp
@@ -59,6 +59,7 @@ TEST(ConfigManTest, ConfigProcessorTest) {
     item2.set_mode(cpp2::ConfigMode::MUTABLE);
     item2.set_value("v2");
 
+    sleep(1);
     // set and get without register
     {
         cpp2::SetConfigReq req;

--- a/src/parser/AdminSentences.h
+++ b/src/parser/AdminSentences.h
@@ -373,6 +373,7 @@ public:
         kUnknown,
         kLeader,
         kData,
+        kDataStop,
         kShowBalancePlan,
     };
 

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -109,7 +109,7 @@ class GraphScanner;
 %token KW_ORDER KW_ASC KW_LIMIT KW_OFFSET
 %token KW_FETCH KW_PROP KW_UPDATE KW_UPSERT KW_WHEN
 %token KW_DISTINCT KW_ALL KW_OF
-%token KW_BALANCE KW_LEADER KW_DATA
+%token KW_BALANCE KW_LEADER KW_DATA KW_STOP
 %token KW_SHORTEST KW_PATH
 
 /* symbols */
@@ -1662,6 +1662,9 @@ balance_sentence
     }
     | KW_BALANCE KW_DATA INTEGER {
         $$ = new BalanceSentence($3);
+    }
+    | KW_BALANCE KW_DATA KW_STOP {
+        $$ = new BalanceSentence(BalanceSentence::SubType::kDataStop);
     }
     ;
 

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -123,6 +123,7 @@ LEADER                      ([Ll][Ee][Aa][Dd][Ee][Rr])
 UUID                        ([Uu][Uu][Ii][Dd])
 OF                          ([Oo][Ff])
 DATA                        ([Dd][Aa][Tt][Aa])
+STOP                        ([Ss][Tt][Oo][Pp])
 SHORTEST                    ([Ss][Hh][Oo][Rr][Tt][Ee][Ss][Tt])
 PATH                        ([Pp][Aa][Tt][Hh])
 LIMIT                       ([Ll][Ii][Mm][Ii][Tt])
@@ -239,6 +240,7 @@ IP_OCTET                    ([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])
 {LEADER}                    { return TokenType::KW_LEADER; }
 {UUID}                      { return TokenType::KW_UUID; }
 {DATA}                      { return TokenType::KW_DATA; }
+{STOP}                      { return TokenType::KW_STOP; }
 {SHORTEST}                  { return TokenType::KW_SHORTEST; }
 {PATH}                      { return TokenType::KW_PATH; }
 {LIMIT}                     { return TokenType::KW_LIMIT; }

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -1382,6 +1382,24 @@ TEST(Parser, BalanceOperation) {
         auto result = parser.parse(query);
         ASSERT_TRUE(result.ok()) << result.status();
     }
+    {
+        GQLParser parser;
+        std::string query = "BALANCE DATA";
+        auto result = parser.parse(query);
+        ASSERT_TRUE(result.ok()) << result.status();
+    }
+    {
+        GQLParser parser;
+        std::string query = "BALANCE DATA 1234567890";
+        auto result = parser.parse(query);
+        ASSERT_TRUE(result.ok()) << result.status();
+    }
+    {
+        GQLParser parser;
+        std::string query = "BALANCE DATA STOP";
+        auto result = parser.parse(query);
+        ASSERT_TRUE(result.ok()) << result.status();
+    }
 }
 
 TEST(Parser, CrashByFuzzer) {

--- a/src/storage/AdminProcessor.h
+++ b/src/storage/AdminProcessor.h
@@ -232,9 +232,10 @@ public:
         folly::async([this, part, peer, spaceId, partId] {
             int retry = FLAGS_waiting_catch_up_retry_times;
             while (retry-- > 0) {
-                LOG(INFO) << "Waiting for " << partId << " catching up data, peer " << peer
-                          << ", remaining retry times: " << retry;
                 auto res = part->isCatchedUp(peer);
+                LOG(INFO) << "Waiting for " << partId << " catching up data, peer " << peer
+                          << ", remaining retry times: " << retry
+                          << ", result " << static_cast<int32_t>(res);
                 switch (res) {
                     case raftex::AppendLogResult::SUCCEEDED:
                         LOG(INFO) << "Finished sending snapshot to " << peer;

--- a/src/storage/AdminProcessor.h
+++ b/src/storage/AdminProcessor.h
@@ -138,6 +138,7 @@ public:
                   << ", add/remove " << (req.get_add() ? "add" : "remove");
         auto ret = kvstore_->part(spaceId, partId);
         if (!ok(ret)) {
+            LOG(INFO) << "[Processor] ???";
             this->pushResultCode(to(error(ret)), partId);
             onFinished();
             return;
@@ -155,10 +156,10 @@ public:
             onFinished();
         };
         if (req.get_add()) {
-            LOG(INFO) << "Add peer " << peer;
+            LOG(INFO) << "Add peer " << peer << " " << partId;
             part->asyncAddPeer(peer, cb);
         } else {
-            LOG(INFO) << "Remove peer " << peer;
+            LOG(INFO) << "Remove peer " << peer << " " << partId;
             part->asyncRemovePeer(peer, cb);
         }
     }
@@ -229,20 +230,28 @@ public:
                                                                req.get_target().get_port()));
 
         folly::async([this, part, peer, spaceId, partId] {
+            // qwer
+            sleep(10);
             int retry = FLAGS_waiting_catch_up_retry_times;
             while (retry-- > 0) {
-                LOG(INFO) << "Waiting for catching up data, peer " << peer
+                LOG(INFO) << "Waiting for " << partId << " catching up data, peer " << peer
                           << ", try " << retry << " times";
                 auto res = part->isCatchedUp(peer);
                 switch (res) {
                     case raftex::AppendLogResult::SUCCEEDED:
+                        // qwer
+                        LOG(INFO) << partId << " aaa";
                         onFinished();
                         return;
                     case raftex::AppendLogResult::E_INVALID_PEER:
+                        // qwer
+                        LOG(INFO) << partId << " bbb";
                         this->pushResultCode(cpp2::ErrorCode::E_INVALID_PEER, partId);
                         onFinished();
                         return;
                     case raftex::AppendLogResult::E_NOT_A_LEADER: {
+                        // qwer
+                        LOG(INFO) << partId << " ccc";
                         auto leaderRet = kvstore_->partLeader(spaceId, partId);
                         CHECK(ok(leaderRet));
                         auto leader = value(std::move(leaderRet));


### PR DESCRIPTION
1. Support stop balance. For all balance tasks which has not started yet, we mark them as stopped. For those tasks which has started, we don't interrupt them. 

    We can run `balance data stop` in console. Just like `balance data`, it will return running balance plan id (if no valid plan running, an error is returned). You can check the status by `balance data id`. Once remaining tasks has finished, you can trigger the plan by `balance data` to continue all tasks stopped previously.

2. Modify leader balance only consider balancing between hosts with valid partitions.

3. Fix several bugs during balance.

close #1032