### PR TITLE
fix compilation errors due to naming conflicts

### DIFF
--- a/src/graph/test/FetchVerticesTest.cpp
+++ b/src/graph/test/FetchVerticesTest.cpp
@@ -353,11 +353,11 @@ TEST_F(FetchVerticesTest, FetchAll) {
         auto code = client_->execute(query, resp);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
         std::vector<std::string> expectedColNames{
-            {"bachelor.name"}, {"bachelor.major"}
+            {"bachelor.name"}, {"bachelor.speciality"}
         };
         ASSERT_TRUE(verifyColNames(resp, expectedColNames));
         std::vector<std::tuple<std::string, std::string>> expected = {
-            {bachelors_["Tim Duncan"].name(), bachelors_["Tim Duncan"].major()},
+            {bachelors_["Tim Duncan"].name(), bachelors_["Tim Duncan"].speciality()},
         };
         ASSERT_TRUE(verifyResult(resp, expected));
     }
@@ -369,12 +369,12 @@ TEST_F(FetchVerticesTest, FetchAll) {
         auto code = client_->execute(query, resp);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
         std::vector<std::string> expectedColNames{
-            {"player.name"}, {"player.age"}, {"bachelor.name"}, {"bachelor.major"}
+            {"player.name"}, {"player.age"}, {"bachelor.name"}, {"bachelor.speciality"}
         };
         ASSERT_TRUE(verifyColNames(resp, expectedColNames));
         std::vector<std::tuple<std::string, int64_t, std::string, std::string>> expected = {
             {player.name(), player.age(),
-                bachelors_["Tim Duncan"].name(), bachelors_["Tim Duncan"].major()},
+                bachelors_["Tim Duncan"].name(), bachelors_["Tim Duncan"].speciality()},
         };
         ASSERT_TRUE(verifyResult(resp, expected));
     }

--- a/src/graph/test/TraverseTestBase.h
+++ b/src/graph/test/TraverseTestBase.h
@@ -278,7 +278,7 @@ public:
             return name_;
         }
 
-        const std::string& major() const {
+        const std::string& speciality() const {
             return speciality_;
         }
 

--- a/src/graph/test/TraverseTestBase.h
+++ b/src/graph/test/TraverseTestBase.h
@@ -268,9 +268,9 @@ public:
     class Bachelor final {
     public:
         Bachelor(std::string name,
-                 std::string major) {
+                 std::string speciality) {
             name_ = std::move(name);
-            major_ = std::move(major);
+            speciality_ = std::move(speciality);
             vid_ = std::hash<std::string>()(name_);
         }
 
@@ -279,7 +279,7 @@ public:
         }
 
         const std::string& major() const {
-            return major_;
+            return speciality_;
         }
 
         int64_t vid() const {
@@ -288,7 +288,7 @@ public:
 
     private:
         std::string     name_;
-        std::string     major_;
+        std::string     speciality_;
         int64_t         vid_{0};
     };
 
@@ -471,7 +471,7 @@ AssertionResult TraverseTestBase::prepareSchema() {
     }
     {
         cpp2::ExecutionResponse resp;
-        std::string cmd = "CREATE TAG bachelor(name string, major string)";
+        std::string cmd = "CREATE TAG bachelor(name string, speciality string)";
         auto code = client_->execute(cmd, resp);
         if (cpp2::ErrorCode::SUCCEEDED != code) {
             return TestError() << "Do cmd:" << cmd << " failed";
@@ -821,7 +821,7 @@ AssertionResult TraverseTestBase::insertData() {
         cpp2::ExecutionResponse resp;
         std::string query;
         query.reserve(1024);
-        query += "INSERT VERTEX bachelor(name, major) VALUES ";
+        query += "INSERT VERTEX bachelor(name, speciality) VALUES ";
         for (auto &bachelor : bachelors_) {
             query += std::to_string(bachelor.vid());
             query += ": ";
@@ -830,7 +830,7 @@ AssertionResult TraverseTestBase::insertData() {
             query += bachelor.name();
             query += "\"";
             query += ",";
-            query += bachelor.major();
+            query += bachelor.speciality();
             query += "),\n\t";
         }
         query.resize(query.size() - 3);


### PR DESCRIPTION
- A compilation error occurred on my PC.

In the GNU C Library, "major" is defined by <sys/sysmacros.h>.
line : 101 
# define major(dev) __SYSMACROS_DM (major) gnu_dev_major (dev)

- Error message:


```
[ 97%] Building CXX object src/graph/test/CMakeFiles/order_by_test.dir/OrderByTest.cpp.o
In file included from /data/source/nebula/src/graph/test/OrderByTest.cpp:10:0:
/data/source/nebula/src/graph/test/TraverseTestBase.h:281:9: internal compiler error: 段错误
         const std::string& major() const {
         ^~~~~
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-7/README.Bugs> for instructions.
src/graph/test/CMakeFiles/order_by_test.dir/build.make:62: recipe for target 'src/graph/test/CMakeFiles/order_by_test.dir/OrderByTest.cpp.o' failed
make[3]: *** [src/graph/test/CMakeFiles/order_by_test.dir/OrderByTest.cpp.o] Error 1
CMakeFiles/Makefile2:6988: recipe for target 'src/graph/test/CMakeFiles/order_by_test.dir/all' failed
make[2]: *** [src/graph/test/CMakeFiles/order_by_test.dir/all] Error 2
CMakeFiles/Makefile2:7000: recipe for target 'src/graph/test/CMakeFiles/order_by_test.dir/rule' failed
make[1]: *** [src/graph/test/CMakeFiles/order_by_test.dir/rule] Error 2
Makefile:1913: recipe for target 'order_by_test' failed
```
