### PR TITLE
Fix meta would send empty raft snapshot

### DIFF
--- a/etc/nebula-metad.conf.production
+++ b/etc/nebula-metad.conf.production
@@ -33,3 +33,6 @@
 ########## storage ##########
 # Root data path, here should be only single path for metad
 --data_path=data/meta
+
+############## rocksdb Options ##############
+--rocksdb_disable_wal=false

--- a/etc/nebula-metad.conf.production
+++ b/etc/nebula-metad.conf.production
@@ -36,3 +36,4 @@
 
 ############## rocksdb Options ##############
 --rocksdb_disable_wal=false
+--rocksdb_wal_sync=true

--- a/src/common/utils/NebulaKeyUtils.cpp
+++ b/src/common/utils/NebulaKeyUtils.cpp
@@ -195,6 +195,15 @@ std::string NebulaKeyUtils::prefix(PartitionID partId) {
 }
 
 // static
+std::string NebulaKeyUtils::snapshotPrefix(PartitionID partId) {
+    // snapshot of meta would be all key-value pairs
+    if (partId == 0) {
+        return "";
+    }
+    return prefix(partId);
+}
+
+// static
 std::string NebulaKeyUtils::vertexPrefix(PartitionID partId, VertexID vId) {
     PartitionID item = (partId << kPartitionOffset) | static_cast<uint32_t>(NebulaKeyType::kData);
     std::string key;

--- a/src/common/utils/NebulaKeyUtils.h
+++ b/src/common/utils/NebulaKeyUtils.h
@@ -104,6 +104,8 @@ public:
 
     static std::string prefix(PartitionID partId);
 
+    static std::string snapshotPrefix(PartitionID partId);
+
     static PartitionID getPart(const folly::StringPiece& rawKey) {
         return readInt<PartitionID>(rawKey.data(), sizeof(PartitionID)) >> 8;
     }

--- a/src/kvstore/KVEngine.h
+++ b/src/kvstore/KVEngine.h
@@ -46,7 +46,8 @@ public:
     virtual std::unique_ptr<WriteBatch> startBatchWrite() = 0;
 
     virtual ResultCode commitBatchWrite(std::unique_ptr<WriteBatch> batch,
-                                        bool disableWAL = true) = 0;
+                                        bool disableWAL = true,
+                                        bool sync = false) = 0;
 
     // Read a single key
     virtual ResultCode get(const std::string& key, std::string* value) = 0;

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -305,8 +305,9 @@ bool Part::commitLogs(std::unique_ptr<LogIterator> iter) {
             return false;
         }
     }
-    return engine_->commitBatchWrite(std::move(batch), FLAGS_rocksdb_disable_wal)
-                    == ResultCode::SUCCEEDED;
+    return engine_->commitBatchWrite(std::move(batch),
+                                     FLAGS_rocksdb_disable_wal,
+                                     FLAGS_rocksdb_wal_sync) == ResultCode::SUCCEEDED;
 }
 
 std::pair<int64_t, int64_t> Part::commitSnapshot(const std::vector<std::string>& rows,

--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -119,9 +119,12 @@ std::unique_ptr<WriteBatch> RocksEngine::startBatchWrite() {
 }
 
 
-ResultCode RocksEngine::commitBatchWrite(std::unique_ptr<WriteBatch> batch, bool disableWAL) {
+ResultCode RocksEngine::commitBatchWrite(std::unique_ptr<WriteBatch> batch,
+                                         bool disableWAL,
+                                         bool sync) {
     rocksdb::WriteOptions options;
     options.disableWAL = disableWAL;
+    options.sync = sync;
     auto* b = static_cast<RocksWriteBatch*>(batch.get());
     rocksdb::Status status = db_->Write(options, b->data());
     if (status.ok()) {

--- a/src/kvstore/RocksEngine.h
+++ b/src/kvstore/RocksEngine.h
@@ -112,7 +112,8 @@ public:
     std::unique_ptr<WriteBatch> startBatchWrite() override;
 
     ResultCode commitBatchWrite(std::unique_ptr<WriteBatch> batch,
-                                bool disableWAL) override;
+                                bool disableWAL,
+                                bool sync) override;
 
     /*********************
      * Data retrieval

--- a/src/kvstore/RocksEngineConfig.cpp
+++ b/src/kvstore/RocksEngineConfig.cpp
@@ -20,6 +20,10 @@ DEFINE_bool(rocksdb_disable_wal,
             true,
             "Whether to disable the WAL in rocksdb");
 
+DEFINE_bool(rocksdb_wal_sync,
+            false,
+            "Whether WAL writes are synchronized to disk or not");
+
 // [DBOptions]
 DEFINE_string(rocksdb_db_options,
               "{}",

--- a/src/kvstore/RocksEngineConfig.h
+++ b/src/kvstore/RocksEngineConfig.h
@@ -28,6 +28,8 @@ DECLARE_string(memtable_factory);
 // rocksdb db wal disable
 DECLARE_bool(rocksdb_disable_wal);
 
+DECLARE_bool(rocksdb_wal_sync);
+
 // BlockBasedTable block_cache
 DECLARE_int64(rocksdb_block_cache);
 

--- a/src/kvstore/SnapshotManagerImpl.cpp
+++ b/src/kvstore/SnapshotManagerImpl.cpp
@@ -17,7 +17,7 @@ void SnapshotManagerImpl::accessAllRowsInSnapshot(GraphSpaceID spaceId,
                                                   raftex::SnapshotCallback cb) {
     CHECK_NOTNULL(store_);
     std::unique_ptr<KVIterator> iter;
-    auto prefix = NebulaKeyUtils::prefix(partId);
+    auto prefix = NebulaKeyUtils::snapshotPrefix(partId);
     std::vector<std::string> data;
     int64_t totalSize = 0;
     int64_t totalCount = 0;


### PR DESCRIPTION
In poc project, 3 replica meta. If we remove the data dir of one. It would failed to start because it won't get the clusterId. It turned out that the leader send an empty snapshot which have nothing it. (Because it only scan the data with prefix space + part, however nothing start with them in meta)
