### PR TITLE
Meta compaction filter

### DIFF
--- a/src/meta/CMakeLists.txt
+++ b/src/meta/CMakeLists.txt
@@ -76,6 +76,7 @@ nebula_add_library(
     MetaHttpIngestHandler.cpp
     MetaHttpDownloadHandler.cpp
     MetaHttpReplaceHostHandler.cpp
+    MetaHttpAdminHandler.cpp
 )
 
 nebula_add_library(

--- a/src/meta/CompactionFilter.h
+++ b/src/meta/CompactionFilter.h
@@ -1,0 +1,71 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef META_COMPACTIONFILTER_H_
+#define META_COMPACTIONFILTER_H_
+
+#include "base/Base.h"
+#include "kvstore/CompactionFilter.h"
+#include "meta/MetaCFHelper.h"
+
+namespace nebula {
+namespace meta {
+
+class MetaCompactionFilter final : public kvstore::KVFilter {
+public:
+    explicit MetaCompactionFilter(meta::MetaCFHelper* cfHelper)
+        : cfHelper_(cfHelper) {}
+
+    bool filter(GraphSpaceID spaceId,
+                const folly::StringPiece& key,
+                const folly::StringPiece& val) const override {
+        UNUSED(spaceId);
+        UNUSED(key);
+        UNUSED(val);
+
+        return false;
+    }
+
+private:
+    meta::MetaCFHelper* cfHelper_ = nullptr;
+};
+
+class MetaCompactionFilterFactory final : public kvstore::KVCompactionFilterFactory {
+public:
+    MetaCompactionFilterFactory(meta::MetaCFHelper* cfHelper, GraphSpaceID spaceId, int32_t customFilterIntervalSecs)
+        : KVCompactionFilterFactory(spaceId, customFilterIntervalSecs), cfHelper_(cfHelper) {}
+
+    std::unique_ptr<kvstore::KVFilter> createKVFilter() override {
+        return std::make_unique<MetaCompactionFilter>(cfHelper_);
+    }
+
+    const char* Name() const override {
+        return "MetaCompactionFilterFactory";
+    }
+
+private:
+    meta::MetaCFHelper* cfHelper_ = nullptr;
+};
+
+class MetaCompactionFilterFactoryBuilder final : public kvstore::CompactionFilterFactoryBuilder {
+public:
+    explicit MetaCompactionFilterFactoryBuilder(meta::MetaCFHelper* cfHelper)
+        : cfHelper_(cfHelper) {}
+
+    std::shared_ptr<kvstore::KVCompactionFilterFactory>
+    buildCfFactory(GraphSpaceID spaceId, int32_t customFilterIntervalSecs) override {
+        return std::make_shared<MetaCompactionFilterFactory>(cfHelper_, spaceId, customFilterIntervalSecs);
+    }
+
+private:
+    meta::MetaCFHelper* cfHelper_ = nullptr;
+};
+
+
+}   // namespace meta
+}   // namespace nebula
+#endif  // META_COMPACTIONFILTER_H_
+

--- a/src/meta/MetaCFHelper.h
+++ b/src/meta/MetaCFHelper.h
@@ -8,6 +8,8 @@
 #define META_CFHELPER_H_
 
 #include "base/Base.h"
+#include "meta/MetaServiceUtils.h"
+#include "meta/processors/Common.h"
 #include "kvstore/NebulaStore.h"
 
 namespace nebula {
@@ -21,8 +23,31 @@ public:
         kv_ = kv;
     }
 
+    void init() {
+        spaces_.clear();
+        if (kv_ != nullptr) {
+            folly::SharedMutex::ReadHolder rHolder(LockUtils::spaceLock());
+            auto prefix = MetaServiceUtils::spacePrefix();
+            std::unique_ptr<kvstore::KVIterator> iter;
+            auto ret = kv_->prefix(kDefaultSpaceId, kDefaultPartId, prefix, &iter);
+            if (ret != kvstore::ResultCode::SUCCEEDED) {
+                return;
+            }
+            while (iter->valid()) {
+                auto spaceId = MetaServiceUtils::spaceId(iter->key());
+                spaces_.insert(spaceId);
+                iter->next();
+            }
+        }
+    }
+
+    bool spaceValid(GraphSpaceID spaceId) const {
+        return spaces_.count(spaceId);
+    }
+
 private:
     kvstore::NebulaStore* kv_;
+    std::unordered_set<GraphSpaceID> spaces_;
 };
 
 }   // namespace meta

--- a/src/meta/MetaCFHelper.h
+++ b/src/meta/MetaCFHelper.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef META_CFHELPER_H_
+#define META_CFHELPER_H_
+
+#include "base/Base.h"
+#include "kvstore/NebulaStore.h"
+
+namespace nebula {
+namespace meta {
+
+class MetaCFHelper {
+public:
+    MetaCFHelper() = default;
+
+    void registerKv(kvstore::NebulaStore* kv) {
+        kv_ = kv;
+    }
+
+private:
+    kvstore::NebulaStore* kv_;
+};
+
+}   // namespace meta
+}   // namespace nebula
+#endif   // META_CFHELPER_H_

--- a/src/meta/MetaHttpAdminHandler.cpp
+++ b/src/meta/MetaHttpAdminHandler.cpp
@@ -1,0 +1,116 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "meta/processors/Common.h"
+#include "meta/MetaHttpAdminHandler.h"
+#include "webservice/Common.h"
+#include "webservice/WebService.h"
+#include "process/ProcessUtils.h"
+#include <proxygen/httpserver/RequestHandler.h>
+#include <proxygen/lib/http/ProxygenErrorEnum.h>
+#include <proxygen/httpserver/ResponseBuilder.h>
+
+namespace nebula {
+namespace meta {
+
+using proxygen::HTTPMessage;
+using proxygen::HTTPMethod;
+using proxygen::ProxygenError;
+using proxygen::UpgradeProtocol;
+using proxygen::ResponseBuilder;
+
+void MetaHttpAdminHandler::init(nebula::kvstore::KVStore *kvstore) {
+    kvstore_ = kvstore;
+    CHECK_NOTNULL(kvstore_);
+}
+
+void MetaHttpAdminHandler::onRequest(std::unique_ptr<HTTPMessage> headers) noexcept {
+    LOG(INFO) << __PRETTY_FUNCTION__;
+    if (headers->getMethod().value() != HTTPMethod::GET) {
+        err_ = HttpCode::E_UNSUPPORTED_METHOD;
+        return;
+    }
+    if (!headers->hasQueryParam("op")) {
+        err_ = HttpCode::E_ILLEGAL_ARGUMENT;
+        return;
+    }
+    if (kvstore_ == nullptr) {
+        err_ = HttpCode::SUCCEEDED;
+        resp_ = folly::stringPrintf("No kvstore");
+        return;
+    }
+
+    err_ = HttpCode::SUCCEEDED;
+    auto* op = headers->getQueryParamPtr("op");
+    if (*op == "compact") {
+        LOG(INFO) << "do compact at default space";
+        auto status = kvstore_->compact(kDefaultSpaceId);
+        if (status != kvstore::ResultCode::SUCCEEDED) {
+            resp_ = folly::stringPrintf("Admin failed! error=%d", static_cast<int32_t>(status));
+            return;
+        }
+    } else if (*op == "flush") {
+        auto status = kvstore_->flush(kDefaultSpaceId);
+        if (status != kvstore::ResultCode::SUCCEEDED) {
+            resp_ = folly::stringPrintf("Flush failed! error=%d", static_cast<int32_t>(status));
+            return;
+        }
+    } else {
+        resp_ = folly::stringPrintf("Unknown operation %s", op->c_str());
+        return;
+    }
+
+    resp_ = "ok";
+}
+
+void MetaHttpAdminHandler::onBody(std::unique_ptr<folly::IOBuf>) noexcept {
+    // Do nothing, we only support GET
+}
+
+void MetaHttpAdminHandler::onEOM() noexcept {
+    switch (err_) {
+        case HttpCode::E_UNSUPPORTED_METHOD:
+            ResponseBuilder(downstream_)
+                .status(WebServiceUtils::to(HttpStatusCode::METHOD_NOT_ALLOWED),
+                        WebServiceUtils::toString(HttpStatusCode::METHOD_NOT_ALLOWED))
+                .body(WebServiceUtils::toString(HttpStatusCode::METHOD_NOT_ALLOWED))
+                .sendWithEOM();
+            return;
+        case HttpCode::E_ILLEGAL_ARGUMENT:
+            ResponseBuilder(downstream_)
+                .status(WebServiceUtils::to(HttpStatusCode::BAD_REQUEST),
+                        WebServiceUtils::toString(HttpStatusCode::BAD_REQUEST))
+                .body(WebServiceUtils::toString(HttpStatusCode::BAD_REQUEST))
+                .sendWithEOM();
+            return;
+        default:
+            break;
+    }
+
+    ResponseBuilder(downstream_)
+        .status(WebServiceUtils::to(HttpStatusCode::OK),
+                WebServiceUtils::toString(HttpStatusCode::OK))
+        .body(resp_)
+        .sendWithEOM();
+}
+
+void MetaHttpAdminHandler::onUpgrade(UpgradeProtocol) noexcept {
+    // Do nothing
+}
+
+
+void MetaHttpAdminHandler::requestComplete() noexcept {
+    delete this;
+}
+
+
+void MetaHttpAdminHandler::onError(ProxygenError error) noexcept {
+    LOG(ERROR) << "Web Service MetaHttpAdminHandler got error : "
+               << proxygen::getErrorString(error);
+}
+
+}  // namespace meta
+}  // namespace nebula

--- a/src/meta/MetaHttpAdminHandler.h
+++ b/src/meta/MetaHttpAdminHandler.h
@@ -1,0 +1,47 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef META_METAHTTPADMINHANDLER_H_
+#define META_METAHTTPADMINHANDLER_H_
+
+#include "base/Base.h"
+#include "webservice/Common.h"
+#include "kvstore/KVStore.h"
+#include <proxygen/httpserver/RequestHandler.h>
+
+namespace nebula {
+namespace meta {
+
+using nebula::HttpCode;
+
+class MetaHttpAdminHandler : public proxygen::RequestHandler {
+public:
+    MetaHttpAdminHandler() = default;
+
+    void init(nebula::kvstore::KVStore *kvstore);
+
+    void onRequest(std::unique_ptr<proxygen::HTTPMessage> headers) noexcept override;
+
+    void onBody(std::unique_ptr<folly::IOBuf> body) noexcept override;
+
+    void onEOM() noexcept override;
+
+    void onUpgrade(proxygen::UpgradeProtocol protocol) noexcept override;
+
+    void requestComplete() noexcept override;
+
+    void onError(proxygen::ProxygenError error) noexcept override;
+
+private:
+    HttpCode err_{HttpCode::SUCCEEDED};
+    std::string resp_;
+    nebula::kvstore::KVStore *kvstore_;
+};
+
+}  // namespace meta
+}  // namespace nebula
+
+#endif  // META_METAHTTPADMINHANDLER_H_

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -11,21 +11,6 @@
 namespace nebula {
 namespace meta {
 
-const std::string kSpacesTable         = "__spaces__";         // NOLINT
-const std::string kPartsTable          = "__parts__";          // NOLINT
-const std::string kHostsTable          = "__hosts__";          // NOLINT
-const std::string kTagsTable           = "__tags__";           // NOLINT
-const std::string kEdgesTable          = "__edges__";          // NOLINT
-const std::string kIndexesTable        = "__indexes__";        // NOLINT
-const std::string kIndexTable          = "__index__";          // NOLINT
-const std::string kUsersTable          = "__users__";          // NOLINT
-const std::string kRolesTable          = "__roles__";          // NOLINT
-const std::string kConfigsTable        = "__configs__";        // NOLINT
-const std::string kDefaultTable        = "__default__";        // NOLINT
-const std::string kSnapshotsTable      = "__snapshots__";      // NOLINT
-const std::string kLastUpdateTimeTable = "__last_update_time__"; // NOLINT
-const std::string kLeadersTable = "__leaders__"; // NOLINT
-
 const std::string kHostOnline  = "Online";       // NOLINT
 const std::string kHostOffline = "Offline";      // NOLINT
 

--- a/src/meta/MetaServiceUtils.h
+++ b/src/meta/MetaServiceUtils.h
@@ -14,6 +14,21 @@
 namespace nebula {
 namespace meta {
 
+const std::string kSpacesTable         = "__spaces__";         // NOLINT
+const std::string kPartsTable          = "__parts__";          // NOLINT
+const std::string kHostsTable          = "__hosts__";          // NOLINT
+const std::string kTagsTable           = "__tags__";           // NOLINT
+const std::string kEdgesTable          = "__edges__";          // NOLINT
+const std::string kIndexesTable        = "__indexes__";        // NOLINT
+const std::string kIndexTable          = "__index__";          // NOLINT
+const std::string kUsersTable          = "__users__";          // NOLINT
+const std::string kRolesTable          = "__roles__";          // NOLINT
+const std::string kConfigsTable        = "__configs__";        // NOLINT
+const std::string kDefaultTable        = "__default__";        // NOLINT
+const std::string kSnapshotsTable      = "__snapshots__";      // NOLINT
+const std::string kLastUpdateTimeTable = "__last_update_time__"; // NOLINT
+const std::string kLeadersTable = "__leaders__"; // NOLINT
+
 enum class EntryType : int8_t {
     SPACE       = 0x01,
     TAG         = 0x02,

--- a/src/meta/test/CMakeLists.txt
+++ b/src/meta/test/CMakeLists.txt
@@ -461,7 +461,13 @@ nebula_add_test(
         $<TARGET_OBJECTS:schema_obj>
         $<TARGET_OBJECTS:gflags_man_obj>
         $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:http_client_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:ws_common_obj>
     LIBRARIES
+        proxygenhttpserver
+        proxygenlib
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
         wangle
@@ -474,7 +480,6 @@ nebula_add_test(
     SOURCES
         MetaHttpReplaceHandlerTest.cpp
     OBJECTS
-        $<TARGET_OBJECTS:storage_http_handler>
         $<TARGET_OBJECTS:meta_http_handler>
         $<TARGET_OBJECTS:meta_client>
         $<TARGET_OBJECTS:stats_obj>
@@ -489,7 +494,6 @@ nebula_add_test(
         $<TARGET_OBJECTS:thrift_obj>
         $<TARGET_OBJECTS:ws_obj>
         $<TARGET_OBJECTS:ws_common_obj>
-        $<TARGET_OBJECTS:hdfs_helper_obj>
         $<TARGET_OBJECTS:http_client_obj>
         $<TARGET_OBJECTS:base_obj>
         $<TARGET_OBJECTS:fs_obj>
@@ -554,11 +558,11 @@ nebula_add_test(
         CompactionTest.cpp
     OBJECTS
         $<TARGET_OBJECTS:meta_http_handler>
-        $<TARGET_OBJECTS:meta_service_handler>
-        $<TARGET_OBJECTS:kvstore_obj>
         $<TARGET_OBJECTS:meta_client>
-        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:meta_service_handler>
         $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:meta_thrift_obj>
         $<TARGET_OBJECTS:common_thrift_obj>
         $<TARGET_OBJECTS:raftex_obj>
         $<TARGET_OBJECTS:raftex_thrift_obj>

--- a/src/meta/test/CMakeLists.txt
+++ b/src/meta/test/CMakeLists.txt
@@ -460,6 +460,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:thread_obj>
         $<TARGET_OBJECTS:schema_obj>
         $<TARGET_OBJECTS:gflags_man_obj>
+        $<TARGET_OBJECTS:meta_service_handler>
     LIBRARIES
         ${ROCKSDB_LIBRARIES}
         ${THRIFT_LIBRARIES}
@@ -513,6 +514,44 @@ nebula_add_test(
         job_manager_test
     SOURCES
         JobManagerTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:meta_http_handler>
+        $<TARGET_OBJECTS:meta_service_handler>
+        $<TARGET_OBJECTS:kvstore_obj>
+        $<TARGET_OBJECTS:meta_client>
+        $<TARGET_OBJECTS:meta_thrift_obj>
+        $<TARGET_OBJECTS:storage_thrift_obj>
+        $<TARGET_OBJECTS:common_thrift_obj>
+        $<TARGET_OBJECTS:raftex_obj>
+        $<TARGET_OBJECTS:raftex_thrift_obj>
+        $<TARGET_OBJECTS:wal_obj>
+        $<TARGET_OBJECTS:thrift_obj>
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:ws_common_obj>
+        $<TARGET_OBJECTS:http_client_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:stats_obj>
+        $<TARGET_OBJECTS:network_obj>
+        $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:process_obj>
+        $<TARGET_OBJECTS:schema_obj>
+        $<TARGET_OBJECTS:gflags_man_obj>
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
+        meta_compaction_test
+    SOURCES
+        CompactionTest.cpp
     OBJECTS
         $<TARGET_OBJECTS:meta_http_handler>
         $<TARGET_OBJECTS:meta_service_handler>

--- a/src/meta/test/CompactionTest.cpp
+++ b/src/meta/test/CompactionTest.cpp
@@ -1,0 +1,279 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/Base.h"
+#include <gtest/gtest.h>
+#include <folly/synchronization/Baton.h>
+#include "fs/TempDir.h"
+#include "meta/CompactionFilter.h"
+#include "meta/processors/partsMan/CreateSpaceProcessor.h"
+#include "meta/processors/partsMan/DropSpaceProcessor.h"
+#include "meta/processors/schemaMan/CreateTagProcessor.h"
+#include "meta/processors/schemaMan/CreateEdgeProcessor.h"
+#include "meta/processors/schemaMan/ListTagsProcessor.h"
+#include "meta/processors/schemaMan/ListEdgesProcessor.h"
+#include "meta/processors/indexMan/CreateTagIndexProcessor.h"
+#include "meta/processors/indexMan/CreateEdgeIndexProcessor.h"
+#include "meta/processors/indexMan/ListTagIndexesProcessor.h"
+#include "meta/processors/indexMan/ListEdgeIndexesProcessor.h"
+#include "meta/test/TestUtils.h"
+
+namespace nebula {
+namespace meta {
+
+std::vector<GraphSpaceID> mockSchema(kvstore::KVStore* kv) {
+    std::vector<GraphSpaceID> spaces;
+    // create 10 space
+    for (int i = 0; i < 10; i++) {
+        // In each space we create:
+        // 11 tags (10 normal tags, 1 with default value)
+        // 11 edges (10 normal edges, 1 with default value)
+        // 1 tag index of tag_0
+        // 1 edge index of edge_0
+        {
+            cpp2::SpaceProperties properties;
+            properties.set_space_name(folly::stringPrintf("test_space_%d", i));
+            properties.set_partition_num(10);
+            properties.set_replica_factor(3);
+            cpp2::CreateSpaceReq req;
+            req.set_properties(std::move(properties));
+            auto* processor = CreateSpaceProcessor::instance(kv);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+            EXPECT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.code);
+            spaces.emplace_back(resp.get_id().get_space_id());
+        }
+        for (int j = 0; j < 10; j++) {
+            nebula::cpp2::Schema schema;
+            nebula::cpp2::ColumnDef column;
+            column.name = folly::stringPrintf("tag_%d_col_0", j);
+            column.type.type = SupportedType::INT;
+            schema.columns.emplace_back(std::move(column));
+
+            cpp2::CreateTagReq req;
+            req.set_space_id(spaces.back());
+            req.set_tag_name(folly::stringPrintf("tag_%d", j));
+            req.set_schema(std::move(schema));
+
+            auto* processor = CreateTagProcessor::instance(kv);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+            EXPECT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.code);
+        }
+        for (int j = 0; j < 10; j++) {
+            nebula::cpp2::Schema schema;
+            nebula::cpp2::ColumnDef column;
+            column.name = folly::stringPrintf("edge_%d_col_0", j);
+            column.type.type = SupportedType::INT;
+            schema.columns.emplace_back(std::move(column));
+
+            cpp2::CreateEdgeReq req;
+            req.set_space_id(spaces.back());
+            req.set_edge_name(folly::stringPrintf("edge_%d", j));
+            req.set_schema(std::move(schema));
+
+            auto* processor = CreateEdgeProcessor::instance(kv);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+            EXPECT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.code);
+        }
+        {
+            nebula::cpp2::Schema schema;
+            nebula::cpp2::ColumnDef column;
+            column.name = "tag_default_col_0";
+            column.type.type = SupportedType::INT;
+            nebula::cpp2::Value defaultValue;
+            defaultValue.set_int_value(123);
+            nebula::cpp2::ValueType valueType;
+            valueType.set_type(SupportedType::INT);
+            column.set_default_value(defaultValue);
+            column.set_type(valueType);
+            schema.columns.emplace_back(std::move(column));
+
+            cpp2::CreateTagReq req;
+            req.set_space_id(spaces.back());
+            req.set_tag_name("default_tag");
+            req.set_schema(std::move(schema));
+
+            auto* processor = CreateTagProcessor::instance(kv);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+            EXPECT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.code);
+        }
+        {
+            nebula::cpp2::Schema schema;
+            nebula::cpp2::ColumnDef column;
+            column.name = "edge_default_col_0";
+            column.type.type = SupportedType::INT;
+            nebula::cpp2::Value defaultValue;
+            defaultValue.set_int_value(321);
+            nebula::cpp2::ValueType valueType;
+            valueType.set_type(SupportedType::INT);
+            column.set_default_value(defaultValue);
+            column.set_type(valueType);
+            schema.columns.emplace_back(std::move(column));
+
+            cpp2::CreateEdgeReq req;
+            req.set_space_id(spaces.back());
+            req.set_edge_name("default_edge");
+            req.set_schema(std::move(schema));
+
+            auto* processor = CreateEdgeProcessor::instance(kv);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+            EXPECT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.code);
+        }
+        {
+            cpp2::CreateTagIndexReq req;
+            req.set_space_id(spaces.back());
+            req.set_tag_name("tag_0");
+            std::vector<std::string> fields{"tag_0_col_0"};
+            req.set_fields(std::move(fields));
+            req.set_index_name("tag_0_col_0_index");
+            auto* processor = CreateTagIndexProcessor::instance(kv);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+            EXPECT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+        }
+        {
+            cpp2::CreateEdgeIndexReq req;
+            req.set_space_id(spaces.back());
+            req.set_edge_name("edge_0");
+            std::vector<std::string> fields{"edge_0_col_0"};
+            req.set_fields(std::move(fields));
+            req.set_index_name("edge_0_col_0_index");
+            auto* processor = CreateEdgeIndexProcessor::instance(kv);
+            auto f = processor->getFuture();
+            processor->process(req);
+            auto resp = std::move(f).get();
+            EXPECT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+        }
+    }
+    return spaces;
+}
+
+size_t checkTags(kvstore::KVStore* kv, GraphSpaceID spaceId) {
+    auto prefix = MetaServiceUtils::schemaTagsPrefix(spaceId);
+    std::unique_ptr<kvstore::KVIterator> iter;
+    auto ret = kv->prefix(kDefaultSpaceId, kDefaultPartId, prefix, &iter);
+    if (ret != kvstore::ResultCode::SUCCEEDED) {
+        return 0;
+    }
+    std::vector<TagID> tagIds;
+    while (iter->valid()) {
+        auto key = iter->key();
+        auto tagId = *reinterpret_cast<const TagID *>(key.data() + prefix.size());
+        tagIds.emplace_back(tagId);
+        iter->next();
+    }
+    return tagIds.size();
+}
+
+size_t checkEdges(kvstore::KVStore* kv, GraphSpaceID spaceId) {
+    auto prefix = MetaServiceUtils::schemaEdgesPrefix(spaceId);
+    std::unique_ptr<kvstore::KVIterator> iter;
+    auto ret = kv->prefix(kDefaultSpaceId, kDefaultPartId, prefix, &iter);
+    if (ret != kvstore::ResultCode::SUCCEEDED) {
+        return 0;
+    }
+    std::vector<EdgeType> edgeTypes;
+    while (iter->valid()) {
+        auto key = iter->key();
+        auto edgeType = *reinterpret_cast<const EdgeType*>(key.data() + prefix.size());
+        edgeTypes.emplace_back(edgeType);
+        iter->next();
+    }
+    return edgeTypes.size();
+}
+
+std::pair<int, int> checkIndexes(kvstore::KVStore* kv, GraphSpaceID spaceId) {
+    auto prefix = MetaServiceUtils::indexPrefix(spaceId);
+    std::unique_ptr<kvstore::KVIterator> iter;
+    auto ret = kv->prefix(kDefaultSpaceId, kDefaultPartId, prefix, &iter);
+    if (ret != kvstore::ResultCode::SUCCEEDED) {
+        return {0, 0};
+    }
+
+    int tagIndexCount = 0, edgeIndexCount = 0;
+    while (iter->valid()) {
+        auto val = iter->val();
+        auto item = MetaServiceUtils::parseIndex(val);
+        if (item.get_schema_id().getType() == nebula::cpp2::SchemaID::Type::tag_id) {
+            tagIndexCount++;
+        } else if (item.get_schema_id().getType() == nebula::cpp2::SchemaID::Type::edge_type) {
+            edgeIndexCount++;
+        }
+        iter->next();
+    }
+    return {tagIndexCount, edgeIndexCount};
+}
+
+void dropSpace(kvstore::KVStore* kv, const std::string& spaceName) {
+    cpp2::DropSpaceReq req;
+    req.set_space_name(spaceName);
+    auto* processor = DropSpaceProcessor::instance(kv);
+    auto f = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(f).get();
+    ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, resp.code);
+}
+
+
+TEST(MetaCompactionFilterTest, InvalidSpaceFilterTest) {
+    fs::TempDir rootPath("/tmp/MetaCompactionFilterTest.XXXXXX");
+    uint32_t localMetaPort = network::NetworkUtils::getAvailablePort();
+    MetaCFHelper cfHelper;
+    auto kv = TestUtils::initKV(rootPath.path(), localMetaPort, &cfHelper);
+    TestUtils::createSomeHosts(kv.get());
+
+    // create 10 spaces
+    auto spaces = mockSchema(kv.get());
+
+    for (size_t i = 0; i < spaces.size(); i++) {
+        ASSERT_EQ(11, checkTags(kv.get(), spaces[i]));
+        ASSERT_EQ(11, checkEdges(kv.get(), spaces[i]));
+        ASSERT_EQ(std::make_pair(1, 1), checkIndexes(kv.get(), spaces[i]));
+    }
+
+    // drop even space of even index
+    for (size_t i = 0; i < spaces.size(); i++) {
+        if (i % 2 == 0) {
+            dropSpace(kv.get(), folly::stringPrintf("test_space_%lu", i));
+        }
+    }
+
+    auto* store = static_cast<kvstore::NebulaStore*>(kv.get());
+    store->compact(0);
+
+    for (size_t i = 0; i < spaces.size(); i++) {
+        if (i % 2 == 0) {
+            ASSERT_EQ(0, checkTags(kv.get(), spaces[i]));
+            ASSERT_EQ(0, checkEdges(kv.get(), spaces[i]));
+            ASSERT_EQ(std::make_pair(0, 0), checkIndexes(kv.get(), spaces[i]));
+        } else {
+            ASSERT_EQ(11, checkTags(kv.get(), spaces[i]));
+            ASSERT_EQ(11, checkEdges(kv.get(), spaces[i]));
+            ASSERT_EQ(std::make_pair(1, 1), checkIndexes(kv.get(), spaces[i]));
+        }
+    }
+}
+
+
+}  // namespace meta
+}  // namespace nebula
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    folly::init(&argc, &argv, true);
+    google::SetStderrLogging(google::INFO);
+    return RUN_ALL_TESTS();
+}

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -279,8 +279,7 @@ public:
         return ret;
     }
 
-    static void mockTag(kvstore::KVStore* kv, int32_t tagNum, GraphSpaceID spaceId = 1,
-                        SchemaVer version = 0) {
+    static void mockTag(kvstore::KVStore* kv, int32_t tagNum, SchemaVer version = 0) {
         std::vector<nebula::kvstore::KV> tags;
         SchemaVer ver = version;
         for (auto t = 0; t < tagNum; t++) {
@@ -294,8 +293,8 @@ public:
             }
             auto tagName = folly::stringPrintf("tag_%d", tagId);
             auto tagIdVal = std::string(reinterpret_cast<const char*>(&tagId), sizeof(tagId));
-            tags.emplace_back(MetaServiceUtils::indexTagKey(spaceId, tagName), tagIdVal);
-            tags.emplace_back(MetaServiceUtils::schemaTagKey(spaceId, tagId, ver++),
+            tags.emplace_back(MetaServiceUtils::indexTagKey(1, tagName), tagIdVal);
+            tags.emplace_back(MetaServiceUtils::schemaTagKey(1, tagId, ver++),
                               MetaServiceUtils::schemaTagVal(tagName, srcsch));
         }
         folly::Baton<true, std::atomic> baton;
@@ -307,8 +306,7 @@ public:
         baton.wait();
     }
 
-    static void mockEdge(kvstore::KVStore* kv, int32_t edgeNum, GraphSpaceID spaceId = 1,
-                         SchemaVer version = 0) {
+    static void mockEdge(kvstore::KVStore* kv, int32_t edgeNum, SchemaVer version = 0) {
         std::vector<nebula::kvstore::KV> edges;
         SchemaVer ver = version;
         for (auto t = 0; t < edgeNum; t++) {
@@ -323,8 +321,8 @@ public:
             auto edgeName = folly::stringPrintf("edge_%d", edgeType);
             auto edgeTypeVal = std::string(reinterpret_cast<const char*>(&edgeType),
                                            sizeof(edgeType));
-            edges.emplace_back(MetaServiceUtils::indexEdgeKey(spaceId, edgeName), edgeTypeVal);
-            edges.emplace_back(MetaServiceUtils::schemaEdgeKey(spaceId, edgeType, ver++),
+            edges.emplace_back(MetaServiceUtils::indexEdgeKey(1, edgeName), edgeTypeVal);
+            edges.emplace_back(MetaServiceUtils::schemaEdgeKey(1, edgeType, ver++),
                                MetaServiceUtils::schemaEdgeVal(edgeName, srcsch));
         }
 


### PR DESCRIPTION
1. Add meta compaction filter, when we drop a space, we can filter the tag/edge/part/... of the space when we compact.
2. Use a MetaCFHelper to get all spaces when we begin to compact.
3. Add a MetaHttpAdminHandler to `compact` and `flush` manually.

close #285