### PR TITLE
Make precompiled header depend on CMakeCache.txt

### DIFF
--- a/cmake/FindPCHSupport.cmake
+++ b/cmake/FindPCHSupport.cmake
@@ -87,7 +87,8 @@ MACRO(ADD_PRECOMPILED_HEADER _targetName _input)
                 -x c++-header
                 -std=${_cxx_standard}
                 -o ${_output} ${_source}
-        MAIN_DEPENDENCY ${_source})
+        MAIN_DEPENDENCY ${_source}
+        DEPENDS ${CMAKE_BINARY_DIR}/CMakeCache.txt)
     ADD_CUSTOM_TARGET(${_targetName}_gch DEPENDS ${_output})
     ADD_DEPENDENCIES(${_targetName} ${_targetName}_gch)
 


### PR DESCRIPTION
Currently, the precompiled header's generation only depends on the source header, i.e. _Base.h_. It could not reflect the changes on other configuarations, e.g. CMAKE_BUILD_TYPE. 

To address such an issue, we make the pch depend on the _CMakeCache.txt_ file, which holds all kinds of configurations. 