### PR TITLE
Fixed linking error with gold

### DIFF
--- a/src/webservice/test/CMakeLists.txt
+++ b/src/webservice/test/CMakeLists.txt
@@ -49,6 +49,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:ws_obj>
         $<TARGET_OBJECTS:stats_obj>
         $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:base_obj>
     LIBRARIES


### PR DESCRIPTION
When using _gold_ as the linker, building fails with undefined referenced symbols. As for the the reason underhood, I will dig it later.