### PR TITLE
[hot fix] pass value in lambda in asyncAtomicOp

### DIFF
--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -45,8 +45,8 @@ void AddEdgesProcessor::process(const cpp2::AddEdgesRequest& req) {
     } else {
         std::for_each(req.parts.begin(), req.parts.end(), [&](auto& partEdges){
             auto partId = partEdges.first;
-            const auto &edges = partEdges.second;
-            auto atomic = [&]() -> std::string {
+            auto atomic = [version, partId, edges = std::move(partEdges.second), this]()
+                          -> std::string {
                 return addEdges(version, partId, edges);
             };
             auto callback = [partId, this](kvstore::ResultCode code) {

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -57,8 +57,8 @@ void AddVerticesProcessor::process(const cpp2::AddVerticesRequest& req) {
     } else {
         std::for_each(partVertices.begin(), partVertices.end(), [&](auto &pv) {
             auto partId = pv.first;
-            const auto &vertices = pv.second;
-            auto atomic = [&]() -> std::string {
+            auto atomic = [version, partId, vertices = std::move(pv.second), this]()
+                          -> std::string {
                 return addVertices(version, partId, vertices);
             };
             auto callback = [partId, this](kvstore::ResultCode code) {

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -47,8 +47,8 @@ void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
         callingNum_ = req.parts.size();
         std::for_each(req.parts.begin(), req.parts.end(), [&](auto &partEdges) {
             auto partId = partEdges.first;
-            const auto &edges = partEdges.second;
-            auto atomic = [&]() -> std::string {
+            auto atomic = [spaceId, partId, edges = std::move(partEdges.second), this]()
+                          -> std::string {
                 return deleteEdges(spaceId, partId, edges);
             };
             auto callback = [spaceId, partId, this](kvstore::ResultCode code) {

--- a/src/storage/mutate/DeleteVertexProcessor.cpp
+++ b/src/storage/mutate/DeleteVertexProcessor.cpp
@@ -74,7 +74,7 @@ void DeleteVertexProcessor::process(const cpp2::DeleteVertexRequest& req) {
          });
     } else {
         callingNum_ = 1;
-        auto atomic = [&]() -> std::string {
+        auto atomic = [spaceId, partId, vId, this]() -> std::string {
             return deleteVertex(spaceId, partId, vId);
         };
         auto callback = [spaceId, partId, this](kvstore::ResultCode code) {


### PR DESCRIPTION
See [failed ut](https://github.com/vesoft-inc/nebula/pull/1677/checks?check_run_id=397469707).

Failed because we pass value by reference in async operation, some of them may be released before we use them.

PS: Since we have merged index, we need to add some UT no matter have index or not. (e.g. DeleteVertexTest only cover delete with index)