### PR TITLE
Fix package/build/release failed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
         CCACHE_DIR: /tmp/ccache/
       options: --mount type=tmpfs,destination=/tmp/ccache,tmpfs-size=1073741824
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
         with:
           fetch-depth: 1
       - uses: actions/cache@v1

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -24,7 +24,7 @@ jobs:
     container:
       image: vesoft/nebula-dev:${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - name: Package
         run: ./package/package.sh
         shell: bash

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
       - name: Cpplint
         run: |
           cd .linters/cpp && ln -snf hooks/pre-commit.sh
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 1
+          fetch-depth: 2
       - name: Ignore only documents changes
         id: ignore_docs
         run: |

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Cpplint
         run: |
           cd .linters/cpp && ln -snf hooks/pre-commit.sh

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     container:
       image: vesoft/nebula-dev:${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
       - name: package
         run: ./package/package.sh
       - name: vars
@@ -63,7 +63,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v1
         with:
           fetch-depth: 1
       - name: build release image

--- a/src/meta/test/CMakeLists.txt
+++ b/src/meta/test/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(meta_test_deps
     $<TARGET_OBJECTS:meta_client>
     $<TARGET_OBJECTS:meta_service_handler>
+    $<TARGET_OBJECTS:ws_common_obj>
+    $<TARGET_OBJECTS:http_client_obj>
     $<TARGET_OBJECTS:gflags_man_obj>
     $<TARGET_OBJECTS:raftex_thrift_obj>
     $<TARGET_OBJECTS:storage_thrift_obj>


### PR DESCRIPTION
Modify package/build/release workflow to checkout@v1, because v2 need node12, but centos6 hasn't.