### PR TITLE
Fix potential raft bug

### DIFF
--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -1086,6 +1086,16 @@ bool RaftPart::leaderElection() {
     cpp2::AskForVoteRequest voteReq;
     decltype(hosts_) hosts;
     if (!prepareElectionRequest(voteReq, hosts)) {
+        // Suppose we have three replias A(leader), B, C, after A crashed,
+        // B, C will begin the election. B win, and send hb, C has gap with B
+        // and need the snapshot from B. Meanwhile C begin the lection,
+        // C will be Candidate, but becasue C is in WAITING_SNAPSHOT,
+        // so prepareElectionRequest will return false and go on the election.
+        // Becasue C is in Candidate, so it will reject the snapshot request from B.
+        // Infinite loop begins.
+        // So we neeed to back the follower to avoid the case.
+        std::lock_guard<std::mutex> g(raftLock_);
+        role_ = Role::FOLLOWER;
         return false;
     }
 

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -1086,14 +1086,14 @@ bool RaftPart::leaderElection() {
     cpp2::AskForVoteRequest voteReq;
     decltype(hosts_) hosts;
     if (!prepareElectionRequest(voteReq, hosts)) {
-        // Suppose we have three replias A(leader), B, C, after A crashed,
+        // Suppose we have three replicas A(leader), B, C, after A crashed,
         // B, C will begin the election. B win, and send hb, C has gap with B
-        // and need the snapshot from B. Meanwhile C begin the lection,
-        // C will be Candidate, but becasue C is in WAITING_SNAPSHOT,
+        // and need the snapshot from B. Meanwhile C begin the election,
+        // C will be Candidate, but because C is in WAITING_SNAPSHOT,
         // so prepareElectionRequest will return false and go on the election.
         // Becasue C is in Candidate, so it will reject the snapshot request from B.
         // Infinite loop begins.
-        // So we neeed to back the follower to avoid the case.
+        // So we neeed to go back to the follower state to avoid the case.
         std::lock_guard<std::mutex> g(raftLock_);
         role_ = Role::FOLLOWER;
         return false;

--- a/src/kvstore/raftex/SnapshotManager.h
+++ b/src/kvstore/raftex/SnapshotManager.h
@@ -19,10 +19,17 @@
 namespace nebula {
 namespace raftex {
 
+
+enum SnapshotStatus {
+    IN_PROGRESS,
+    DONE,
+    FAILED,
+};
+
 using SnapshotCallback = folly::Function<void(std::vector<std::string>&& rows,
                                               int64_t totalCount,
                                               int64_t totalSize,
-                                              bool finished)>;
+                                              SnapshotStatus status)>;
 class RaftPart;
 
 class SnapshotManager {

--- a/src/kvstore/raftex/test/TestShard.h
+++ b/src/kvstore/raftex/test/TestShard.h
@@ -174,7 +174,7 @@ public:
                           << ", total count sended " << totalCount
                           << ", total size sended " << totalSize
                           << ", finished false";
-                cb(std::move(data), totalCount, totalSize, false);
+                cb(std::move(data), totalCount, totalSize, SnapshotStatus::IN_PROGRESS);
                 data.clear();
             }
             auto encoded = encodeSnapshotRow(row.first, row.second);
@@ -182,13 +182,11 @@ public:
             totalCount++;
             data.emplace_back(std::move(encoded));
         }
-        if (data.size() > 0) {
-            LOG(INFO) << part->idStr_ << "Send snapshot total rows " << data.size()
-                      << ", total count sended " << totalCount
-                      << ", total size sended " << totalSize
-                      << ", finished true";
-            cb(std::move(data), totalCount, totalSize, true);
-        }
+        LOG(INFO) << part->idStr_ << "Send snapshot total rows " << data.size()
+                  << ", total count sended " << totalCount
+                  << ", total size sended " << totalSize
+                  << ", finished true";
+        cb(std::move(data), totalCount, totalSize, SnapshotStatus::DONE);
     }
 
     RaftexService* service_;


### PR DESCRIPTION
It happens in our users testing.

case 1:
Suppose we have three replicas A(leader), B, C, after A crashed,
B, C will begin the election. B win, and send hb, C has gap with B
and need the snapshot from B. Meanwhile C begin the election,
C will be Candidate, but because C is in WAITING_SNAPSHOT,
so prepareElectionRequest will return false and go on the election.
Because C is in Candidate, so it will reject the snapshot request from B.
Infinite loop begins.

So we need to back the follower to avoid the case.


case 2:
It maybe loss data during balance,  because kvstore::prefix maybe return leader-change, 
at this time,  an empty snapshot will be sent to related learner. 

