### PR TITLE
Invalid leader when LEADER_CHANGED with leader = (0, 0)

### DIFF
--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -388,10 +388,7 @@ void MetaClient::getResponse(Request req,
                 return;
             } else if (resp.code == cpp2::ErrorCode::E_LEADER_CHANGED) {
                 HostAddr leader(resp.get_leader().get_ip(), resp.get_leader().get_port());
-                {
-                    folly::RWSpinLock::WriteHolder holder(hostLock_);
-                    leader_ = leader;
-                }
+                updateLeader(leader);
                 if (retry < retryLimit) {
                     evb->runAfterDelay([req = std::move(req), remoteFunc = std::move(remoteFunc),
                                         respGen = std::move(respGen), pro = std::move(pro),

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -384,9 +384,14 @@ protected:
         active_ = addrs_[folly::Random::rand64(addrs_.size())];
     }
 
-    void updateLeader() {
-        folly::RWSpinLock::WriteHolder holder(hostLock_);
-        leader_ = addrs_[folly::Random::rand64(addrs_.size())];
+    void updateLeader(HostAddr leader = {0, 0}) {
+        if (leader != HostAddr(0, 0)) {
+            folly::RWSpinLock::WriteHolder holder(hostLock_);
+            leader_ = leader;
+        } else {
+            folly::RWSpinLock::WriteHolder holder(hostLock_);
+            leader_ = addrs_[folly::Random::rand64(addrs_.size())];
+        }
     }
 
     void diff(const LocalCache& oldCache, const LocalCache& newCache);

--- a/src/storage/client/StorageClient.inl
+++ b/src/storage/client/StorageClient.inl
@@ -129,6 +129,8 @@ folly::SemiFuture<StorageRpcResponse<Response>> StorageClient::collectResponse(
                                 updateLeader(spaceId,
                                              code.get_part_id(),
                                              HostAddr(leader->get_ip(), leader->get_port()));
+                            } else {
+                                invalidLeader(spaceId, code.get_part_id());
                             }
                         } else if (code.get_code() == storage::cpp2::ErrorCode::E_PART_NOT_FOUND
                                 || code.get_code() == storage::cpp2::ErrorCode::E_SPACE_NOT_FOUND) {
@@ -215,8 +217,11 @@ folly::Future<StatusOr<Response>> StorageClient::getResponse(
                     if (leader != nullptr && leader->get_ip() != 0 && leader->get_port() != 0) {
                         updateLeader(spaceId, code.get_part_id(),
                                      HostAddr(leader->get_ip(), leader->get_port()));
+                    } else {
+                        invalidLeader(spaceId, code.get_part_id());
                     }
-                } else if (code.get_code() == storage::cpp2::ErrorCode::E_PART_NOT_FOUND) {
+                } else if (code.get_code() == storage::cpp2::ErrorCode::E_PART_NOT_FOUND ||
+                           code.get_code() == storage::cpp2::ErrorCode::E_SPACE_NOT_FOUND) {
                     invalidLeader(spaceId, code.get_part_id());
                 }
             }


### PR DESCRIPTION
We should randomly pick a host to send request if LEADER_CHANGED is returned with leader = (0, 0), both in MetaClient and StorageClient.