### PR TITLE
Delete duplicate IndexID

### DIFF
--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -17,7 +17,6 @@ typedef i32 (cpp.type = "nebula::TagID") TagID
 typedef i32 (cpp.type = "nebula::EdgeType") EdgeType
 typedef i64 (cpp.type = "nebula::EdgeRanking") EdgeRanking
 typedef i64 (cpp.type = "nebula::VertexID") VertexID
-typedef i32 (cpp.type = "nebula::IndexID") IndexID
 
 typedef i32 (cpp.type = "nebula::IPv4") IPv4
 typedef i32 (cpp.type = "nebula::Port") Port


### PR DESCRIPTION
IndexID is re-defined in file src/interface/common.thrift.