### PR TITLE
add a flag to close config cmd

### DIFF
--- a/src/graph/ConfigExecutor.cpp
+++ b/src/graph/ConfigExecutor.cpp
@@ -24,6 +24,11 @@ Status ConfigExecutor::prepare() {
 }
 
 void ConfigExecutor::execute() {
+
+    if (FLAG_disable_config_executor) {
+        doError(Status::Error("do not support"));
+    }
+
     auto showType = sentence_->subType();
     switch (showType) {
         case ConfigSentence::SubType::kShow:

--- a/src/graph/ConfigExecutor.h
+++ b/src/graph/ConfigExecutor.h
@@ -14,6 +14,8 @@
 namespace nebula {
 namespace graph {
 
+DEFINE_bool(disable_config_executor, false, "disable config cmds");
+
 class ConfigExecutor final : public Executor {
 public:
     ConfigExecutor(Sentence *sentence, ExecutionContext *ectx);


### PR DESCRIPTION
For security, We must disable config command in some situation.