### PR TITLE
Fixed possible data loss in raft.

### DIFF
--- a/src/graph/GroupByExecutor.cpp
+++ b/src/graph/GroupByExecutor.cpp
@@ -348,7 +348,7 @@ void GroupByExecutor::feedResult(std::unique_ptr<InterimResult> result) {
         return;
     }
     rows_ = std::move(ret).value();
-    schema_ = std::move(result->schema());
+    schema_ = result->schema();
 }
 
 


### PR DESCRIPTION
When in the vote phase, the rollbacklog operation cannot be performed because the leader has not been selected.