### PR TITLE
enhance for 'if not exists'

### DIFF
--- a/src/common/base/Status.cpp
+++ b/src/common/base/Status.cpp
@@ -21,12 +21,15 @@ Status::Status(Code code, folly::StringPiece msg) {
 
 
 std::string Status::toString() const {
-    if (code() == kOk) {
+    if (code() == kOk && size() == 0) {
         return "OK";
     }
     char tmp[64];
     const char *str;
     switch (code()) {
+        case kOk:
+            str = "";
+            break;
         case kError:
             str = "";
             break;

--- a/src/common/base/Status.h
+++ b/src/common/base/Status.h
@@ -72,6 +72,10 @@ public:
         return Status();
     }
 
+    static Status OK(folly::StringPiece msg) {
+        return Status(Code::kOk, msg);
+    }
+
 #define STATUS_GENERATOR(ERROR)                         \
     static Status ERROR() {                             \
         return Status(k##ERROR, "");                    \

--- a/src/console/CmdProcessor.cpp
+++ b/src/console/CmdProcessor.cpp
@@ -422,6 +422,9 @@ void CmdProcessor::processServerCmd(folly::StringPiece cmd) {
                       << " rows (Time spent: ";
         } else if (resp.get_rows()) {
             std::cout << "Empty set (Time spent: ";
+        } else if (resp.get_error_msg() != nullptr) {
+            std::cout << *resp.get_error_msg() <<"\n"
+                      << "Execution succeeded (Time spent: ";
         } else {
             std::cout << "Execution succeeded (Time spent: ";
         }

--- a/src/graph/CreateEdgeExecutor.cpp
+++ b/src/graph/CreateEdgeExecutor.cpp
@@ -47,6 +47,18 @@ void CreateEdgeExecutor::execute() {
     auto *name = sentence_->name();
     auto spaceId = ectx()->rctx()->session()->space();
 
+    // check if exist
+    if (sentence_->isIfNotExist()) {
+        auto result = ectx()->getMetaClient()->getEdgeSchema(spaceId, *name).get();
+        if (result.ok()) {
+            auto msg = folly::stringPrintf("The edge `%s' existes，nothing changed.",
+                        name->c_str());
+            doInfo(Status::OK(std::move(msg)));
+            return;
+        }
+    }
+
+    // create edge
     auto future = mc->createEdgeSchema(spaceId, *name, schema_, sentence_->isIfNotExist());
     auto *runner = ectx()->rctx()->runner();
     auto cb = [this] (auto &&resp) {

--- a/src/graph/CreateEdgeIndexExecutor.cpp
+++ b/src/graph/CreateEdgeIndexExecutor.cpp
@@ -32,6 +32,17 @@ void CreateEdgeIndexExecutor::execute() {
     auto columns = sentence_->names();
     auto spaceId = ectx()->rctx()->session()->space();
 
+    // check if exist
+    if (sentence_->isIfNotExist()) {
+        auto result = ectx()->getMetaClient()->getEdgeIndex(spaceId, *name).get();
+        if (result.ok()) {
+            auto msg = folly::stringPrintf("The edge index `%s' existes，nothing changed.",
+                            name->c_str());
+            doInfo(Status::OK(std::move(msg)));
+            return;
+        }
+    }
+
     auto future = mc->createEdgeIndex(spaceId,
                                       *name,
                                       *edgeName,

--- a/src/graph/CreateSpaceExecutor.cpp
+++ b/src/graph/CreateSpaceExecutor.cpp
@@ -39,6 +39,17 @@ Status CreateSpaceExecutor::prepare() {
 
 
 void CreateSpaceExecutor::execute() {
+    // check if exist
+    if (sentence_->isIfNotExist()) {
+        auto result = ectx()->getMetaClient()->getSpace(*spaceName_).get();
+        if (result.ok()) {
+            auto msg = folly::stringPrintf("The space `%s' existes，nothing changed.",
+                            spaceName_->c_str());
+            doInfo(Status::OK(std::move(msg)));
+            return;
+        }
+    }
+
     auto future = ectx()->getMetaClient()->createSpace(
         *spaceName_, partNum_, replicaFactor_, sentence_->isIfNotExist());
     auto *runner = ectx()->rctx()->runner();

--- a/src/graph/CreateTagExecutor.cpp
+++ b/src/graph/CreateTagExecutor.cpp
@@ -48,6 +48,17 @@ void CreateTagExecutor::execute() {
     auto *name = sentence_->name();
     auto spaceId = ectx()->rctx()->session()->space();
 
+    // check if exist
+    if (sentence_->isIfNotExist()) {
+        auto result = ectx()->getMetaClient()->getTagSchema(spaceId, *name).get();
+        if (result.ok()) {
+            auto msg = folly::stringPrintf("The tag `%s' existes，nothing changed.",
+                            name->c_str());
+            doInfo(Status::OK(std::move(msg)));
+            return;
+        }
+    }
+
     auto future = mc->createTagSchema(spaceId, *name, schema_, sentence_->isIfNotExist());
     auto *runner = ectx()->rctx()->runner();
     auto cb = [this] (auto &&resp) {

--- a/src/graph/CreateTagIndexExecutor.cpp
+++ b/src/graph/CreateTagIndexExecutor.cpp
@@ -32,6 +32,17 @@ void CreateTagIndexExecutor::execute() {
     auto columns = sentence_->names();
     auto spaceId = ectx()->rctx()->session()->space();
 
+    // check if exist
+    if (sentence_->isIfNotExist()) {
+        auto result = ectx()->getMetaClient()->getTagIndex(spaceId, *name).get();
+        if (result.ok()) {
+            auto msg = folly::stringPrintf("The tag index `%s' existes，nothing changed.",
+                            name->c_str());
+            doInfo(Status::OK(std::move(msg)));
+            return;
+        }
+    }
+
     auto future = mc->createTagIndex(spaceId,
                                      *name,
                                      *tagName,

--- a/src/graph/ExecutionPlan.h
+++ b/src/graph/ExecutionPlan.h
@@ -48,6 +48,8 @@ public:
      */
     void onError(Status);
 
+    void onInfo(Status);
+
     ExecutionContext* ectx() const {
         return ectx_.get();
     }

--- a/src/graph/Executor.cpp
+++ b/src/graph/Executor.cpp
@@ -438,6 +438,12 @@ void Executor::doError(Status status, uint32_t count) const {
     onError_(std::move(status));
 }
 
+void Executor::doInfo(Status status, uint32_t count) const {
+    stats::Stats::addStatsValue(stats_.get(), true, duration().elapsedInUSec(), count);
+    DCHECK(onInfo_);
+    onInfo_(std::move(status));
+}
+
 void Executor::doFinish(ProcessControl pro, uint32_t count) const {
     stats::Stats::addStatsValue(stats_.get(), true, duration().elapsedInUSec(), count);
     DCHECK(onFinish_);

--- a/src/graph/Executor.h
+++ b/src/graph/Executor.h
@@ -71,6 +71,11 @@ public:
     void setOnError(std::function<void(Status)> onError) {
         onError_ = onError;
     }
+
+    void setOnInfo(std::function<void(Status)> onInfo) {
+        onInfo_ = onInfo;
+    }
+
     /**
      * Upon finished successfully, `setupResponse' would be invoked on the last executor.
      * Any Executor implementation, which wants to send its meaningful result to the client,
@@ -114,12 +119,14 @@ protected:
     StatusOr<VariantType> transformDefaultValue(nebula::cpp2::SupportedType type,
                                                 std::string& originalValue);
     void doError(Status status, uint32_t count = 1) const;
+    void doInfo(Status status, uint32_t count = 1) const;
     void doFinish(ProcessControl pro, uint32_t count = 1) const;
 
 protected:
     ExecutionContext                           *ectx_;
     std::function<void(ProcessControl)>         onFinish_;
     std::function<void(Status)>                 onError_;
+    std::function<void(Status)>                 onInfo_;
     time::Duration                              duration_;
     std::unique_ptr<stats::Stats>               stats_;
 };

--- a/src/graph/GraphService.cpp
+++ b/src/graph/GraphService.cpp
@@ -62,10 +62,10 @@ GraphService::future_execute(int64_t sessionId, const std::string& query) {
     auto future = ctx->future();
     {
         auto result = sessionManager_->findSession(sessionId);
+        ctx->resp().set_error_msg(result.status().toString());
         if (!result.ok()) {
             FLOG_ERROR("Session not found, id[%ld]", sessionId);
             ctx->resp().set_error_code(cpp2::ErrorCode::E_SESSION_INVALID);
-            ctx->resp().set_error_msg(result.status().toString());
             ctx->finish();
             return future;
         }

--- a/src/graph/SequentialExecutor.cpp
+++ b/src/graph/SequentialExecutor.cpp
@@ -44,6 +44,10 @@ Status SequentialExecutor::prepare() {
         DCHECK(onError_);
         onError_(std::move(status));
     };
+    auto onInfo = [this] (Status status) {
+        DCHECK(onInfo_);
+        onInfo_(std::move(status));
+    };
     for (auto i = 0U; i < executors_.size() - 1; i++) {
         auto onFinish = [this, current = i, next = i + 1] (Executor::ProcessControl ctr) {
             switch (ctr) {
@@ -62,6 +66,7 @@ Status SequentialExecutor::prepare() {
         };
         executors_[i]->setOnFinish(onFinish);
         executors_[i]->setOnError(onError);
+        executors_[i]->setOnInfo(onInfo);
     }
     // The whole execution is done upon the last executor finishes.
     auto onFinish = [this] (Executor::ProcessControl ctr) {
@@ -71,6 +76,7 @@ Status SequentialExecutor::prepare() {
     };
     executors_.back()->setOnFinish(onFinish);
     executors_.back()->setOnError(onError);
+    executors_.back()->setOnInfo(onInfo);
 
     return Status::OK();
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enhance for 'if not exists'.  


### Why are the changes needed?
It can not give a user-friendly  tip when the edge type exists and the user create the same edge type on console.  Detail for #1591


### Does this PR introduce any user-facing change?
Yes.
```
(user@127.0.0.1:3699) [(none)]> create space if not exists test1
The space `test1' existes，nothing changed.
Execution succeeded (Time spent: 41.134/42.466 ms)

(user@127.0.0.1:3699) [test1]> create tag if not exists field()
The tag `field' existes，nothing changed.
Execution succeeded (Time spent: 28.77/29.787 ms)

(user@127.0.0.1:3699) [test1]> create tag index if not exists idx1 on field(src_pri_value);
The tag index `idx1' existes，nothing changed.
Execution succeeded (Time spent: 1.68/2.95 ms)

(user@127.0.0.1:3699) [(none)]> create edge if not exists choose();
The edge `choose' existes，nothing changed.
Execution succeeded (Time spent: 19.458/21.182 ms)

(user@127.0.0.1:3699) [test1]> create edge index if not exists idx2 on choose(grade);
The edge index `idx2' existes，nothing changed.
Execution succeeded (Time spent: 1.074/2.121 ms)
```


### How was this patch tested?
Manual testing
