### PR TITLE
Limit total partitions

### DIFF
--- a/src/graph/test/CMakeLists.txt
+++ b/src/graph/test/CMakeLists.txt
@@ -87,6 +87,22 @@ nebula_add_test(
 
 nebula_add_test(
     NAME
+        partiton_test
+    SOURCES
+        PartitionTest.cpp
+    OBJECTS
+        ${GRAPH_TEST_CLIENT_LIBS}
+        ${GRAPH_TEST_LIBS}
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        ${ROCKSDB_LIBRARIES}
+        proxygenlib
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
         go_test
     SOURCES
         GoTest.cpp

--- a/src/graph/test/PartitionTest.cpp
+++ b/src/graph/test/PartitionTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 vesoft inc. All rights reserved.
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License,
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.

--- a/src/graph/test/PartitionTest.cpp
+++ b/src/graph/test/PartitionTest.cpp
@@ -10,8 +10,6 @@
 #include "meta/test/TestUtils.h"
 #include "storage/test/TestUtils.h"
 
-DECLARE_int32(heartbeat_interval_secs);
-
 namespace nebula {
 namespace graph {
 

--- a/src/graph/test/PartitionTest.cpp
+++ b/src/graph/test/PartitionTest.cpp
@@ -1,0 +1,57 @@
+/* Copyright (c) 2018 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/Base.h"
+#include "graph/test/TestEnv.h"
+#include "graph/test/TestBase.h"
+#include "meta/test/TestUtils.h"
+#include "storage/test/TestUtils.h"
+
+DECLARE_int32(heartbeat_interval_secs);
+
+namespace nebula {
+namespace graph {
+
+class PartitionTest : public TestBase {
+protected:
+    void SetUp() override {
+        TestBase::SetUp();
+        // ...
+    }
+
+    void TearDown() override {
+        // ...
+        TestBase::TearDown();
+    }
+};
+
+TEST_F(PartitionTest, limit_partitions) {
+    auto client = gEnv->getClient();
+    ASSERT_NE(nullptr, client);
+    {
+        cpp2::ExecutionResponse resp;
+        std::string query = "CREATE SPACE space1 (partition_num=50)";
+        auto code = client->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        query = "CREATE SPACE space2 (partition_num=51)";
+        code = client->execute(query, resp);
+        ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        std::string query = "drop SPACE space1";
+        auto code = client->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        std::string query = "CREATE SPACE space_partitions(partition_num=101)";
+        auto code = client->execute(query, resp);
+        ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+}
+}   // namespace graph
+}   // namespace nebula

--- a/src/graph/test/SchemaTest.cpp
+++ b/src/graph/test/SchemaTest.cpp
@@ -376,12 +376,6 @@ TEST_F(SchemaTest, TestSpace) {
         client->execute(query, resp);
         ASSERT_EQ(0, (*(resp.get_rows())).size());
     }
-    {
-        cpp2::ExecutionResponse resp;
-        std::string query = "CREATE SPACE space_partitions (partition_num=100)";
-        auto code = client->execute(query, resp);
-        ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, code);
-    }
 }
 
 TEST_F(SchemaTest, TestTagAndEdge) {

--- a/src/graph/test/SchemaTest.cpp
+++ b/src/graph/test/SchemaTest.cpp
@@ -376,6 +376,12 @@ TEST_F(SchemaTest, TestSpace) {
         client->execute(query, resp);
         ASSERT_EQ(0, (*(resp.get_rows())).size());
     }
+    {
+        cpp2::ExecutionResponse resp;
+        std::string query = "CREATE SPACE space_partitions (partition_num=100)";
+        auto code = client->execute(query, resp);
+        ASSERT_NE(cpp2::ErrorCode::SUCCEEDED, code);
+    }
 }
 
 TEST_F(SchemaTest, TestTagAndEdge) {

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -21,7 +21,7 @@ enum ErrorCode {
     E_LEADER_CHANGED   = -11,
 
     // Operation Failure
-    E_TOO_MANY_SPACE   = -20,
+    E_TOO_MANY_PARTS   = -20,
     E_NO_HOSTS         = -21,
     E_EXISTED          = -22,
     E_NOT_FOUND        = -23,

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -21,6 +21,7 @@ enum ErrorCode {
     E_LEADER_CHANGED   = -11,
 
     // Operation Failure
+    E_TOO_MANY_SPACE   = -20,
     E_NO_HOSTS         = -21,
     E_EXISTED          = -22,
     E_NOT_FOUND        = -23,

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -558,8 +558,8 @@ Status MetaClient::handleResponse(const RESP& resp) {
             return Status::Error("existed!");
         case cpp2::ErrorCode::E_NOT_FOUND:
             return Status::Error("not existed!");
-        case cpp2::ErrorCode::E_TOO_MANY_SPACES: 
-            return Status::Error("too many spaces!");
+        case cpp2::ErrorCode::E_TOO_MANY_PARTS:
+            return Status::Error("too many parts!");
         case cpp2::ErrorCode::E_NO_HOSTS:
             return Status::Error("no hosts!");
         case cpp2::ErrorCode::E_CONFIG_IMMUTABLE:

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -558,6 +558,8 @@ Status MetaClient::handleResponse(const RESP& resp) {
             return Status::Error("existed!");
         case cpp2::ErrorCode::E_NOT_FOUND:
             return Status::Error("not existed!");
+        case cpp2::ErrorCode::E_TOO_MANY_SPACES: 
+            return Status::Error("too many spaces!");
         case cpp2::ErrorCode::E_NO_HOSTS:
             return Status::Error("no hosts!");
         case cpp2::ErrorCode::E_CONFIG_IMMUTABLE:

--- a/src/meta/processors/partsMan/CreateSpaceProcessor.cpp
+++ b/src/meta/processors/partsMan/CreateSpaceProcessor.cpp
@@ -145,22 +145,8 @@ int32_t CreateSpaceProcessor::GetPartsNumbers() {
     }
 
     while (iter->valid()) {
-        auto spaceId = MetaServiceUtils::spaceId(iter->key());
-        auto partPrefix = MetaServiceUtils::partPrefix(spaceId);
-        auto spaceName = MetaServiceUtils::spaceName(iter->val());
-        std::unique_ptr<kvstore::KVIterator> partIter;
-        auto kvRet = kvstore_->prefix(kDefaultSpaceId, kDefaultPartId, partPrefix, &partIter);
-        if ( kvRet != kvstore::ResultCode::SUCCEEDED ) {
-            LOG(ERROR) << "List Partitions From " << spaceName
-                       << ", Space id " << spaceId << " Failed";
-            return -1;
-        }
-
-        while (partIter->valid()) {
-            count++;
-            partIter->next();
-        }
-
+        auto properties = MetaServiceUtils::parseSpace(iter->val());
+        count += properties.get_partition_num();
         iter->next();
     }
 

--- a/src/meta/processors/partsMan/CreateSpaceProcessor.cpp
+++ b/src/meta/processors/partsMan/CreateSpaceProcessor.cpp
@@ -140,7 +140,7 @@ int32_t CreateSpaceProcessor::GetPartsNumbers() {
     std::unique_ptr<kvstore::KVIterator> iter;
     auto ret = kvstore_->prefix(kDefaultSpaceId, kDefaultPartId, prefix, &iter);
     if (ret != kvstore::ResultCode::SUCCEEDED) {
-        LOG(ERROR) << "List Spaces " << spaceName << " Failed";
+        LOG(ERROR) << "List Spaces Failed";
         return -1;
     }
 

--- a/src/meta/processors/partsMan/CreateSpaceProcessor.h
+++ b/src/meta/processors/partsMan/CreateSpaceProcessor.h
@@ -26,6 +26,7 @@ protected:
                                             const std::vector<network::InetAddress>& hosts,
                                             int32_t replicaFactor);
 
+    int32_t GetPartsNumbers();
 private:
     explicit CreateSpaceProcessor(kvstore::KVStore* kvstore)
             : BaseProcessor<cpp2::ExecResp>(kvstore) {}


### PR DESCRIPTION
because we leave limited memory and cpu for nebula in pubilc cloud, we must limit the number of spaces and partitions. Otherwise it's very dangerous. consider trial-version take one storaged, this may cause data loss. Never miss this