### PR TITLE
fix test case for ubuntu docker

### DIFF
--- a/src/kvstore/test/NebulaStoreTest.cpp
+++ b/src/kvstore/test/NebulaStoreTest.cpp
@@ -760,13 +760,13 @@ TEST(NebulaStoreTest, ThreeCopiesCheckpointTest) {
         fs::FileUtils::remove(folly::stringPrintf("%s/data", rm.data()).c_str(), true);
         fs::FileUtils::remove(folly::stringPrintf("%s/wal", rm.data()).c_str(), true);
         std::string mv = folly::stringPrintf(
-                "/usr/bin/mv %s/disk%d/nebula/0/checkpoints/snapshot/data %s/disk%d/nebula/0/data",
+                "mv %s/disk%d/nebula/0/checkpoints/snapshot/data %s/disk%d/nebula/0/data",
                 rootPath.path(), i , rootPath.path(), i);
         sleep(1);
         auto ret = system(mv.c_str());
         ASSERT_EQ(0, ret);
         mv = folly::stringPrintf(
-                "/usr/bin/mv %s/disk%d/nebula/0/checkpoints/snapshot/wal %s/disk%d/nebula/0/wal",
+                "mv %s/disk%d/nebula/0/checkpoints/snapshot/wal %s/disk%d/nebula/0/wal",
                 rootPath.path(), i , rootPath.path(), i);
         sleep(1);
         ret = system(mv.c_str());


### PR DESCRIPTION
Temporary fix test case for ubuntu docker. The mv command file is in the /bin directory on ubuntu docker. 
I will add a renameDir method to FileUtils at later.