### PR TITLE
Detect OS type and exit if not built in Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,13 @@ project("Nebula Graph" C CXX)
 
 # Set the project home dir
 set(NEBULA_HOME ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+	MESSAGE(FATAL_ERROR "Only Linux is supported")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+	MESSAGE(FATAL_ERROR "Only Linux is supported")
+endif ()
+
 # To include customized FindXXX.cmake modules
 set(CMAKE_MODULE_PATH "${NEBULA_HOME}/cmake" ${CMAKE_MODULE_PATH})
 include(LinkerConfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,7 @@ project("Nebula Graph" C CXX)
 # Set the project home dir
 set(NEBULA_HOME ${CMAKE_CURRENT_SOURCE_DIR})
 
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
-	MESSAGE(FATAL_ERROR "Only Linux is supported")
-elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+if(${CMAKE_SYSTEM_NAME} MATCHES "(Darwin|FreeBSD|Windows)")
 	MESSAGE(FATAL_ERROR "Only Linux is supported")
 endif ()
 

--- a/cmake/LinkerConfig.cmake
+++ b/cmake/LinkerConfig.cmake
@@ -9,7 +9,7 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-if (${default_linker_type} STREQUAL "ld")
+if ("${default_linker_type}" STREQUAL "ld")
     set(default_linker_type "bfd")
 endif()
 

--- a/third-party/install-third-party.sh
+++ b/third-party/install-third-party.sh
@@ -7,6 +7,11 @@
 
 # Usage: install-third-party.sh --prefix=/opt/vesoft/third-party
 
+[[ $(uname) = Linux ]] || {
+    echo "Only Linux is supported"
+    exit 1
+}
+
 # Always use bash
 shell=$(basename $(readlink /proc/$$/exe))
 if [ ! x$shell = x"bash" ]
@@ -14,11 +19,6 @@ then
     bash $0 $@
     exit $?
 fi
-
-[[ $(uname) = Linux ]] || {
-    echo "Only Linux is supported"
-    exit 1
-}
 
 url_base=https://nebula-graph.oss-accelerate.aliyuncs.com/third-party
 this_dir=$(dirname $(readlink -f $0))


### PR DESCRIPTION
<!--
Thank you for contributing to **Nebula Graph**! Please read the [CONTRIBUTING](https://github.com/vesoft-inc/nebula/blob/master/docs/manual-EN/4.contributions/how-to-contribute.md
) document **BEFORE** filing this PR.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some nGQL features, you can provide some references.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Make it more friendly to tell users that now building nebula under MacOS X is not supported.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When I try to build nebula in my macbook, it print error like this.
```
>  cmake -DENABLE_TESTING=OFF ..
ld: unknown option: --version
CMake Error at cmake/LinkerConfig.cmake:12 (if):
  if given arguments:

    "STREQUAL" "ld"

  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:35 (include)
```
After ` cmake/LinkerConfig.cmake` fixed, it print error like this. And I found that "Only Linux is supported".
```
>  cmake -DENABLE_TESTING=OFF ..
ld: unknown option: --version
-- NEBULA_USE_LINKER: 
-- ENABLE_ASAN: OFF
-- ENABLE_TESTING: OFF
-- ENABLE_UBSAN: OFF
-- ENABLE_FUZZ_TEST: OFF
-- ENABLE_TSAN: OFF
-- ENABLE_STATIC_ASAN : OFF
-- ENABLE_STATIC_UBSAN : OFF
-- CCACHE: enabled but not found
-- CMAKE_BUILD_TYPE = Debug (Options are: Debug, Release, RelWithDebInfo, MinSizeRel)
-- CMAKE_INSTALL_PREFIX: /usr/local/nebula
-- Downloading prebuilt third party automatically...
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
```

I think it is better to detect OS type in CMake and let it exit more earlier with friendly message.

### Does this PR introduce any user-facing change?
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual test