### PR TITLE
Fix external llvm symbolizer error for clang asan test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,4 +47,4 @@ jobs:
         run: cd build && make -j $(nproc)
       - name: CTest with single thread
         timeout-minutes: 40
-        run: cd build && ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-8 ASAN_OPTIONS=fast_unwind_on_malloc=0 ctest --timeout 300 --output-on-failure
+        run: cd build && ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer ASAN_OPTIONS=fast_unwind_on_malloc=0 ctest --timeout 300 --output-on-failure

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: CTest with single thread
         if: failure() && steps.ignore_docs.outputs.num_source_files != 0
         timeout-minutes: 30
-        run: cd build && ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-8 ASAN_OPTIONS=fast_unwind_on_malloc=0 ctest --timeout 300 --output-on-failure --rerun-failed
+        run: cd build && ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer ASAN_OPTIONS=fast_unwind_on_malloc=0 ctest --timeout 300 --output-on-failure --rerun-failed
       - name: Cleanup
         if: always()
         run: rm -rf build


### PR DESCRIPTION
This PR depends on vesoft-inc/nebula-dev-docker#28