### PR TITLE
Keep relevant targets even if testing disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,6 +490,7 @@ endmacro(nebula_link_libraries)
 
 function(nebula_add_subdirectory dir_name)
     if ((NOT ENABLE_TESTING) AND (${dir_name} STREQUAL test))
+        add_subdirectory(${dir_name} EXCLUDE_FROM_ALL)
         return()
     endif()
     add_subdirectory(${dir_name})


### PR DESCRIPTION
When `ENABLE_TESTING` is set to `OFF`, this PR excludes the _**test**_ subdirectories out of the default build, while still keep the targets. So that we can build specific target explicitly. Meanwhile, targets will get built automatically if needed.