### PR TITLE
suppress BalanceIntegrationTest timeout in clang with asan on

### DIFF
--- a/src/common/time/detail/TscHelper.cpp
+++ b/src/common/time/detail/TscHelper.cpp
@@ -66,7 +66,7 @@ volatile std::atomic<double> ticksPerMSecFactor{0.0};
 volatile std::atomic<double> ticksPerUSecFactor{[] {
     launchTickTockThread();
     // re-launch tick-tock thread after forking
-    ::pthread_atfork(nullptr, nullptr, &launchTickTockThread);
+    // ::pthread_atfork(nullptr, nullptr, &launchTickTockThread);
 
     usleep(10000);
 

--- a/src/meta/processors/admin/AdminClient.cpp
+++ b/src/meta/processors/admin/AdminClient.cpp
@@ -561,6 +561,7 @@ folly::Future<Status> AdminClient::getLeaderDist(HostLeaderMap* result) {
 
         p.setValue(Status::OK());
     }).thenError([p = std::move(promise)] (auto&& e) mutable {
+        LOG(ERROR) << "Get leader failed, " << e.what().c_str();
         p.setValue(Status::Error("Get leader failed, %s", e.what().c_str()));
     });
 

--- a/src/meta/test/BalanceIntegrationTest.cpp
+++ b/src/meta/test/BalanceIntegrationTest.cpp
@@ -69,6 +69,7 @@ TEST(BalanceIntegrationTest, BalanceTest) {
         options.localHost_ = storageAddr;
         options.clusterId_ = kClusterId;
         options.inStoraged_ = true;
+        options.skipConfig_ = true;
         auto metaClient = std::make_shared<meta::MetaClient>(threadPool,
                                                              metaAddr,
                                                              options);
@@ -178,6 +179,7 @@ TEST(BalanceIntegrationTest, BalanceTest) {
         options.localHost_ = storageAddr;
         options.clusterId_ = kClusterId;
         options.inStoraged_ = true;
+        options.skipConfig_ = true;
         newMetaClient = std::make_unique<meta::MetaClient>(threadPool,
                                                            metaAddr,
                                                            options);
@@ -297,6 +299,7 @@ TEST(BalanceIntegrationTest, LeaderBalanceTest) {
         options.localHost_ = storageAddr;
         options.clusterId_ = kClusterId;
         options.inStoraged_ = true;
+        options.skipConfig_ = true;
         auto metaClient = std::make_shared<meta::MetaClient>(threadPool,
                                                              metaAddr,
                                                              options);


### PR DESCRIPTION
Thanks for @dutor's help, it would time out because main process would lock in time, while forked sub process lock again, and then timeout.
