### PR TITLE
[WIP] Specify unique name for Nebula storaged

### DIFF
--- a/src/daemons/StorageDaemon.cpp
+++ b/src/daemons/StorageDaemon.cpp
@@ -15,6 +15,7 @@ DEFINE_string(data_path, "", "Root data path, multi paths should be split by com
                              "For rocksdb engine, one path one instance.");
 DEFINE_string(local_ip, "", "IP address which is used to identify this server, "
                             "combined with the listen port");
+DEFINE_string(hostname, "", "Specify this instance Name");
 DEFINE_bool(daemonize, true, "Whether to run the process as a daemon");
 DEFINE_string(pid_file, "pids/nebula-storaged.pid", "File to hold the process id");
 DEFINE_string(meta_server_addrs, "", "list of meta server addresses,"
@@ -67,6 +68,13 @@ int main(int argc, char *argv[]) {
     if (FLAGS_data_path.empty()) {
         LOG(ERROR) << "Storage Data Path should not empty";
         return EXIT_FAILURE;
+    }
+    
+    auto hostname = FLAGS_hostname; 
+    if( hostname == "" ) {
+        hostname = FLAGS_local_ip + ":" + FLAGS_port; 
+    } else {
+        hostname = hostname + ":" + FLAGS_port; 
     }
 
     auto result = nebula::network::NetworkUtils::getLocalIP(FLAGS_local_ip);

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -403,8 +403,9 @@ struct HBResp {
 struct HBReq {
     1: bool in_storaged,
     2: common.HostAddr host,
-    3: common.ClusterID cluster_id,
-    4: optional map<common.GraphSpaceID, list<common.PartitionID>> (cpp.template = "std::unordered_map") leader_partIds;
+    3: string hostname,
+    4: common.ClusterID cluster_id,
+    5: optional map<common.GraphSpaceID, list<common.PartitionID>> (cpp.template = "std::unordered_map") leader_partIds;
 }
 
 struct CreateTagIndexReq {

--- a/src/meta/ActiveHostsMan.h
+++ b/src/meta/ActiveHostsMan.h
@@ -53,6 +53,13 @@ public:
                                               const HostInfo& info,
                                               const LeaderParts* leaderParts = nullptr);
 
+    static kvstore::ResultCode updateHostName(kvstore::KVStore* kv,
+                                              const HostAddr& hostAddr,
+                                              const std::string& hostname);
+    
+    static std::string getHostName(kvstore::KVStore* kv,
+                                   const HostAddr& hostAddr);
+                                   
     static std::vector<HostAddr> getActiveHosts(kvstore::KVStore* kv, int32_t expiredTTL = 0);
 
     static bool isLived(kvstore::KVStore* kv, const HostAddr& host);

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -26,6 +26,7 @@ const std::string kDefaultTable        = "__default__";        // NOLINT
 const std::string kSnapshotsTable      = "__snapshots__";      // NOLINT
 const std::string kLastUpdateTimeTable = "__last_update_time__"; // NOLINT
 const std::string kLeadersTable = "__leaders__"; // NOLINT
+const std::string kHostNameTable = "__hostname__"; //NOLINT
 
 const std::string kHostOnline  = "Online";       // NOLINT
 const std::string kHostOffline = "Offline";      // NOLINT
@@ -157,6 +158,21 @@ nebula::cpp2::HostAddr MetaServiceUtils::parseHostKey(folly::StringPiece key) {
     return host;
 }
 
+std::string MetaServiceUtils::hostnameKey(IPv4 ip, Port port) {
+    std::string key;
+    key.reserve(128);
+    key.append(kHostNameTable.data(), kHostNameTable.size());
+    key.append(reinterpret_cast<const char*>(&ip), sizeof(ip))
+    key.append(reinterpret_cast<const char*>(&port), sizeof(port));
+    return key;
+}
+
+nebula::cpp2::HostAddr MetaServiceUtils::parseHostNameKey(folly::StringPiece key) {
+    nebula::cpp2::HostAddr host;
+    memcpy(&host, key.data() + kHostsTable.size(), sizeof(host));
+    return host;
+}
+
 std::string MetaServiceUtils::leaderKey(IPv4 ip, Port port) {
     std::string key;
     key.reserve(128);
@@ -183,6 +199,10 @@ std::string MetaServiceUtils::leaderVal(const LeaderParts& leaderParts) {
 
 const std::string& MetaServiceUtils::leaderPrefix() {
     return kLeadersTable;
+}
+
+const std::string& hostnamePrefix() {
+    return kHostNameTable; 
 }
 
 nebula::cpp2::HostAddr MetaServiceUtils::parseLeaderKey(folly::StringPiece key) {

--- a/src/meta/MetaServiceUtils.h
+++ b/src/meta/MetaServiceUtils.h
@@ -63,6 +63,8 @@ public:
 
     static std::string hostKey(IPv4 ip, Port port);
 
+    static std::string hostnameKey(IPv4 ip, Port port);
+
     static std::string hostValOnline();
 
     static std::string hostValOffline();
@@ -76,6 +78,8 @@ public:
     static std::string leaderVal(const LeaderParts& leaderParts);
 
     static const std::string& leaderPrefix();
+
+    static const std::string& hostnamePrefix();
 
     static nebula::cpp2::HostAddr parseLeaderKey(folly::StringPiece key);
 

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -1399,6 +1399,7 @@ folly::Future<StatusOr<bool>> MetaClient::heartbeat() {
         if (options_.clusterId_.load() == 0) {
             options_.clusterId_ = ClusterIdMan::getClusterIdFromFile(FLAGS_cluster_id_path);
         }
+        req.set_hostname(options_.hostname_);
         req.set_cluster_id(options_.clusterId_.load());
         std::unordered_map<GraphSpaceID, std::vector<PartitionID>> leaderIds;
         if (listener_ != nullptr) {

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -107,6 +107,7 @@ struct MetaClientOptions {
     MetaClientOptions() = default;
     MetaClientOptions(const MetaClientOptions& opt)
         : localHost_(opt.localHost_)
+        , hostname_(opt.hostname_), 
         , clusterId_(opt.clusterId_.load())
         , inStoraged_(opt.inStoraged_)
         , serviceName_(opt.serviceName_)
@@ -118,6 +119,8 @@ struct MetaClientOptions {
     std::atomic<ClusterID> clusterId_{0};
     // If current client being used in storaged.
     bool inStoraged_ = false;
+    // specify name 
+    std::string hostname_;
     // Current service name, used in StatsManager
     std::string serviceName_ = "";
     // Whether to skip the config manager
@@ -482,6 +485,7 @@ private:
     HostAddr active_;
     HostAddr leader_;
     HostAddr localHost_;
+    std::string hostname_;
 
     std::unique_ptr<thread::GenericWorker> bgThread_;
     SpaceNameIdMap        spaceIndexByName_;

--- a/src/meta/processors/admin/HBProcessor.cpp
+++ b/src/meta/processors/admin/HBProcessor.cpp
@@ -39,7 +39,11 @@ void HBProcessor::process(const cpp2::HBReq& req) {
             onFinished();
             return;
         }
+        std::string hostname = req.get_hostname();
         HostInfo info(time::WallClock::fastNowInMilliSec());
+
+        ActiveHostsMan::updateHostName(kvstore_, host, hostname); 
+        
         if (req.__isset.leader_partIds) {
             ret = ActiveHostsMan::updateHostInfo(kvstore_, host, info,
                                                  req.get_leader_partIds());

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -93,6 +93,7 @@ bool StorageServer::start() {
     meta::MetaClientOptions options;
     options.localHost_ = localHost_;
     options.inStoraged_ = true;
+    options.hostname_ = hostname_;
     options.serviceName_ = "";
     options.skipConfig_ = FLAGS_local_config;
     metaClient_ = std::make_unique<meta::MetaClient>(ioThreadPool_,

--- a/src/storage/StorageServer.h
+++ b/src/storage/StorageServer.h
@@ -22,8 +22,10 @@ class StorageServer final {
 public:
     StorageServer(HostAddr localHost,
                   std::vector<HostAddr> metaAddrs,
+                  std::string hostname,
                   std::vector<std::string> dataPaths)
         : localHost_(localHost)
+        , hostname_(hostname),
         , metaAddrs_(std::move(metaAddrs))
         , dataPaths_(std::move(dataPaths)) {}
 
@@ -61,6 +63,7 @@ private:
 
     std::atomic_bool stopped_{false};
     HostAddr localHost_;
+    std::string hostname_;
     std::vector<HostAddr> metaAddrs_;
     std::vector<std::string> dataPaths_;
     std::atomic<Status> webStatus_{Status::STOPPED};


### PR DESCRIPTION
1. Special the unique Name For Nebula 
2. If Nebula Host IP Changes, We can still see Right Result for `show hosts`
3. Easy to Get some Failover information of Nebula 