### PR TITLE
Fix exit-on-failure in build-third-party.sh

### DIFF
--- a/third-party/build-third-party.sh
+++ b/third-party/build-third-party.sh
@@ -66,10 +66,6 @@ function check_cxx {
 check_cmake
 check_cxx
 
-# Exit on any failure here after
-set -e
-set -o pipefail
-
 # Directories setup
 cur_dir=`pwd`
 source_dir=$(readlink -f $(dirname $0)/..)/third-party
@@ -85,6 +81,10 @@ cxx_cmd=${CXX:-g++}
 gcc_version=$(${CXX:-g++} -dumpfullversion -dumpversion)
 abi_version=$($this_dir/cxx-compiler-abi-version.sh)
 libc_version=$(ldd --version | head -1 | cut -d ' ' -f4 | cut -d '-' -f1)
+
+# Exit on any failure here after
+set -e
+set -o pipefail
 
 
 trap '[[ $? -ne 0 ]] && echo "Building failed, see $logfile for more details." 1>&2' EXIT


### PR DESCRIPTION
There were some local fixes on #1895 that were not committed by mistake. My bad.

This fix prevent exit when the libc version detection fails due to the `ldd` outputs differ in different  platforms.