### PR TITLE
Return default value when prop is not find in old version tag/edge.

### DIFF
--- a/src/dataman/RowReader.h
+++ b/src/dataman/RowReader.h
@@ -91,7 +91,11 @@ public:
     static StatusOr<VariantType> getDefaultProp(const meta::SchemaProviderIf* schema,
                                                 const std::string& prop) {
         auto& vType = schema->getFieldType(prop);
-        switch (vType.type) {
+        return getDefaultProp(vType.type);
+    }
+
+    static StatusOr<VariantType> getDefaultProp(const nebula::cpp2::SupportedType& type) {
+        switch (type) {
             case nebula::cpp2::SupportedType::BOOL: {
                 return false;
             }
@@ -109,7 +113,7 @@ public:
                 return static_cast<std::string>("");
             }
             default:
-                auto msg = folly::sformat("Unknown type: {}", static_cast<int32_t>(vType.type));
+                auto msg = folly::sformat("Unknown type: {}", static_cast<int32_t>(type));
                 LOG(ERROR) << "Unknown type: " << msg;
                 return Status::Error(msg);
         }
@@ -169,7 +173,7 @@ public:
                 return v.toString();
             }
             default:
-                LOG(FATAL) << "Unknown type: " << static_cast<int32_t>(vType.type);
+                LOG(ERROR) << "Unknown type: " << static_cast<int32_t>(vType.type);
                 return ResultType::E_DATA_INVALID;
         }
     }
@@ -229,7 +233,7 @@ public:
                 return v.toString();
             }
             default:
-                LOG(FATAL) << "Unknown type: " << static_cast<int32_t>(vType.get_type());
+                LOG(ERROR) << "Unknown type: " << static_cast<int32_t>(vType.get_type());
                 return ResultType::E_DATA_INVALID;
         }
     }

--- a/src/kvstore/Common.h
+++ b/src/kvstore/Common.h
@@ -26,6 +26,8 @@ enum ResultCode {
     ERR_UNSUPPORTED         = -8,
     ERR_CHECKPOINT_ERROR    = -9,
     ERR_WRITE_BLOCK_ERROR   = -10,
+    ERR_TAG_NOT_FOUND       = -11,
+    ERR_EDGE_NOT_FOUND      = -12,
     ERR_UNKNOWN             = -100,
 };
 

--- a/src/storage/Collector.h
+++ b/src/storage/Collector.h
@@ -39,28 +39,65 @@ public:
                 : writer_(writer) {}
 
     void collectVid(int64_t v, const PropContext& prop) override {
-        UNUSED(prop);
+        switch (prop.type_.type) {
+            case nebula::cpp2::SupportedType::VID:
+                break;
+            default:
+                // Give a default value
+                // TODO: Should give null
+                v = 0;
+        }
         (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::VID) << v;
     }
 
     void collectBool(bool v, const PropContext& prop) override {
-        UNUSED(prop);
+        switch (prop.type_.type) {
+            case nebula::cpp2::SupportedType::BOOL:
+                break;
+            default:
+                // Give a default value
+                // TODO: Should give null
+                v = false;
+        }
         (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::BOOL) << v;
     }
 
     void collectInt64(int64_t v, const PropContext& prop) override {
-        UNUSED(prop);
+        switch (prop.type_.type) {
+            case nebula::cpp2::SupportedType::INT:
+            case nebula::cpp2::SupportedType::TIMESTAMP:
+                break;
+            default:
+                // Give a default value
+                // TODO: Should give null
+                v = 0;
+        }
         (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::INT) << v;
     }
 
     void collectDouble(double v, const PropContext& prop) override {
-        UNUSED(prop);
+        switch (prop.type_.type) {
+            case nebula::cpp2::SupportedType::DOUBLE:
+            case nebula::cpp2::SupportedType::FLOAT:
+                break;
+            default:
+                // Give a default value
+                // TODO: Should give null
+                v = 0;
+        }
         (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::DOUBLE) << v;
     }
 
     void collectString(const std::string& v, const PropContext& prop) override {
-        UNUSED(prop);
-        (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::STRING) << v;
+        switch (prop.type_.type) {
+            case nebula::cpp2::SupportedType::STRING:
+                (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::STRING) << v;
+                break;
+            default:
+                // Give a default value
+                // TODO: Should give null
+                (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::STRING) << "";
+        }
     }
 
     template<typename V>

--- a/src/storage/Collector.h
+++ b/src/storage/Collector.h
@@ -39,65 +39,28 @@ public:
                 : writer_(writer) {}
 
     void collectVid(int64_t v, const PropContext& prop) override {
-        switch (prop.type_.type) {
-            case nebula::cpp2::SupportedType::VID:
-                break;
-            default:
-                // Give a default value
-                // TODO: Should give null
-                v = 0;
-        }
-        (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::VID) << v;
+        (*writer_) << v;
+        VLOG(3) << "collect vid: " << prop.prop_.name << ", value = " << v;
     }
 
     void collectBool(bool v, const PropContext& prop) override {
-        switch (prop.type_.type) {
-            case nebula::cpp2::SupportedType::BOOL:
-                break;
-            default:
-                // Give a default value
-                // TODO: Should give null
-                v = false;
-        }
-        (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::BOOL) << v;
+        (*writer_) << v;
+        VLOG(3) << "collect bool: " << prop.prop_.name << ", value = " << v;
     }
 
     void collectInt64(int64_t v, const PropContext& prop) override {
-        switch (prop.type_.type) {
-            case nebula::cpp2::SupportedType::INT:
-            case nebula::cpp2::SupportedType::TIMESTAMP:
-                break;
-            default:
-                // Give a default value
-                // TODO: Should give null
-                v = 0;
-        }
-        (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::INT) << v;
+        (*writer_) << v;
+        VLOG(3) << "collect int: " << prop.prop_.name << ", value = " << v;
     }
 
     void collectDouble(double v, const PropContext& prop) override {
-        switch (prop.type_.type) {
-            case nebula::cpp2::SupportedType::DOUBLE:
-            case nebula::cpp2::SupportedType::FLOAT:
-                break;
-            default:
-                // Give a default value
-                // TODO: Should give null
-                v = 0;
-        }
-        (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::DOUBLE) << v;
+        (*writer_) << v;
+        VLOG(3) << "collect double: " << prop.prop_.name << ", value = " << v;
     }
 
     void collectString(const std::string& v, const PropContext& prop) override {
-        switch (prop.type_.type) {
-            case nebula::cpp2::SupportedType::STRING:
-                (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::STRING) << v;
-                break;
-            default:
-                // Give a default value
-                // TODO: Should give null
-                (*writer_) << RowWriter::ColType(nebula::cpp2::SupportedType::STRING) << "";
-        }
+        (*writer_) << v;
+        VLOG(3) << "collect string: " << prop.prop_.name << ", value = " << v;
     }
 
     template<typename V>

--- a/src/storage/query/QueryBaseProcessor.h
+++ b/src/storage/query/QueryBaseProcessor.h
@@ -116,12 +116,18 @@ protected:
 
     bool checkExp(const Expression* exp);
 
+    void buildRespSchema();
+
 protected:
     GraphSpaceID  spaceId_;
     std::unique_ptr<ExpressionContext> expCtx_;
     std::unique_ptr<Expression> exp_;
     std::vector<TagContext> tagContexts_;
     std::unordered_map<EdgeType, std::vector<PropContext>> edgeContexts_;
+    std::unordered_map<TagID, nebula::cpp2::Schema> vertexSchemaResp_;
+    std::unordered_map<EdgeType, nebula::cpp2::Schema> edgeSchemaResp_;
+    std::unordered_map<TagID, std::shared_ptr<nebula::meta::SchemaProviderIf>> vertexSchema_;
+    std::unordered_map<EdgeType, std::shared_ptr<nebula::meta::SchemaProviderIf>> edgeSchema_;
     folly::Executor* executor_ = nullptr;
     VertexCache* vertexCache_ = nullptr;
     std::unordered_map<std::string, EdgeType> edgeMap_;

--- a/src/storage/query/QueryBaseProcessor.inl
+++ b/src/storage/query/QueryBaseProcessor.inl
@@ -343,7 +343,7 @@ void QueryBaseProcessor<REQ, RESP>::collectProps(RowReader* reader,
                 auto defaultVal = RowReader::getDefaultProp(prop.type_.type);
                 if (!defaultVal.ok()) {
                     // Should never reach here.
-                    LOG(ERROR) << "Get default value failed for " << name.;
+                    LOG(FATAL) << "Get default value failed for " << name;
                     continue;
                 } else {
                     v = std::move(defaultVal).value();
@@ -351,6 +351,7 @@ void QueryBaseProcessor<REQ, RESP>::collectProps(RowReader* reader,
             } else {
                 v = value(std::move(res));
             }
+
             if (prop.fromTagFilter()) {
                 fcontext->tagFilters_.emplace(std::make_pair(prop.tagOrEdgeName(), name), v);
             }

--- a/src/storage/query/QueryBoundProcessor.cpp
+++ b/src/storage/query/QueryBoundProcessor.cpp
@@ -19,7 +19,12 @@ kvstore::ResultCode QueryBoundProcessor::processEdgeImpl(const PartitionID partI
                                                          const std::vector<PropContext>& props,
                                                          FilterContext& fcontext,
                                                          cpp2::VertexData& vdata) {
-    RowSetWriter rsWriter;
+    auto schema = edgeSchema_.find(edgeType);
+    if (schema == edgeSchema_.end()) {
+        LOG(ERROR) << "Not found the edge type: " << edgeType;
+        return kvstore::ResultCode::ERR_EDGE_NOT_FOUND;
+    }
+    RowSetWriter rsWriter(std::move(schema)->second);
     auto ret = collectEdgeProps(
         partId, vId, edgeType, props, &fcontext,
         [&, this](RowReader* reader, folly::StringPiece k, const std::vector<PropContext>& p) {
@@ -44,14 +49,11 @@ kvstore::ResultCode QueryBoundProcessor::processEdge(PartitionID partId, VertexI
                                                      FilterContext& fcontext,
                                                      cpp2::VertexData& vdata) {
     for (const auto& ec : edgeContexts_) {
-        RowSetWriter rsWriter;
         auto edgeType = ec.first;
         auto& props   = ec.second;
         if (!props.empty()) {
             CHECK(!onlyVertexProps_);
-
             auto ret = processEdgeImpl(partId, vId, edgeType, props, fcontext, vdata);
-
             if (ret != kvstore::ResultCode::SUCCEEDED) {
                 return ret;
             }
@@ -68,7 +70,12 @@ kvstore::ResultCode QueryBoundProcessor::processVertex(PartitionID partId, Verte
     if (!tagContexts_.empty()) {
         std::vector<cpp2::TagData> td;
         for (auto& tc : tagContexts_) {
-            RowWriter writer;
+            auto schema = vertexSchema_.find(tc.tagId_);
+            if (schema == vertexSchema_.end()) {
+                LOG(ERROR) << "Not found the tag: " << tc.tagId_;
+                return kvstore::ResultCode::ERR_TAG_NOT_FOUND;
+            }
+            RowWriter writer(schema->second);
             PropsCollector collector(&writer);
             VLOG(3) << "partId " << partId << ", vId " << vId << ", tagId " << tc.tagId_
                     << ", prop size " << tc.props_.size();
@@ -113,50 +120,13 @@ kvstore::ResultCode QueryBoundProcessor::processVertex(PartitionID partId, Verte
 void QueryBoundProcessor::onProcessFinished(int32_t retNum) {
     (void)retNum;
     resp_.set_vertices(std::move(vertices_));
-    std::unordered_map<TagID, nebula::cpp2::Schema> vertexSchema;
-    if (!this->tagContexts_.empty()) {
-        for (auto& tc : this->tagContexts_) {
-            nebula::cpp2::Schema respTag;
-            for (auto& prop : tc.props_) {
-                if (prop.returned_) {
-                    respTag.columns.emplace_back(
-                        columnDef(std::move(prop.prop_.name), prop.type_.type));
-                }
-            }
 
-            if (!respTag.columns.empty()) {
-                auto it = vertexSchema.find(tc.tagId_);
-                if (it == vertexSchema.end()) {
-                    vertexSchema.emplace(tc.tagId_, respTag);
-                }
-            }
-        }
-        if (!vertexSchema.empty()) {
-            resp_.set_vertex_schema(std::move(vertexSchema));
-        }
+    if (!vertexSchemaResp_.empty()) {
+        resp_.set_vertex_schema(std::move(vertexSchemaResp_));
     }
 
-    std::unordered_map<EdgeType, nebula::cpp2::Schema> edgeSchema;
-    if (!edgeContexts_.empty()) {
-        for (const auto& ec : edgeContexts_) {
-            nebula::cpp2::Schema respEdge;
-            RowSetWriter rsWriter;
-            auto& props = ec.second;
-            for (auto& p : props) {
-                respEdge.columns.emplace_back(columnDef(std::move(p.prop_.name), p.type_.type));
-            }
-
-            if (!respEdge.columns.empty()) {
-                auto it = edgeSchema.find(ec.first);
-                if (it == edgeSchema.end()) {
-                    edgeSchema.emplace(ec.first, std::move(respEdge));
-                }
-            }
-        }
-
-        if (!edgeSchema.empty()) {
-            resp_.set_edge_schema(std::move(edgeSchema));
-        }
+    if (!edgeSchemaResp_.empty()) {
+        resp_.set_edge_schema(std::move(edgeSchemaResp_));
     }
 }
 

--- a/src/storage/query/QueryBoundProcessor.h
+++ b/src/storage/query/QueryBoundProcessor.h
@@ -50,7 +50,6 @@ private:
                                         const EdgeType edgeType,
                                         const std::vector<PropContext>& props,
                                         FilterContext& fcontext, cpp2::VertexData& vdata);
-
 protected:
     // Indicate the request only get vertex props.
     bool onlyVertexProps_ = false;

--- a/src/storage/query/QueryEdgePropsProcessor.cpp
+++ b/src/storage/query/QueryEdgePropsProcessor.cpp
@@ -26,6 +26,7 @@ kvstore::ResultCode QueryEdgePropsProcessor::collectEdgesProps(
     if (ret != kvstore::ResultCode::SUCCEEDED) {
         return ret;
     }
+
     // Only use the latest version.
     if (iter && iter->valid()) {
         RowWriter writer(rsWriter.schema());
@@ -67,17 +68,20 @@ void QueryEdgePropsProcessor::doProcess(const cpp2::EdgePropRequest& req) {
         return;
     }
 
-    int32_t edgeSize = std::accumulate(edgeContexts_.cbegin(), edgeContexts_.cend(), 0,
-                                       [](int ac, auto& ec) { return ac + ec.second.size(); });
-
-    int32_t returnColumnsNum = req.get_return_columns().size() + edgeSize;
-    RowSetWriter rsWriter;
+    auto schema = edgeSchema_.find(req.edge_type);
+    if (schema == edgeSchema_.end()) {
+        LOG(ERROR) << "Not found the edge type: " << req.edge_type;
+        this->onFinished();
+        return;
+    }
+    RowSetWriter rsWriter(std::move(schema)->second);
     std::for_each(req.get_parts().begin(), req.get_parts().end(), [&](auto& partE) {
         auto partId = partE.first;
         kvstore::ResultCode ret = kvstore::ResultCode::SUCCEEDED;
         for (auto& edgeKey : partE.second) {
             for (auto& ec : edgeContexts_) {
-                ret = this->collectEdgesProps(partId, edgeKey, ec.second, rsWriter);
+                ret = this->collectEdgesProps(
+                        partId, edgeKey, ec.second, rsWriter);
                 if (ret != kvstore::ResultCode::SUCCEEDED) {
                     break;
                 }
@@ -95,28 +99,10 @@ void QueryEdgePropsProcessor::doProcess(const cpp2::EdgePropRequest& req) {
     });
     resp_.set_data(std::move(rsWriter.data()));
 
-    std::vector<PropContext> props;
-    props.reserve(returnColumnsNum);
-    for (auto& ec : this->edgeContexts_) {
-        auto p = ec.second;
-        for (auto& prop : p) {
-            props.emplace_back(std::move(prop));
-        }
+    auto schemaResp = edgeSchemaResp_.find(req.edge_type);
+    if (!(schemaResp == edgeSchemaResp_.end())) {
+        resp_.set_schema(std::move(schemaResp)->second);
     }
-
-    std::sort(props.begin(), props.end(), [](auto& l, auto& r){
-        return l.retIndex_ < r.retIndex_;
-    });
-    decltype(resp_.schema) s;
-    decltype(resp_.schema.columns) cols;
-    for (auto& prop : props) {
-        VLOG(3) << prop.prop_.name << "," << static_cast<int32_t>(prop.type_.type);
-        cols.emplace_back(
-                columnDef(std::move(prop.prop_.name),
-                          prop.type_.type));
-    }
-    s.set_columns(std::move(cols));
-    resp_.set_schema(std::move(s));
     this->onFinished();
 }
 

--- a/src/storage/test/AdHocSchemaManager.cpp
+++ b/src/storage/test/AdHocSchemaManager.cpp
@@ -11,11 +11,12 @@ namespace storage {
 
 void AdHocSchemaManager::addTagSchema(GraphSpaceID space,
                                       TagID tag,
-                                      std::shared_ptr<nebula::meta::SchemaProviderIf> schema) {
+                                      std::shared_ptr<nebula::meta::SchemaProviderIf> schema,
+                                      SchemaVer version) {
     {
         folly::RWSpinLock::WriteHolder wh(tagLock_);
         // Only version 0
-        tagSchemas_[std::make_pair(space, tag)][0] = schema;
+        tagSchemas_[std::make_pair(space, tag)][version] = schema;
         auto key = folly::stringPrintf("%d_%d", space, tag);
         tagNameToId_[key] = tag;
     }
@@ -27,11 +28,12 @@ void AdHocSchemaManager::addTagSchema(GraphSpaceID space,
 
 void AdHocSchemaManager::addEdgeSchema(GraphSpaceID space,
                                        EdgeType edge,
-                                       std::shared_ptr<nebula::meta::SchemaProviderIf> schema) {
+                                       std::shared_ptr<nebula::meta::SchemaProviderIf> schema,
+                                       SchemaVer version) {
     {
         folly::RWSpinLock::WriteHolder wh(edgeLock_);
         // Only version 0
-        edgeSchemas_[std::make_pair(space, edge)][0] = schema;
+        edgeSchemas_[std::make_pair(space, edge)][version] = schema;
     }
     {
         folly::RWSpinLock::WriteHolder wh(spaceLock_);

--- a/src/storage/test/AdHocSchemaManager.h
+++ b/src/storage/test/AdHocSchemaManager.h
@@ -23,11 +23,13 @@ public:
 
     void addTagSchema(GraphSpaceID space,
                       TagID tag,
-                      std::shared_ptr<nebula::meta::SchemaProviderIf> schema);
+                      std::shared_ptr<nebula::meta::SchemaProviderIf> schema,
+                      SchemaVer version = 0);
 
     void addEdgeSchema(GraphSpaceID space,
                        EdgeType edge,
-                       std::shared_ptr<nebula::meta::SchemaProviderIf> schema);
+                       std::shared_ptr<nebula::meta::SchemaProviderIf> schema,
+                       SchemaVer version = 0);
 
     void removeTagSchema(GraphSpaceID space, TagID tag);
 
@@ -54,6 +56,7 @@ public:
 
     StatusOr<std::string> toTagName(GraphSpaceID, TagID) override {
         LOG(FATAL) << "Unimplemented";
+        return Status::Error("Unimplemented");
     }
 
     StatusOr<EdgeType> toEdgeType(GraphSpaceID space, folly::StringPiece typeName) override;
@@ -72,6 +75,7 @@ public:
 
     StatusOr<std::vector<std::string>> getAllEdge(GraphSpaceID) override {
         LOG(FATAL) << "Unimplemented";
+        return Status::Error("Unimplemented");
     }
 
     void init(nebula::meta::MetaClient *) override {

--- a/src/storage/test/QueryEdgePropsTest.cpp
+++ b/src/storage/test/QueryEdgePropsTest.cpp
@@ -17,15 +17,21 @@
 namespace nebula {
 namespace storage {
 
-void mockData(kvstore::KVStore* kv) {
+void mockData(kvstore::KVStore* kv,
+              meta::SchemaManager* schemaMng,
+              EdgeVersion version) {
+    auto edgeType = 101;
+    auto spaceId = 0;
+    auto schema = schemaMng->getEdgeSchema(spaceId, edgeType);
     for (auto partId = 0; partId < 3; partId++) {
         std::vector<kvstore::KV> data;
         for (auto vertexId = partId * 10; vertexId < (partId + 1) * 10; vertexId++) {
             // Generate 7 edges for each source vertex id
             for (auto dstId = 10001; dstId <= 10007; dstId++) {
                 VLOG(3) << "Write part " << partId << ", vertex " << vertexId << ", dst " << dstId;
-                auto key = NebulaKeyUtils::edgeKey(partId, vertexId, 101, dstId - 10001, dstId, 0);
-                RowWriter writer(nullptr);
+                auto key = NebulaKeyUtils::edgeKey(
+                        partId, vertexId, edgeType, dstId - 10001, dstId, version);
+                RowWriter writer(schema);
                 for (int64_t numInt = 0; numInt < 10; numInt++) {
                     writer << numInt;
                 }
@@ -69,17 +75,16 @@ void buildRequest(cpp2::EdgePropRequest& req) {
     req.set_return_columns(std::move(tmpColumns));
 }
 
-
-void checkResponse(cpp2::EdgePropResponse& resp) {
+void checkResponse(cpp2::EdgePropResponse& resp, uint32_t expectedColSize) {
     EXPECT_EQ(0, resp.result.failed_codes.size());
-    EXPECT_EQ(14, resp.schema.columns.size());
+    EXPECT_EQ(expectedColSize, resp.schema.columns.size());
     auto provider = std::make_shared<ResultSchemaProvider>(resp.schema);
     LOG(INFO) << "Check edge props...";
     RowSetReader rsReader(provider, resp.data);
     auto it = rsReader.begin();
     int32_t rowNum = 0;
     while (static_cast<bool>(it)) {
-        EXPECT_EQ(14, it->numFields());
+        EXPECT_EQ(expectedColSize, it->numFields());
        {
             // _src
             // We can't ensure the order, so just check the srcId range.
@@ -118,11 +123,53 @@ void checkResponse(cpp2::EdgePropResponse& resp) {
             EXPECT_EQ(ResultType::SUCCEEDED, it->getString(i, v));
             CHECK_EQ(folly::stringPrintf("string_col_%d", (i - 9 + 5) * 2), v);
         }
+
         ++it;
         rowNum++;
     }
     EXPECT_EQ(it, rsReader.end());
     EXPECT_EQ(210, rowNum);
+}
+
+void checkAlteredProp(cpp2::EdgePropResponse& resp,
+                      const std::string& prop,
+                      const VariantType& val) {
+    LOG(INFO) << "Check: " << prop;
+    auto provider = std::make_shared<ResultSchemaProvider>(resp.schema);
+    RowSetReader rsReader(provider, resp.data);
+    auto it = rsReader.begin();
+    while (it) {
+        switch (val.which()) {
+            case VAR_INT64: {
+                int64_t v;
+                EXPECT_EQ(ResultType::SUCCEEDED, it->getInt(prop, v));
+                EXPECT_EQ(boost::get<int64_t>(val), v);
+                break;
+            }
+            case VAR_DOUBLE: {
+                double v;
+                EXPECT_EQ(ResultType::SUCCEEDED, it->getDouble(prop, v));
+                EXPECT_EQ(boost::get<double>(val), v);
+                break;
+            }
+           case VAR_BOOL: {
+                bool v;
+                EXPECT_EQ(ResultType::SUCCEEDED, it->getBool(prop, v));
+                EXPECT_EQ(boost::get<bool>(val), v);
+                break;
+           }
+           case VAR_STR: {
+                folly::StringPiece v;
+                EXPECT_EQ(ResultType::SUCCEEDED, it->getString(prop, v));
+                EXPECT_EQ(boost::get<std::string>(val), v);
+                break;
+           }
+           default:
+                LOG(FATAL) << "No such type: " << val.which();
+                break;
+        }
+        ++it;
+    }
 }
 
 
@@ -131,21 +178,168 @@ TEST(QueryEdgePropsTest, SimpleTest) {
     std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path());
 
     LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
+    auto schemaMng = TestUtils::mockSchemaMan();
     LOG(INFO) << "Prepare data...";
-    mockData(kv.get());
+    mockData(kv.get(), schemaMng.get(), 0);
     LOG(INFO) << "Build EdgePropRequest...";
     cpp2::EdgePropRequest req;
     buildRequest(req);
 
     LOG(INFO) << "Test QueryEdgePropsRequest...";
-    auto* processor = QueryEdgePropsProcessor::instance(kv.get(), schemaMan.get(), nullptr);
+    auto* processor = QueryEdgePropsProcessor::instance(kv.get(), schemaMng.get(), nullptr);
     auto f = processor->getFuture();
     processor->process(req);
     auto resp = std::move(f).get();
 
     LOG(INFO) << "Check the results...";
-    checkResponse(resp);
+    checkResponse(resp, 14);
+}
+
+
+TEST(QueryEdgePropsTest, QueryAfterEdgeAltered) {
+    fs::TempDir rootPath("/tmp/QueryEdgePropsTest.XXXXXX");
+    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path());
+
+    LOG(INFO) << "Prepare meta...";
+    auto schemaMng = TestUtils::mockSchemaMan();
+    LOG(INFO) << "Prepare data...";
+    auto spaceId = 0;
+    EdgeVersion version = std::numeric_limits<int64_t>::max() - 0;
+    mockData(kv.get(), schemaMng.get(), version);
+
+    {
+        LOG(INFO) << "Alter the edge schema with adding a prop.";
+        auto schemaVer = 1;
+        for (auto edgeType = 101; edgeType < 110; edgeType++) {
+                auto schema = schemaMng->getEdgeSchema(0, edgeType);
+                auto iter = schema->begin();
+                auto schemaWriter = std::make_shared<SchemaWriter>(schemaVer);
+                while (iter) {
+                    auto* name = iter->getName();
+                    auto type = iter->getType();
+                    schemaWriter->appendCol(name, std::move(type));
+                    ++iter;
+                }
+                nebula::cpp2::ValueType type;
+                type.type = nebula::cpp2::SupportedType::STRING;
+                schemaWriter->appendCol("AddedProp", std::move(type));
+                schemaMng->addEdgeSchema(spaceId, edgeType, schemaWriter, schemaVer);
+        }
+
+        LOG(INFO) << "Build EdgePropRequest...";
+        cpp2::EdgePropRequest req;
+        buildRequest(req);
+        req.return_columns.emplace_back(TestUtils::edgePropDef("AddedProp", 101));
+
+        LOG(INFO) << "Test QueryEdgePropsRequest...";
+        auto* processor = QueryEdgePropsProcessor::instance(kv.get(), schemaMng.get(), nullptr);
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+
+        LOG(INFO) << "Check the results...";
+        checkResponse(resp, 15);
+
+        std::string prop = "AddedProp";
+        std::string val = "";
+        checkAlteredProp(resp, prop, val);
+    }
+
+    version = std::numeric_limits<int64_t>::max() - 1;
+    {
+        LOG(INFO) << "Now update data with new edge prop";
+        auto edgeType = 101;
+        for (auto partId = 0; partId < 3; partId++) {
+            std::vector<kvstore::KV> data;
+            for (auto vertexId = partId * 10; vertexId < (partId + 1) * 10; vertexId++) {
+                // Generate 7 edges for each source vertex id
+                for (auto dstId = 10001; dstId <= 10007; dstId++) {
+                    VLOG(3) << "Write part " << partId << ", vertex "
+                            << vertexId << ", dst " << dstId;
+                    auto key = NebulaKeyUtils::edgeKey(
+                            partId, vertexId, edgeType, dstId - 10001, dstId, version);
+                    auto schema = schemaMng->getEdgeSchema(spaceId, edgeType);
+                    RowWriter writer(schema);
+                    for (int64_t numInt = 0; numInt < 10; numInt++) {
+                        writer << numInt;
+                    }
+                    for (auto numString = 10; numString < 20; numString++) {
+                        writer << folly::stringPrintf("string_col_%d", numString);
+                    }
+                    writer << "AddedPropValue";
+                    auto val = writer.encode();
+                    data.emplace_back(std::move(key), std::move(val));
+                }
+            }
+            folly::Baton<true, std::atomic> baton;
+            kv->asyncMultiPut(
+                0, partId, std::move(data),
+                [&](kvstore::ResultCode code) {
+                    EXPECT_EQ(code, kvstore::ResultCode::SUCCEEDED);
+                    baton.post();
+                });
+            baton.wait();
+        }
+
+        LOG(INFO) << "Build EdgePropRequest...";
+        cpp2::EdgePropRequest req;
+        buildRequest(req);
+        req.return_columns.emplace_back(TestUtils::edgePropDef("AddedProp", 101));
+
+        LOG(INFO) << "Test QueryEdgePropsRequest...";
+        auto* processor = QueryEdgePropsProcessor::instance(kv.get(), schemaMng.get(), nullptr);
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+
+        LOG(INFO) << "Check the results...";
+        checkResponse(resp, 15);
+
+        std::string prop = "AddedProp";
+        std::string val = "AddedPropValue";
+        checkAlteredProp(resp, prop, val);
+    }
+    {
+        LOG(INFO) << "Alter the edge schema with altering the prop type.";
+        auto schemaVer = 2;
+        for (auto edgeType = 101; edgeType < 110; edgeType++) {
+                auto schema = schemaMng->getEdgeSchema(0, edgeType, 0);
+                auto iter = schema->begin();
+                auto schemaWriter = std::make_shared<SchemaWriter>(schemaVer);
+                while (iter) {
+                    auto* name = iter->getName();
+                    auto type = iter->getType();
+                    schemaWriter->appendCol(name, std::move(type));
+                    ++iter;
+                }
+                nebula::cpp2::ValueType type;
+                type.type = nebula::cpp2::SupportedType::INT;
+                schemaWriter->appendCol("AddedProp", std::move(type));
+                schemaMng->addEdgeSchema(spaceId, edgeType, schemaWriter, schemaVer);
+        }
+
+        LOG(INFO) << "Build EdgePropRequest...";
+        cpp2::EdgePropRequest req;
+        buildRequest(req);
+        req.return_columns.emplace_back(TestUtils::edgePropDef("AddedProp", 101));
+
+        LOG(INFO) << "Test QueryEdgePropsRequest...";
+        auto* processor = QueryEdgePropsProcessor::instance(kv.get(), schemaMng.get(), nullptr);
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+
+        LOG(INFO) << "Check the results...";
+        EXPECT_EQ(0, resp.result.failed_codes.size());
+        EXPECT_EQ(15, resp.schema.columns.size());
+        auto provider = std::make_shared<ResultSchemaProvider>(resp.schema);
+        LOG(INFO) << "Check edge props...";
+        checkResponse(resp, 15);
+
+        std::string prop = "AddedProp";
+        int64_t val = 0;
+        checkAlteredProp(resp, prop, val);
+    }
 }
 
 }  // namespace storage

--- a/src/storage/test/QueryVertexPropsTest.cpp
+++ b/src/storage/test/QueryVertexPropsTest.cpp
@@ -272,7 +272,7 @@ TEST(QueryVertexPropsTest, QueryAfterTagAltered) {
         }
     }
 
-    version = std::numeric_limits<int64_t>::max() - 1;
+    version = std::numeric_limits<int64_t>::max() - 100;
     {
         LOG(INFO) << "Now update the data with new tag prop.";
         for (auto partId = 0; partId < 3; partId++) {
@@ -439,7 +439,6 @@ TEST(QueryVertexPropsTest, QueryAfterTagAltered) {
         }
     }
 }
-
 }  // namespace storage
 }  // namespace nebula
 

--- a/src/storage/test/QueryVertexPropsTest.cpp
+++ b/src/storage/test/QueryVertexPropsTest.cpp
@@ -17,14 +17,17 @@
 namespace nebula {
 namespace storage {
 
-void mockData(kvstore::KVStore* kv, TagVersion version) {
+void mockData(kvstore::KVStore* kv,
+              meta::SchemaManager* schemaMng,
+              TagVersion version) {
     LOG(INFO) << "Prepare data...";
     for (auto partId = 0; partId < 3; partId++) {
         std::vector<kvstore::KV> data;
         for (auto vertexId = partId * 10; vertexId < (partId + 1) * 10; vertexId++) {
             for (auto tagId = 3001; tagId < 3010; tagId++) {
                 auto key = NebulaKeyUtils::vertexKey(partId, vertexId, tagId, version);
-                RowWriter writer;
+                auto schema = schemaMng->getTagSchema(0, tagId);
+                RowWriter writer(schema);
                 for (int64_t numInt = 0; numInt < 3; numInt++) {
                     writer << (numInt + version);
                 }
@@ -166,17 +169,277 @@ TEST(QueryVertexPropsTest, SimpleTest) {
     std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path());
 
     LOG(INFO) << "Prepare meta...";
-    auto schemaMan = TestUtils::mockSchemaMan();
+    auto schemaMng = TestUtils::mockSchemaMan();
 
     auto executor = std::make_unique<folly::CPUThreadPoolExecutor>(3);
     TagVersion version = 1;
-    mockData(kv.get(), version);
-    testWithVersion(kv.get(), schemaMan.get(), executor.get(), version);
+    mockData(kv.get(), schemaMng.get(), version);
+    testWithVersion(kv.get(), schemaMng.get(), executor.get(), version);
 
     version = 0;
-    mockData(kv.get(), version);
-    testWithVersion(kv.get(), schemaMan.get(), executor.get(), version);
+    mockData(kv.get(), schemaMng.get(), version);
+    testWithVersion(kv.get(), schemaMng.get(), executor.get(), version);
 }
+
+TEST(QueryVertexPropsTest, QueryAfterTagAltered) {
+    fs::TempDir rootPath("/tmp/QueryVertexPropsTest.XXXXXX");
+    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path());
+    auto executor = std::make_unique<folly::CPUThreadPoolExecutor>(3);
+
+    LOG(INFO) << "Prepare meta...";
+    auto schemaMng = TestUtils::mockSchemaMan();
+
+    auto spaceId = 0;
+    TagVersion version = std::numeric_limits<int64_t>::max() - 0;
+
+    {
+        LOG(INFO) << "Prepare data...";
+        mockData(kv.get(), schemaMng.get(), version);
+
+        LOG(INFO) << "Alter the tag schema with adding a prop.";
+        auto schemaVer = 1;
+        for (auto tagId = 3001; tagId < 3010; tagId++) {
+            auto schema = schemaMng->getTagSchema(spaceId, tagId);
+            auto iter = schema->begin();
+            auto schemaWriter = std::make_shared<SchemaWriter>(schemaVer);
+            while (iter) {
+                auto* name = iter->getName();
+                auto type = iter->getType();
+                schemaWriter->appendCol(name, std::move(type));
+                ++iter;
+            }
+            nebula::cpp2::ValueType type;
+            type.type = nebula::cpp2::SupportedType::STRING;
+            schemaWriter->appendCol("AddedProp", std::move(type));
+            schemaMng->addTagSchema(spaceId, tagId, schemaWriter, schemaVer);
+        }
+
+        LOG(INFO) << "Build VertexPropsRequest...";
+        cpp2::VertexPropRequest req;
+        req.set_space_id(spaceId);
+        decltype(req.parts) tmpIds;
+        for (auto partId = 0; partId < 3; partId++) {
+            for (auto vertexId =  partId * 10;
+                vertexId < (partId + 1) * 10;
+                vertexId++) {
+                tmpIds[partId].emplace_back(vertexId);
+            }
+        }
+        req.set_parts(std::move(tmpIds));
+        // Return tag props col_0, col_2, col_4
+        decltype(req.return_columns) tmpColumns;
+        for (int i = 0; i < 3; i++) {
+            tmpColumns.emplace_back(TestUtils::vertexPropDef(
+                folly::stringPrintf("tag_%d_col_%d", 3001 + i * 2, i * 2), 3001 + i * 2));
+            tmpColumns.emplace_back(TestUtils::vertexPropDef("AddedProp", 3001 + i * 2));
+        }
+        req.set_return_columns(std::move(tmpColumns));
+
+        LOG(INFO) << "Test QueryVertexPropsRequest...";
+        auto* processor = QueryVertexPropsProcessor::instance(kv.get(),
+                                                            schemaMng.get(),
+                                                            nullptr,
+                                                            executor.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+
+        LOG(INFO) << "Check the results...";
+        EXPECT_EQ(0, resp.result.failed_codes.size());
+
+        EXPECT_EQ(30, resp.vertices.size());
+
+        auto* vschema = resp.get_vertex_schema();
+        DCHECK(vschema != nullptr);
+
+        for (auto& vp : resp.vertices) {
+            auto size = std::accumulate(vp.tag_data.cbegin(), vp.tag_data.cend(), 0,
+                                        [vschema](int acc, auto& td) {
+                                            auto it = vschema->find(td.tag_id);
+                                            DCHECK(it != vschema->end());
+                                            return acc + it->second.columns.size();
+                                        });
+
+            EXPECT_EQ(6, size);
+
+            checkTagData<int64_t>(vp.tag_data, 3001, "tag_3001_col_0", vschema, 0 + version);
+            checkTagData<std::string>(vp.tag_data, 3001, "AddedProp", vschema, "");
+            checkTagData<int64_t>(vp.tag_data, 3003, "tag_3003_col_2", vschema, 2 + version);
+            checkTagData<std::string>(vp.tag_data, 3003, "AddedProp", vschema, "");
+            checkTagData<std::string>(vp.tag_data, 3005, "tag_3005_col_4", vschema,
+                                    folly::stringPrintf("tag_string_col_%ld", 4 + version));
+            checkTagData<std::string>(vp.tag_data, 3005, "AddedProp", vschema, "");
+        }
+    }
+
+    version = std::numeric_limits<int64_t>::max() - 1;
+    {
+        LOG(INFO) << "Now update the data with new tag prop.";
+        for (auto partId = 0; partId < 3; partId++) {
+            std::vector<kvstore::KV> data;
+            for (auto vertexId = partId * 10; vertexId < (partId + 1) * 10; vertexId++) {
+                for (auto tagId = 3001; tagId < 3010; tagId++) {
+                    auto key = NebulaKeyUtils::vertexKey(partId, vertexId, tagId, version);
+                    auto schema = schemaMng->getTagSchema(spaceId, tagId);
+                    RowWriter writer(schema);
+                    for (int64_t numInt = 0; numInt < 3; numInt++) {
+                        writer << (numInt + version);
+                    }
+                    for (auto numString = 3; numString < 6; numString++) {
+                        writer << folly::stringPrintf("tag_string_col_%ld", numString + version);
+                    }
+                    writer << "AddedPropValue";
+                    auto val = writer.encode();
+                    data.emplace_back(std::move(key), std::move(val));
+                }
+            }
+            folly::Baton<true, std::atomic> baton;
+            kv->asyncMultiPut(
+                0,
+                partId,
+                std::move(data),
+                [&](kvstore::ResultCode code) {
+                    EXPECT_EQ(code, kvstore::ResultCode::SUCCEEDED);
+                    baton.post();
+                });
+            baton.wait();
+        }
+
+        LOG(INFO) << "Build VertexPropsRequest...";
+        cpp2::VertexPropRequest req;
+        req.set_space_id(0);
+        decltype(req.parts) tmpIds;
+        for (auto partId = 0; partId < 3; partId++) {
+            for (auto vertexId =  partId * 10;
+                vertexId < (partId + 1) * 10;
+                vertexId++) {
+                tmpIds[partId].emplace_back(vertexId);
+            }
+        }
+        req.set_parts(std::move(tmpIds));
+        // Return tag props col_0, col_2, col_4
+        decltype(req.return_columns) tmpColumns;
+        for (int i = 0; i < 3; i++) {
+            tmpColumns.emplace_back(TestUtils::vertexPropDef(
+                folly::stringPrintf("tag_%d_col_%d", 3001 + i * 2, i * 2), 3001 + i * 2));
+            tmpColumns.emplace_back(TestUtils::vertexPropDef("AddedProp", 3001 + i * 2));
+        }
+        req.set_return_columns(std::move(tmpColumns));
+
+        LOG(INFO) << "Test QueryVertexPropsRequest...";
+        auto* processor = QueryVertexPropsProcessor::instance(kv.get(),
+                                                            schemaMng.get(),
+                                                            nullptr,
+                                                            executor.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+
+        LOG(INFO) << "Check the results...";
+        EXPECT_EQ(0, resp.result.failed_codes.size());
+
+        EXPECT_EQ(30, resp.vertices.size());
+
+        auto* vschema = resp.get_vertex_schema();
+        DCHECK(vschema != nullptr);
+
+        for (auto& vp : resp.vertices) {
+            auto size = std::accumulate(vp.tag_data.cbegin(), vp.tag_data.cend(), 0,
+                                        [vschema](int acc, auto& td) {
+                                            auto it = vschema->find(td.tag_id);
+                                            DCHECK(it != vschema->end());
+                                            return acc + it->second.columns.size();
+                                        });
+
+            EXPECT_EQ(6, size);
+
+            checkTagData<int64_t>(vp.tag_data, 3001, "tag_3001_col_0", vschema, 0 + version);
+            checkTagData<std::string>(vp.tag_data, 3001, "AddedProp", vschema, "AddedPropValue");
+            checkTagData<int64_t>(vp.tag_data, 3003, "tag_3003_col_2", vschema, 2 + version);
+            checkTagData<std::string>(vp.tag_data, 3003, "AddedProp", vschema, "AddedPropValue");
+            checkTagData<std::string>(vp.tag_data, 3005, "tag_3005_col_4", vschema,
+                                    folly::stringPrintf("tag_string_col_%ld", 4 + version));
+            checkTagData<std::string>(vp.tag_data, 3005, "AddedProp", vschema, "AddedPropValue");
+        }
+    }
+    {
+        LOG(INFO) << "Alter the tag schema with altering the prop type.";
+        auto schemaVer = 2;
+        for (auto tagId = 3001; tagId < 3010; tagId++) {
+            auto schema = schemaMng->getTagSchema(spaceId, tagId, 0);
+            auto iter = schema->begin();
+            auto schemaWriter = std::make_shared<SchemaWriter>(schemaVer);
+            while (iter) {
+                auto* name = iter->getName();
+                auto type = iter->getType();
+                schemaWriter->appendCol(name, std::move(type));
+                ++iter;
+            }
+            nebula::cpp2::ValueType type;
+            type.type = nebula::cpp2::SupportedType::INT;
+            schemaWriter->appendCol("AddedProp", std::move(type));
+            schemaMng->addTagSchema(spaceId, tagId, schemaWriter, schemaVer);
+        }
+
+        LOG(INFO) << "Build VertexPropsRequest...";
+        cpp2::VertexPropRequest req;
+        req.set_space_id(spaceId);
+        decltype(req.parts) tmpIds;
+        for (auto partId = 0; partId < 3; partId++) {
+            for (auto vertexId =  partId * 10;
+                vertexId < (partId + 1) * 10;
+                vertexId++) {
+                tmpIds[partId].emplace_back(vertexId);
+            }
+        }
+        req.set_parts(std::move(tmpIds));
+        // Return tag props col_0, col_2, col_4
+        decltype(req.return_columns) tmpColumns;
+        for (int i = 0; i < 3; i++) {
+            tmpColumns.emplace_back(TestUtils::vertexPropDef(
+                folly::stringPrintf("tag_%d_col_%d", 3001 + i * 2, i * 2), 3001 + i * 2));
+            tmpColumns.emplace_back(TestUtils::vertexPropDef("AddedProp", 3001 + i * 2));
+        }
+        req.set_return_columns(std::move(tmpColumns));
+
+        LOG(INFO) << "Test QueryVertexPropsRequest...";
+        auto* processor = QueryVertexPropsProcessor::instance(kv.get(),
+                                                            schemaMng.get(),
+                                                            nullptr,
+                                                            executor.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+
+        LOG(INFO) << "Check the results...";
+        EXPECT_EQ(0, resp.result.failed_codes.size());
+
+        EXPECT_EQ(30, resp.vertices.size());
+
+        auto* vschema = resp.get_vertex_schema();
+        DCHECK(vschema != nullptr);
+
+        for (auto& vp : resp.vertices) {
+            auto size = std::accumulate(vp.tag_data.cbegin(), vp.tag_data.cend(), 0,
+                                        [vschema](int acc, auto& td) {
+                                            auto it = vschema->find(td.tag_id);
+                                            DCHECK(it != vschema->end());
+                                            return acc + it->second.columns.size();
+                                        });
+
+            EXPECT_EQ(6, size);
+
+            checkTagData<int64_t>(vp.tag_data, 3001, "tag_3001_col_0", vschema, 0 + version);
+            checkTagData<int64_t>(vp.tag_data, 3001, "AddedProp", vschema, 0);
+            checkTagData<int64_t>(vp.tag_data, 3003, "tag_3003_col_2", vschema, 2 + version);
+            checkTagData<int64_t>(vp.tag_data, 3003, "AddedProp", vschema, 0);
+            checkTagData<std::string>(vp.tag_data, 3005, "tag_3005_col_4", vschema,
+                                    folly::stringPrintf("tag_string_col_%ld", 4 + version));
+            checkTagData<int64_t>(vp.tag_data, 3005, "AddedProp", vschema, 0);
+        }
+    }
+}
+
 }  // namespace storage
 }  // namespace nebula
 

--- a/src/storage/test/TestUtils.h
+++ b/src/storage/test/TestUtils.h
@@ -77,8 +77,8 @@ public:
         return store;
     }
 
-    static std::unique_ptr<meta::SchemaManager> mockSchemaMan(GraphSpaceID spaceId = 0) {
-        auto* schemaMan = new AdHocSchemaManager();
+    static std::unique_ptr<AdHocSchemaManager> mockSchemaMan(GraphSpaceID spaceId = 0) {
+        auto schemaMan = std::make_unique<AdHocSchemaManager>();
         for (auto edgeType = 101; edgeType < 110; edgeType++) {
             schemaMan->addEdgeSchema(spaceId /*space id*/, edgeType /*edge type*/,
                                      TestUtils::genEdgeSchemaProvider(10, 10));
@@ -87,8 +87,7 @@ public:
             schemaMan->addTagSchema(
                 spaceId /*space id*/, tagId, TestUtils::genTagSchemaProvider(tagId, 3, 3));
         }
-        std::unique_ptr<meta::SchemaManager> sm(schemaMan);
-        return sm;
+        return schemaMan;
     }
 
     static std::vector<cpp2::Vertex> setupVertices(


### PR DESCRIPTION
close #1185 , close #1154

For now, the storage would be crashed when we want a new property from the latest version tag/edge. The reason is that the data was stored with old tag/edge version, while the storage can't figure out what value type the property is.
