### PR TITLE
Fix the read performance issue after delete range with rocksdb-5.15.10

### DIFF
--- a/src/storage/BaseProcessor.h
+++ b/src/storage/BaseProcessor.h
@@ -65,9 +65,6 @@ protected:
 
     void doRemove(GraphSpaceID spaceId, PartitionID partId, std::vector<std::string> keys);
 
-    void doRemoveRange(GraphSpaceID spaceId, PartitionID partId, std::string start,
-                       std::string end);
-
     kvstore::ResultCode doRange(GraphSpaceID spaceId, PartitionID partId, std::string start,
                                 std::string end, std::unique_ptr<kvstore::KVIterator>* iter);
 

--- a/src/storage/BaseProcessor.inl
+++ b/src/storage/BaseProcessor.inl
@@ -93,17 +93,6 @@ void BaseProcessor<RESP>::doRemove(GraphSpaceID spaceId,
         });
 }
 
-template <typename RESP>
-void BaseProcessor<RESP>::doRemoveRange(GraphSpaceID spaceId,
-                                        PartitionID partId,
-                                        std::string start,
-                                        std::string end) {
-    this->kvstore_->asyncRemoveRange(
-        spaceId, partId, start, end, [spaceId, partId, this](kvstore::ResultCode code) {
-            handleAsync(spaceId, partId, code);
-        });
-}
-
 template<typename RESP>
 kvstore::ResultCode BaseProcessor<RESP>::doRange(GraphSpaceID spaceId,
                                                  PartitionID partId,

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -45,6 +45,7 @@ void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
                 if (ret != kvstore::ResultCode::SUCCEEDED) {
                     VLOG(3) << "Error! ret = " << static_cast<int32_t>(ret)
                             << ", spaceID " << spaceId;
+                    this->handleErrorCode(ret, spaceId, partId);
                     this->onFinished();
                     return;
                 }

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -48,6 +48,7 @@ void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
                     this->onFinished();
                     return;
                 }
+                keys.clear();
                 while (iter && iter->valid()) {
                     auto key = iter->key();
                     keys.emplace_back(key.data(), key.size());

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -53,7 +53,7 @@ void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
                     keys.emplace_back(key.data(), key.size());
                     iter->next();
                 }
-                doRemove(spaceId, partId, std::move(keys));
+                doRemove(spaceId, partId, keys);
             }
         }
     } else {


### PR DESCRIPTION
The problem comes from the implementation about deleteRange in rocksdb 5.15.10.

In version 5.15.10,  when calling deleteRange, rocksdb save tombstone as a whole range,  which means for each read, we should scan the range with O(n).

After upgrade the version to the newest one,  rocksdb do split the tombstone range which could allow to do a binary search with O(log(n))

This is why i upgrade the rocksdb's version. 


For more information about deleteRange,  please refer to 
https://github.com/facebook/rocksdb/wiki/DeleteRange-Implementation