### PR TITLE
Fix coredump for update if encountering bad format row

### DIFF
--- a/src/dataman/RowReader.cpp
+++ b/src/dataman/RowReader.cpp
@@ -119,7 +119,10 @@ std::unique_ptr<RowReader> RowReader::getTagPropReader(
         folly::StringPiece row,
         GraphSpaceID space,
         TagID tag) {
-    CHECK_NOTNULL(schemaMan);
+    if (schemaMan == nullptr) {
+        LOG(ERROR) << "schemaMan should not be nullptr!";
+        return nullptr;
+    }
     int32_t ver = getSchemaVer(row);
     if (ver >= 0) {
         auto schema = schemaMan->getTagSchema(space, tag, ver);
@@ -130,9 +133,7 @@ std::unique_ptr<RowReader> RowReader::getTagPropReader(
             row,
             schema));
     } else {
-        // Invalid data
-        // TODO We need a better error handler here
-        LOG(FATAL) << "Invalid schema version in the row data!";
+        LOG(WARNING) << "Invalid schema version in the row data!";
         return nullptr;
     }
 }
@@ -144,16 +145,21 @@ std::unique_ptr<RowReader> RowReader::getEdgePropReader(
         folly::StringPiece row,
         GraphSpaceID space,
         EdgeType edge) {
-    CHECK_NOTNULL(schemaMan);
+    if (schemaMan == nullptr) {
+        LOG(ERROR) << "schemaMan should not be nullptr!";
+        return nullptr;
+    }
     int32_t ver = getSchemaVer(row);
     if (ver >= 0) {
+        auto schema = schemaMan->getEdgeSchema(space, edge, ver);
+        if (schema == nullptr) {
+            return nullptr;
+        }
         return std::unique_ptr<RowReader>(new RowReader(
             row,
-            schemaMan->getEdgeSchema(space, edge, ver)));
+            schema));
     } else {
-        // Invalid data
-        // TODO We need a better error handler here
-        LOG(FATAL) << "Invalid schema version in the row data!";
+        LOG(WARNING) << "Invalid schema version in the row data!";
         return nullptr;
     }
 }
@@ -173,7 +179,7 @@ int32_t RowReader::getSchemaVer(folly::StringPiece row) {
     const uint8_t* it = reinterpret_cast<const uint8_t*>(row.begin());
     if (reinterpret_cast<const char*>(it) == row.end()) {
         LOG(ERROR) << "Row data is empty, so there is no schema version";
-        return 0;
+        return -1;
     }
 
     // The first three bits indicate the number of bytes for the
@@ -185,7 +191,7 @@ int32_t RowReader::getSchemaVer(folly::StringPiece row) {
         if (verBytes + 1 > row.size()) {
             // Data is too short
             LOG(ERROR) << "Row data is too short";
-            return 0;
+            return -1;
         }
         // Schema Version is stored in Little Endian
         for (size_t i = 0; i < verBytes; i++) {

--- a/src/kvstore/Common.h
+++ b/src/kvstore/Common.h
@@ -29,6 +29,7 @@ enum ResultCode {
     ERR_TAG_NOT_FOUND       = -11,
     ERR_EDGE_NOT_FOUND      = -12,
     ERR_ATOMIC_OP_FAILED    = -13,
+    ERR_CORRUPT_DATA        = -14,
     ERR_PARTIAL_RESULT      = -99,
     ERR_UNKNOWN             = -100,
 };

--- a/src/storage/CommonUtils.h
+++ b/src/storage/CommonUtils.h
@@ -132,6 +132,7 @@ enum class FilterResult {
     SUCCEEDED     = 0,   // pass filter
     E_FILTER_OUT  = -1,  // filter out
     E_ERROR       = -2,  // exception when filter
+    E_BAD_SCHEMA  = -3,  // Bad schema
 };
 
 

--- a/src/storage/mutate/UpdateVertexProcessor.cpp
+++ b/src/storage/mutate/UpdateVertexProcessor.cpp
@@ -100,6 +100,12 @@ kvstore::ResultCode UpdateVertexProcessor::collectVertexProps(
                                                   iter->val(),
                                                   this->spaceId_,
                                                   tagId);
+        if (reader == nullptr) {
+            LOG(WARNING) << "Can't find the schema for tagId " << tagId;
+            // It offen happens after updating schema but current storaged has not
+            // load it. To protect the data, we just return failed to graphd.
+            return kvstore::ResultCode::ERR_CORRUPT_DATA;
+        }
         const auto constSchema = reader->getSchema();
         for (auto& prop : props) {
             auto res = RowReader::getPropByName(reader.get(), prop.prop_.name);
@@ -157,8 +163,13 @@ FilterResult UpdateVertexProcessor::checkFilter(const PartitionID partId, const 
         VLOG(3) << "partId " << partId << ", vId " << vId
                 << ", tagId " << tc.tagId_ << ", prop size " << tc.props_.size();
         auto ret = collectVertexProps(partId, vId, tc.tagId_, tc.props_);
-        if (ret != kvstore::ResultCode::SUCCEEDED) {
-            return FilterResult::E_ERROR;
+        switch (ret) {
+            case kvstore::ResultCode::SUCCEEDED:
+                break;
+            case kvstore::ResultCode::ERR_CORRUPT_DATA:
+                return FilterResult::E_BAD_SCHEMA;
+            default:
+                return FilterResult::E_ERROR;
         }
     }
 
@@ -425,6 +436,7 @@ void UpdateVertexProcessor::process(const cpp2::UpdateVertexRequest& req) {
             // Fallthrough
             case FilterResult::E_ERROR:
             // Fallthrough
+            case FilterResult::E_BAD_SCHEMA:
             default: {
                 return folly::none;
             }
@@ -442,16 +454,25 @@ void UpdateVertexProcessor::process(const cpp2::UpdateVertexRequest& req) {
                     handleLeaderChanged(this->spaceId_, partId);
                     break;
                 }
-                if (code == kvstore::ResultCode::ERR_ATOMIC_OP_FAILED
-                    && filterResult_ == FilterResult::E_FILTER_OUT) {
-                    // Filter out
-                    // https://github.com/vesoft-inc/nebula/issues/1888
-                    // Only filter out so we still return the data
-                    onProcessFinished(req.get_return_columns().size());
-                    this->pushResultCode(cpp2::ErrorCode::E_FILTER_OUT, partId);
-                } else if (code == kvstore::ResultCode::ERR_ATOMIC_OP_FAILED
-                    && filterResult_ == FilterResult::E_ERROR) {
-                    this->pushResultCode(cpp2::ErrorCode::E_INVALID_FILTER, partId);
+                if (code == kvstore::ResultCode::ERR_ATOMIC_OP_FAILED) {
+                    switch (filterResult_) {
+                        case FilterResult::E_FILTER_OUT:
+                            // Filter out
+                            // https://github.com/vesoft-inc/nebula/issues/1888
+                            // Only filter out so we still return the data
+                            onProcessFinished(req.get_return_columns().size());
+                            this->pushResultCode(cpp2::ErrorCode::E_FILTER_OUT, partId);
+                            break;
+                         case FilterResult::E_ERROR:
+                            this->pushResultCode(cpp2::ErrorCode::E_INVALID_FILTER, partId);
+                            break;
+                         case FilterResult::E_BAD_SCHEMA:
+                            this->pushResultCode(cpp2::ErrorCode::E_TAG_NOT_FOUND, partId);
+                            break;
+                         default:
+                            this->pushResultCode(to(code), partId);
+                            break;
+                    }
                 } else {
                     this->pushResultCode(to(code), partId);
                 }

--- a/src/storage/test/UpdateEdgeTest.cpp
+++ b/src/storage/test/UpdateEdgeTest.cpp
@@ -352,6 +352,72 @@ TEST(UpdateEdgeTest, Insertable_Test) {
     EXPECT_STREQ("", boost::get<std::string>(v3).c_str());
 }
 
+
+TEST(UpdateEdgeTest, CorruptDataTest) {
+    fs::TempDir rootPath("/tmp/UpdateEdgeTest.XXXXXX");
+    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path());
+    LOG(INFO) << "Prepare meta...";
+    auto schemaMan = TestUtils::mockSchemaMan();
+    auto indexMan = TestUtils::mockIndexMan();
+    LOG(INFO) << "Write an edge with empty value!";
+
+    // partId, srcId, edgeType, rank, dstId, version
+    auto key = NebulaKeyUtils::edgeKey(0, 10, 101, 0, 11, 0);
+    std::vector<kvstore::KV> data;
+    data.emplace_back(std::make_pair(key, ""));
+    folly::Baton<> baton;
+    kv->asyncMultiPut(0, 0, std::move(data),
+        [&](kvstore::ResultCode code) {
+            CHECK_EQ(code, kvstore::ResultCode::SUCCEEDED);
+            baton.post();
+        });
+    baton.wait();
+
+    LOG(INFO) << "Build UpdateEdgeRequest...";
+    GraphSpaceID spaceId = 0;
+    PartitionID partId = 0;
+    VertexID srcId = 10;
+    VertexID dstId = 11;
+    // src = 1, edge_type = 101, ranking = 0, dst = 10001
+    storage::cpp2::EdgeKey edgeKey;
+    edgeKey.set_src(srcId);
+    edgeKey.set_edge_type(101);
+    edgeKey.set_ranking(0);
+    edgeKey.set_dst(dstId);
+
+    cpp2::UpdateEdgeRequest req;
+    req.set_space_id(spaceId);
+    req.set_edge_key(edgeKey);
+    req.set_part_id(partId);
+    req.set_filter("");
+    LOG(INFO) << "Build update items...";
+    std::vector<cpp2::UpdateItem> items;
+    // string: 101.col_10 = string_col_10_2_new
+    cpp2::UpdateItem item;
+    item.set_name("101");
+    item.set_prop("col_10");
+    std::string col10new("string_col_10_2_new");
+    PrimaryExpression val2(col10new);
+    item.set_value(Expression::encode(&val2));
+    items.emplace_back(item);
+    req.set_update_items(std::move(items));
+    req.set_insertable(true);
+
+    LOG(INFO) << "Test UpdateEdgeRequest...";
+    auto* processor = UpdateEdgeProcessor::instance(kv.get(),
+                                                    schemaMan.get(),
+                                                    indexMan.get(),
+                                                    nullptr);
+    auto f = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(f).get();
+
+
+    EXPECT_EQ(1, resp.result.failed_codes.size());
+    EXPECT_TRUE(cpp2::ErrorCode::E_EDGE_NOT_FOUND == resp.result.failed_codes[0].code);
+    EXPECT_EQ(0, resp.result.failed_codes[0].part_id);
+}
+
 }  // namespace storage
 }  // namespace nebula
 

--- a/src/storage/test/UpdateVertexTest.cpp
+++ b/src/storage/test/UpdateVertexTest.cpp
@@ -407,6 +407,63 @@ TEST(UpdateVertexTest, Invalid_Filter_Test) {
                     == resp.result.failed_codes[0].code);
 }
 
+TEST(UpdateVertexTest, CorruptDataTest) {
+    fs::TempDir rootPath("/tmp/UpdateVertexTest.XXXXXX");
+    std::unique_ptr<kvstore::KVStore> kv = TestUtils::initKV(rootPath.path());
+
+    LOG(INFO) << "Prepare meta...";
+    auto schemaMan = TestUtils::mockSchemaMan();
+    auto indexMan = TestUtils::mockIndexMan();
+    LOG(INFO) << "Write a vertex with empty value!";
+
+    // partId, srcId, tagId, version
+    auto key = NebulaKeyUtils::vertexKey(0, 10, 3001, 0);
+    std::vector<kvstore::KV> data;
+    data.emplace_back(std::make_pair(key, ""));
+    folly::Baton<> baton;
+    kv->asyncMultiPut(0, 0, std::move(data),
+        [&](kvstore::ResultCode code) {
+            CHECK_EQ(code, kvstore::ResultCode::SUCCEEDED);
+            baton.post();
+        });
+    baton.wait();
+
+    LOG(INFO) << "Build UpdateVertexRequest...";
+    GraphSpaceID spaceId = 0;
+    PartitionID partId = 0;
+    VertexID vertexId = 10;
+    cpp2::UpdateVertexRequest req;
+    req.set_space_id(spaceId);
+    req.set_vertex_id(vertexId);
+    req.set_part_id(partId);
+    req.set_filter("");
+    LOG(INFO) << "Build update items...";
+    std::vector<cpp2::UpdateItem> items;
+    // int: 3001.tag_3001_col_0 = 1L
+    cpp2::UpdateItem item;
+    item.set_name("3001");
+    item.set_prop("tag_3001_col_0");
+    PrimaryExpression val(1L);
+    item.set_value(Expression::encode(&val));
+    items.emplace_back(item);
+    req.set_update_items(std::move(items));
+    req.set_insertable(false);
+
+    LOG(INFO) << "Test UpdateVertexRequest...";
+    auto* processor = UpdateVertexProcessor::instance(kv.get(),
+                                                      schemaMan.get(),
+                                                      indexMan.get(),
+                                                      nullptr);
+    auto f = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(f).get();
+
+    LOG(INFO) << "Check the results...";
+    EXPECT_EQ(1, resp.result.failed_codes.size());
+    EXPECT_TRUE(cpp2::ErrorCode::E_TAG_NOT_FOUND == resp.result.failed_codes[0].code);
+    EXPECT_EQ(0, resp.result.failed_codes[0].part_id);
+}
+
 }  // namespace storage
 }  // namespace nebula
 


### PR DESCRIPTION
Currently,  there are so many CHECK and LOG(FATAL) inside RowReader,  so if encountering bad format row (For example, upgrade the cluster),  it will core dump. 

Now, instead crash,  storaged report TAG/EDGE NOT FOUND to graphd. 


close #2016 