### PR TITLE
fix some problems during balance

### DIFF
--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -488,7 +488,7 @@ void RaftPart::addPeer(const HostAddr& peer) {
 void RaftPart::removePeer(const HostAddr& peer) {
     CHECK(!raftLock_.try_lock());
     if (peer == addr_) {
-        //    status_ = Status::STOPPED;
+        // The part will be removed in REMOVE_PART_ON_SRC phase
         LOG(INFO) << idStr_ << "Remove myself from the raft group.";
         return;
     }

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -556,7 +556,7 @@ void MetaClient::diff(const LocalCache& oldCache, const LocalCache& newCache) {
         const auto& newParts = it->second;
         auto oldIt = oldPartsMap.find(spaceId);
         if (oldIt == oldPartsMap.end()) {
-            VLOG(1) << "SpaceId " << spaceId << " was added!";
+            LOG(INFO) << "SpaceId " << spaceId << " was added!";
             listener_->onSpaceAdded(spaceId);
             for (auto partIt = newParts.begin(); partIt != newParts.end(); partIt++) {
                 listener_->onPartAdded(partIt->second);
@@ -587,7 +587,7 @@ void MetaClient::diff(const LocalCache& oldCache, const LocalCache& newCache) {
         const auto& oldParts = it->second;
         auto newIt = newPartsMap.find(spaceId);
         if (newIt == newPartsMap.end()) {
-            VLOG(1) << "SpaceId " << spaceId << " was removed!";
+            LOG(INFO) << "SpaceId " << spaceId << " was removed!";
             for (auto partIt = oldParts.begin(); partIt != oldParts.end(); partIt++) {
                 listener_->onPartRemoved(spaceId, partIt->first);
             }

--- a/src/meta/processors/admin/BalanceProcessor.cpp
+++ b/src/meta/processors/admin/BalanceProcessor.cpp
@@ -90,7 +90,6 @@ void BalanceProcessor::process(const cpp2::BalanceReq& req) {
     }
     resp_.set_id(value(ret));
     resp_.set_code(cpp2::ErrorCode::SUCCEEDED);
-    LastUpdateTimeMan::update(kvstore_, time::WallClock::fastNowInMilliSec());
     onFinished();
 }
 

--- a/src/meta/processors/admin/BalanceTask.cpp
+++ b/src/meta/processors/admin/BalanceTask.cpp
@@ -152,14 +152,6 @@ void BalanceTask::invoke() {
                 if (!resp.ok()) {
                     LOG(INFO) << taskIdStr_ << "Update meta failed, status " << resp;
                     ret_ = Result::FAILED;
-                } else if (kv_ != nullptr) {
-                    if (LastUpdateTimeMan::update(kv_, time::WallClock::fastNowInMilliSec()) !=
-                            kvstore::ResultCode::SUCCEEDED) {
-                        LOG(INFO) << taskIdStr_ << "Update meta failed";
-                        ret_ = Result::FAILED;
-                    } else {
-                        status_ = Status::REMOVE_PART_ON_SRC;
-                    }
                 } else {
                     status_ = Status::REMOVE_PART_ON_SRC;
                 }

--- a/src/meta/processors/admin/BalanceTask.cpp
+++ b/src/meta/processors/admin/BalanceTask.cpp
@@ -152,6 +152,14 @@ void BalanceTask::invoke() {
                 if (!resp.ok()) {
                     LOG(INFO) << taskIdStr_ << "Update meta failed, status " << resp;
                     ret_ = Result::FAILED;
+                } else if (kv_ != nullptr) {
+                    if (LastUpdateTimeMan::update(kv_, time::WallClock::fastNowInMilliSec()) !=
+                            kvstore::ResultCode::SUCCEEDED) {
+                        LOG(INFO) << taskIdStr_ << "Update meta failed";
+                        ret_ = Result::FAILED;
+                    } else {
+                        status_ = Status::REMOVE_PART_ON_SRC;
+                    }
                 } else {
                     status_ = Status::REMOVE_PART_ON_SRC;
                 }

--- a/src/meta/processors/admin/Balancer.h
+++ b/src/meta/processors/admin/Balancer.h
@@ -106,6 +106,10 @@ public:
 
     void finish() {
         CHECK(!lock_.try_lock());
+        if (LastUpdateTimeMan::update(kv_, time::WallClock::fastNowInMilliSec()) !=
+                kvstore::ResultCode::SUCCEEDED) {
+            LOG(INFO) << "Balance plan " << plan_->id() << " update meta failed";
+        }
         plan_.reset();
         running_ = false;
     }

--- a/src/meta/processors/admin/LeaderBalanceProcessor.cpp
+++ b/src/meta/processors/admin/LeaderBalanceProcessor.cpp
@@ -15,7 +15,6 @@ void LeaderBalanceProcessor::process(const cpp2::LeaderBalanceReq& req) {
     UNUSED(req);
     auto ret = Balancer::instance(kvstore_)->leaderBalance();
     resp_.set_code(ret);
-    LastUpdateTimeMan::update(kvstore_, time::WallClock::fastNowInMilliSec());
     onFinished();
 }
 

--- a/src/meta/processors/partsMan/ListHostsProcessor.cpp
+++ b/src/meta/processors/partsMan/ListHostsProcessor.cpp
@@ -74,7 +74,7 @@ Status ListHostsProcessor::allHostsWithStatus() {
     }
 
     // get hosts which have send heartbeat recently
-    auto activeHosts = ActiveHostsMan::getActiveHosts(kvstore_, FLAGS_heartbeat_interval_secs + 1);
+    auto activeHosts = ActiveHostsMan::getActiveHosts(kvstore_, FLAGS_heartbeat_interval_secs * 2);
     while (iter->valid()) {
         auto host = MetaServiceUtils::parseLeaderKey(iter->key());
         if (std::find(activeHosts.begin(), activeHosts.end(),

--- a/src/storage/StorageServiceHandler.cpp
+++ b/src/storage/StorageServiceHandler.cpp
@@ -160,7 +160,7 @@ StorageServiceHandler::future_transLeader(const cpp2::TransLeaderReq& req) {
 
 folly::Future<cpp2::AdminExecResp>
 StorageServiceHandler::future_addPart(const cpp2::AddPartReq& req) {
-    auto* processor = AddPartProcessor::instance(kvstore_, metaClient_);
+    auto* processor = AddPartProcessor::instance(kvstore_);
     RETURN_FUTURE(processor);
 }
 

--- a/src/storage/admin/AdminProcessor.h
+++ b/src/storage/admin/AdminProcessor.h
@@ -93,8 +93,8 @@ private:
 
 class AddPartProcessor : public BaseProcessor<cpp2::AdminExecResp> {
 public:
-    static AddPartProcessor* instance(kvstore::KVStore* kvstore, meta::MetaClient* mClient) {
-        return new AddPartProcessor(kvstore, mClient);
+    static AddPartProcessor* instance(kvstore::KVStore* kvstore) {
+        return new AddPartProcessor(kvstore);
     }
 
     void process(const cpp2::AddPartReq& req) {
@@ -119,12 +119,8 @@ public:
     }
 
 private:
-    explicit AddPartProcessor(kvstore::KVStore* kvstore, meta::MetaClient* mClient)
-            : BaseProcessor<cpp2::AdminExecResp>(kvstore, nullptr, nullptr)
-            , mClient_(mClient) {}
-
-private:
-    meta::MetaClient* mClient_ = nullptr;
+    explicit AddPartProcessor(kvstore::KVStore* kvstore)
+            : BaseProcessor<cpp2::AdminExecResp>(kvstore, nullptr, nullptr) {}
 };
 
 class RemovePartProcessor : public BaseProcessor<cpp2::AdminExecResp> {

--- a/src/storage/admin/AdminProcessor.h
+++ b/src/storage/admin/AdminProcessor.h
@@ -114,12 +114,6 @@ public:
             LOG(INFO) << "Space " << spaceId << " not exist, create it!";
             store->addSpace(spaceId);
         }
-        auto st = mClient_->refreshCache();
-        if (!st.ok()) {
-            this->pushResultCode(cpp2::ErrorCode::E_LOAD_META_FAILED, partId);
-            onFinished();
-            return;
-        }
         store->addPart(spaceId, partId, req.get_as_learner());
         onFinished();
     }


### PR DESCRIPTION
Fix some problems during test:
1. Previously we update when BalanceProcessor has return, but the part alloc probably would be updated later, so some machine won't `loadData` in MetaClient. So I update meta when a BalanceTask has done `updateMeta`.
2. When we `balance remove xxx`, the src of BalanceTask could be alive, but previously we regard them as dead, which would cause some part was not removed.
3. We should forbid `balance leader` during `balance data`.
4. We don't need to `refreshCache` when add a part.