### PR TITLE
fix leader will try to send snapshot by mistake, fix clean wal

### DIFF
--- a/src/kvstore/raftex/Host.cpp
+++ b/src/kvstore/raftex/Host.cpp
@@ -119,7 +119,6 @@ folly::Future<cpp2::AppendLogResponse> Host::appendLogs(
 
         if (requestOnGoing_ && res == cpp2::ErrorCode::SUCCEEDED) {
             if (cachingPromise_.size() <= FLAGS_max_outstanding_requests) {
-                logIdToSend_ = logId;
                 pendingReq_ = std::make_tuple(term,
                                               logId,
                                               committedLogId);

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -1254,7 +1254,7 @@ void RaftPart::cleanupSnapshot() {
 
 bool RaftPart::needToCleanWal() {
     std::lock_guard<std::mutex> g(raftLock_);
-    if (status_ == Status::WAITING_SNAPSHOT) {
+    if (status_ == Status::STARTING || status_ == Status::WAITING_SNAPSHOT) {
         return false;
     }
     for (auto& host : hosts_) {


### PR DESCRIPTION
Hard to tell why...

1. The leader want to append log in range [1, 3], normally we expect the start point of the range is equal to `lastLogIdSent_ + 1`, and the end point of the range is `logIdToSend_`.
2. After we send these logs, but before the response comes back, here comes log 4, and then `logIdToSend_` is set to 4.
3. The response [1, 3] is coming back, leader found that follower has accepted them, and leader check whether there is more logs to send by comparing `lastLogIdSent_ < logIdToSend_` in line 242, it is true (3 < 4), and leader will send log [4, 4] to follower.
4. When the response of log [4, 4] comes back, compare `lastLogIdSent_ < logIdToSend_` again, in this case, they are both 4. So the leader would check `noRequest` on line 253. `noRequest` is false because the `pendingReq_` is not empty, the logId would be 4. But the pendingReq_ of log 4 has already been sent, this is wrong.
5. That would cause leader will try to send log from `lastLogIdSent_ + 1`(5) to `logIdToSend_`(4), the iterator is not valid, and start send snapshot.

We could remove step 2, or empty `pendingReq_` when we find more logs to send in step 3, both will work.

Also fix some problems during clean wal.