### PR TITLE
Remove the LOG(FATAL) when encountering the unknown log.

### DIFF
--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -292,7 +292,7 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
             break;
         }
         default: {
-            LOG(FATAL) << idStr_ << "Unknown operation: " << static_cast<uint8_t>(log[0]);
+            LOG(WARNING) << idStr_ << "Unknown operation: " << static_cast<int32_t>(log[0]);
         }
         }
 


### PR DESCRIPTION
For the backward compatibility, we should not crash directly when encountering unknown log. Instead, we just skip it and give a LOG message. 


close #1967  
