### PR TITLE
meta client thread local access.

### DIFF
--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -297,6 +297,9 @@ std::shared_ptr<Part> NebulaStore::newPart(GraphSpaceID spaceId,
                                        snapshot_);
     auto metaStatus = options_.partMan_->partMeta(spaceId, partId);
     if (!metaStatus.ok()) {
+        LOG(ERROR) << "options_.partMan_->partMeta(spaceId, partId); error: "
+                   << metaStatus.status().toString()
+                   << " spaceId: " << spaceId << ", partId: " << partId;
         return nullptr;
     }
 

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -60,15 +60,8 @@ bool MetaClient::isMetadReady() {
         ready_ = false;
         return ready_;
     }
-
-    bool ldRet = loadData();
-    bool lcRet = true;
-    if (!options_.skipConfig_) {
-        lcRet = loadCfg();
-    }
-    if (ldRet && lcRet) {
-        localLastUpdateTime_ = metadLastUpdateTime_;
-    }
+    loadData();
+    loadCfg();
     return ready_;
 }
 
@@ -120,16 +113,8 @@ void MetaClient::heartBeatThreadFunc() {
     }
 
     // if MetaServer has some changes, refesh the localCache_
-    if (localLastUpdateTime_ < metadLastUpdateTime_) {
-        bool ldRet = loadData();
-        bool lcRet = true;
-        if (!options_.skipConfig_) {
-            lcRet = loadCfg();
-        }
-        if (ldRet && lcRet) {
-            localLastUpdateTime_ = metadLastUpdateTime_;
-        }
-    }
+    loadData();
+    loadCfg();
 }
 
 bool MetaClient::loadUsersAndRoles() {
@@ -158,6 +143,10 @@ bool MetaClient::loadUsersAndRoles() {
 }
 
 bool MetaClient::loadData() {
+    if (localDataLastUpdateTime_ == metadLastUpdateTime_) {
+        return true;
+    }
+
     if (ioThreadPool_->numThreads() <= 0) {
         LOG(ERROR) << "The threads number in ioThreadPool should be greater than 0";
         return false;
@@ -237,9 +226,49 @@ bool MetaClient::loadData() {
         spaceTagIndexById_     = std::move(spaceTagIndexById);
         spaceAllEdgeMap_       = std::move(spaceAllEdgeMap);
     }
+    localDataLastUpdateTime_.store(metadLastUpdateTime_.load());
     diff(oldCache, localCache_);
     ready_ = true;
     return true;
+}
+
+static TagSchemas __buildTagSchemas(std::vector<cpp2::TagItem> tagItemVec) {
+    TagSchemas tagSchemas;
+    for (auto& tagIt : tagItemVec) {
+        std::shared_ptr<NebulaSchemaProvider> schema(new NebulaSchemaProvider(tagIt.version));
+        for (auto colIt : tagIt.schema.get_columns()) {
+            VLOG(3) << "Load TagId: " << tagIt.tag_id
+                    << ", prop: " << colIt.name
+                    << ", type: " << static_cast<int32_t>(colIt.type.type)
+                    << ", default_type: " << colIt.default_value.getType();
+            schema->addField(colIt.name, std::move(colIt.type));
+            schema->addDefaultValue(colIt.name, std::move(colIt.default_value));
+        }
+        // handle schema property
+        schema->setProp(tagIt.schema.get_schema_prop());
+        tagSchemas.emplace(std::make_pair(tagIt.tag_id, tagIt.version), schema);
+    }
+    return tagSchemas;
+}
+
+static EdgeSchemas __buildEdgeSchemas(std::vector<cpp2::EdgeItem> edgeItemVec) {
+    EdgeSchemas edgeSchemas;
+    std::unordered_set<std::pair<GraphSpaceID, EdgeType>> edges;
+    for (auto& edgeIt : edgeItemVec) {
+        std::shared_ptr<NebulaSchemaProvider> schema(new NebulaSchemaProvider(edgeIt.version));
+        for (auto colIt : edgeIt.schema.get_columns()) {
+            VLOG(3) << "Load EdgeType: " << edgeIt.edge_type
+                    << ", prop: " << colIt.name
+                    << ", type: " << static_cast<int32_t>(colIt.type.type)
+                    << ", default_type: " << colIt.default_value.getType();
+            schema->addField(colIt.name, std::move(colIt.type));
+            schema->addDefaultValue(colIt.name, std::move(colIt.default_value));
+        }
+        // handle shcem property
+        schema->setProp(edgeIt.schema.get_schema_prop());
+        edgeSchemas.emplace(std::make_pair(edgeIt.edge_type, edgeIt.version), schema);
+    }
+    return edgeSchemas;
 }
 
 bool MetaClient::loadSchemas(GraphSpaceID spaceId,
@@ -266,21 +295,12 @@ bool MetaClient::loadSchemas(GraphSpaceID spaceId,
     allEdgeMap[spaceId] = {};
     auto tagItemVec = tagRet.value();
     auto edgeItemVec = edgeRet.value();
-    TagSchemas tagSchemas;
-    EdgeSchemas edgeSchemas;
+    spaceInfoCache->tagItemVec_ = tagItemVec;
+    spaceInfoCache->tagSchemas_ = __buildTagSchemas(tagItemVec);
+    spaceInfoCache->edgeItemVec_ = edgeItemVec;
+    spaceInfoCache->edgeSchemas_ = __buildEdgeSchemas(edgeItemVec);
+
     for (auto& tagIt : tagItemVec) {
-        std::shared_ptr<NebulaSchemaProvider> schema(new NebulaSchemaProvider(tagIt.version));
-        for (auto colIt : tagIt.schema.get_columns()) {
-            VLOG(3) << "Load TagId: " << tagIt.tag_id
-                    << ", prop: " << colIt.name
-                    << ", type: " << static_cast<int32_t>(colIt.type.type)
-                    << ", default_type: " << colIt.default_value.getType();
-            schema->addField(colIt.name, std::move(colIt.type));
-            schema->addDefaultValue(colIt.name, std::move(colIt.default_value));
-        }
-        // handle schema property
-        schema->setProp(tagIt.schema.get_schema_prop());
-        tagSchemas.emplace(std::make_pair(tagIt.tag_id, tagIt.version), schema);
         tagNameIdMap.emplace(std::make_pair(spaceId, tagIt.tag_name), tagIt.tag_id);
         tagIdNameMap.emplace(std::make_pair(spaceId, tagIt.tag_id), tagIt.tag_name);
         // get the latest tag version
@@ -298,18 +318,6 @@ bool MetaClient::loadSchemas(GraphSpaceID spaceId,
 
     std::unordered_set<std::pair<GraphSpaceID, EdgeType>> edges;
     for (auto& edgeIt : edgeItemVec) {
-        std::shared_ptr<NebulaSchemaProvider> schema(new NebulaSchemaProvider(edgeIt.version));
-        for (auto colIt : edgeIt.schema.get_columns()) {
-            VLOG(3) << "Load EdgeType: " << edgeIt.edge_type
-                    << ", prop: " << colIt.name
-                    << ", type: " << static_cast<int32_t>(colIt.type.type)
-                    << ", default_type: " << colIt.default_value.getType();
-            schema->addField(colIt.name, std::move(colIt.type));
-            schema->addDefaultValue(colIt.name, std::move(colIt.default_value));
-        }
-        // handle shcem property
-        schema->setProp(edgeIt.schema.get_schema_prop());
-        edgeSchemas.emplace(std::make_pair(edgeIt.edge_type, edgeIt.version), schema);
         edgeNameTypeMap.emplace(std::make_pair(spaceId, edgeIt.edge_name), edgeIt.edge_type);
         edgeTypeNameMap.emplace(std::make_pair(spaceId, edgeIt.edge_type), edgeIt.edge_name);
         if (edges.find({spaceId, edgeIt.edge_type}) != edges.cend()) {
@@ -330,10 +338,18 @@ bool MetaClient::loadSchemas(GraphSpaceID spaceId,
                 << ", Name " << edgeIt.edge_name << ", Version " << edgeIt.version
                 << " Successfully!";
     }
-
-    spaceInfoCache->tagSchemas_ = std::move(tagSchemas);
-    spaceInfoCache->edgeSchemas_ = std::move(edgeSchemas);
     return true;
+}
+
+static Indexes __buildIndexes(std::vector<nebula::cpp2::IndexItem> indexItemVec) {
+    Indexes indexes;
+    for (auto index : indexItemVec) {
+        auto indexName = index.get_index_name();
+        auto indexID = index.get_index_id();
+        auto indexPtr = std::make_shared<nebula::cpp2::IndexItem>(index);
+        indexes.emplace(indexID, indexPtr);
+    }
+    return indexes;
 }
 
 bool MetaClient::loadIndexes(GraphSpaceID spaceId,
@@ -352,34 +368,63 @@ bool MetaClient::loadIndexes(GraphSpaceID spaceId,
         return false;
     }
 
-    Indexes tagIndexes;
-    for (auto tagIndex : tagIndexesRet.value()) {
+    auto tagIndexItemVec = tagIndexesRet.value();
+    cache->tagIndexItemVec_ = tagIndexItemVec;
+    cache->tagIndexes_ = __buildIndexes(tagIndexItemVec);
+    for (auto tagIndex : tagIndexItemVec) {
         auto indexName = tagIndex.get_index_name();
         auto indexID = tagIndex.get_index_id();
         std::pair<GraphSpaceID, std::string> pair(spaceId, indexName);
         tagNameIndexMap_.emplace(std::move(pair), indexID);
-        auto tagIndexPtr = std::make_shared<nebula::cpp2::IndexItem>(tagIndex);
-        tagIndexes.emplace(indexID, tagIndexPtr);
     }
-    cache->tagIndexes_ = std::move(tagIndexes);
 
-    Indexes edgeIndexes;
-    for (auto& edgeIndex : edgeIndexesRet.value()) {
+    auto edgeIndexItemVec = edgeIndexesRet.value();
+    cache->edgeIndexItemVec_ = edgeIndexItemVec;
+    cache->edgeIndexes_ = __buildIndexes(edgeIndexItemVec);
+    for (auto& edgeIndex : edgeIndexItemVec) {
         auto indexName = edgeIndex.get_index_name();
         auto indexID = edgeIndex.get_index_id();
         std::pair<GraphSpaceID, std::string> pair(spaceId, indexName);
         edgeNameIndexMap_.emplace(std::move(pair), indexID);
-        auto edgeIndexPtr = std::make_shared<nebula::cpp2::IndexItem>(edgeIndex);
-        edgeIndexes.emplace(indexID, edgeIndexPtr);
     }
-    cache->edgeIndexes_ = std::move(edgeIndexes);
     return true;
 }
 
+const MetaClient::ThreadLocalInfo& MetaClient::getThreadLocalInfo() {
+    ThreadLocalInfo& threadLocalInfo = folly::SingletonThreadLocal<ThreadLocalInfo>::get();
+
+    if (threadLocalInfo.localLastUpdateTime_ < localDataLastUpdateTime_) {
+        threadLocalInfo.localLastUpdateTime_ = localDataLastUpdateTime_;
+
+        folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+        for (auto& spaceInfo : localCache_) {
+            GraphSpaceID spaceId = spaceInfo.first;
+            std::shared_ptr<SpaceInfoCache> info = spaceInfo.second;
+            std::shared_ptr<SpaceInfoCache> infoDeepCopy = std::make_shared<SpaceInfoCache>(*info);
+            infoDeepCopy->tagSchemas_ = __buildTagSchemas(infoDeepCopy->tagItemVec_);
+            infoDeepCopy->edgeSchemas_ = __buildEdgeSchemas(infoDeepCopy->edgeItemVec_);
+            infoDeepCopy->tagIndexes_ = __buildIndexes(infoDeepCopy->tagIndexItemVec_);
+            infoDeepCopy->edgeIndexes_ = __buildIndexes(infoDeepCopy->edgeIndexItemVec_);
+            threadLocalInfo.localCache_[spaceId] = infoDeepCopy;
+        }
+        threadLocalInfo.spaceIndexByName_ = spaceIndexByName_;
+        threadLocalInfo.spaceTagIndexByName_ = spaceTagIndexByName_;
+        threadLocalInfo.spaceEdgeIndexByName_ = spaceEdgeIndexByName_;
+        threadLocalInfo.spaceNewestTagVerMap_ = spaceNewestTagVerMap_;
+        threadLocalInfo.spaceNewestEdgeVerMap_ = spaceNewestEdgeVerMap_;
+        threadLocalInfo.spaceEdgeIndexByType_ = spaceEdgeIndexByType_;
+        threadLocalInfo.spaceTagIndexById_ = spaceTagIndexById_;
+        threadLocalInfo.spaceAllEdgeMap_ = spaceAllEdgeMap_;
+    }
+
+    return threadLocalInfo;
+}
+
 Status MetaClient::checkTagIndexed(GraphSpaceID space, TagID tagID) {
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = localCache_.find(space);
-    if (it != localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.localCache_.find(space);
+    if (it != threadLocalInfo.localCache_.end()) {
         auto tagIt = it->second->tagIndexes_.find(tagID);
         if (tagIt != it->second->tagIndexes_.end()) {
             return Status::OK();
@@ -391,9 +436,10 @@ Status MetaClient::checkTagIndexed(GraphSpaceID space, TagID tagID) {
 }
 
 Status MetaClient::checkEdgeIndexed(GraphSpaceID space, EdgeType edgeType) {
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = localCache_.find(space);
-    if (it != localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.localCache_.find(space);
+    if (it != threadLocalInfo.localCache_.end()) {
         auto edgeIt = it->second->edgeIndexes_.find(edgeType);
         if (edgeIt != it->second->edgeIndexes_.end()) {
             return Status::OK();
@@ -790,9 +836,10 @@ MetaClient::getSpaceIdByNameFromCache(const std::string& name) {
     if (!ready_) {
         return Status::Error("Not ready!");
     }
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = spaceIndexByName_.find(name);
-    if (it != spaceIndexByName_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.spaceIndexByName_.find(name);
+    if (it != threadLocalInfo.spaceIndexByName_.end()) {
         return it->second;
     }
     return Status::SpaceNotFound();
@@ -804,9 +851,10 @@ StatusOr<TagID> MetaClient::getTagIDByNameFromCache(const GraphSpaceID& space,
     if (!ready_) {
         return Status::Error("Not ready!");
     }
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = spaceTagIndexByName_.find(std::make_pair(space, name));
-    if (it == spaceTagIndexByName_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.spaceTagIndexByName_.find(std::make_pair(space, name));
+    if (it == threadLocalInfo.spaceTagIndexByName_.end()) {
         std::string error = folly::stringPrintf("TagName `%s'  is nonexistent", name.c_str());
         return Status::Error(std::move(error));
     }
@@ -818,9 +866,10 @@ StatusOr<std::string> MetaClient::getTagNameByIdFromCache(const GraphSpaceID& sp
     if (!ready_) {
         return Status::Error("Not ready!");
     }
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = spaceTagIndexById_.find(std::make_pair(space, tagId));
-    if (it == spaceTagIndexById_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.spaceTagIndexById_.find(std::make_pair(space, tagId));
+    if (it == threadLocalInfo.spaceTagIndexById_.end()) {
         std::string error = folly::stringPrintf("TagID `%d'  is nonexistent", tagId);
         return Status::Error(std::move(error));
     }
@@ -833,9 +882,10 @@ StatusOr<EdgeType> MetaClient::getEdgeTypeByNameFromCache(const GraphSpaceID& sp
     if (!ready_) {
         return Status::Error("Not ready!");
     }
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = spaceEdgeIndexByName_.find(std::make_pair(space, name));
-    if (it == spaceEdgeIndexByName_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.spaceEdgeIndexByName_.find(std::make_pair(space, name));
+    if (it == threadLocalInfo.spaceEdgeIndexByName_.end()) {
         std::string error = folly::stringPrintf("EdgeName `%s'  is nonexistent", name.c_str());
         return Status::Error(std::move(error));
     }
@@ -847,9 +897,10 @@ StatusOr<std::string> MetaClient::getEdgeNameByTypeFromCache(const GraphSpaceID&
     if (!ready_) {
         return Status::Error("Not ready!");
     }
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = spaceEdgeIndexByType_.find(std::make_pair(space, edgeType));
-    if (it == spaceEdgeIndexByType_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.spaceEdgeIndexByType_.find(std::make_pair(space, edgeType));
+    if (it == threadLocalInfo.spaceEdgeIndexByType_.end()) {
         std::string error = folly::stringPrintf("EdgeType `%d'  is nonexistent", edgeType);
         return Status::Error(std::move(error));
     }
@@ -860,9 +911,10 @@ StatusOr<std::vector<std::string>> MetaClient::getAllEdgeFromCache(const GraphSp
     if (!ready_) {
         return Status::Error("Not ready!");
     }
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = spaceAllEdgeMap_.find(space);
-    if (it == spaceAllEdgeMap_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.spaceAllEdgeMap_.find(space);
+    if (it == threadLocalInfo.spaceAllEdgeMap_.end()) {
         std::string error = folly::stringPrintf("SpaceId `%d'  is nonexistent", space);
         return Status::Error(std::move(error));
     }
@@ -1000,15 +1052,17 @@ MetaClient::removeRange(std::string segment, std::string start, std::string end)
 
 
 PartsMap MetaClient::getPartsMapFromCache(const HostAddr& host) {
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    return doGetPartsMap(host, localCache_);
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    return doGetPartsMap(host, threadLocalInfo.localCache_);
 }
 
 
 StatusOr<PartMeta> MetaClient::getPartMetaFromCache(GraphSpaceID spaceId, PartitionID partId) {
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = localCache_.find(spaceId);
-    if (it == localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.localCache_.find(spaceId);
+    if (it == threadLocalInfo.localCache_.end()) {
         return Status::Error("Space not found, spaceid: %d", spaceId);
     }
     auto& cache = it->second;
@@ -1027,9 +1081,10 @@ StatusOr<PartMeta> MetaClient::getPartMetaFromCache(GraphSpaceID spaceId, Partit
 Status  MetaClient::checkPartExistInCache(const HostAddr& host,
                                           GraphSpaceID spaceId,
                                           PartitionID partId) {
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = localCache_.find(spaceId);
-    if (it != localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.localCache_.find(spaceId);
+    if (it != threadLocalInfo.localCache_.end()) {
         auto partsIt = it->second->partsOnHost_.find(host);
         if (partsIt != it->second->partsOnHost_.end()) {
             for (auto& pId : partsIt->second) {
@@ -1047,9 +1102,10 @@ Status  MetaClient::checkPartExistInCache(const HostAddr& host,
 
 Status MetaClient::checkSpaceExistInCache(const HostAddr& host,
                                           GraphSpaceID spaceId) {
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = localCache_.find(spaceId);
-    if (it != localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.localCache_.find(spaceId);
+    if (it != threadLocalInfo.localCache_.end()) {
         auto partsIt = it->second->partsOnHost_.find(host);
         if (partsIt != it->second->partsOnHost_.end() && !partsIt->second.empty()) {
             return Status::OK();
@@ -1061,9 +1117,10 @@ Status MetaClient::checkSpaceExistInCache(const HostAddr& host,
 }
 
 StatusOr<int32_t> MetaClient::partsNum(GraphSpaceID spaceId) {
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = localCache_.find(spaceId);
-    if (it == localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.localCache_.find(spaceId);
+    if (it == threadLocalInfo.localCache_.end()) {
         return Status::Error("Space not found, spaceid: %d", spaceId);
     }
     return it->second->partsAlloc_.size();
@@ -1466,9 +1523,10 @@ MetaClient::getTagSchemaFromCache(GraphSpaceID spaceId, TagID tagID, SchemaVer v
     if (!ready_) {
         return Status::Error("Not ready!");
     }
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto spaceIt = localCache_.find(spaceId);
-    if (spaceIt == localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto spaceIt = threadLocalInfo.localCache_.find(spaceId);
+    if (spaceIt == threadLocalInfo.localCache_.end()) {
         LOG(ERROR) << "Space " << spaceId << " not found!";
         return std::shared_ptr<const SchemaProviderIf>();
     } else {
@@ -1487,9 +1545,10 @@ MetaClient::getEdgeSchemaFromCache(GraphSpaceID spaceId, EdgeType edgeType, Sche
     if (!ready_) {
         return Status::Error("Not ready!");
     }
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto spaceIt = localCache_.find(spaceId);
-    if (spaceIt == localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto spaceIt = threadLocalInfo.localCache_.find(spaceId);
+    if (spaceIt == threadLocalInfo.localCache_.end()) {
         LOG(ERROR) << "Space " << spaceId << " not found!";
         return std::shared_ptr<const SchemaProviderIf>();
     } else {
@@ -1546,9 +1605,10 @@ MetaClient::getTagIndexFromCache(GraphSpaceID spaceId, IndexID indexID) {
         return Status::Error("Not ready!");
     }
 
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto spaceIt = localCache_.find(spaceId);
-    if (spaceIt == localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto spaceIt = threadLocalInfo.localCache_.find(spaceId);
+    if (spaceIt == threadLocalInfo.localCache_.end()) {
         LOG(ERROR) << "Space " << spaceId << " not found!";
         return Status::SpaceNotFound();
     } else {
@@ -1584,9 +1644,10 @@ MetaClient::getEdgeIndexFromCache(GraphSpaceID spaceId, IndexID indexID) {
         return Status::Error("Not ready!");
     }
 
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto spaceIt = localCache_.find(spaceId);
-    if (spaceIt == localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto spaceIt = threadLocalInfo.localCache_.find(spaceId);
+    if (spaceIt == threadLocalInfo.localCache_.end()) {
         VLOG(3) << "Space " << spaceId << " not found!";
         return Status::SpaceNotFound();
     } else {
@@ -1622,9 +1683,10 @@ MetaClient::getTagIndexesFromCache(GraphSpaceID spaceId) {
         return Status::Error("Not ready!");
     }
 
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto spaceIt = localCache_.find(spaceId);
-    if (spaceIt == localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto spaceIt = threadLocalInfo.localCache_.find(spaceId);
+    if (spaceIt == threadLocalInfo.localCache_.end()) {
         VLOG(3) << "Space " << spaceId << " not found!";
         return Status::SpaceNotFound();
     } else {
@@ -1645,9 +1707,10 @@ MetaClient::getEdgeIndexesFromCache(GraphSpaceID spaceId) {
         return Status::Error("Not ready!");
     }
 
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto spaceIt = localCache_.find(spaceId);
-    if (spaceIt == localCache_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto spaceIt = threadLocalInfo.localCache_.find(spaceId);
+    if (spaceIt == threadLocalInfo.localCache_.end()) {
         VLOG(3) << "Space " << spaceId << " not found!";
         return Status::SpaceNotFound();
     } else {
@@ -1696,9 +1759,10 @@ StatusOr<SchemaVer> MetaClient::getLatestTagVersionFromCache(const GraphSpaceID&
     if (!ready_) {
         return Status::Error("Not ready!");
     }
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = spaceNewestTagVerMap_.find(std::make_pair(space, tagId));
-    if (it == spaceNewestTagVerMap_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.spaceNewestTagVerMap_.find(std::make_pair(space, tagId));
+    if (it == threadLocalInfo.spaceNewestTagVerMap_.end()) {
         return Status::TagNotFound();
     }
     return it->second;
@@ -1709,9 +1773,10 @@ StatusOr<SchemaVer> MetaClient::getLatestEdgeVersionFromCache(const GraphSpaceID
     if (!ready_) {
         return Status::Error("Not ready!");
     }
-    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
-    auto it = spaceNewestEdgeVerMap_.find(std::make_pair(space, edgeType));
-    if (it == spaceNewestEdgeVerMap_.end()) {
+//    folly::RWSpinLock::ReadHolder holder(localCacheLock_);
+    const ThreadLocalInfo& threadLocalInfo = getThreadLocalInfo();
+    auto it = threadLocalInfo.spaceNewestEdgeVerMap_.find(std::make_pair(space, edgeType));
+    if (it == threadLocalInfo.spaceNewestEdgeVerMap_.end()) {
         return Status::EdgeNotFound();
     }
     return it->second;
@@ -2112,6 +2177,9 @@ bool MetaClient::registerCfg() {
 }
 
 bool MetaClient::loadCfg() {
+    if (options_.skipConfig_ || localCfgLastUpdateTime_ == metadLastUpdateTime_) {
+        return true;
+    }
     if (!configReady_ && !registerCfg()) {
         return false;
     }
@@ -2145,6 +2213,7 @@ bool MetaClient::loadCfg() {
         LOG(ERROR) << "Load configs failed: " << ret.status();
         return false;
     }
+    localCfgLastUpdateTime_.store(metadLastUpdateTime_.load());
     return true;
 }
 

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -48,9 +48,13 @@ struct SpaceInfoCache {
     std::string spaceName;
     PartsAlloc partsAlloc_;
     std::unordered_map<HostAddr, std::vector<PartitionID>> partsOnHost_;
+    std::vector<cpp2::TagItem> tagItemVec_;
     TagSchemas  tagSchemas_;
+    std::vector<cpp2::EdgeItem> edgeItemVec_;
     EdgeSchemas edgeSchemas_;
+    std::vector<nebula::cpp2::IndexItem> tagIndexItemVec_;
     Indexes tagIndexes_;
+    std::vector<nebula::cpp2::IndexItem> edgeIndexItemVec_;
     Indexes edgeIndexes_;
 };
 
@@ -570,8 +574,24 @@ private:
 
     std::unordered_map<GraphSpaceID, std::vector<PartitionID>> leaderIds_;
     folly::RWSpinLock     leaderIdsLock_;
-    int64_t               localLastUpdateTime_{0};
-    int64_t               metadLastUpdateTime_{0};
+    std::atomic<int64_t>  localDataLastUpdateTime_{-1};
+    std::atomic<int64_t>  localCfgLastUpdateTime_{-1};
+    std::atomic<int64_t>  metadLastUpdateTime_{0};
+
+    struct ThreadLocalInfo {
+        int64_t               localLastUpdateTime_{-1};
+        LocalCache            localCache_;
+        SpaceNameIdMap        spaceIndexByName_;
+        SpaceTagNameIdMap     spaceTagIndexByName_;
+        SpaceEdgeNameTypeMap  spaceEdgeIndexByName_;
+        SpaceEdgeTypeNameMap  spaceEdgeIndexByType_;
+        SpaceTagIdNameMap     spaceTagIndexById_;
+        SpaceNewestTagVerMap  spaceNewestTagVerMap_;
+        SpaceNewestEdgeVerMap spaceNewestEdgeVerMap_;
+        SpaceAllEdgeMap       spaceAllEdgeMap_;
+    };
+
+    const ThreadLocalInfo& getThreadLocalInfo();
 
     LocalCache localCache_;
     std::vector<HostAddr> addrs_;


### PR DESCRIPTION
use thread local object when access meta client cache. folly::SingletonThreadLocal supply efficient access wrapper by using pointer.