### PR TITLE
add uuid cache

### DIFF
--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -25,6 +25,7 @@ enum ErrorCode {
     E_PART_NOT_FOUND = -14,
     E_KEY_NOT_FOUND = -15,
     E_CONSENSUS_ERROR = -16,
+    E_ATOMIC_OP_FAIL = -17,
 
     // meta failures
     E_EDGE_PROP_NOT_FOUND = -21,

--- a/src/kvstore/Common.h
+++ b/src/kvstore/Common.h
@@ -26,6 +26,7 @@ enum ResultCode {
     ERR_UNSUPPORTED         = -8,
     ERR_CHECKPOINT_ERROR    = -9,
     ERR_WRITE_BLOCK_ERROR   = -10,
+    ERR_ATOMIC_OP_FAILURE   = -11,
     ERR_UNKNOWN             = -100,
 };
 

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -431,6 +431,8 @@ ResultCode Part::toResultCode(raftex::AppendLogResult res) {
             return ResultCode::ERR_LEADER_CHANGED;
         case raftex::AppendLogResult::E_WRITE_BLOCKING:
             return ResultCode::ERR_WRITE_BLOCK_ERROR;
+        case raftex::AppendLogResult::E_ATOMIC_OP_FAILURE:
+            return ResultCode::ERR_ATOMIC_OP_FAILURE;
         default:
             LOG(ERROR) << idStr_ << "Consensus error "
                        << static_cast<int32_t>(res);

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -655,7 +655,7 @@ void RaftPart::appendLogsInternal(AppendLogsIterator iter, TermID termId) {
                 << iter.logId() << " (Current term is "
                 << currTerm << ")";
     } else {
-        LOG(ERROR) << idStr_ << "Only happend when Atomic op failed";
+        VLOG(2) << idStr_ << "Only happend when Atomic op failed";
         replicatingLogs_ = false;
         return;
     }

--- a/src/storage/BaseProcessor.h
+++ b/src/storage/BaseProcessor.h
@@ -121,10 +121,9 @@ protected:
         return tHost;
     }
 
-private:
+protected:
     void handleAsync(GraphSpaceID spaceId, PartitionID partId, kvstore::ResultCode code);
 
-protected:
     kvstore::KVStore*                               kvstore_ = nullptr;
     meta::SchemaManager*                            schemaMan_ = nullptr;
     stats::Stats*                                   stats_ = nullptr;

--- a/src/storage/BaseProcessor.inl
+++ b/src/storage/BaseProcessor.inl
@@ -27,6 +27,8 @@ cpp2::ErrorCode BaseProcessor<RESP>::to(kvstore::ResultCode code) {
         return cpp2::ErrorCode::E_FAILED_TO_CHECKPOINT;
     case kvstore::ResultCode::ERR_WRITE_BLOCK_ERROR:
         return cpp2::ErrorCode::E_CHECKPOINT_BLOCKED;
+    case kvstore::ResultCode::ERR_ATOMIC_OP_FAILURE:
+        return cpp2::ErrorCode::E_ATOMIC_OP_FAIL;
     default:
         return cpp2::ErrorCode::E_UNKNOWN;
     }

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -8,6 +8,7 @@ nebula_add_library(
     query/QueryEdgePropsProcessor.cpp
     query/QueryStatsProcessor.cpp
     query/QueryEdgeKeysProcessor.cpp
+    query/GetUUIDProcessor.cpp
     mutate/AddVerticesProcessor.cpp
     mutate/AddEdgesProcessor.cpp
     mutate/DeleteEdgesProcessor.cpp

--- a/src/storage/CommonUtils.h
+++ b/src/storage/CommonUtils.h
@@ -17,6 +17,7 @@ namespace storage {
 using TagProp = std::pair<std::string, std::string>;
 
 using VertexCache = ConcurrentLRUCache<std::pair<VertexID, TagID>, std::string>;
+using UUIDCache = ConcurrentLRUCache<std::string, VertexID>;
 
 struct FilterContext {
     // key: <tagName, propName> -> propValue

--- a/src/storage/GetUUIDProcessor.cpp
+++ b/src/storage/GetUUIDProcessor.cpp
@@ -1,0 +1,80 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "storage/GetUUIDProcessor.h"
+#include "base/NebulaKeyUtils.h"
+#include "base/MurmurHash2.h"
+#include "kvstore/LogEncoder.h"
+#include "time/WallClock.h"
+
+DEFINE_bool(enable_uuid_cache, true, "Enable uuid cache");
+
+namespace nebula {
+namespace storage {
+
+void GetUUIDProcessor::process(const cpp2::GetUUIDReq& req) {
+    constexpr size_t hashMask = 0xFFFFFFFF00000000;
+    constexpr size_t timeMask = 0x00000000FFFFFFFF;
+    CHECK_NOTNULL(kvstore_);
+    auto spaceId = req.get_space_id();
+    auto partId = req.get_part_id();
+    auto name = req.get_name();
+    auto key = NebulaKeyUtils::uuidKey(partId, name.c_str());
+
+    if (FLAGS_enable_uuid_cache && uuidCache_ != nullptr) {
+        auto result = uuidCache_->get(key, partId);
+        if (result.ok()) {
+            auto vId = std::move(result).value();
+            VLOG(3) << "Hit cache for uuid(" << name << "), vId = " << vId;
+            resp_.set_id(vId);
+            this->onFinished();
+            return;
+        } else {
+            VLOG(3) << "Miss cache for uuid(" << name << ")";
+        }
+    }
+
+    callingNum_ = 1;
+    auto atomicOp = [spaceId, partId, key, name = std::move(name), this]() -> std::string {
+        std::string value;
+        auto code = this->kvstore_->get(spaceId, partId, key, &value);
+        if (code == kvstore::ResultCode::SUCCEEDED) {
+            vId_ = *reinterpret_cast<const VertexID*>(value.c_str());
+            succeeded_ = true;
+            LOG(INFO) << "!!!";
+            return std::string("");
+        } else if (code == kvstore::ResultCode::ERR_KEY_NOT_FOUND) {
+            // need to generate new vertex id of this uuid
+            MurmurHash2 hashFunc;
+            auto hashValue = hashFunc(name);
+            auto now = time::WallClock::fastNowInSec();
+            vId_ = (hashValue & hashMask) | (now & timeMask);
+            value.append(reinterpret_cast<char*>(&vId_), sizeof(VertexID));
+            LOG(INFO) << "@@@";
+            return kvstore::encodeMultiValues(kvstore::LogType::OP_PUT,
+                                              std::move(key), std::move(value));
+        }
+        return std::string("");
+    };
+    auto callback = [spaceId, partId, key, this](kvstore::ResultCode code) {
+        if (succeeded_ || code == kvstore::ResultCode::SUCCEEDED) {
+            LOG(INFO) << "###";
+            resp_.set_id(vId_);
+            if (FLAGS_enable_uuid_cache && uuidCache_ != nullptr) {
+                uuidCache_->putIfAbsent(std::move(key), vId_, partId);
+                VLOG(3) << "Insert cache of " << key;
+            }
+            this->onFinished();
+            return;
+        }
+        LOG(INFO) << "$$$";
+        handleAsync(spaceId, partId, code);
+    };
+    this->kvstore_->asyncAtomicOp(spaceId, partId, atomicOp, callback);
+}
+
+}  // namespace storage
+}  // namespace nebula

--- a/src/storage/StorageServiceHandler.cpp
+++ b/src/storage/StorageServiceHandler.cpp
@@ -32,6 +32,8 @@
 
 DEFINE_int32(vertex_cache_num, 16 * 1000 * 1000, "Total keys inside the cache");
 DEFINE_int32(vertex_cache_bucket_exp, 4, "Total buckets number is 1 << cache_bucket_exp");
+DEFINE_int32(uuid_cache_num, 16 * 1000 * 1000, "Total keys inside the cache");
+DEFINE_int32(uuid_cache_bucket_exp, 4, "Total buckets number is 1 << cache_bucket_exp");
 
 namespace nebula {
 namespace storage {
@@ -188,7 +190,7 @@ StorageServiceHandler::future_get(const cpp2::GetRequest& req) {
 
 folly::Future<cpp2::GetUUIDResp>
 StorageServiceHandler::future_getUUID(const cpp2::GetUUIDReq& req) {
-    auto* processor = GetUUIDProcessor::instance(kvstore_);
+    auto* processor = GetUUIDProcessor::instance(kvstore_, &uuidCache_);
     RETURN_FUTURE(processor);
 }
 

--- a/src/storage/StorageServiceHandler.h
+++ b/src/storage/StorageServiceHandler.h
@@ -18,6 +18,8 @@
 
 DECLARE_int32(vertex_cache_num);
 DECLARE_int32(vertex_cache_bucket_exp);
+DECLARE_int32(uuid_cache_num);
+DECLARE_int32(uuid_cache_bucket_exp);
 
 namespace nebula {
 namespace storage {
@@ -32,7 +34,8 @@ public:
         : kvstore_(kvstore)
         , schemaMan_(schemaMan)
         , metaClient_(client)
-        , vertexCache_(FLAGS_vertex_cache_num, FLAGS_vertex_cache_bucket_exp) {
+        , vertexCache_(FLAGS_vertex_cache_num, FLAGS_vertex_cache_bucket_exp)
+        , uuidCache_(FLAGS_uuid_cache_num, FLAGS_uuid_cache_bucket_exp) {
         getBoundQpsStat_ = stats::Stats("storage", "get_bound");
         boundStatsQpsStat_ = stats::Stats("storage", "bound_stats");
         vertexPropsQpsStat_ = stats::Stats("storage", "vertex_props");
@@ -128,6 +131,7 @@ private:
     meta::SchemaManager* schemaMan_ = nullptr;
     meta::MetaClient* metaClient_ = nullptr;
     VertexCache vertexCache_;
+    UUIDCache uuidCache_;
 
     stats::Stats getBoundQpsStat_;
     stats::Stats boundStatsQpsStat_;

--- a/src/storage/query/GetUUIDProcessor.h
+++ b/src/storage/query/GetUUIDProcessor.h
@@ -8,62 +8,28 @@
 #define STORAGE_QUERY_GETUUIDPROCESSOR_H_
 
 #include "base/Base.h"
-#include "base/MurmurHash2.h"
 #include "storage/BaseProcessor.h"
-#include "kvstore/NebulaStore.h"
-#include "time/WallClock.h"
 
 namespace nebula {
 namespace storage {
 
 class GetUUIDProcessor : public BaseProcessor<cpp2::GetUUIDResp> {
 public:
-    static GetUUIDProcessor* instance(kvstore::KVStore* kvstore) {
-        return new GetUUIDProcessor(kvstore);
+    static GetUUIDProcessor* instance(kvstore::KVStore* kvstore,
+                                      UUIDCache* uuidCache = nullptr) {
+        return new GetUUIDProcessor(kvstore, uuidCache);
     }
 
-    void process(const cpp2::GetUUIDReq& req) {
-        constexpr size_t hashMask = 0xFFFFFFFF00000000;
-        constexpr size_t timeMask = 0x00000000FFFFFFFF;
-        CHECK_NOTNULL(kvstore_);
-        auto spaceId = req.get_space_id();
-        auto partId = req.get_part_id();
-        auto name = req.get_name();
-        auto key = NebulaKeyUtils::uuidKey(partId, name.c_str());
-        std::string val;
-        VertexID vId;
-        auto ret = kvstore_->get(spaceId, partId, key, &val);
-        // try to get the corresponding vertex id
-        if (ret != kvstore::ResultCode::SUCCEEDED) {
-            // need to generate new vertex id of this uuid
-            MurmurHash2 hashFunc;
-            auto hashValue = hashFunc(name);
-            auto now = time::WallClock::fastNowInSec();
-            vId = (hashValue & hashMask) | (now & timeMask);
-            val.append(reinterpret_cast<char*>(&vId), sizeof(VertexID));
-            std::vector<kvstore::KV> data;
-            data.emplace_back(std::move(key), std::move(val));
-
-            kvstore_->asyncMultiPut(spaceId, partId, std::move(data),
-                                    [vId, spaceId, partId, this] (kvstore::ResultCode code) {
-                if (code == kvstore::ResultCode::SUCCEEDED) {
-                    resp_.set_id(vId);
-                } else {
-                    this->handleErrorCode(code, spaceId, partId);
-                }
-                this->onFinished();
-            });
-        } else {
-            CHECK_EQ(val.size(), sizeof(VertexID));
-            vId = *reinterpret_cast<const VertexID*>(val.c_str());
-            resp_.set_id(vId);
-            this->onFinished();
-        }
-    }
+    void process(const cpp2::GetUUIDReq& req);
 
 private:
-    explicit GetUUIDProcessor(kvstore::KVStore* kvstore)
-            : BaseProcessor<cpp2::GetUUIDResp>(kvstore, nullptr) {}
+    explicit GetUUIDProcessor(kvstore::KVStore* kvstore, UUIDCache* uuidCache)
+            : BaseProcessor<cpp2::GetUUIDResp>(kvstore, nullptr)
+            , uuidCache_(uuidCache) {}
+
+    UUIDCache* uuidCache_ = nullptr;
+    VertexID vId_;
+    bool succeeded_{false};
 };
 
 }  // namespace storage

--- a/src/storage/test/CMakeLists.txt
+++ b/src/storage/test/CMakeLists.txt
@@ -300,6 +300,12 @@ nebula_add_test(
     LIBRARIES ${ROCKSDB_LIBRARIES} ${THRIFT_LIBRARIES} wangle gtest
 )
 
+nebula_add_test(
+    NAME uuid_cache_test
+    SOURCES UUIDCacheTest.cpp
+    OBJECTS $<TARGET_OBJECTS:adHocSchema_obj> ${storage_test_deps}
+    LIBRARIES ${ROCKSDB_LIBRARIES} ${THRIFT_LIBRARIES} wangle gtest
+)
 
 nebula_add_test(
     NAME checkpoint_test

--- a/src/storage/test/UUIDCacheTest.cpp
+++ b/src/storage/test/UUIDCacheTest.cpp
@@ -8,7 +8,7 @@
 #include <gtest/gtest.h>
 #include "fs/TempDir.h"
 #include "storage/test/TestUtils.h"
-#include "storage/GetUUIDProcessor.h"
+#include "storage/query/GetUUIDProcessor.h"
 
 DECLARE_int32(max_handlers_per_req);
 

--- a/src/storage/test/UUIDCacheTest.cpp
+++ b/src/storage/test/UUIDCacheTest.cpp
@@ -1,0 +1,74 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/Base.h"
+#include <gtest/gtest.h>
+#include "fs/TempDir.h"
+#include "storage/test/TestUtils.h"
+#include "storage/GetUUIDProcessor.h"
+
+DECLARE_int32(max_handlers_per_req);
+
+namespace nebula {
+namespace storage {
+
+void getUUID(kvstore::KVStore* kv, UUIDCache* cache, size_t start, size_t end) {
+    for (size_t i = start; i < end; i++) {
+        auto* processor = GetUUIDProcessor::instance(kv, cache);
+        cpp2::GetUUIDReq req;
+        req.set_space_id(0);
+        req.set_part_id(i % 10);
+        req.set_name(std::to_string(i));
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_codes.size());
+    }
+}
+
+void checkCache(UUIDCache* cache, uint64_t evicts, uint64_t hits) {
+    EXPECT_EQ(evicts, cache->evicts());
+    EXPECT_EQ(hits, cache->hits());
+}
+
+
+TEST(UUIDCacheTest, SimpleTest) {
+    fs::TempDir rootPath("/tmp/UUIDCacheTest.XXXXXX");
+    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path(), 10);
+    auto schemaMan = TestUtils::mockSchemaMan();
+    auto executor = std::make_unique<folly::CPUThreadPoolExecutor>(1);
+
+    UUIDCache cache(1000, 0);
+
+    LOG(INFO) << "Get uuid";
+    getUUID(kv.get(), &cache, 0, 1000);
+    checkCache(&cache, 0, 0);
+
+    LOG(INFO) << "Get again";
+    getUUID(kv.get(), &cache, 0, 1000);
+    checkCache(&cache, 0, 1000);
+
+    LOG(INFO) << "Get a part of cached";
+    getUUID(kv.get(), &cache, 500, 1500);
+    checkCache(&cache, 500, 1500);
+
+    LOG(INFO) << "Get non-cached uuid";
+    getUUID(kv.get(), &cache, 2000, 3000);
+    checkCache(&cache, 1500, 1500);
+}
+
+}  // namespace storage
+}  // namespace nebula
+
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    folly::init(&argc, &argv, true);
+    google::SetStderrLogging(google::INFO);
+    return RUN_ALL_TESTS();
+}
+
+


### PR DESCRIPTION
Add uuid cache.

We first check if we cached. If not we need to create one in a CAS operation. If CAS succeeded, we can return the result, if failed, return errorcode.