### PR TITLE
Job Manager judged some tasks failed. However they can run success manually by curl. 

### DIFF
--- a/src/meta/processors/jobMan/JobManager.cpp
+++ b/src/meta/processors/jobMan/JobManager.cpp
@@ -153,6 +153,9 @@ bool JobManager::runJobInternal(const JobDescription& jobDesc) {
             if (succeed) {
                 taskDesc.setStatus(cpp2::JobStatus::FINISHED);
             } else {
+                LOG(INFO) << "task " << iTask << " failed"
+                          << ", httpResult.ok()=" << httpResult.ok()
+                          << ", httpResult.value()=" << httpResult.value();
                 taskDesc.setStatus(cpp2::JobStatus::FAILED);
             }
 
@@ -170,6 +173,10 @@ bool JobManager::runJobInternal(const JobDescription& jobDesc) {
             for (const auto& t : tries) {
                 if (t.hasException()) {
                     LOG(ERROR) << "admin Failed: " << t.exception();
+                    successfully = false;
+                    break;
+                }
+                if (!t.value()) {
                     successfully = false;
                     break;
                 }


### PR DESCRIPTION
Job Manager judged some tasks as failed. However they can run success manually. 

I guess this may caused by different output of curl. 

print more info if this happen again. and why job manager think those tasks failed. 