### PR TITLE
Disable ubsan check temporarily since OOM error

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           fetch-depth: 1
       - uses: actions/cache@v1
-        if: matrix.os != "centos6"
+        if: matrix.os != 'centos6'
         with:
           path: /tmp/ccache/
           key: ${{ matrix.os }}-${{ matrix.compiler }}-${{ hashFiles('**/CMakeLists.txt') }}
@@ -55,7 +55,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_C_COMPILER=clang \
             -DENABLE_ASAN=on \
-            -DENABLE_UBSAN=on \
             ..
       - name: Make
         run: |

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -69,7 +69,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_C_COMPILER=clang \
             -DENABLE_ASAN=on \
-            -DENABLE_UBSAN=on \
             ..
       - name: Make
         if: steps.ignore_docs.outputs.num_source_files != 0
@@ -82,10 +81,13 @@ jobs:
         continue-on-error: true
         run: |
           cd build
+          ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer \
+          ASAN_OPTIONS=fast_unwind_on_malloc=1 \
           ctest \
-            -j 6 \
+            -j $(($(nproc)/2)) \
             --timeout 400 \
             --output-on-failure
+        shell: bash
       - name: CTest with single thread
         if: failure() && steps.ignore_docs.outputs.num_source_files != 0
         timeout-minutes: 30


### PR DESCRIPTION
Undefined behavior sanitizer uses lots of memories and will result in OOM error in runner machine. We should consider a better solution for UBSAN.