### PR TITLE
Remove removePrefix interface in kvstore

### DIFF
--- a/src/kvstore/KVEngine.h
+++ b/src/kvstore/KVEngine.h
@@ -23,8 +23,6 @@ public:
 
     virtual ResultCode remove(folly::StringPiece key) = 0;
 
-    virtual ResultCode removePrefix(folly::StringPiece prefix) = 0;
-
     // Remove all keys in the range [start, end)
     virtual ResultCode removeRange(folly::StringPiece start,
                                    folly::StringPiece end) = 0;
@@ -44,7 +42,9 @@ public:
     virtual const char* getDataRoot() const = 0;
 
     virtual std::unique_ptr<WriteBatch> startBatchWrite() = 0;
-    virtual ResultCode commitBatchWrite(std::unique_ptr<WriteBatch> batch) = 0;
+
+    virtual ResultCode commitBatchWrite(std::unique_ptr<WriteBatch> batch,
+                                        bool disableWAL = true) = 0;
 
     // Read a single key
     virtual ResultCode get(const std::string& key, std::string* value) = 0;
@@ -83,9 +83,6 @@ public:
     // Remove range [start, end)
     virtual ResultCode removeRange(const std::string& start,
                                    const std::string& end) = 0;
-
-    // Remove rows with the given prefix
-    virtual ResultCode removePrefix(const std::string& prefix) = 0;
 
     // Add partId into current storage engine.
     virtual void addPart(PartitionID partId) = 0;

--- a/src/kvstore/KVStore.h
+++ b/src/kvstore/KVStore.h
@@ -153,11 +153,6 @@ public:
                                   const std::string& end,
                                   KVCallback cb) = 0;
 
-    virtual void asyncRemovePrefix(GraphSpaceID spaceId,
-                                   PartitionID partId,
-                                   const std::string& prefix,
-                                   KVCallback cb) = 0;
-
     virtual void asyncAtomicOp(GraphSpaceID spaceId,
                                PartitionID partId,
                                raftex::AtomicOp op,

--- a/src/kvstore/LogEncoder.h
+++ b/src/kvstore/LogEncoder.h
@@ -17,7 +17,6 @@ enum LogType : char {
     OP_MULTI_PUT      = 0x2,
     OP_REMOVE         = 0x3,
     OP_MULTI_REMOVE   = 0x4,
-    OP_REMOVE_PREFIX  = 0x5,
     OP_REMOVE_RANGE   = 0x6,
     OP_ADD_LEARNER    = 0x07,
     OP_TRANS_LEADER   = 0x08,
@@ -30,7 +29,6 @@ enum BatchLogType : char {
     OP_BATCH_PUT            = 0x1,
     OP_BATCH_REMOVE         = 0x2,
     OP_BATCH_REMOVE_RANGE   = 0x3,
-    OP_BATCH_REMOVE_PREFIX  = 0x4,
 };
 
 std::string encodeKV(const folly::StringPiece& key,
@@ -83,13 +81,6 @@ public:
         auto op = std::make_tuple(BatchLogType::OP_BATCH_REMOVE_RANGE,
                                   std::forward<std::string>(begin),
                                   std::forward<std::string>(end));
-        batch_.emplace_back(std::move(op));
-    }
-
-    void removePrefix(std::string&& key) {
-        auto op = std::make_tuple(BatchLogType::OP_BATCH_REMOVE_PREFIX,
-                                  std::forward<std::string>(key),
-                                  "");
         batch_.emplace_back(std::move(op));
     }
 

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -520,20 +520,6 @@ void NebulaStore::asyncRemoveRange(GraphSpaceID spaceId,
     part->asyncRemoveRange(start, end, std::move(cb));
 }
 
-
-void NebulaStore::asyncRemovePrefix(GraphSpaceID spaceId,
-                                    PartitionID partId,
-                                    const std::string& prefix,
-                                    KVCallback cb) {
-    auto ret = part(spaceId, partId);
-    if (!ok(ret)) {
-        cb(error(ret));
-        return;
-    }
-    auto part = nebula::value(ret);
-    part->asyncRemovePrefix(prefix, std::move(cb));
-}
-
 void NebulaStore::asyncAtomicOp(GraphSpaceID spaceId,
                                 PartitionID partId,
                                 raftex::AtomicOp op,

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -171,11 +171,6 @@ public:
                           const std::string& end,
                           KVCallback cb) override;
 
-    void asyncRemovePrefix(GraphSpaceID spaceId,
-                           PartitionID partId,
-                           const std::string& prefix,
-                           KVCallback cb) override;
-
     void asyncAtomicOp(GraphSpaceID spaceId,
                        PartitionID partId,
                        raftex::AtomicOp op,

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -7,6 +7,7 @@
 #include "kvstore/Part.h"
 #include "kvstore/LogEncoder.h"
 #include "base/NebulaKeyUtils.h"
+#include "kvstore/RocksEngineConfig.h"
 
 DEFINE_int32(cluster_id, 0, "A unique id for each cluster");
 
@@ -90,16 +91,6 @@ void Part::asyncRemove(folly::StringPiece key, KVCallback cb) {
 
 void Part::asyncMultiRemove(const std::vector<std::string>& keys, KVCallback cb) {
     std::string log = encodeMultiValues(OP_MULTI_REMOVE, keys);
-
-    appendAsync(FLAGS_cluster_id, std::move(log))
-        .thenValue([this, callback = std::move(cb)] (AppendLogResult res) mutable {
-            callback(this->toResultCode(res));
-        });
-}
-
-
-void Part::asyncRemovePrefix(folly::StringPiece prefix, KVCallback cb) {
-    std::string log = encodeSingleValue(OP_REMOVE_PREFIX, prefix);
 
     appendAsync(FLAGS_cluster_id, std::move(log))
         .thenValue([this, callback = std::move(cb)] (AppendLogResult res) mutable {
@@ -249,14 +240,6 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
             }
             break;
         }
-        case OP_REMOVE_PREFIX: {
-            auto prefix = decodeSingleValue(log);
-            if (batch->removePrefix(prefix) != ResultCode::SUCCEEDED) {
-                LOG(ERROR) << idStr_ << "Failed to call WriteBatch::removePrefix()";
-                return false;
-            }
-            break;
-        }
         case OP_REMOVE_RANGE: {
             auto range = decodeMultiValues(log);
             DCHECK_EQ(2, range.size());
@@ -276,10 +259,7 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
                     code = batch->remove(op.second.first);
                 } else if (op.first == BatchLogType::OP_BATCH_REMOVE_RANGE) {
                     code = batch->removeRange(op.second.first, op.second.second);
-                } else if (op.first == BatchLogType::OP_BATCH_REMOVE_PREFIX) {
-                    code = batch->removePrefix(op.second.first);
                 }
-
                 if (code != ResultCode::SUCCEEDED) {
                     LOG(ERROR) << idStr_ << "Failed to call WriteBatch";
                     return false;
@@ -325,7 +305,8 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
             return false;
         }
     }
-    return engine_->commitBatchWrite(std::move(batch)) == ResultCode::SUCCEEDED;
+    return engine_->commitBatchWrite(std::move(batch), FLAGS_rocksdb_disable_wal)
+                    == ResultCode::SUCCEEDED;
 }
 
 std::pair<int64_t, int64_t> Part::commitSnapshot(const std::vector<std::string>& rows,
@@ -350,7 +331,8 @@ std::pair<int64_t, int64_t> Part::commitSnapshot(const std::vector<std::string>&
             return std::make_pair(0, 0);
         }
     }
-    if (ResultCode::SUCCEEDED != engine_->commitBatchWrite(std::move(batch))) {
+    // For snapshot, we open the rocksdb's wal to avoid loss data if crash.
+    if (ResultCode::SUCCEEDED != engine_->commitBatchWrite(std::move(batch), false)) {
         LOG(ERROR) << idStr_ << "Put failed in commit";
         return std::make_pair(0, 0);
     }

--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -45,7 +45,6 @@ public:
 
     void asyncRemove(folly::StringPiece key, KVCallback cb);
     void asyncMultiRemove(const std::vector<std::string>& keys, KVCallback cb);
-    void asyncRemovePrefix(folly::StringPiece prefix, KVCallback cb);
     void asyncRemoveRange(folly::StringPiece start,
                           folly::StringPiece end,
                           KVCallback cb);

--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -27,10 +27,9 @@ namespace {
 class RocksWriteBatch : public WriteBatch {
 private:
     rocksdb::WriteBatch batch_;
-    rocksdb::DB* db_{nullptr};
 
 public:
-    explicit RocksWriteBatch(rocksdb::DB* db) : batch_(FLAGS_rocksdb_batch_size), db_(db) {}
+    RocksWriteBatch() : batch_(FLAGS_rocksdb_batch_size) {}
 
     virtual ~RocksWriteBatch() = default;
 
@@ -48,25 +47,6 @@ public:
         } else {
             return ResultCode::ERR_UNKNOWN;
         }
-    }
-
-    ResultCode removePrefix(folly::StringPiece prefix) override {
-        rocksdb::Slice pre(prefix.begin(), prefix.size());
-        rocksdb::ReadOptions options;
-        std::unique_ptr<rocksdb::Iterator> iter(db_->NewIterator(options));
-        iter->Seek(pre);
-        while (iter->Valid()) {
-            if (iter->key().starts_with(pre)) {
-                if (!batch_.Delete(iter->key()).ok()) {
-                    return ResultCode::ERR_UNKNOWN;
-                }
-            } else {
-                // Done
-                break;
-            }
-            iter->Next();
-        }
-        return ResultCode::SUCCEEDED;
     }
 
     // Remove all keys in the range [start, end)
@@ -127,13 +107,13 @@ RocksEngine::RocksEngine(GraphSpaceID spaceId,
 
 
 std::unique_ptr<WriteBatch> RocksEngine::startBatchWrite() {
-    return std::make_unique<RocksWriteBatch>(db_.get());
+    return std::make_unique<RocksWriteBatch>();
 }
 
 
-ResultCode RocksEngine::commitBatchWrite(std::unique_ptr<WriteBatch> batch) {
+ResultCode RocksEngine::commitBatchWrite(std::unique_ptr<WriteBatch> batch, bool disableWAL) {
     rocksdb::WriteOptions options;
-    options.disableWAL = FLAGS_rocksdb_disable_wal;
+    options.disableWAL = disableWAL;
     auto* b = static_cast<RocksWriteBatch*>(batch.get());
     rocksdb::Status status = db_->Write(options, b->data());
     if (status.ok()) {
@@ -285,8 +265,6 @@ ResultCode RocksEngine::removeRange(const std::string& start,
                                     const std::string& end) {
     rocksdb::WriteOptions options;
     options.disableWAL = FLAGS_rocksdb_disable_wal;
-    // TODO(sye) Given the RocksDB version we are using,
-    // we should avoud using DeleteRange
     auto status = db_->DeleteRange(options, db_->DefaultColumnFamily(), start, end);
     if (status.ok()) {
         return ResultCode::SUCCEEDED;
@@ -296,40 +274,9 @@ ResultCode RocksEngine::removeRange(const std::string& start,
     }
 }
 
-
-ResultCode RocksEngine::removePrefix(const std::string& prefix) {
-    rocksdb::Slice pre(prefix.data(), prefix.size());
-    rocksdb::ReadOptions readOptions;
-    rocksdb::WriteBatch batch;
-    std::unique_ptr<rocksdb::Iterator> iter(db_->NewIterator(readOptions));
-    iter->Seek(pre);
-    while (iter->Valid()) {
-        if (iter->key().starts_with(pre)) {
-            auto status = batch.Delete(iter->key());
-            if (!status.ok()) {
-                return ResultCode::ERR_UNKNOWN;
-            }
-        } else {
-            // Done
-            break;
-        }
-        iter->Next();
-    }
-
-    rocksdb::WriteOptions writeOptions;
-    writeOptions.disableWAL = FLAGS_rocksdb_disable_wal;
-    if (db_->Write(writeOptions, &batch).ok()) {
-        return ResultCode::SUCCEEDED;
-    } else {
-        return ResultCode::ERR_UNKNOWN;
-    }
-}
-
-
 std::string RocksEngine::partKey(PartitionID partId) {
     return NebulaKeyUtils::systemPartKey(partId);
 }
-
 
 void RocksEngine::addPart(PartitionID partId) {
     auto ret = put(partKey(partId), "");

--- a/src/kvstore/RocksEngine.h
+++ b/src/kvstore/RocksEngine.h
@@ -108,7 +108,9 @@ public:
     }
 
     std::unique_ptr<WriteBatch> startBatchWrite() override;
-    ResultCode commitBatchWrite(std::unique_ptr<WriteBatch> batch) override;
+
+    ResultCode commitBatchWrite(std::unique_ptr<WriteBatch> batch,
+                                bool disableWAL) override;
 
     /*********************
      * Data retrieval
@@ -142,8 +144,6 @@ public:
 
     ResultCode removeRange(const std::string& start,
                            const std::string& end) override;
-
-    ResultCode removePrefix(const std::string& prefix) override;
 
     /*********************
      * Non-data operation

--- a/src/kvstore/plugins/hbase/HBaseStore.h
+++ b/src/kvstore/plugins/hbase/HBaseStore.h
@@ -156,7 +156,7 @@ public:
     void asyncRemovePrefix(GraphSpaceID spaceId,
                            PartitionID partId,
                            const std::string& prefix,
-                           KVCallback cb) override;
+                           KVCallback cb);
 
     void asyncAtomicOp(GraphSpaceID,
                        PartitionID,

--- a/src/storage/BaseProcessor.h
+++ b/src/storage/BaseProcessor.h
@@ -68,8 +68,6 @@ protected:
     void doRemoveRange(GraphSpaceID spaceId, PartitionID partId, std::string start,
                        std::string end);
 
-    void doRemovePrefix(GraphSpaceID spaceId, PartitionID partId, std::string prefix);
-
     kvstore::ResultCode doRange(GraphSpaceID spaceId, PartitionID partId, std::string start,
                                 std::string end, std::unique_ptr<kvstore::KVIterator>* iter);
 

--- a/src/storage/BaseProcessor.inl
+++ b/src/storage/BaseProcessor.inl
@@ -104,16 +104,6 @@ void BaseProcessor<RESP>::doRemoveRange(GraphSpaceID spaceId,
         });
 }
 
-template <typename RESP>
-void BaseProcessor<RESP>::doRemovePrefix(GraphSpaceID spaceId,
-                                         PartitionID partId,
-                                         std::string prefix) {
-    this->kvstore_->asyncRemovePrefix(
-        spaceId, partId, prefix, [spaceId, partId, this](kvstore::ResultCode code) {
-            handleAsync(spaceId, partId, code);
-        });
-}
-
 template<typename RESP>
 kvstore::ResultCode BaseProcessor<RESP>::doRange(GraphSpaceID spaceId,
                                                  PartitionID partId,


### PR DESCRIPTION
Current implementation of removePrefix in kvstore is unusable.  It will block current thread for a long time due to scan all data with 'prefix'.  

After upgrade the rocksdb,  we could use removeRange interface to replace the 'removePrefix' in our codebase.   

I will give some basic interfaces about 'nextKey' operations to figure out the end key later.  To avoid the wrong usage,  let's remove the interface firstly. 