### PR TITLE
Using tuple to replace the nested pair

### DIFF
--- a/src/kvstore/LogEncoder.cpp
+++ b/src/kvstore/LogEncoder.cpp
@@ -164,8 +164,8 @@ std::vector<folly::StringPiece> decodeMultiValues(folly::StringPiece encoded) {
     return values;
 }
 
-std::string encodeBatchValue(const std::vector<std::pair<BatchLogType,
-                             std::pair<std::string, std::string>>>& batch) {
+std::string
+encodeBatchValue(const std::vector<std::tuple<BatchLogType, std::string, std::string>>& batch) {
     auto type = LogType::OP_BATCH_WRITE;
     std::string encoded;
     encoded.reserve(1024);
@@ -180,17 +180,16 @@ std::string encodeBatchValue(const std::vector<std::pair<BatchLogType,
     encoded.append(reinterpret_cast<char*>(&num), sizeof(uint32_t));
     // Values
     for (auto& op : batch) {
-        auto bType = op.first;
-        auto bPair = op.second;
-        encoded.append(reinterpret_cast<char*>(&bType), 1);
-        auto v1 = bPair.first;
-        auto v2 = bPair.second;
-        auto len = v1.size();
-        encoded.append(reinterpret_cast<char*>(&len), sizeof(uint32_t));
-        encoded.append(v1.data(), len);
-        len = v2.size();
-        encoded.append(reinterpret_cast<char*>(&len), sizeof(uint32_t));
-        encoded.append(v2.data(), len);
+        auto opType = std::get<0>(op);
+        auto key = std::get<1>(op);
+        auto val = std::get<2>(op);
+        auto keySize = key.size();
+        auto valSize = val.size();
+        encoded.append(reinterpret_cast<char*>(&opType), 1)
+               .append(reinterpret_cast<char*>(&keySize), sizeof(uint32_t))
+               .append(key.data(), keySize)
+               .append(reinterpret_cast<char*>(&valSize), sizeof(uint32_t))
+               .append(val.data(), valSize);
     }
 
     return encoded;
@@ -222,12 +221,10 @@ decodeBatchValue(folly::StringPiece encoded) {
 std::string encodeHost(LogType type, const HostAddr& host) {
     std::string encoded;
     encoded.reserve(sizeof(int64_t) + 1 + sizeof(HostAddr));
-    // Timestamp (8 bytes)
     int64_t ts = time::WallClock::fastNowInMilliSec();
-    encoded.append(reinterpret_cast<char*>(&ts), sizeof(int64_t));
-    // Log type
-    encoded.append(reinterpret_cast<char*>(&type), 1);
-    encoded.append(reinterpret_cast<const char*>(&host), sizeof(HostAddr));
+    encoded.append(reinterpret_cast<char*>(&ts), sizeof(int64_t))
+           .append(reinterpret_cast<char*>(&type), 1)
+           .append(reinterpret_cast<const char*>(&host), sizeof(HostAddr));
     return encoded;
 }
 

--- a/src/kvstore/LogEncoder.h
+++ b/src/kvstore/LogEncoder.h
@@ -47,8 +47,8 @@ std::string encodeMultiValues(LogType type,
                               folly::StringPiece v2);
 std::vector<folly::StringPiece> decodeMultiValues(folly::StringPiece encoded);
 
-std::string encodeBatchValue(const std::vector<std::pair<BatchLogType,
-                             std::pair<std::string, std::string>>>& batch);
+std::string
+encodeBatchValue(const std::vector<std::tuple<BatchLogType, std::string, std::string>>& batch);
 
 std::vector<std::pair<BatchLogType, std::pair<folly::StringPiece, folly::StringPiece>>>
 decodeBatchValue(folly::StringPiece encoded);
@@ -65,33 +65,36 @@ public:
     ~BatchHolder() = default;
 
     void put(std::string&& key, std::string&& val) {
-        batch_.emplace_back(BatchLogType::OP_BATCH_PUT,
-                            std::make_pair(std::forward<std::string>(key),
-                                           std::forward<std::string>(val)));
+        auto op = std::make_tuple(BatchLogType::OP_BATCH_PUT,
+                                  std::forward<std::string>(key),
+                                  std::forward<std::string>(val));
+        batch_.emplace_back(std::move(op));
     }
 
     void remove(std::string&& key) {
-        batch_.emplace_back(BatchLogType::OP_BATCH_REMOVE,
-                            std::make_pair(std::forward<std::string>(key), ""));
+        auto op = std::make_tuple(BatchLogType::OP_BATCH_REMOVE,
+                                  std::forward<std::string>(key),
+                                  "");
+        batch_.emplace_back(std::move(op));
     }
 
     void rangeRemove(std::string&& begin, std::string&& end) {
-        batch_.emplace_back(BatchLogType::OP_BATCH_REMOVE_RANGE,
-                            std::make_pair(std::forward<std::string>(begin),
-                                           std::forward<std::string>(end)));
+        auto op = std::make_tuple(BatchLogType::OP_BATCH_REMOVE_RANGE,
+                                  std::forward<std::string>(begin),
+                                  std::forward<std::string>(end));
+        batch_.emplace_back(std::move(op));
     }
 
     void clear() {
         batch_.clear();
     }
 
-    const std::vector<std::pair<BatchLogType,
-                                std::pair<std::string, std::string>>>& getBatch() {
+    const std::vector<std::tuple<BatchLogType, std::string, std::string>>& getBatch() {
         return batch_;
     }
 
 private:
-    std::vector<std::pair<BatchLogType, std::pair<std::string, std::string>>> batch_;
+    std::vector<std::tuple<BatchLogType, std::string, std::string>> batch_;
 };
 }  // namespace kvstore
 }  // namespace nebula


### PR DESCRIPTION
 Using `std::tuple` to replace `std::pair<BatchLogType, std::pair>`