### PR TITLE
Fix meta would crash when balance in multiple relica

### DIFF
--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -139,6 +139,7 @@ ResultCode RocksEngine::commitBatchWrite(std::unique_ptr<WriteBatch> batch) {
     if (status.ok()) {
         return ResultCode::SUCCEEDED;
     }
+    LOG(ERROR) << "Write into rocksdb failed because of " << status.ToString();
     return ResultCode::ERR_UNKNOWN;
 }
 

--- a/src/meta/processors/admin/Balancer.cpp
+++ b/src/meta/processors/admin/Balancer.cpp
@@ -113,6 +113,10 @@ cpp2::ErrorCode Balancer::recovery() {
             auto self = plan_;
             {
                 std::lock_guard<std::mutex> lg(lock_);
+                if (LastUpdateTimeMan::update(kv_, time::WallClock::fastNowInMilliSec()) !=
+                        kvstore::ResultCode::SUCCEEDED) {
+                    LOG(INFO) << "Balance plan " << plan_->id() << " update meta failed";
+                }
                 finish();
             }
         };
@@ -165,6 +169,10 @@ cpp2::ErrorCode Balancer::buildBalancePlan(std::vector<HostAddr> hostDel) {
         auto self = plan_;
         {
             std::lock_guard<std::mutex> lg(lock_);
+            if (LastUpdateTimeMan::update(kv_, time::WallClock::fastNowInMilliSec()) !=
+                    kvstore::ResultCode::SUCCEEDED) {
+                LOG(INFO) << "Balance plan " << plan_->id() << " update meta failed";
+            }
             finish();
         }
     };

--- a/src/meta/processors/admin/Balancer.h
+++ b/src/meta/processors/admin/Balancer.h
@@ -106,10 +106,6 @@ public:
 
     void finish() {
         CHECK(!lock_.try_lock());
-        if (LastUpdateTimeMan::update(kv_, time::WallClock::fastNowInMilliSec()) !=
-                kvstore::ResultCode::SUCCEEDED) {
-            LOG(INFO) << "Balance plan " << plan_->id() << " update meta failed";
-        }
         plan_.reset();
         running_ = false;
     }

--- a/src/storage/admin/AdminProcessor.h
+++ b/src/storage/admin/AdminProcessor.h
@@ -249,6 +249,7 @@ public:
             while (retry-- > 0) {
                 auto res = part->isCatchedUp(peer);
                 LOG(INFO) << "Waiting for catching up data, peer " << peer
+                          << ", space " << spaceId << ", part " << partId
                           << ", remaining " << retry << " retry times"
                           << ", result " << static_cast<int32_t>(res);
                 switch (res) {
@@ -265,7 +266,8 @@ public:
                         return;
                     }
                     case raftex::AppendLogResult::E_SENDING_SNAPSHOT:
-                        LOG(INFO) << "Still sending snapshot, please wait...";
+                        LOG(INFO) << "Space " << spaceId << ", partId " << partId
+                                  << " is still sending snapshot, please wait...";
                         break;
                     default:
                         LOG(INFO) << "Unknown error " << static_cast<int32_t>(res);


### PR DESCRIPTION
1. As title, introduced in #1786, when recovery failed, the plan would be nullptr.
2. Add an error log when commit failed.

close #1820