### PR TITLE
Added support for Clang to use a non-standard-location GCC's toolchain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,17 +6,18 @@
 # The build can be controlled by defining following variables on the
 # <cmake> command line
 #
-#   CMAKE_C_COMPILER               -- Specify the compiler for C language
-#   CMAKE_CXX_COMPILER             -- Specify the compiler for C++ language
+#   CMAKE_C_COMPILER                -- Specify the compiler for C language
+#   CMAKE_CXX_COMPILER              -- Specify the compiler for C++ language
 #
-#   NEBULA_THIRDPARTY_ROOT         -- Specify the root directory for third-party
-#   NEBULA_OTHER_ROOT              -- Specify the root directory for user build
-#                                  -- Split with ":", exp: DIR:DIR
-#   NEBULA_CLANG_USED_GCC_TOOLCHAIN           -- Set the gcc installation directory used by Clang(libstdc++)
+#   NEBULA_THIRDPARTY_ROOT          -- Specify the root directory for third-party
+#   NEBULA_OTHER_ROOT               -- Specify the root directory for user build
+#                                   -- Split with ":", exp: DIR:DIR
+#   NEBULA_CLANG_USE_GCC_TOOLCHAIN  -- Specify the root of GCC's toolchain, used by Clang
+#   NEBULA_USE_LINKER               -- Set linker to use, options are: bfd, gold
 #
-#   ENABLE_JEMALLOC                -- Link jemalloc into all executables
-#   ENABLE_NATIVE                  -- Build native client
-#   ENABLE_TESTING                 -- Build unit test
+#   ENABLE_JEMALLOC                 -- Link jemalloc into all executables
+#   ENABLE_NATIVE                   -- Build native client
+#   ENABLE_TESTING                  -- Build unit test
 #
 cmake_minimum_required(VERSION 3.5.0)
 
@@ -164,10 +165,6 @@ if("${NEBULA_THIRDPARTY_ROOT}" STREQUAL "")
     endif()
 endif()
 
-if ("${NEBULA_CLANG_USED_GCC_TOOLCHAIN}" STREQUAL "")
-    SET(NEBULA_CLANG_USED_GCC_TOOLCHAIN "${NEBULA_THIRDPARTY_ROOT}")
-endif()
-
 # third-party
 if(NOT ${NEBULA_THIRDPARTY_ROOT} STREQUAL "")
     message(STATUS "Specified NEBULA_THIRDPARTY_ROOT: " ${NEBULA_THIRDPARTY_ROOT})
@@ -242,17 +239,27 @@ if(ENABLE_WERROR)
     add_compile_options(-Werror)
 endif()
 
+# TODO(dutor) Move all compiler-config-related operations to a separate file
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     # This requries GCC 5.1+
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.1)
         add_compile_options(-Wsuggest-override)
     endif()
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    MESSAGE(STATUS "NEBULA_CLANG_USED_GCC_TOOLCHAIN: ${NEBULA_CLANG_USED_GCC_TOOLCHAIN}")
+    MESSAGE(STATUS "NEBULA_CLANG_USE_GCC_TOOLCHAIN: ${NEBULA_CLANG_USE_GCC_TOOLCHAIN}")
     # Here we need to specify the path of libstdc++ used by Clang
-    if(NOT ${NEBULA_CLANG_USED_GCC_TOOLCHAIN} STREQUAL "")
-        add_compile_options("--gcc-toolchain=${NEBULA_CLANG_USED_GCC_TOOLCHAIN}")
-        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --gcc-toolchain=${NEBULA_CLANG_USED_GCC_TOOLCHAIN}")
+    if(NOT ${NEBULA_CLANG_USE_GCC_TOOLCHAIN} STREQUAL "")
+        execute_process(
+            COMMAND ${NEBULA_CLANG_USE_GCC_TOOLCHAIN}/bin/gcc -dumpmachine
+            OUTPUT_VARIABLE gcc_target_triplet
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+        add_compile_options("--gcc-toolchain=${NEBULA_CLANG_USE_GCC_TOOLCHAIN}")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --gcc-toolchain=${NEBULA_CLANG_USE_GCC_TOOLCHAIN}")
+        if(NOT "${gcc_target_triplet}" STREQUAL "")
+            add_compile_options(--target=${gcc_target_triplet})
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --target=${gcc_target_triplet}")
+        endif()
     endif()
     add_compile_options(-Wno-overloaded-virtual)
     add_compile_options(-Wno-self-assign-overloaded)

--- a/cmake/InstallThirdParty.cmake
+++ b/cmake/InstallThirdParty.cmake
@@ -1,8 +1,15 @@
 set(third_party_install_prefix ${CMAKE_BINARY_DIR}/third-party/install)
 message(STATUS "Downloading prebuilt third party automatically...")
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    if(NOT ${NEBULA_CLANG_USED_GCC_TOOLCHAIN} STREQUAL "")
+        set(cxx_cmd ${NEBULA_CLANG_USED_GCC_TOOLCHAIN}/bin/g++)
+    else()
+        set(cxx_cmd g++)
+    endif()
+endif()
 execute_process(
     COMMAND
-        env CXX=${CMAKE_CXX_COMPILER} ${CMAKE_SOURCE_DIR}/third-party/install-third-party.sh --prefix=${third_party_install_prefix}
+        env CXX=${cxx_cmd} ${CMAKE_SOURCE_DIR}/third-party/install-third-party.sh --prefix=${third_party_install_prefix}
     WORKING_DIRECTORY
         ${CMAKE_BINARY_DIR}
 )


### PR DESCRIPTION
Ordinarily, in Linux, Clang will automatically choose to use GCC's toolchain, such as libstdc++, ld, as, etc.
 
But if the standard GCC is not applicable(e.g. too old), or we just want to use an alternative one, we must tell Clang explicitly with the `--gcc-toolchain` option.

This PR accomplishes this.

Examples to use:
```bash
# If the standard GCC is 7.1.0+
$ cmake -DCMAKE_C_COMPILER=/path/to/clang 
        -DCMAKE_CXX_COMPILER=/path/to/clang++
        ..
# Else
$ cmake -DCMAKE_C_COMPILER=/path/to/clang 
        -DCMAKE_CXX_COMPILER=/path/to/clang++
        -DNEBULA_CLANG_USE_GCC_TOOLCHAIN=/opt/vesoft/toolset/gcc/7.5.0
        ..
```