### PR TITLE
Build rocksdb with RTTI

### DIFF
--- a/third-party/externals/rocksdb.cmake
+++ b/third-party/externals/rocksdb.cmake
@@ -27,6 +27,7 @@ ExternalProject_Add(
         -DWITH_GFLAGS=OFF
         -DWITH_TESTS=OFF
         -DWITH_TOOLS=OFF
+        -DUSE_RTTI=ON
         -DFAIL_ON_WARNINGS=OFF
         -DCMAKE_BUILD_TYPE=Release
 #-DCMAKE_CXX_FLAGS:STRING=${ROCKSDB_CXX_FLAGS}


### PR DESCRIPTION
UBsan requires RTTI, while RocksDB disable it by default.