### PR TITLE
Add config for AWS EC2 c5d.xlarge

### DIFF
--- a/etc/nebula-storage.conf.c5d.12xlarge
+++ b/etc/nebula-storage.conf.c5d.12xlarge
@@ -1,3 +1,9 @@
+########## bench ########### 
+# AWS EC2 c5d.12xlarge
+# vCPU 48 
+# memory 96 GiB
+# Disk 2 * 900GiB NVMe SSD
+
 ########## basics ##########
 # Whether to run as a daemon process
 --daemonize=true
@@ -29,7 +35,7 @@
 --ws_h2_port=12002
 
 ########## storage ##########
-# Root data path, multiple paths should be splitted by comma.
+# Root data path, multiple paths should be separated by comma.
 # One path per instance, if --engine_type is `rocksdb'
 --data_path=data/storage
 
@@ -38,14 +44,14 @@
 
 # The default block cache size used in BlockBasedTable.
 # The unit is MB.
---rocksdb_block_cache=1024
+--rocksdb_block_cache=32768
 
 ############## rocksdb Options ##############
 --rocksdb_disable_wal=true
 # rocksdb DBOptions in json, each name and value of option is a string, given as "option_name":"option_value" separated by comma
 --rocksdb_db_options={}
 # rocksdb ColumnFamilyOptions in json, each name and value of option is string, given as "option_name":"option_value" separated by comma
---rocksdb_column_family_options={"write_buffer_size":"67108864","max_write_buffer_number":"4","max_bytes_for_level_base":"268435456"}
+--rocksdb_column_family_options={"write_buffer_size":"536870912‬","max_write_buffer_number":"4","max_bytes_for_level_base":"268435456"}
 # rocksdb BlockBasedTableOptions in json, each name and value of option is string, given as "option_name":"option_value" separated by comma
 --rocksdb_block_based_table_options={"block_size":"8192"}
 

--- a/etc/nebula-storage.conf.c5d.xlarge
+++ b/etc/nebula-storage.conf.c5d.xlarge
@@ -1,0 +1,60 @@
+########## bench ########### 
+# AWS EC2 c5d.xlarge
+# vCPU 4
+# memory 8 GiB
+# Disk 100GiB NVMe SSD
+
+########## basics ##########
+# Whether to run as a daemon process
+--daemonize=true
+# The file to host the process id
+--pid_file=pids/nebula-storaged.pid
+
+########## logging ##########
+# The directory to host logging files, which must already exists
+--log_dir=logs
+# Log level, 0, 1, 2, 3 for INFO, WARNING, ERROR, FATAL respectively
+--minloglevel=0
+# Verbose log level, 1, 2, 3, 4, the higher of the level, the more verbose of the logging
+--v=0
+# Maximum seconds to buffer the log messages
+--logbufsecs=0
+
+########## networking ##########
+# Meta server address
+--meta_server_addrs=127.0.0.1:45500
+# Local ip
+--local_ip=127.0.0.1
+# Storage daemon listening port
+--port=44500
+# HTTP service ip
+--ws_ip=127.0.0.1
+# HTTP service port
+--ws_http_port=12000
+# HTTP2 service port
+--ws_h2_port=12002
+
+########## storage ##########
+# Root data path, multiple paths should be separated by comma.
+# One path per instance, if --engine_type is `rocksdb'
+--data_path=data/storage
+
+# The default reserved bytes for one batch operation
+--rocksdb_batch_size=4096
+
+# The default block cache size used in BlockBasedTable.
+# The unit is MB.
+--rocksdb_block_cache=512
+
+############## rocksdb Options ##############
+--rocksdb_disable_wal=true
+# rocksdb DBOptions in json, each name and value of option is a string, given as "option_name":"option_value" separated by comma
+--rocksdb_db_options={}
+# rocksdb ColumnFamilyOptions in json, each name and value of option is string, given as "option_name":"option_value" separated by comma
+--rocksdb_column_family_options={"write_buffer_size":"67108864‬‬","max_write_buffer_number":"4","max_bytes_for_level_base":"268435456"}
+# rocksdb BlockBasedTableOptions in json, each name and value of option is string, given as "option_name":"option_value" separated by comma
+--rocksdb_block_based_table_options={"block_size":"8192"}
+
+--max_handlers_per_req=1
+
+--heartbeat_interval_secs=10


### PR DESCRIPTION
<!--
Thank you for contributing to **Nebula Graph**! Please read the [CONTRIBUTING](https://github.com/vesoft-inc/nebula/blob/master/docs/manual-EN/4.contributions/how-to-contribute.md
) document **BEFORE** filing this PR.
-->

### What changes were proposed in this pull request?

I think an AWS EC2 config will be more comparable/illustrative for users to set conf file.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some nGQL features, you can provide some references.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
These are conf file examples. I've been asked many times of recommended configs.
AWS EC2 is typical. AWS EC2 xlarge is for minimal & 12xlarge is for standard usage.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce any user-facing change?
No.
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
Not necessary.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
