### PR TITLE
drop index through compact

### DIFF
--- a/src/common/base/NebulaKeyUtils.h
+++ b/src/common/base/NebulaKeyUtils.h
@@ -204,6 +204,12 @@ public:
         return readInt<int64_t>(rawKey.data() + offset, sizeof(int64_t));
     }
 
+    static IndexID getIndexId(const folly::StringPiece& rawKey) {
+        CHECK_GT(rawKey.size(), kIndexLen);
+        auto offset = sizeof(PartitionID);
+        return readInt<IndexID>(rawKey.data() + offset, sizeof(IndexID));
+    }
+
     template<typename T>
     static typename std::enable_if<std::is_integral<T>::value, T>::type
     readInt(const char* data, int32_t len) {
@@ -218,6 +224,9 @@ public:
     }
 
     static bool isIndexKey(const folly::StringPiece& key) {
+        if (key.size() < kIndexLen) {
+            return false;
+        }
         constexpr int32_t len = static_cast<int32_t>(sizeof(NebulaKeyType));
         auto type = readInt<int32_t>(key.data(), len) & kTypeMask;
         return static_cast<uint32_t>(NebulaKeyType::kIndex) == type;
@@ -385,6 +394,8 @@ private:
 
     static constexpr int32_t kEdgeIndexLen = sizeof(PartitionID) + sizeof(IndexID)
                                              + sizeof(VertexID) * 2 + sizeof(EdgeRanking);
+
+    static constexpr int32_t kIndexLen = std::min(kVertexIndexLen, kEdgeIndexLen);
 
     static constexpr int32_t kSystemLen = sizeof(PartitionID) + sizeof(NebulaSystemKeyType);
 

--- a/src/storage/CompactionFilter.h
+++ b/src/storage/CompactionFilter.h
@@ -21,8 +21,10 @@ namespace storage {
 
 class StorageCompactionFilter final : public kvstore::KVFilter {
 public:
-    explicit StorageCompactionFilter(meta::SchemaManager* schemaMan)
-        : schemaMan_(schemaMan) {
+    StorageCompactionFilter(meta::SchemaManager* schemaMan,
+                            meta::IndexManager* indexMan)
+        : schemaMan_(schemaMan)
+        , indexMan_(indexMan) {
         CHECK_NOTNULL(schemaMan_);
     }
 
@@ -47,7 +49,7 @@ public:
                 return true;
             }
         } else if (NebulaKeyUtils::isIndexKey(key)) {
-            if (!indexValid(key)) {
+            if (!indexValid(spaceId, key)) {
                 VLOG(3) << "Index invalid for the key " << key;
                 return true;
             }
@@ -131,33 +133,46 @@ public:
 
     bool filterVersions(const folly::StringPiece& key) const {
         folly::StringPiece keyWithNoVersion = NebulaKeyUtils::keyWithNoVersion(key);
-        if (keyWithNoVersion == lastKeyWithNoVerison_) {
+        if (keyWithNoVersion == lastKeyWithNoVersion_) {
             // TODO(heng): we could support max-versions configuration in schema if needed.
             return true;
         }
-        lastKeyWithNoVerison_ = keyWithNoVersion.str();
+        lastKeyWithNoVersion_ = keyWithNoVersion.str();
         return false;
     }
 
-    bool indexValid(const folly::StringPiece&) const {
-        return true;
+    bool indexValid(GraphSpaceID spaceId, const folly::StringPiece& key) const {
+        auto indexId = NebulaKeyUtils::getIndexId(key);
+        auto eRet = this->indexMan_->getEdgeIndex(spaceId, indexId);
+        if (eRet.ok()) {
+            return true;
+        }
+        auto tRet = this->indexMan_->getTagIndex(spaceId, indexId);
+        if (tRet.ok()) {
+            return true;
+        }
+        return !(eRet.status() == Status::IndexNotFound() &&
+                 tRet.status() == Status::IndexNotFound());
     }
 
 private:
-    mutable std::string lastKeyWithNoVerison_;
+    mutable std::string lastKeyWithNoVersion_;
     meta::SchemaManager* schemaMan_ = nullptr;
+    meta::IndexManager* indexMan_ = nullptr;
 };
 
 class StorageCompactionFilterFactory final : public kvstore::KVCompactionFilterFactory {
 public:
     StorageCompactionFilterFactory(meta::SchemaManager* schemaMan,
+                                   meta::IndexManager* indexMan,
                                    GraphSpaceID spaceId,
                                    int32_t customFilterIntervalSecs):
         KVCompactionFilterFactory(spaceId, customFilterIntervalSecs),
-        schemaMan_(schemaMan) {}
+        schemaMan_(schemaMan),
+        indexMan_(indexMan) {}
 
     std::unique_ptr<kvstore::KVFilter> createKVFilter() override {
-        return std::make_unique<StorageCompactionFilter>(schemaMan_);
+        return std::make_unique<StorageCompactionFilter>(schemaMan_, indexMan_);
     }
 
     const char* Name() const override {
@@ -166,24 +181,29 @@ public:
 
 private:
     meta::SchemaManager* schemaMan_ = nullptr;
+    meta::IndexManager* indexMan_ = nullptr;
 };
 
 class StorageCompactionFilterFactoryBuilder : public kvstore::CompactionFilterFactoryBuilder {
 public:
-    explicit StorageCompactionFilterFactoryBuilder(meta::SchemaManager* schemaMan)
-        : schemaMan_(schemaMan) {}
+    StorageCompactionFilterFactoryBuilder(meta::SchemaManager* schemaMan,
+                                          meta::IndexManager* indexMan)
+        : schemaMan_(schemaMan)
+        , indexMan_(indexMan) {}
 
     virtual ~StorageCompactionFilterFactoryBuilder() = default;
 
     std::shared_ptr<kvstore::KVCompactionFilterFactory>
     buildCfFactory(GraphSpaceID spaceId, int32_t customFilterIntervalSecs) override {
         return std::make_shared<StorageCompactionFilterFactory>(schemaMan_,
+                                                                indexMan_,
                                                                 spaceId,
                                                                 customFilterIntervalSecs);
     }
 
 private:
     meta::SchemaManager* schemaMan_ = nullptr;
+    meta::IndexManager* indexMan_ = nullptr;
 };
 
 

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -45,7 +45,8 @@ std::unique_ptr<kvstore::KVStore> StorageServer::getStoreInstance() {
     options.partMan_ = std::make_unique<kvstore::MetaServerBasedPartManager>(
                                                 localHost_,
                                                 metaClient_.get());
-    options.cffBuilder_ = std::make_unique<StorageCompactionFilterFactoryBuilder>(schemaMan_.get());
+    options.cffBuilder_ = std::make_unique<StorageCompactionFilterFactoryBuilder>(schemaMan_.get(),
+                                                                                  indexMan_.get());
     if (FLAGS_store_type == "nebula") {
         auto nbStore = std::make_unique<kvstore::NebulaStore>(std::move(options),
                                                               ioThreadPool_,
@@ -119,8 +120,8 @@ bool StorageServer::start() {
     schemaMan_->init(metaClient_.get());
 
     LOG(INFO) << "Init index manager";
-    auto indexMan = meta::IndexManager::create();
-    indexMan->init(metaClient_.get());
+    indexMan_ = meta::IndexManager::create();
+    indexMan_->init(metaClient_.get());
 
     LOG(INFO) << "Init kvstore";
     kvstore_ = getStoreInstance();
@@ -137,7 +138,7 @@ bool StorageServer::start() {
 
     auto handler = std::make_shared<StorageServiceHandler>(kvstore_.get(),
                                                            schemaMan_.get(),
-                                                           indexMan.get(),
+                                                           indexMan_.get(),
                                                            metaClient_.get());
     try {
         LOG(INFO) << "The storage deamon start on " << localHost_;

--- a/src/storage/StorageServer.h
+++ b/src/storage/StorageServer.h
@@ -11,6 +11,7 @@
 #include <thrift/lib/cpp2/server/ThriftServer.h>
 #include "kvstore/NebulaStore.h"
 #include "meta/SchemaManager.h"
+#include "meta/IndexManager.h"
 #include "meta/client/MetaClient.h"
 #include "meta/ClientBasedGflagsManager.h"
 #include "hdfs/HdfsHelper.h"
@@ -51,6 +52,7 @@ private:
     std::unique_ptr<nebula::thread::GenericThreadPool> webWorkers_;
     std::unique_ptr<meta::ClientBasedGflagsManager> gFlagsMan_;
     std::unique_ptr<meta::SchemaManager> schemaMan_;
+    std::unique_ptr<meta::IndexManager> indexMan_;
 
     std::atomic_bool stopped_{false};
     HostAddr localHost_;

--- a/src/storage/test/CMakeLists.txt
+++ b/src/storage/test/CMakeLists.txt
@@ -218,6 +218,7 @@ nebula_add_test(
     OBJECTS
         $<TARGET_OBJECTS:storage_service_handler>
         $<TARGET_OBJECTS:adHocSchema_obj>
+        $<TARGET_OBJECTS:adHocIndex_obj>
         $<TARGET_OBJECTS:kvstore_obj>
         $<TARGET_OBJECTS:raftex_obj>
         $<TARGET_OBJECTS:raftex_thrift_obj>


### PR DESCRIPTION
When `DROP INDEX` command is complete, At this time, only the metadata of index was removed.
Then, index data needs to be deleted through the compact in storage layer.