### PR TITLE
Add dump edges tool

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,5 +1,6 @@
 nebula_add_subdirectory(storage-perf)
 nebula_add_subdirectory(simple-kv-verify)
+nebula_add_subdirectory(dump-edges)
 
 if (ENABLE_NATIVE)
     add_subdirectory(native-client)

--- a/src/tools/dump-edges/CMakeLists.txt
+++ b/src/tools/dump-edges/CMakeLists.txt
@@ -1,0 +1,13 @@
+nebula_add_executable(
+    NAME
+        dump_edges
+    SOURCES
+        DumpEdgesTool.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:base_obj>
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        glog
+        gflags
+)
+

--- a/src/tools/dump-edges/DumpEdgesTool.cpp
+++ b/src/tools/dump-edges/DumpEdgesTool.cpp
@@ -1,0 +1,60 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/NebulaKeyUtils.h"
+#include <rocksdb/db.h>
+
+DEFINE_string(path, "", "rocksdb instance path");
+
+namespace nebula {
+
+class DumpEdges {
+public:
+    static void scan(const char* path) {
+        LOG(INFO) << "open rocksdb on " << path;
+        rocksdb::DB* db = nullptr;
+        rocksdb::Options options;
+        auto status = rocksdb::DB::OpenForReadOnly(options, path, &db);
+        CHECK(status.ok()) << status.ToString();
+        rocksdb::ReadOptions roptions;
+        rocksdb::Iterator* iter = db->NewIterator(roptions);
+        if (!iter) {
+            LOG(FATAL) << "null iterator!";
+        }
+        iter->SeekToFirst();
+        size_t count = 0;
+        while (iter->Valid()) {
+            auto key = folly::StringPiece(iter->key().data(), iter->key().size());
+            if (NebulaKeyUtils::isEdge(key)) {
+                LOG(INFO) << NebulaKeyUtils::getSrcId(key) << "," << NebulaKeyUtils::getDstId(key);
+                count++;
+            }
+            iter->Next();
+        }
+        LOG(INFO) << "Total edges:" << count;
+        if (iter) {
+            delete iter;
+        }
+
+        if (db) {
+            db->Close();
+            delete db;
+        }
+    }
+};
+
+}  // namespace nebula
+
+int main(int argc, char *argv[]) {
+    folly::init(&argc, &argv, true);
+    google::SetStderrLogging(google::INFO);
+    if (FLAGS_path.empty()) {
+        LOG(INFO) << "Specify the path!";
+        return -1;
+    }
+    nebula::DumpEdges::scan(FLAGS_path.c_str());
+    return 0;
+}


### PR DESCRIPTION
It will dump the edges (srcId, dstId) in the rocksdb.
Sometimes,  our users want to check the data imported.  
The tool could help them to check all edges imported.  
Of course,  currently it just check the srcId->dstId and the total edges number. 

Usage:  dump_edges --path=/rocksdb_path

