### PR TITLE
[doc]Fix doc headings

### DIFF
--- a/docs/manual-EN/1.overview/0.introduction.md
+++ b/docs/manual-EN/1.overview/0.introduction.md
@@ -6,7 +6,7 @@
 
 **Nebula Graph's** goal is to provide reading, writing, and computing with high concurrency, low latency for super large scale graphs. Nebula Graph is an open source project and we are looking forward to working with the community to popularize and promote the graph database.
 
-## Main features of Nebula Graph
+## Main Features of Nebula Graph
 
 This section describes some of the important characteristics of **Nebula Graph**.
 

--- a/docs/manual-EN/1.overview/1.concepts/2.nGQL-overview.md
+++ b/docs/manual-EN/1.overview/1.concepts/2.nGQL-overview.md
@@ -45,7 +45,7 @@
  <vid, <edge_type, rank>, vid, ...>
 ```
 
-## Language Specification At A Glance
+## Language Specification at a Glance
 
 > ***For most readers, You can skip this section if you are not familiar with BNF.***
 
@@ -108,13 +108,13 @@
 
 ### Statements
 
-#### Choose a graph space
+#### Choose a Graph Space
 
 **Nebula Graph** supports multiple graph spaces. Data in different graph spaces are physically isolated. Before executing a query, a graph space needs to be selected using the following statement
 
 <span style="color:blue">**USE**</span>  <graphspace_name>
 
-#### Return a data set
+#### Return a Data Set
 
 Simply return a single value or a data set
 

--- a/docs/manual-EN/1.overview/1.concepts/2.nGQL-overview.md
+++ b/docs/manual-EN/1.overview/1.concepts/2.nGQL-overview.md
@@ -110,7 +110,7 @@
 
 #### Choose a Graph Space
 
-**Nebula Graph** supports multiple graph spaces. Data in different graph spaces are physically isolated. Before executing a query, a graph space needs to be selected using the following statement
+Nebula supports multiple graph spaces. Data in different graph spaces are physically isolated. Before executing a query, a graph space needs to be selected using the following statement
 
 <span style="color:blue">**USE**</span>  <graphspace_name>
 
@@ -122,7 +122,7 @@ Simply return a single value or a data set
 
 <return\_value\_decl> ::= **vid** | <vid\_list> | <tuple\_list\_decl> | <var\>
 
-#### Create a tag
+#### Create a Tag
 
 The following statement defines a **new** tag
 
@@ -133,7 +133,7 @@ The following statement defines a **new** tag
 <prop\_def> ::= <prop\_name>,<type\> <br>
 <prop\_name> ::= <label\> <br>
 
-#### Create an edge type
+#### Create an Edge Type
 
 The following statement defines a **new** edge type
 
@@ -141,7 +141,7 @@ The following statement defines a **new** edge type
 
 <edge\_type\_name> := <label\>
 
-#### Insert vertices
+#### Insert Vertices
 
 The following statement inserts one or more vertices
 
@@ -153,7 +153,7 @@ The following statement inserts one or more vertices
 <prop\_list> ::= <prop\_name> (, <prop\_name>)\* <br/>
 <prop\_value\_list> ::= **VALUE** (, **VALUE**)\* <br/>
 
-#### Insert edges
+#### Insert Edges
 
 The following statement inserts one or more edges
 
@@ -161,7 +161,8 @@ The following statement inserts one or more edges
 
 edge\_value ::= <vertex\_id> -> <vertex\_id> [@ <weight\>] : <prop\_value\_list>
 
-#### Update a vertex
+#### Update a Vertex
+
 The following statement updates a vertex
 
 <span style="color:blue">**UPDATE VERTEX**</span>  <vertex\_id>
@@ -173,7 +174,8 @@ The following statement updates a vertex
 <update\_form1> ::= <prop\_name> = <expression\> {,<prop\_name> = <expression\>}+ <br>
 <update\_form2> ::= (<prop\_list>) = (<value\_list>) | (<prop\_list>) = <var\> <br>
 
-#### Update an edge
+#### Update an Edge
+
 The following statement updates an edge
 
 <span style="color:blue">**UPDATE EDGE**</span>  <vertex\_id> -> <vertex\_id> [@<weight\>] <span style="color:blue">**OF**</span> <edge\_type>
@@ -181,7 +183,8 @@ The following statement updates an edge
 [<span style="color:blue">**WHERE**</span> <conditions\>]
 [<span style="color:blue">**YIELD**</span> <field\_list>]
 
-#### Traverse the graph
+#### Traverse the Graph
+
 Navigate from given vertices to their neighbors according to the given conditions. It returns either a list of vertex IDs, or a list of tuples
 
 <span style="color:blue">**GO**</span>
@@ -267,7 +270,7 @@ $- refers to the input stream, while $$ refers to the destination objects
 
 All property names start with a letter. There are a few system property names starting with "\_". All properties names starting with "\_" are reserved.
 
-### Built-in properties
+### Built-in Properties
 
 \_id : Vertex id
 \_type : Edge type

--- a/docs/manual-EN/1.overview/2.quick-start/1.get-started.md
+++ b/docs/manual-EN/1.overview/2.quick-start/1.get-started.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-## Try Nebula Graph from Docker
+## Try Nebula Graph From Docker
 
 The easiest way to get **Nebula Graph** up and running is using Docker. Before you start, make sure that you have:
 

--- a/docs/manual-EN/1.overview/2.quick-start/2.trouble-shooting.md
+++ b/docs/manual-EN/1.overview/2.quick-start/2.trouble-shooting.md
@@ -1,6 +1,6 @@
 # Trouble Shooting
 
-## graphd config file doesn't register to meta server
+## graphd Config File Doesn't Register to Meta Server
 
    When starting **Nebula Graph** services with the `nebula.service` script, `graphd`, `metad` and `storaged` processes start too fast to make the graphd config file registered into the meta server. The same problem may also occur when restarting.
 
@@ -26,7 +26,7 @@
    [INFO] Done
    ```
 
-## Errors thrown when inserting data after tag or edge is created
+## Errors Thrown When Inserting Data After Tag or Edge is Created
 
 This is likely caused by setting the `load_data_interval_secs` value to fetch data from the meta server. Conduct the following steps to resolve:
 
@@ -46,7 +46,7 @@ If the value is large, change it to 1s with the following command.
 
 > Note the changes take effect in the next period.
 
-## Errors thrown when executing command in docker
+## Errors Thrown When Executing Command in Docker
 
 This is likely caused by the inconsistency between the docker IP and the default listening address (172.17.0.2). Thus we need to change the the latter one.
 

--- a/docs/manual-EN/1.overview/2.quick-start/4.import-csv-file.md
+++ b/docs/manual-EN/1.overview/2.quick-start/4.import-csv-file.md
@@ -206,7 +206,7 @@ The data in the `team.csv` file is as follows:
 
 After all the previous four steps are complete, you can import the CSV data with `Docker` or `Go`.
 
-### Importing the CSV Data with Go
+### Importing the CSV Data With Go
 
 Before you import CSV data with `Go`, you must ensure `Go` is installed and the environment variable for `Go` is configured.
 
@@ -226,7 +226,7 @@ $ go run importer.go --config /home/nebula/config.yaml
 
 **Note**: You must change the directory for the `import.go` file and the directory for the `config.yaml` file to yours, otherwise, the importing operation might fail.
 
-### Importing the CSV Data with Docker
+### Importing the CSV Data With Docker
 
 Before you import the CSV data with `Docker`, you must ensure that `Docker` is up and running.
 
@@ -240,4 +240,3 @@ $ sudo docker run --rm -ti --network=host \
 ```
 
 **Note**: You must change the directory for the `config.yaml` file to yours, otherwise the importing operation might fail.
-

--- a/docs/manual-EN/1.overview/3.design-and-architecture/1.design-and-architecture.md
+++ b/docs/manual-EN/1.overview/3.design-and-architecture/1.design-and-architecture.md
@@ -17,7 +17,7 @@ Right beside the graph streaming is the online response system, whose requiremen
 
 The rightmost field is graph database and its use cases are completely different from the one on the left. The **Nebula Graph** we're working on can find its usage here in OLTP.
 
-### Native Vs Multi-model
+### Native Vs Multi-Model
 
 Graph databases can be classified into two kinds: native graph database and multi-model graph database. Using a `graph first` design, native graph databases are specifically optimized in storage and processing, thus they tend to perform queries faster, scale bigger and run more efficiently, calling for much less hardware at the same time. As for multi-model products, their storage comes from an outside source, such as a relational, columnar, or other NoSQL database. These databases use other algorithms to store data about vertices and edges and can lead to latent results as their storage layer is not optimized for graphs.
 
@@ -39,7 +39,7 @@ The dashed line in the above picture divided computing and storage as two indepe
 
 The right side is the meta service, similar to the NameNode in HDFS, it stores all metadata like schema and controls scaling.
 
-### Design thinking: Storage Service
+### Design Thinking: Storage Service
 
 **Nebula Graph** adopted the **shared-nothing** distributed architecture in storage so nodes do not share memory or storage, which means there are no central nodes in the whole system. Benefits of such design are:
 
@@ -67,7 +67,7 @@ In Raft protocol, the master replicates log entries to all the followers and com
 
 Migrating the partitions on an overworked server to other relatively idle servers to increases availability and capacity of the system.
 
-### Design-thinking: Meta Service
+### Design-Thinking: Meta Service
 
 The binary of the meta service is **nebula-metad**. Here is the list of its main functionalities:
 
@@ -89,7 +89,7 @@ The binary of the meta service is **nebula-metad**. Here is the list of its main
   - TTL (time-to-live) management, supporting automatic data deletion and space reclamation.
 The meta service is stateful, and just like the storage service, it persists data to a key-value store.
 
-### Design-thinking: Query Engine
+### Design-tThinking: Query Engine
 
 **Nebula Graph**'s query language **nGQL** is a SQL-like descriptive language rather than an imperative one. It's compossible but not embeddable, it uses Shell pipe as an alternative, aka output in the former query acts as the input in the latter one. Key features of nGQL are as follows:
 
@@ -111,6 +111,6 @@ The binary of the query engine is **nebula-graphd**. Each nebula-graphd instance
 
     In a distributed system, transferring a large amount of data on the network really extends the overall latency. In **Nebula Graph**, the query engine will make decisions to push some filter and aggregation down to the storage service. The purpose is to reduce the amount of data passing back from the storage.
 
-### Design-thinking: API and SDK
+### Design-Thinking: API and SDK
 
 **Nebula Graph** provides SDKs in C++, Java, and Golang. **Nebula Graph** uses fbthrift as the RPC framework to communicate among servers. **Nebula Graph**'s web console is in progress and will be released soon.

--- a/docs/manual-EN/1.overview/3.design-and-architecture/2.storage-design.md
+++ b/docs/manual-EN/1.overview/3.design-and-architecture/2.storage-design.md
@@ -120,7 +120,7 @@ Transfer leadership is extremely important for balance. When moving a partition 
 
 When transferring leadership, note that when the leader abandons its leadership and when the follower starts a leader election. When a transfer leadership command is committed, the original leader abandons its leadership. And as for followers, when receiving the command, it starts a leader election. This is the same execution process with common raft leader election. Otherwise, some corner cases will occur.
 
-### Membership change
+### Membership Change
 
 To avoid split-brain, when members in a Raft Group change, an intermediate state is required. In such state, the majority of the old group and  new group always have an overlap, thus preventing the old or new group from making decisions unilaterally. This is the `joint consensus` mentioned in the thesis. To make it even simpler, Diego Ongaro suggests **adding or removing a peer once to ensure the overlap between the majority of the new group and the old group** in his doctoral thesis. **Nebula Graph**'s implementation also uses this approach, except that the way to add or remove member is different. For details, please refer to `addPeer/removePeer` in Raft Part class.
 

--- a/docs/manual-EN/2.query-language/1.data-types/type-conversion.md
+++ b/docs/manual-EN/2.query-language/1.data-types/type-conversion.md
@@ -2,7 +2,7 @@
 
 Converting an expression of a given type to another type is known as type-conversion. In nGQL,  type conversion is divided into implicit conversion and explicit conversion.
 
-## Implicit type conversion
+## Implicit Type Conversion
 
 Implicit conversions are automatically performed when a value is copied to a compatible type.
 
@@ -14,16 +14,14 @@ Implicit conversions are automatically performed when a value is copied to a com
 
 2. `int` can implicitly converted to `double`.
 
-## Explicit type conversion
+## Explicit Type Conversion
 
 In addition to implicit type conversion, explicit type conversion is also supported in case of semantics compliance. The syntax is similar to the `C` language:
 
 `(type_name)expression`.
 
 For example, the results of
-
 `YIELD length((string)(123)), (int)"123" + 1`
 
 are `3, 124` respectively.
-
 And `YIELD (int)("12ab3")` fails in conversion.

--- a/docs/manual-EN/2.query-language/2.functions-and-operators/comparison-functions-and-operators.md
+++ b/docs/manual-EN/2.query-language/2.functions-and-operators/comparison-functions-and-operators.md
@@ -1,4 +1,4 @@
-# Comparison Functions And Operators
+# Comparison Functions and Operators
 
 | Name  | Description |
 |:----|:----:|

--- a/docs/manual-EN/2.query-language/2.functions-and-operators/group-by-function.md
+++ b/docs/manual-EN/2.query-language/2.functions-and-operators/group-by-function.md
@@ -1,4 +1,4 @@
-# Aggregate (Group by) function
+# Aggregate (Group by) Function
 
 The `GROUP BY` functions are similar with SQL. It can only be applied in the `YIELD` syntax.
 

--- a/docs/manual-EN/2.query-language/2.functions-and-operators/order-by-function.md
+++ b/docs/manual-EN/2.query-language/2.functions-and-operators/order-by-function.md
@@ -1,4 +1,4 @@
-# Order By Function
+# Order by Function
 
 Similar with SQL, `ORDER BY` can be used to sort in ascending (`ASC`) or descending (`DESC`) order for returned results.
 And it can only be used in the `PIPE`-syntax (`|`).

--- a/docs/manual-EN/2.query-language/3.language-structure/identifier-case-sensitivity.md
+++ b/docs/manual-EN/2.query-language/3.language-structure/identifier-case-sensitivity.md
@@ -1,6 +1,6 @@
 # Identifer Case Sensitivity
 
-## Identifiers are case-sensitive
+## Identifiers are Case-Sensitive
 
 The following statements would not work because they refer to two different spaces, i.e. `my_space` and `MY_SPACE`:
 
@@ -9,7 +9,7 @@ nebula> CREATE SPACE my_space;
 nebula> use MY_SPACE;  -- my_space and MY_SPACE are two different spaces
 ```
 
-## Keywords and reserved words are case-insensitive
+## Keywords and Reserved Words are Case-Insensitive
 
 The following statements are equivalent:
 

--- a/docs/manual-EN/2.query-language/3.language-structure/literal-values/numeric-literals.md
+++ b/docs/manual-EN/2.query-language/3.language-structure/literal-values/numeric-literals.md
@@ -8,7 +8,7 @@ Integers are 64 bit digitals, and can be preceded by + or - to indicate a positi
 
 Notice that the maximum value for the positive integers is `9223372036854775807`. It's syntax-error if you try to input any value greater than the maximum. So as the minimum value `-9223372036854775808` for the negative integers.
 
-## Floating-point Literals (doubles)
+## Floating-Point Literals (Doubles)
 
 Floating-points are the same as `double` in the `C` language.
 

--- a/docs/manual-EN/2.query-language/3.language-structure/property-reference.md
+++ b/docs/manual-EN/2.query-language/3.language-structure/property-reference.md
@@ -2,9 +2,9 @@
 
 You can refer a vertex or edge's property in `WHERE` or `YIELD` syntax.
 
-## Reference from vertex
+## Reference From Vertex
 
-### For source vertex
+### For Source Vertex
 
 ```ngql
 $^.tag_name.prop_name
@@ -14,7 +14,7 @@ where symbol `$^` is used to get a source vertex's property,
 `tag_name` indicates the source vertex's `tag`,
 and `prop_name` specifies the property name.
 
-### For destination vertex
+### For Destination Vertex
 
 ```ngql
 $$.tag_name.prop_name
@@ -30,9 +30,9 @@ nebula> GO FROM 1 OVER e1 YIELD $^.start.name AS startName, $$.end.Age AS endAge
 
 Use the above query to get the source vertex's property name and ending vertex's property age.
 
-## Reference from edge
+## Reference From Edge
 
-### For property
+### For Property
 
 You can use the following syntax to get an edge's property.
 
@@ -48,7 +48,7 @@ For example,
 nebula> GO FROM 1 OVER e1 YIELD e1.prop1
 ```
 
-### For build-in properties
+### For Build-in Properties
 
 There are four build-in properties in the edge:
 

--- a/docs/manual-EN/2.query-language/4.statement-syntax/1.data-definition-statements/create-tag-edge-syntax.md
+++ b/docs/manual-EN/2.query-language/4.statement-syntax/1.data-definition-statements/create-tag-edge-syntax.md
@@ -46,7 +46,7 @@ The features of this syntax are described in the following sections:
 
     > Since it's so error-prone to modify the default value with new one, using `Alter` to change the default value is not supported. -->
 
-### Time-to-Live (TTL) syntax
+### Time-to-Live (TTL) Syntax
 
 * TTL_DURATION
 

--- a/docs/manual-EN/2.query-language/4.statement-syntax/2.data-query-and-manipulation-statements/update-vertex-edge-syntax.md
+++ b/docs/manual-EN/2.query-language/4.statement-syntax/2.data-query-and-manipulation-statements/update-vertex-edge-syntax.md
@@ -25,7 +25,7 @@ nebula> UPDATE VERTEX 101 SET course.credits = $^.course.credits + 1, building.n
 
 There are two tags in vertex 101, namely course and building.
 
-## Update edge
+## Update Edge
 
 ```ngql
 UPDATE EDGE $edge SET $update_columns WHEN $condition YIELD $columns

--- a/docs/manual-EN/2.query-language/4.statement-syntax/2.data-query-and-manipulation-statements/yield-syntax.md
+++ b/docs/manual-EN/2.query-language/4.statement-syntax/2.data-query-and-manipulation-statements/yield-syntax.md
@@ -2,7 +2,7 @@
 
  Keyword `YIELD` can be used as a clause in a `FETCH` or `GO` statement, or as a separate statement in `PIPE`, or as a single sentence for calculation.
 
-## As Clause (with GO-syntax)
+## As Clause (With GO-Syntax)
 
 ```ngql
 YIELD

--- a/docs/manual-EN/3.build-develop-and-administration/1.build/1.build-source-code.md
+++ b/docs/manual-EN/3.build-develop-and-administration/1.build/1.build-source-code.md
@@ -125,7 +125,7 @@ nebula> SHOW HOSTS;
 
 ## Trouble Shooting
 
-### Error info: `/usr/bin/ld: cannot find Scrt1.o: No such file or directory`
+### Error Info: `/usr/bin/ld: cannot find Scrt1.o: No such file or directory`
 
 1. Modify **~/.bashrc** by appending following line to the end
 
@@ -139,7 +139,7 @@ export LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:$LIBRARY_PATH
 bash> source ~/.bashrc
 ```
 
-### Error info: `[ERROR] No compiler is provided in this environment. Perhaps you are running on a JRE rather than a JDK?`
+### Error Info: `[ERROR] No compiler is provided in this environment. Perhaps you are running on a JRE rather than a JDK?`
 
 1. Get your java jdk version with the command `java -version`
 1. If your java version is not `1.8.0_xxx`, please install it

--- a/docs/manual-EN/3.build-develop-and-administration/2.develop-and-interface/kv-interfaces.md
+++ b/docs/manual-EN/3.build-develop-and-administration/2.develop-and-interface/kv-interfaces.md
@@ -49,7 +49,7 @@ auto future = storageClient->get(spaceId, std::move(keys));
 auto resp = std::move(future).get()
 ```
 
-### Processing returned results
+### Processing Returned Results
 
 Check the returned results of the rpc to examine if the corresponding operation runs successfully. In addition, since **Nebula Graph** storage shards data, if one partition fails, the error code is also returned. If any of the partition fails, the entire requirement fails (resp.succeeded() is false). But those succeed are still read/written.
 
@@ -72,7 +72,7 @@ if (!resp.failedParts().empty()) {
 }
 ```
 
-#### Read values
+#### Read Values
 
 For the Get interface, we need some more operations to get the corresponding values. **Nebula Graph** storage is a multi-copy based on Raft, and all read/written operations can only be sent to the leader of the corresponding partition. When a get request contains multiple keys across partitions, the Storage Client requests the keys from the Partition leader. Each rpc return is stored separately in an unordered_map, and the user is currently required to traverse these unordered_maps to check if the key exists. An example is as follows:
 

--- a/docs/manual-EN/3.build-develop-and-administration/3.deploy-and-administrations/deployment/deploy-cluster.md
+++ b/docs/manual-EN/3.build-develop-and-administration/3.deploy-and-administrations/deployment/deploy-cluster.md
@@ -2,7 +2,7 @@
 
 This section provides an introduction to deploy `Nebula Graph` cluster.
 
-## Download and install package
+## Download and Install Package
 
 Currently, we have offered packages for `CentOS 7.5`, `CentOS 6.5`, `Ubuntu 1604` and `Ubuntu 1804`. You can download rpm or deb packages by clicking the [**Assets**](https://github.com/vesoft-inc/nebula/releases).
 
@@ -53,7 +53,7 @@ The metas, storages and graphs contain the host of themselves.
 
 Then you’re now ready to start using **Nebula Graph**.
 
-## Config reference
+## Configuration Reference
 
 **Meta Service** supports the following config properties.
 

--- a/docs/manual-EN/4.contributions/contribute-to-documentation.md
+++ b/docs/manual-EN/4.contributions/contribute-to-documentation.md
@@ -1,8 +1,8 @@
-# Contribute to documentation
+# Contribute to Documentation
 
 Contributing to the **Nebula Graph** documentation can be a rewarding experience. We welcome your participation to help make the documentation better!
 
-## How to contribute to the docs
+## How to Contribute to the Docs
 
 There are many ways to contribute:
 

--- a/docs/manual-EN/4.contributions/cpp-coding-style.md
+++ b/docs/manual-EN/4.contributions/cpp-coding-style.md
@@ -1,3 +1,3 @@
-# Cpp Coding style
+# Cpp Coding Style
 
 Please Refer to [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).

--- a/docs/manual-EN/4.contributions/developer-documentation-style-guide.md
+++ b/docs/manual-EN/4.contributions/developer-documentation-style-guide.md
@@ -1,4 +1,4 @@
-# Developer documentation style guide
+# Developer Documentation Style Guide
 
 **Key Point:** Use this guide as a style reference for our developer documentation.
 
@@ -11,25 +11,25 @@ and writing your documentation, and can help
 you keep your documentation consistent with
 our other documentation.
 
-## Non-goals
+## Non-Goals
 
 This guide isn't intended to provide an industry documentation standard, nor to compete with other well-known style guides. It's a description of our house style, not a statement that our decisions are objectively correct.
 
 This guide is a living document; it changes over time, and when it changes, we generally don't change previously published documentation to match. We strive for consistency to the extent feasible, but at any given time there are certain to be parts of our documentation that don't match this style guide. When in doubt, follow this guide rather than imitating existing documents.
 
-## Breaking the "rules"
+## Breaking the "Rules"
 
 In most contexts, **Nebula Graph** has no ability nor desire to enforce these guidelines if they're not appropriate to the context. But we hope that you'll join us in striving for high-quality documentation.
 
 Like most style guides, our style guide aims to improve our documentation, especially by improving consistency; therefore, there may be contexts where it makes sense to diverge from our guidelines in order to make your documentation better.
 
-## Style and authorial tone
+## Style and Authorial Tone
 
 Aim, in your documents, for a voice and tone that's conversational, friendly, and respectful without being overly colloquial or frivolous; a voice that's casual and natural and approachable, not pedantic or pushy. Try to sound like a knowledgeable friend who understands what the developer wants to do.
 
 Don't try to write exactly the way you speak; you probably speak more colloquially and verbosely than you should write, at least for developer documentation. But aim for a conversational tone rather than a formal one.
 
-### Some techniques and approaches to consider
+### Some Techniques and Approaches to Consider
 
 - If you're having trouble expressing something, step back and ask yourself, "What am I trying to say?" Often, the answer you give yourself reveals what you should be saying in the document.
 - If you're uncertain about your phrasing or tone, ask a colleague to take a look.
@@ -56,13 +56,13 @@ A couple of specific things to not do in link text:
 - Similarly, don't use phrases like "this document." (It's easy to read "this" as meaning "the one you're reading now" rather than "the one I'm pointing to.")
 - Don't use a URL as link text. Instead, use the page title or a description of the page.
 
-### Punctuation with links
+### Punctuation With Links
 
 If you have punctuation immediately before or after a link, put the punctuation outside of the link tags where possible. In particular, put quotation marks outside of link tags.
 
-## Accessible content
+## Accessible Content
 
-### General dos and don'ts
+### General dos and Don'ts
 
 - Ensure that readers can reach all parts of the document (including tabs, form-submission buttons, and interactive elements) using only a keyboard, without a mouse or trackpad.
 - Don't use color, size, location, or other visual cues as the primary way of communicating information.
@@ -94,7 +94,7 @@ If you have punctuation immediately before or after a link, put the punctuation 
 - Provide captions.
 - Ensure that captions can be translated into major languages.
 
-## Language and grammar
+## Language and Grammar
 
 - Use second person: "you" rather than "we."
 - Use active voice; make clear who's performing the action.
@@ -102,7 +102,7 @@ Use standard American spelling and punctuation.
 Put conditional clauses before instructions, not after.
 For usage and spelling of specific words, see the word list.
 
-## Formatting, punctuation, and organization
+## Formatting, Punctuation, and Organization
 
 - [Use sentence case](https://developers.google.cn/style/capitalization) for document titles and section headings.
 - [Use numbered lists](https://developers.google.cn/style/lists) for sequences.

--- a/docs/manual-EN/4.contributions/how-to-contribute.md
+++ b/docs/manual-EN/4.contributions/how-to-contribute.md
@@ -1,11 +1,11 @@
 # How to Contribute
 
-## Step 1: Fork in the cloud
+## Step 1: Fork in the Cloud
 
 1. Visit https://github.com/vesoft-inc/nebula
 1. Click `Fork` button (top right) to establish a cloud-based fork.
 
-## Step 2: Clone fork to local storage
+## Step 2: Clone Fork to Local Storage
 
 Define a local working directory:
 
@@ -45,7 +45,7 @@ git remote set-url --push upstream no_push
 git remote -v
 ```
 
-### Define a pre-commit hook
+### Define a Pre-Commit Hook
 
 Please link the **Nebula Graph** pre-commit hook into your `.git` directory.
 
@@ -95,11 +95,11 @@ git push --force origin master
 
 ### Step 4: Develop
 
-#### Edit the code
+#### Edit the Code
 
 You can now edit the code on the `myfeature` branch. We are following [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html).
 
-#### Run stand-alone mode
+#### Run Stand-Alone Mode
 
 If you want to reproduce and investigate an issue, you may need
 to run Nebula Graph in stand-alone mode.
@@ -124,7 +124,7 @@ Then you can connect the **Nebula Graph** console to your local server
 # Run unit test to make sure all tests passed.
 ```
 
-### Step 5: Keep your branch in sync
+### Step 5: Keep Your Branch in Sync
 
 ```bash
 # While on your myfeature branch.
@@ -151,12 +151,12 @@ push your branch to your fork on `github.com`:
 git push -f origin myfeature
 ```
 
-### Step 8: Create a pull request
+### Step 8: Create a Pull Request
 
 1. Visit your fork at https://github.com/$user/nebula (replace `$user` obviously).
 2. Click the `Compare & pull request` button next to your `myfeature` branch.
 
-### Step 9: Get a code review
+### Step 9: Get a Code Review
 
 Once your pull request has been opened, it will be assigned to at least two
 reviewers. Those reviewers will do a thorough code review to ensure the changes meet the repository's contributing guidelines and other quality standards.

--- a/docs/manual-EN/README.md
+++ b/docs/manual-EN/README.md
@@ -1,4 +1,4 @@
-# Welcome to the official Nebula Graph documentation
+# Welcome to the Official Nebula Graph Documentation
 
 **Nebula Graph** is a distributed, scalable, lightning-fast graph database.
 
@@ -9,7 +9,7 @@ It is the optimal solution in the world capable to host graphs with dozens of bi
 * [About This Manual](0.about-this-manual.md)
 * [Manual Change Log](CHANGELOG.md)
 
-## Overview (For Beginners)
+## Overview (for Beginners)
 
 * [Introduction](1.overview/0.introduction.md)
 * Concepts
@@ -23,16 +23,16 @@ It is the optimal solution in the world capable to host graphs with dozens of bi
   * [Ingest .sst File](3.build-develop-and-administration/3.deploy-and-administrations/server-administration/storage-service-administration/data-import/download-and-ingest-sst-file.md)
   * [Nebula Graph Clients](1.overview/2.quick-start/3.supported-clients.md)
 
-* Design And Architecture
+* Design and Architecture
   * [Design Overview](1.overview/3.design-and-architecture/1.design-and-architecture.md)
   * [Storage Architecture](1.overview/3.design-and-architecture/2.storage-design.md)
 
-## Query Language (For All Users)
+## Query Language (for All Users)
 
 * Data Types
   * [Data Types](2.query-language/1.data-types/data-types.md)
   * [Type Conversion](2.query-language/1.data-types/type-conversion.md)
-* Functions And Operators
+* Functions and Operators
   * [Bitwise Operators](2.query-language/2.functions-and-operators/bitwise-operators.md)
   * [Built-In Functions](2.query-language/2.functions-and-operators/built-in-functions.md)
   * [Comparison Functions And Operators](2.query-language/2.functions-and-operators/comparison-functions-and-operators.md)
@@ -61,7 +61,7 @@ It is the optimal solution in the world capable to host graphs with dozens of bi
     * [Drop Edge Syntax](2.query-language/4.statement-syntax/1.data-definition-statements/drop-edge-syntax.md)
     * [Drop Space Syntax](2.query-language/4.statement-syntax/1.data-definition-statements/drop-space-syntax.md)
     * [Drop Tag Syntax](2.query-language/4.statement-syntax/1.data-definition-statements/drop-tag-syntax.md)
-  * Data Query And Manipulation Statements
+  * Data Query and Manipulation Statements
     * [Delete Edge Syntax](2.query-language/4.statement-syntax/2.data-query-and-manipulation-statements/delete-edge-syntax.md)
     * [Delete Vertex Syntax](2.query-language/4.statement-syntax/2.data-query-and-manipulation-statements/delete-vertex-syntax.md)
     * [Fetch Syntax](2.query-language/4.statement-syntax/2.data-query-and-manipulation-statements/fetch-syntax.md)
@@ -84,11 +84,11 @@ It is the optimal solution in the world capable to host graphs with dozens of bi
 * Build
   * [Build Source Code](3.build-develop-and-administration/1.build/1.build-source-code.md)
   * [Build By Docker](3.build-develop-and-administration/1.build/2.build-by-docker.md)
-* Develop And Interface
+* Develop and Interface
   * [Key Value API](3.build-develop-and-administration/2.develop-and-interface/kv-interfaces.md)
   * [Nebula Graph Clients](1.overview/2.quick-start/3.supported-clients.md)
 
-* Deploy And Administrations
+* Deploy and Administrations
   * Deployment
     * [Deploy Cluster On Docker](3.build-develop-and-administration/3.deploy-and-administrations/deployment/deploy-cluster-on-docker.md)
     * [Deploy Cluster](3.build-develop-and-administration/3.deploy-and-administrations/deployment/deploy-cluster.md)
@@ -109,9 +109,9 @@ It is the optimal solution in the world capable to host graphs with dozens of bi
       * [Storage Balance](3.build-develop-and-administration/3.deploy-and-administrations/server-administration/storage-service-administration/storage-balance.md)
       * [Storage Metrics](3.build-develop-and-administration/3.deploy-and-administrations/server-administration/storage-service-administration/storage-metrics.md)
 
-## Contributions (For Contributors)
+## Contributions (for Contributors)
 
-* [Contribute To Documentations](4.contributions/contribute-to-documentation.md)
+* [Contribute to Documentations](4.contributions/contribute-to-documentation.md)
 * [Cpp Coding Style](4.contributions/cpp-coding-style.md)
 * [Developer Documentation Style Guide](4.contributions/developer-documentation-style-guide.md)
 * [How to Contribute](4.contributions/how-to-contribute.md)


### PR DESCRIPTION
Fix all heading format in English doc.
The rules of word capitalization in headings:
1.  **Always capitalize the first and last word of a title.**
2. Between the first and last word of a title **Capitalize all words except:**
    **Articles:** a, an, the
    Coordinate **conjunctions:** and, but, or, nor
    **Short prepositions** (three letters or less): as, at, by, for, in, of, on, to, but, cum, mid, off, per, qua, re, up, via -- except when used as adverbs or as an inseparable part of a verb 
    When used to form an **infinitive: to**
3. In compounds formed by hyphens, capitalize each part exactly as if they were a separate word.


