### PR TITLE
increase job mgr default internal threads from 3 to 10.

### DIFF
--- a/src/meta/processors/jobMan/JobManager.cpp
+++ b/src/meta/processors/jobMan/JobManager.cpp
@@ -23,7 +23,7 @@
 #include "webservice/Common.h"
 #include "common/time/WallClock.h"
 
-DEFINE_int32(dispatch_thread_num, 3, "Number of job dispatch http thread");
+DEFINE_int32(dispatch_thread_num, 10, "Number of job dispatch http thread");
 DEFINE_int32(job_check_intervals, 5000, "job intervals in us");
 DEFINE_double(job_expired_secs, 7*24*60*60, "job expired intervals in sec");
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

job manager send curl request to every storaged in blocking mode.

which means if user have 4 storaged,, then submit a compact job. 

they will confused why there are only 3 compact sub-job running, not 4. 

### Does this PR introduce any user-facing change?
no


### How was this patch tested?
gflags
