### PR TITLE
Fix GitHub Actions failure and upload release assets automatically

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,10 +10,14 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        tag: [centos6, centos7, ubuntu1604, ubuntu1804]
+        tag:
+          - centos6
+          - centos7
+          - ubuntu1604
+          - ubuntu1804
     container:
       image: vesoft/nebula-dev:${{ matrix.tag }}
     steps:
@@ -26,7 +30,7 @@ jobs:
           LIBRARY_PATH: /usr/lib/x86_64-linux-gnu:/lib/x86_64-linux-gnu:${LIBRARY_PATH}
         run: |
           mkdir _build && cd _build
-          ${NEBULA_DEP_BIN}/cmake -DCMAKE_C_COMPILER=${NEBULA_DEP_BIN}/gcc -DCMAKE_CXX_COMPILER=${NEBULA_DEP_BIN}/g++ ..
+          ${NEBULA_DEP_BIN}/cmake -DCMAKE_C_COMPILER=${NEBULA_DEP_BIN}/gcc -DCMAKE_CXX_COMPILER=${NEBULA_DEP_BIN}/g++ -DCMAKE_BUILD_TYPE=Release ..
         shell: bash
       - name: make
         env:
@@ -35,7 +39,6 @@ jobs:
           cd _build && make -j $(nproc)
         shell: bash
       - name: test in multithreads
-        continue-on-error: true
         timeout-minutes: 20
         env:
           NEBULA_DEP_BIN: /opt/nebula/third-party/bin

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,14 +3,11 @@ name: docker
 on:
   schedule:
     - cron: '0 18 * * *'
-  release:
-    types:
-      - published
 
 jobs:
   docker:
     name: build docker image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         service:
@@ -28,19 +25,9 @@ jobs:
         with:
           fetch-depth: 1
       - name: build nightly image
-        if: github.event_name == 'schedule'
         env:
           IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/nebula-${{ matrix.service }}:nightly
         run: |
           docker build -t ${IMAGE_NAME} -f docker/Dockerfile.${{ matrix.service }} .
           docker push ${IMAGE_NAME}
-        shell: bash
-      - name: build release image
-        if: github.event_name == 'release'
-        env:
-          IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/nebula-${{ matrix.service }}
-        run: |
-          TAG=$(git describe --exact-match --abbrev=0 --tags)
-          docker build -t ${IMAGE_NAME}:${TAG} -f docker/Dockerfile.${{ matrix.service }} .
-          docker push ${IMAGE_NAME}:${TAG}
         shell: bash

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -17,7 +17,7 @@ jobs:
           - console
           - graph
     steps:
-      - uses: azure/container-actions/docker-login@master
+      - uses: azure/docker-login@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -3,14 +3,11 @@ name: package
 on:
   schedule:
     - cron: '0 18 * * *'
-  release:
-    types:
-      - published
 
 jobs:
   package:
     name: build package
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
@@ -26,14 +23,7 @@ jobs:
         run: ./package/package.sh
         shell: bash
       - name: Upload nightly artifacts
-        if: github.event_name == 'schedule'
         uses: actions/upload-artifact@v1
         with:
           name: ${{ matrix.os }}-nightly
-          path: build/cpack_output
-      - name: Upload release artifacts
-        if: github.event_name == 'release'
-        uses: actions/upload-artifact@v1
-        with:
-          name: ${{ matrix.os }}-release
           path: build/cpack_output

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,15 +26,15 @@ jobs:
         id: vars
         env:
           CPACK_OUTPUT_DIR: build/cpack_output
-          SHA_FILE: sha256sum.txt
+          SHA_EXT: sha256sum.txt
         run: |
           tag=$(echo ${{ github.ref }} | rev | cut -d/ -f1 | rev)
           cd $CPACK_OUTPUT_DIR
           filename=$(find . -type f \( -iname \*.deb -o -iname \*.rpm \) -exec ls {} \;)
-          sha256sum $filename > $filename.$SHA_FILE
+          sha256sum $filename > $filename.$SHA_EXT
           echo ::set-output name=tag::$tag
           echo ::set-output name=filepath::$(echo $CPACK_OUTPUT_DIR/$filename)
-          echo ::set-output name=shafilepath::$(echo $CPACK_OUTPUT_DIR/$filename.$SHA_FILE)
+          echo ::set-output name=shafilepath::$(echo $CPACK_OUTPUT_DIR/$filename.$SHA_EXT)
       - name: upload release asset
         run: |
           ./ci/scripts/upload-github-release-asset.sh github_token=${{ secrets.GITHUB_TOKEN }} repo=${{ github.repository }} tag=${{ steps.vars.outputs.tag }} filepath=${{ steps.vars.outputs.filepath }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,11 +30,11 @@ jobs:
         run: |
           tag=$(echo ${{ github.ref }} | rev | cut -d/ -f1 | rev)
           cd $CPACK_OUTPUT_DIR
-          filename=$(find . -type f \( -iname \*.deb -o -iname \*.rpm \) -exec ls {} \;)
+          filename=$(find . -type f \( -iname \*.deb -o -iname \*.rpm \) -exec basename {} \;)
           sha256sum $filename > $filename.$SHA_EXT
-          echo ::set-output name=tag::$tag
-          echo ::set-output name=filepath::$(echo $CPACK_OUTPUT_DIR/$filename)
-          echo ::set-output name=shafilepath::$(echo $CPACK_OUTPUT_DIR/$filename.$SHA_EXT)
+          echo "::set-output name=tag::$tag"
+          echo "::set-output name=filepath::$CPACK_OUTPUT_DIR/$filename"
+          echo "::set-output name=shafilepath::$CPACK_OUTPUT_DIR/$filename.$SHA_EXT"
       - name: upload release asset
         run: |
           ./ci/scripts/upload-github-release-asset.sh github_token=${{ secrets.GITHUB_TOKEN }} repo=${{ github.repository }} tag=${{ steps.vars.outputs.tag }} filepath=${{ steps.vars.outputs.filepath }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,72 @@
+name: release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  package:
+    name: build and upload
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu1604
+          - ubuntu1804
+          - centos6
+          - centos7
+    container:
+      image: vesoft/nebula-dev:${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: package
+        run: ./package/package.sh
+      - name: vars
+        id: vars
+        run: |
+          tag=$(echo ${{ github.ref }} | rev | cut -d/ -f1 | rev)
+          filepath=$(find build/cpack_output -type f \( -iname \*.deb -o -iname \*.rpm \) -exec ls {} \;)
+          md5sum $filepath | cut -d' ' -f1 > $filepath.md5
+          echo ::set-output name=tag::$tag
+          echo ::set-output name=filepath::$filepath
+          echo ::set-output name=md5filepath::$filepath.md5
+      - name: upload release asset
+        run: |
+          ./ci/scripts/upload-github-release-asset.sh github_token=${{ secrets.GITHUB_TOKEN }} repo=${{ github.repository }} tag=${{ steps.vars.outputs.tag }} filepath=${{ steps.vars.outputs.filepath }}
+          ./ci/scripts/upload-github-release-asset.sh github_token=${{ secrets.GITHUB_TOKEN }} repo=${{ github.repository }} tag=${{ steps.vars.outputs.tag }} filepath=${{ steps.vars.outputs.md5filepath }}
+      - name: upload release artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ matrix.os }}-release
+          path: build/cpack_output
+
+  docker:
+    name: docker
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - metad
+          - storaged
+          - graphd
+          - console
+          - graph
+    steps:
+      - uses: azure/container-actions/docker-login@master
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: build release image
+        env:
+          IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/nebula-${{ matrix.service }}
+        run: |
+          tag=$(echo ${{ github.ref }} | rev | cut -d/ -f1 | rev)
+          docker build -t ${IMAGE_NAME}:${tag} -f docker/Dockerfile.${{ matrix.service }} .
+          docker tag ${IMAGE_NAME}:${tag} ${IMAGE_NAME}:latest
+          docker push ${IMAGE_NAME}:${tag}
+          docker push ${IMAGE_NAME}:latest
+        shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
           - console
           - graph
     steps:
-      - uses: azure/container-actions/docker-login@master
+      - uses: azure/docker-login@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   package:
-    name: build and upload
+    name: package and upload release assets
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,17 +24,21 @@ jobs:
         run: ./package/package.sh
       - name: vars
         id: vars
+        env:
+          CPACK_OUTPUT_DIR: build/cpack_output
+          SHA_FILE: sha256sum.txt
         run: |
           tag=$(echo ${{ github.ref }} | rev | cut -d/ -f1 | rev)
-          filepath=$(find build/cpack_output -type f \( -iname \*.deb -o -iname \*.rpm \) -exec ls {} \;)
-          md5sum $filepath | cut -d' ' -f1 > $filepath.md5
+          cd $CPACK_OUTPUT_DIR
+          filename=$(find . -type f \( -iname \*.deb -o -iname \*.rpm \) -exec ls {} \;)
+          sha256sum $filename > $filename.$SHA_FILE
           echo ::set-output name=tag::$tag
-          echo ::set-output name=filepath::$filepath
-          echo ::set-output name=md5filepath::$filepath.md5
+          echo ::set-output name=filepath::$(echo $CPACK_OUTPUT_DIR/$filename)
+          echo ::set-output name=shafilepath::$(echo $CPACK_OUTPUT_DIR/$filename.$SHA_FILE)
       - name: upload release asset
         run: |
           ./ci/scripts/upload-github-release-asset.sh github_token=${{ secrets.GITHUB_TOKEN }} repo=${{ github.repository }} tag=${{ steps.vars.outputs.tag }} filepath=${{ steps.vars.outputs.filepath }}
-          ./ci/scripts/upload-github-release-asset.sh github_token=${{ secrets.GITHUB_TOKEN }} repo=${{ github.repository }} tag=${{ steps.vars.outputs.tag }} filepath=${{ steps.vars.outputs.md5filepath }}
+          ./ci/scripts/upload-github-release-asset.sh github_token=${{ secrets.GITHUB_TOKEN }} repo=${{ github.repository }} tag=${{ steps.vars.outputs.tag }} filepath=${{ steps.vars.outputs.shafilepath }}
       - name: upload release artifacts
         uses: actions/upload-artifact@v1
         with:
@@ -42,7 +46,7 @@ jobs:
           path: build/cpack_output
 
   docker:
-    name: docker
+    name: build docker images
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,12 @@ Testing/
 target/
 cluster.id
 pids/
+
+# IDE
 .idea/
 .project
 .settings/
 .classpath
 cmake-build-debug/
+cmake-build-release/
 .vscode/

--- a/ci/scripts/upload-github-release-asset.sh
+++ b/ci/scripts/upload-github-release-asset.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# This script accepts the following 4 parameters to upload a release asset using the GitHub API v3.
+#
+# - github_token
+# - repo
+# - tag
+# - filepath
+#
+# Example:
+#
+#   upload-github-release-asset.sh github_token=TOKEN repo=vesoft-inc/nebula tag=v0.1.0 filepath=./asset.zip
+
+set -e
+
+for op in $@; do
+  eval "$op"
+done
+
+GH_RELEASE="https://api.github.com/repos/$repo/releases/tags/$tag"
+
+upload_url=$(curl -s --request GET --url $GH_RELEASE | grep -oP '(?<="upload_url": ")[^"]*' | cut -d'{' -f1)
+
+content_type=$(file -b --mime-type $filepath)
+
+# basename
+filename=$(echo "$filepath" | rev | cut -d'/' -f1 | rev)
+
+echo "Uploading asset... "
+
+curl --silent \
+     --request POST \
+     --url "$upload_url?name=$filename" \
+     --header "authorization: Bearer $github_token" \
+     --header "content-type: $content_type" \
+     --data-binary @"$filepath"

--- a/ci/scripts/upload-github-release-asset.sh
+++ b/ci/scripts/upload-github-release-asset.sh
@@ -23,8 +23,7 @@ upload_url=$(curl -s --request GET --url $GH_RELEASE | grep -oP '(?<="upload_url
 
 content_type=$(file -b --mime-type $filepath)
 
-# basename
-filename=$(echo "$filepath" | rev | cut -d'/' -f1 | rev)
+filename=$(basename "$filepath")
 
 echo "Uploading asset... "
 

--- a/package/package.sh
+++ b/package/package.sh
@@ -32,8 +32,8 @@ done
 
 # version is null, get from tag name
 [[ -z $version ]] && version=`git describe --exact-match --abbrev=0 --tags | sed 's/^v//'`
-# version is null, get from short commit sha
-[[ -z $version ]] && version=`git describe --always`
+# version is null, use UTC date as version
+[[ -z $version ]] && version=$(date -u +%Y.%m.%d)-nightly
 
 if [[ -z $version ]]; then
     echo "version is null, exit"

--- a/src/common/fs/test/FileUtilsTest.cpp
+++ b/src/common/fs/test/FileUtilsTest.cpp
@@ -234,13 +234,15 @@ TEST(FileUtils, listContentInDir) {
     std::string fn1 = FileUtils::joinPath(dirTemp, "file1");
     FILE* f1 = fopen(fn1.c_str(), "w");
     ASSERT_NE(nullptr, f1);
-    fwrite("file1", 5, 1, f1);
+    auto r = fwrite("file1", 5, 1, f1);
+    ASSERT_EQ(r, 1);
     ASSERT_EQ(0, fclose(f1));
 
     std::string fn2 = FileUtils::joinPath(dirTemp, "file2");
     FILE* f2 = fopen(fn2.c_str(), "w");
     ASSERT_NE(nullptr, f2);
-    fwrite("file2", 5, 1, f2);
+    r = fwrite("file2", 5, 1, f2);
+    ASSERT_EQ(r, 1);
     ASSERT_EQ(0, fclose(f2));
 
     // Create two symbolic links


### PR DESCRIPTION
- Fix failed UT caused by default timezone of docker container
- Fix GitHub Actions error without enough disk, change build type to `Release`
- Upload packages and sha256sum files to release assets automatically
- Update docker images latest tag
- Change nightly version format of packages

closes #863 