### PR TITLE
fix potential wal bug in ut

### DIFF
--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -235,8 +235,6 @@ RaftPart::RaftPart(ClusterID clusterId,
                                                                logClusterId,
                                                                log);
                                 });
-    lastLogId_ = wal_->lastLogId();
-    lastLogTerm_ = wal_->lastLogTerm();
     logs_.reserve(FLAGS_max_batch_size);
     CHECK(!!executor_) << idStr_ << "Should not be nullptr";
 }
@@ -270,6 +268,9 @@ const char* RaftPart::roleStr(Role role) const {
 
 void RaftPart::start(std::vector<HostAddr>&& peers, bool asLearner) {
     std::lock_guard<std::mutex> g(raftLock_);
+
+    lastLogId_ = wal_->lastLogId();
+    lastLogTerm_ = wal_->lastLogTerm();
 
     // Set the quorum number
     quorum_ = (peers.size() + 1) / 2;

--- a/src/kvstore/raftex/test/RaftexTestBase.cpp
+++ b/src/kvstore/raftex/test/RaftexTestBase.cpp
@@ -319,7 +319,6 @@ void killOneCopy(std::vector<std::shared_ptr<RaftexService>>& services,
                  std::vector<std::shared_ptr<test::TestShard>>& copies,
                  std::shared_ptr<test::TestShard>& leader,
                  size_t index) {
-    copies[index]->stop();
     services[index]->removePartition(copies[index]);
     if (leader != nullptr && index == leader->index()) {
         std::lock_guard<std::mutex> lock(leaderMutex);


### PR DESCRIPTION
https://github.com/vesoft-inc/nebula/pull/1424/checks?check_run_id=445093798

Let me try to clarify what happens:
1. A is leader of term 5, append some logs
2. A is killed and rebooted, lastLogId = 42
3. A is elected as leader of term 6.
![image](https://user-images.githubusercontent.com/13706157/74510158-1b21fb80-4f3e-11ea-9219-d4439b85dd78.png)

However, A keeps saying `There is a gap in the log id. The last log id is 43, and the id being appended is 43`, ant test case failed.

The problem is that we only `stop` and `start` the part in test, so when we reboot a part, the `lastLogId` could be previous result when it was killed. 

So I reload the last log id in wal. I think we don't need to scan wal files here in test, since we don't actually kill it. In reality, whenever we kill a node and restart, we will always scan all files in constructor.