### PR TITLE
Fix the dst vertex use default value when use the nonexistent tag

### DIFF
--- a/src/graph/GoExecutor.cpp
+++ b/src/graph/GoExecutor.cpp
@@ -1121,7 +1121,8 @@ bool GoExecutor::processFinalResult(RpcResponse &rpcResp, Callback cb) const {
                         return value(res);
                     };
                     // In reverse mode, it is used to get the src props.
-                    getters.getDstTagProp = [&dstId,
+                    getters.getDstTagProp = [&spaceId,
+                                             &dstId,
                                              this] (const std::string &tag,
                                                     const std::string &prop) -> OptVariantType {
                         TagID tagId;
@@ -1130,7 +1131,15 @@ bool GoExecutor::processFinalResult(RpcResponse &rpcResp, Callback cb) const {
                             return Status::Error(
                                     "Get tag id for `%s' failed in getters.", tag.c_str());
                         }
-                        return vertexHolder_->get(dstId, tagId, prop);
+                        auto ret = vertexHolder_->get(dstId, tagId, prop);
+                        if (!ret.ok()) {
+                            auto ts = ectx()->schemaManager()->getTagSchema(spaceId, tagId);
+                            if (ts == nullptr) {
+                                return Status::Error("No tag schema for %s", tag.c_str());
+                            }
+                            return RowReader::getDefaultProp(ts.get(), prop);
+                        }
+                        return ret.value();
                     };
                     getters.getVariableProp = [&srcId,
                                                this] (const std::string &prop) {
@@ -1238,7 +1247,8 @@ OptVariantType GoExecutor::VertexHolder::getDefaultProp(TagID tid, const std::st
         }
     }
 
-    return Status::Error("Unknown Vertex");
+
+    return Status::Error("Unknown property: `%s'", prop.c_str());
 }
 
 SupportedType GoExecutor::VertexHolder::getDefaultPropType(TagID tid,

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -2400,6 +2400,18 @@ TEST_P(GoTest, ZeroStep) {
     }
 }
 
+TEST_P(GoTest, ErrorMsg) {
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "GO FROM %ld OVER serve YIELD $$.player.name as name";
+        auto query = folly::stringPrintf(fmt, players_["Tim Duncan"].vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<std::string>> expected = {""};
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+}
+
 INSTANTIATE_TEST_CASE_P(IfPushdownFilter, GoTest, ::testing::Bool());
 }   // namespace graph
 }   // namespace nebula


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/48548375/81786381-2501cd80-9532-11ea-8fc1-3a9ca516fefe.png)

If the dst vertex without the tag `Company` it returns error message which is not clear.
If the src vertex without the tag `Company` it returns the default value.
So unify return default value.