### PR TITLE
Supports older version of schema for index write

### DIFF
--- a/src/storage/BaseProcessor.h
+++ b/src/storage/BaseProcessor.h
@@ -150,8 +150,8 @@ protected:
         return tHost;
     }
 
-    IndexValues collectIndexValues(RowReader* reader,
-                                   const std::vector<nebula::cpp2::ColumnDef>& cols);
+    StatusOr<IndexValues> collectIndexValues(RowReader* reader,
+                                             const std::vector<nebula::cpp2::ColumnDef>& cols);
 
     void collectProps(RowReader* reader, const std::vector<PropContext>& props,
                       Collector* collector);

--- a/src/storage/admin/RebuildEdgeIndexProcessor.cpp
+++ b/src/storage/admin/RebuildEdgeIndexProcessor.cpp
@@ -87,8 +87,11 @@ void RebuildEdgeIndexProcessor::process(const cpp2::RebuildIndexRequest& req) {
                     continue;
                 }
                 auto values = collectIndexValues(reader.get(), item->get_fields());
+                if (!values.ok()) {
+                    continue;
+                }
                 auto indexKey = NebulaKeyUtils::edgeIndexKey(part, indexID, source,
-                                                             ranking, destination, values);
+                                                             ranking, destination, values.value());
                 data.emplace_back(std::move(indexKey), "");
                 batchNum += 1;
                 iter->next();

--- a/src/storage/admin/RebuildTagIndexProcessor.cpp
+++ b/src/storage/admin/RebuildTagIndexProcessor.cpp
@@ -84,8 +84,11 @@ void RebuildTagIndexProcessor::process(const cpp2::RebuildIndexRequest& req) {
                     continue;
                 }
                 auto values = collectIndexValues(reader.get(), item->get_fields());
-
-                auto indexKey = NebulaKeyUtils::vertexIndexKey(part, indexID, vertex, values);
+                if (!values.ok()) {
+                    continue;
+                }
+                auto indexKey = NebulaKeyUtils::vertexIndexKey(part, indexID,
+                                                               vertex, values.value());
                 data.emplace_back(std::move(indexKey), "");
                 batchNum += 1;
                 iter->next();

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -125,7 +125,9 @@ std::string AddEdgesProcessor::addEdges(int64_t version, PartitionID partId,
                     }
                 }
                 auto ni = indexKey(partId, nReader.get(), e.first, index);
-                batchHolder->put(std::move(ni), "");
+                if (!ni.empty()) {
+                    batchHolder->put(std::move(ni), "");
+                }
             }
         }
         /*
@@ -164,12 +166,15 @@ std::string AddEdgesProcessor::indexKey(PartitionID partId,
                                         const folly::StringPiece& rawKey,
                                         std::shared_ptr<nebula::cpp2::IndexItem> index) {
     auto values = collectIndexValues(reader, index->get_fields());
+    if (!values.ok()) {
+        return "";
+    }
     return NebulaKeyUtils::edgeIndexKey(partId,
                                         index->get_index_id(),
                                         NebulaKeyUtils::getSrcId(rawKey),
                                         NebulaKeyUtils::getRank(rawKey),
                                         NebulaKeyUtils::getDstId(rawKey),
-                                        values);
+                                        values.value());
 }
 
 }  // namespace storage

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -142,7 +142,9 @@ std::string AddVerticesProcessor::addVertices(int64_t version, PartitionID partI
                     }
                 }
                 auto ni = indexKey(partId, vId, nReader.get(), index);
-                batchHolder->put(std::move(ni), "");
+                if (!ni.empty()) {
+                    batchHolder->put(std::move(ni), "");
+                }
             }
         }
         /*
@@ -177,9 +179,12 @@ std::string AddVerticesProcessor::indexKey(PartitionID partId,
                                            RowReader* reader,
                                            std::shared_ptr<nebula::cpp2::IndexItem> index) {
     auto values = collectIndexValues(reader, index->get_fields());
+    if (!values.ok()) {
+        return "";
+    }
     return NebulaKeyUtils::vertexIndexKey(partId,
                                           index->get_index_id(),
-                                          vId, values);
+                                          vId, values.value());
 }
 
 }  // namespace storage

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -114,12 +114,15 @@ DeleteEdgesProcessor::deleteEdges(GraphSpaceID spaceId,
                         }
                         auto values = collectIndexValues(reader.get(),
                                                          index->get_fields());
+                        if (!values.ok()) {
+                            continue;
+                        }
                         auto indexKey = NebulaKeyUtils::edgeIndexKey(partId,
                                                                      indexId,
                                                                      srcId,
                                                                      rank,
                                                                      dstId,
-                                                                     values);
+                                                                     values.value());
                         batchHolder->remove(std::move(indexKey));
                     }
                 }

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -135,10 +135,13 @@ DeleteVerticesProcessor::deleteVertices(GraphSpaceID spaceId,
                         }
                         const auto& cols = index->get_fields();
                         auto values = collectIndexValues(reader.get(), cols);
+                        if (!values.ok()) {
+                            continue;
+                        }
                         auto indexKey = NebulaKeyUtils::vertexIndexKey(partId,
                                                                        indexId,
                                                                        vertex,
-                                                                       values);
+                                                                       values.value());
                         batchHolder->remove(std::move(indexKey));
                     }
                 }

--- a/src/storage/mutate/UpdateEdgeProcessor.cpp
+++ b/src/storage/mutate/UpdateEdgeProcessor.cpp
@@ -296,13 +296,15 @@ std::string UpdateEdgeProcessor::updateAndWriteBack(PartitionID partId,
                     }
                     auto rValues = collectIndexValues(rReader.get(),
                                                       index->get_fields());
-                    auto rIndexKey = NebulaKeyUtils::edgeIndexKey(partId,
-                                                                  indexId,
-                                                                  edgeKey.src,
-                                                                  edgeKey.ranking,
-                                                                  edgeKey.dst,
-                                                                  rValues);
-                    batchHolder->remove(std::move(rIndexKey));
+                    if (rValues.ok()) {
+                        auto rIndexKey = NebulaKeyUtils::edgeIndexKey(partId,
+                                                                      indexId,
+                                                                      edgeKey.src,
+                                                                      edgeKey.ranking,
+                                                                      edgeKey.dst,
+                                                                      rValues.value());
+                        batchHolder->remove(std::move(rIndexKey));
+                    }
                 }
                 if (reader == nullptr) {
                     reader = RowReader::getEdgePropReader(this->schemaMan_,
@@ -313,13 +315,15 @@ std::string UpdateEdgeProcessor::updateAndWriteBack(PartitionID partId,
 
                 auto values = collectIndexValues(reader.get(),
                                                  index->get_fields());
-                auto indexKey = NebulaKeyUtils::edgeIndexKey(partId,
-                                                             indexId,
-                                                             edgeKey.src,
-                                                             edgeKey.ranking,
-                                                             edgeKey.dst,
-                                                             values);
-                batchHolder->put(std::move(indexKey), "");
+                if (values.ok()) {
+                    auto indexKey = NebulaKeyUtils::edgeIndexKey(partId,
+                                                                 indexId,
+                                                                 edgeKey.src,
+                                                                 edgeKey.ranking,
+                                                                 edgeKey.dst,
+                                                                 values.value());
+                    batchHolder->put(std::move(indexKey), "");
+                }
             }
         }
     }

--- a/src/storage/mutate/UpdateVertexProcessor.cpp
+++ b/src/storage/mutate/UpdateVertexProcessor.cpp
@@ -289,11 +289,13 @@ std::string UpdateVertexProcessor::updateAndWriteBack(const PartitionID partId,
                         }
                         const auto &oCols = index->get_fields();
                         auto oValues = collectIndexValues(oReader.get(), oCols);
-                        auto oIndexKey = NebulaKeyUtils::vertexIndexKey(partId,
-                                                                        index->index_id,
-                                                                        vId,
-                                                                        oValues);
-                        batchHolder->remove(std::move(oIndexKey));
+                        if (oValues.ok()) {
+                            auto oIndexKey = NebulaKeyUtils::vertexIndexKey(partId,
+                                                                            index->index_id,
+                                                                            vId,
+                                                                            oValues.value());
+                            batchHolder->remove(std::move(oIndexKey));
+                        }
                     }
                     if (reader == nullptr) {
                         reader = RowReader::getTagPropReader(this->schemaMan_,
@@ -303,11 +305,13 @@ std::string UpdateVertexProcessor::updateAndWriteBack(const PartitionID partId,
                     }
                     const auto &cols = index->get_fields();
                     auto values = collectIndexValues(reader.get(), cols);
-                    auto indexKey = NebulaKeyUtils::vertexIndexKey(partId,
-                                                                   index->get_index_id(),
-                                                                   vId,
-                                                                   values);
-                    batchHolder->put(std::move(indexKey), "");
+                    if (values.ok()) {
+                        auto indexKey = NebulaKeyUtils::vertexIndexKey(partId,
+                                                                       index->get_index_id(),
+                                                                       vId,
+                                                                       values.value());
+                        batchHolder->put(std::move(indexKey), "");
+                    }
                 }
             }
         }


### PR DESCRIPTION
When insert vertex, need to check if an old index exists, if so, drop the old index and write a new index. At this point, an old index key needs to be assembled by old prop for index check, however, the old property values do not have this new column. so leads to `storaged` crash by `CHECK(prop)`.
Improved this logic，When an invalid property value appears, write index skipped .

repeat step : 

- create space
- use space
- create tag1 (col1, col2)
- create index1 on tag1 (col1)
- insert vertex tag1 values (...)
- alter tag add column col3
- create index2 on tag1 (col3)
- insert vertex tag1 values (...)
