### PR TITLE
Correct/issue2087 go cover input NG-141

### DIFF
--- a/src/common/filter/Expressions.cpp
+++ b/src/common/filter/Expressions.cpp
@@ -143,6 +143,14 @@ OptVariantType AliasPropertyExpression::eval(Getters &getters) const {
     return getters.getAliasProp(*alias_, *prop_);
 }
 
+Status AliasPropertyExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
+}
+
 Status AliasPropertyExpression::prepare() {
     context_->addAliasProp(*alias_, *prop_);
     return Status::OK();
@@ -210,6 +218,14 @@ OptVariantType InputPropertyExpression::eval(Getters &getters) const {
     return getters.getInputProp(*prop_);
 }
 
+Status
+InputPropertyExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
+}
 
 DestPropertyExpression::DestPropertyExpression(std::string *tag, std::string *prop) {
     kind_ = kDestProp;
@@ -225,6 +241,13 @@ OptVariantType DestPropertyExpression::eval(Getters &getters) const {
     return getters.getDstTagProp(*alias_, *prop_);
 }
 
+Status DestPropertyExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
+}
 
 Status DestPropertyExpression::prepare() {
     context_->addDstTagProp(*alias_, *prop_);
@@ -246,6 +269,14 @@ OptVariantType VariablePropertyExpression::eval(Getters &getters) const {
     return getters.getVariableProp(*prop_);
 }
 
+Status VariablePropertyExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
+}
+
 Status VariablePropertyExpression::prepare() {
     context_->addVariableProp(*alias_, *prop_);
     return Status::OK();
@@ -256,6 +287,14 @@ OptVariantType EdgeTypeExpression::eval(Getters &getters) const {
         return Status::Error("`getAliasProp' function is not implemented");
     }
     return getters.getAliasProp(*alias_, *prop_);
+}
+
+Status EdgeTypeExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
 }
 
 Status EdgeTypeExpression::prepare() {
@@ -271,6 +310,13 @@ OptVariantType EdgeSrcIdExpression::eval(Getters &getters) const {
     return getters.getAliasProp(*alias_, *prop_);
 }
 
+Status EdgeSrcIdExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
+}
 
 Status EdgeSrcIdExpression::prepare() {
     context_->addAliasProp(*alias_, *prop_);
@@ -283,6 +329,14 @@ OptVariantType EdgeDstIdExpression::eval(Getters &getters) const {
         return Status::Error("`getEdgeDstId' function is not implemented");
     }
     return getters.getEdgeDstId(*alias_);
+}
+
+Status EdgeDstIdExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
 }
 
 Status EdgeDstIdExpression::prepare() {
@@ -298,6 +352,13 @@ OptVariantType EdgeRankExpression::eval(Getters &getters) const {
     return getters.getAliasProp(*alias_, *prop_);
 }
 
+Status EdgeRankExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
+}
 
 Status EdgeRankExpression::prepare() {
     context_->addAliasProp(*alias_, *prop_);
@@ -319,6 +380,13 @@ OptVariantType SourcePropertyExpression::eval(Getters &getters) const {
     return getters.getSrcTagProp(*alias_, *prop_);
 }
 
+Status SourcePropertyExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
+}
 
 Status SourcePropertyExpression::prepare() {
     context_->addSrcTagProp(*alias_, *prop_);
@@ -364,6 +432,14 @@ OptVariantType PrimaryExpression::eval(Getters &getters) const {
     }
 
     return OptVariantType(Status::Error("Unknown type"));
+}
+
+Status PrimaryExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
 }
 
 Status PrimaryExpression::prepare() {
@@ -463,6 +539,17 @@ OptVariantType FunctionCallExpression::eval(Getters &getters) const {
     return r;
 }
 
+Status FunctionCallExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    for (const auto &it : args_) {
+        it->traversal(visitor);
+    }
+    visitor(this);
+    return Status::OK();
+}
+
 Status FunctionCallExpression::prepare() {
     auto result = FunctionManager::get(*name_, args_.size());
     if (!result.ok()) {
@@ -540,6 +627,14 @@ OptVariantType UUIDExpression::eval(Getters &getters) const {
      return v.get_id();
 }
 
+Status UUIDExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    visitor(this);
+    return Status::OK();
+}
+
 Status UUIDExpression::prepare() {
     return Status::OK();
 }
@@ -583,6 +678,15 @@ OptVariantType UnaryExpression::eval(Getters &getters) const {
     return OptVariantType(Status::Error(folly::sformat(
         "attempt to perform unary arithmetic on a `{}'",
         VARIANT_TYPE_NAME[value.value().which()])));
+}
+
+Status UnaryExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    operand_->traversal(visitor);
+    visitor(this);
+    return Status::OK();
 }
 
 Status UnaryExpression::prepare() {
@@ -658,6 +762,14 @@ OptVariantType TypeCastingExpression::eval(Getters &getters) const {
     LOG(FATAL) << "casting to unknown type: " << static_cast<int>(type_);
 }
 
+Status TypeCastingExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    operand_->traversal(visitor);
+    visitor(this);
+    return Status::OK();
+}
 
 Status TypeCastingExpression::prepare() {
     return operand_->prepare();
@@ -858,6 +970,16 @@ OptVariantType ArithmeticExpression::eval(Getters &getters) const {
         VARIANT_TYPE_NAME[l.which()], VARIANT_TYPE_NAME[r.which()])));
 }
 
+Status ArithmeticExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    left_->traversal(visitor);
+    right_->traversal(visitor);
+    visitor(this);
+    return Status::OK();
+}
+
 Status ArithmeticExpression::prepare() {
     auto status = left_->prepare();
     if (!status.ok()) {
@@ -981,6 +1103,16 @@ OptVariantType RelationalExpression::eval(Getters &getters) const {
     return OptVariantType(Status::Error("Wrong operator"));
 }
 
+Status RelationalExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    left_->traversal(visitor);
+    right_->traversal(visitor);
+    visitor(this);
+    return Status::OK();
+}
+
 Status RelationalExpression::implicitCasting(VariantType &lhs, VariantType &rhs) const {
     // Rule: bool -> int64_t -> double
     if (lhs.which() == VAR_STR || rhs.which() == VAR_STR) {
@@ -1087,6 +1219,16 @@ OptVariantType LogicalExpression::eval(Getters &getters) const {
         }
         return OptVariantType(true);
     }
+}
+
+Status LogicalExpression::traversal(std::function<void(const Expression*)> visitor) const {
+    if (!visitor) {
+        return Status::Error("Null visitor.");
+    }
+    left_->traversal(visitor);
+    right_->traversal(visitor);
+    visitor(this);
+    return Status::OK();
 }
 
 Status LogicalExpression::prepare() {

--- a/src/common/filter/Expressions.h
+++ b/src/common/filter/Expressions.h
@@ -206,6 +206,8 @@ public:
 
     virtual OptVariantType eval(Getters &getters) const = 0;
 
+    virtual Status traversal(std::function<void(const Expression*)> visitor) const = 0;
+
     virtual bool isInputExpression() const {
         return kind_ == kInputProp;
     }
@@ -232,6 +234,16 @@ public:
 
     bool isEdgeDstIdExpression() const {
         return kind_ == kEdgeDstId;
+    }
+
+    bool fromVarInput() const {
+        bool isFromVar = false;
+        traversal([&isFromVar](const Expression *expr) {
+            if (expr->kind() == Kind::kVariableProp || expr->kind() == Kind::kInputProp) {
+                isFromVar = true;
+            }
+        });
+        return isFromVar;
     }
 
     /**
@@ -464,6 +476,8 @@ public:
 
     OptVariantType eval(Getters &getters) const override;
 
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
+
     Status MUST_USE_RESULT prepare() override;
 
     std::string* alias() const {
@@ -495,6 +509,8 @@ public:
 
     OptVariantType eval(Getters &getters) const override;
 
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
+
     Status MUST_USE_RESULT prepare() override;
 };
 
@@ -510,6 +526,8 @@ public:
 
     OptVariantType eval(Getters &getters) const override;
 
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
+
     Status MUST_USE_RESULT prepare() override;
 };
 
@@ -524,6 +542,8 @@ public:
     VariablePropertyExpression(std::string *var, std::string *prop);
 
     OptVariantType eval(Getters &getters) const override;
+
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
 
     Status MUST_USE_RESULT prepare() override;
 };
@@ -545,6 +565,8 @@ public:
 
     OptVariantType eval(Getters &getters) const override;
 
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
+
     Status MUST_USE_RESULT prepare() override;
 };
 
@@ -564,6 +586,8 @@ public:
     }
 
     OptVariantType eval(Getters &getters) const override;
+
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
 
     Status MUST_USE_RESULT prepare() override;
 };
@@ -585,6 +609,8 @@ public:
 
     OptVariantType eval(Getters &getters) const override;
 
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
+
     Status MUST_USE_RESULT prepare() override;
 };
 
@@ -605,6 +631,8 @@ public:
 
     OptVariantType eval(Getters &getters) const override;
 
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
+
     Status MUST_USE_RESULT prepare() override;
 };
 
@@ -619,6 +647,8 @@ public:
     SourcePropertyExpression(std::string *tag, std::string *prop);
 
     OptVariantType eval(Getters &getters) const override;
+
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
 
     Status MUST_USE_RESULT prepare() override;
 };
@@ -654,6 +684,8 @@ public:
     std::string toString() const override;
 
     OptVariantType eval(Getters &getters) const override;
+
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -712,6 +744,8 @@ public:
 
     OptVariantType eval(Getters &getters) const override;
 
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
+
     Status MUST_USE_RESULT prepare() override;
 
     void setContext(ExpressionContext *ctx) override {
@@ -751,6 +785,8 @@ public:
     std::string toString() const override;
 
     OptVariantType eval(Getters &getters) const override;
+
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -793,6 +829,8 @@ public:
 
     OptVariantType eval(Getters &getters) const override;
 
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
+
     Status MUST_USE_RESULT prepare() override;
 
     void setContext(ExpressionContext *context) override {
@@ -831,6 +869,8 @@ public:
     std::string toString() const override;
 
     OptVariantType eval(Getters &getters) const override;
+
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -880,6 +920,8 @@ public:
     std::string toString() const override;
 
     OptVariantType eval(Getters &getters) const override;
+
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -931,6 +973,8 @@ public:
     std::string toString() const override;
 
     OptVariantType eval(Getters &getters) const override;
+
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
 
     Status MUST_USE_RESULT prepare() override;
 
@@ -988,6 +1032,8 @@ public:
     std::string toString() const override;
 
     OptVariantType eval(Getters &getters) const override;
+
+    Status traversal(std::function<void(const Expression*)> visitor) const override;
 
     Status MUST_USE_RESULT prepare() override;
 

--- a/src/graph/GoExecutor.cpp
+++ b/src/graph/GoExecutor.cpp
@@ -4,6 +4,8 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
+#include <folly/ScopeGuard.h>
+
 #include "base/Base.h"
 #include "graph/GoExecutor.h"
 #include "graph/SchemaHelper.h"
@@ -464,6 +466,11 @@ Status GoExecutor::checkNeededProps() {
 
 
 Status GoExecutor::setupStarts() {
+    SCOPE_EXIT {
+        // unique the start vid
+        std::unordered_set<VertexID> uni(starts_.begin(), starts_.end());
+        starts_.assign(uni.begin(), uni.end());
+    };
     // Literal vertex ids
     if (!starts_.empty()) {
         return Status::OK();

--- a/src/graph/GoExecutor.cpp
+++ b/src/graph/GoExecutor.cpp
@@ -1063,6 +1063,9 @@ bool GoExecutor::processFinalResult(Callback cb) const {
                 auto srcId = vdata.get_vertex_id();
                 const auto rootId = getRoot(srcId, recordIn);
                 auto inputRows = index_->rowsOfVid(rootId);
+                // Here if join the input we extend the input rows coresponding to current vertex;
+                // Or just loop once as previous that not join anything,
+                // in fact result what in responses.
                 bool notJoinOnce = false;
                 for (auto inputRow = inputRows.first;
                      !joinInput || inputRow != inputRows.second;

--- a/src/graph/GoExecutor.cpp
+++ b/src/graph/GoExecutor.cpp
@@ -1136,8 +1136,9 @@ bool GoExecutor::processFinalResult(Callback cb) const {
                                 auto vreader = RowReader::getRowReader(it2->data, tagSchema[tagId]);
                                 auto res = RowReader::getPropByName(vreader.get(), prop);
                                 if (!ok(res)) {
-                                    return Status::Error(
-                                        folly::sformat("get prop({}.{}) failed", tag, prop));
+                                    return Status::Error("get prop(%s.%s) failed",
+                                                         tag.c_str(),
+                                                         prop.c_str());
                                 }
                                 return value(res);
                             };

--- a/src/graph/GoExecutor.cpp
+++ b/src/graph/GoExecutor.cpp
@@ -1070,12 +1070,11 @@ bool GoExecutor::processFinalResult(Callback cb) const {
                 auto srcId = vdata.get_vertex_id();
                 const auto rootId = getRoot(srcId, recordIn);
                 auto inputRows = index_->rowsOfVid(rootId);
-                const bool notJoinInput = !joinInput;
                 bool notJoinOnce = false;
                 for (auto inputRow = inputRows.first;
-                     notJoinInput || inputRow != inputRows.second;
-                     !notJoinInput ? ++inputRow : inputRow) {
-                    if (notJoinInput) {
+                     !joinInput || inputRow != inputRows.second;
+                     joinInput ? ++inputRow : inputRow) {
+                    if (!joinInput) {
                         if (notJoinOnce) {
                             break;
                         }

--- a/src/graph/GoExecutor.cpp
+++ b/src/graph/GoExecutor.cpp
@@ -1163,12 +1163,10 @@ bool GoExecutor::processFinalResult(Callback cb) const {
                                 return ret.value();
                             };
                             getters.getVariableProp = [inputRow, this] (const std::string &prop) {
-//                                return getPropFromInterim(srcId, prop);
                                 return index_->getColumnWithRow(inputRow->second, prop);
                             };
 
                             getters.getInputProp = [inputRow, this] (const std::string &prop) {
-//                                return getPropFromInterim(srcId, prop);
                                 return index_->getColumnWithRow(inputRow->second, prop);
                             };
 

--- a/src/graph/GoExecutor.cpp
+++ b/src/graph/GoExecutor.cpp
@@ -4,8 +4,6 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#include <folly/ScopeGuard.h>
-
 #include "base/Base.h"
 #include "graph/GoExecutor.h"
 #include "graph/SchemaHelper.h"
@@ -466,11 +464,6 @@ Status GoExecutor::checkNeededProps() {
 
 
 Status GoExecutor::setupStarts() {
-    SCOPE_EXIT {
-        // unique the start vid
-        std::unordered_set<VertexID> uni(starts_.begin(), starts_.end());
-        starts_.assign(uni.begin(), uni.end());
-    };
     // Literal vertex ids
     if (!starts_.empty()) {
         return Status::OK();

--- a/src/graph/GoExecutor.cpp
+++ b/src/graph/GoExecutor.cpp
@@ -108,6 +108,9 @@ void GoExecutor::execute() {
         doError(std::move(status));
         return;
     }
+    if (index_ == nullptr) {
+        index_ = std::make_unique<InterimIndex>();
+    }
     if (starts_.empty()) {
         onEmptyInputs();
         return;
@@ -1012,13 +1015,17 @@ void GoExecutor::onEmptyInputs() {
 }
 
 bool GoExecutor::processFinalResult(Callback cb) const {
+    const bool joinInput = yieldInput();
     auto uniqResult = std::make_unique<std::unordered_set<size_t>>();
     auto spaceId = ectx()->rctx()->session()->space();
     std::vector<SupportedType> colTypes;
     for (auto *column : yields_) {
         colTypes.emplace_back(calculateExprType(column->expr()));
     }
-    for (auto rpcResp = records_.begin() + recordFrom_ - 1; rpcResp != records_.end(); ++rpcResp) {
+    std::size_t recordIn = recordFrom_;
+    for (auto rpcResp = records_.begin() + recordFrom_ - 1;
+         rpcResp != records_.end();
+         ++rpcResp, ++recordIn) {
         const auto& all = rpcResp->responses();
 
         std::vector<VariantType> record;
@@ -1051,191 +1058,208 @@ bool GoExecutor::processFinalResult(Callback cb) const {
             VLOG(1) << "Total resp.vertices size " << resp.vertices.size();
             for (const auto &vdata : resp.vertices) {
                 DCHECK(vdata.__isset.edge_data);
+                VLOG(1) << "Total vdata.edge_data size " << vdata.edge_data.size();
                 auto tagData = vdata.get_tag_data();
                 auto srcId = vdata.get_vertex_id();
-                VLOG(1) << "Total vdata.edge_data size " << vdata.edge_data.size();
-                for (const auto &edata : vdata.edge_data) {
-                    auto edgeType = edata.type;
-                    VLOG(1) << "Total edata.edges size " << edata.edges.size()
-                            << ", for edge " << edgeType;
-                    std::shared_ptr<ResultSchemaProvider> currEdgeSchema;
-                    auto it = edgeSchema.find(edgeType);
-                    if (it != edgeSchema.end()) {
-                        currEdgeSchema = it->second;
+                const auto rootId = getRoot(srcId, recordIn);
+                auto inputRows = index_->rowsOfVid(rootId);
+                const bool notJoinInput = !joinInput;
+                bool notJoinOnce = false;
+                for (auto inputRow = inputRows.first;
+                     notJoinInput || inputRow != inputRows.second;
+                     !notJoinInput ? ++inputRow : inputRow) {
+                    if (notJoinInput) {
+                        if (notJoinOnce) {
+                            break;
+                        }
+                        notJoinOnce = true;
                     }
-                    VLOG(1) << "CurrEdgeSchema is null? " << (currEdgeSchema == nullptr);
-                    for (const auto& edge : edata.edges) {
-                        auto dstId = edge.get_dst();
-                        Getters getters;
-                        getters.getEdgeDstId = [this,
-                                                &dstId,
-                                                &edgeType] (const std::string& edgeName)
-                                                                -> OptVariantType {
-                            if (edgeTypes_.size() > 1) {
+                    for (const auto &edata : vdata.edge_data) {
+                        auto edgeType = edata.type;
+                        VLOG(1) << "Total edata.edges size " << edata.edges.size()
+                                << ", for edge " << edgeType;
+                        std::shared_ptr<ResultSchemaProvider> currEdgeSchema;
+                        auto it = edgeSchema.find(edgeType);
+                        if (it != edgeSchema.end()) {
+                            currEdgeSchema = it->second;
+                        }
+                        VLOG(1) << "CurrEdgeSchema is null? " << (currEdgeSchema == nullptr);
+                        for (const auto& edge : edata.edges) {
+                            auto dstId = edge.get_dst();
+                            Getters getters;
+                            getters.getEdgeDstId = [this,
+                                                    &dstId,
+                                                    &edgeType] (const std::string& edgeName)
+                                                                    -> OptVariantType {
+                                if (edgeTypes_.size() > 1) {
+                                    EdgeType type;
+                                    auto found = expCtx_->getEdgeType(edgeName, type);
+                                    if (!found) {
+                                        return Status::Error(
+                                                "Get edge type for `%s' failed in getters.",
+                                                edgeName.c_str());
+                                    }
+                                    if (type != std::abs(edgeType)) {
+                                        return 0L;
+                                    }
+                                }
+                                return dstId;
+                            };
+                            getters.getSrcTagProp = [&spaceId,
+                                                    &tagData,
+                                                    &tagSchema,
+                                                    this] (const std::string &tag,
+                                                       const std::string &prop) -> OptVariantType {
+                                TagID tagId;
+                                auto found = expCtx_->getTagId(tag, tagId);
+                                if (!found) {
+                                    return Status::Error(
+                                            "Get tag id for `%s' failed in getters.", tag.c_str());
+                                }
+
+                                auto it2 = std::find_if(tagData.cbegin(),
+                                                        tagData.cend(),
+                                                        [&tagId] (auto &td) {
+                                    if (td.tag_id == tagId) {
+                                        return true;
+                                    }
+                                    return false;
+                                });
+                                if (it2 == tagData.cend()) {
+                                    auto ts = ectx()->schemaManager()->getTagSchema(spaceId, tagId);
+                                    if (ts == nullptr) {
+                                        return Status::Error("No tag schema for %s", tag.c_str());
+                                    }
+                                    return RowReader::getDefaultProp(ts.get(), prop);
+                                }
+                                DCHECK(it2->__isset.data);
+                                auto vreader = RowReader::getRowReader(it2->data, tagSchema[tagId]);
+                                auto res = RowReader::getPropByName(vreader.get(), prop);
+                                if (!ok(res)) {
+                                    return Status::Error(
+                                        folly::sformat("get prop({}.{}) failed", tag, prop));
+                                }
+                                return value(res);
+                            };
+                            // In reverse mode, it is used to get the src props.
+                            getters.getDstTagProp = [&spaceId,
+                                                    &dstId,
+                                                    this] (const std::string &tag,
+                                                        const std::string &prop) -> OptVariantType {
+                                TagID tagId;
+                                auto found = expCtx_->getTagId(tag, tagId);
+                                if (!found) {
+                                    return Status::Error(
+                                            "Get tag id for `%s' failed in getters.", tag.c_str());
+                                }
+                                auto ret = vertexHolder_->get(dstId, tagId, prop);
+                                if (!ret.ok()) {
+                                    auto ts = ectx()->schemaManager()->getTagSchema(spaceId, tagId);
+                                    if (ts == nullptr) {
+                                        return Status::Error("No tag schema for %s", tag.c_str());
+                                    }
+                                    return RowReader::getDefaultProp(ts.get(), prop);
+                                }
+                                return ret.value();
+                            };
+                            getters.getVariableProp = [inputRow, this] (const std::string &prop) {
+//                                return getPropFromInterim(srcId, prop);
+                                return index_->getColumnWithRow(inputRow->second, prop);
+                            };
+
+                            getters.getInputProp = [inputRow, this] (const std::string &prop) {
+//                                return getPropFromInterim(srcId, prop);
+                                return index_->getColumnWithRow(inputRow->second, prop);
+                            };
+
+                            std::unique_ptr<RowReader> reader;
+                            if (currEdgeSchema) {
+                                reader = RowReader::getRowReader(edge.props, currEdgeSchema);
+                            }
+
+                            // In reverse mode, we should handle _src
+                            getters.getAliasProp = [&reader,
+                                                    &srcId,
+                                                    &edgeType,
+                                                    &edgeSchema,
+                                                    this] (const std::string &edgeName,
+                                                        const std::string &prop) mutable
+                                                                        -> OptVariantType {
                                 EdgeType type;
                                 auto found = expCtx_->getEdgeType(edgeName, type);
                                 if (!found) {
                                     return Status::Error(
-                                            "Get edge type for `%s' failed in getters.",
-                                            edgeName.c_str());
+                                        "Get edge type for `%s' failed in getters.",
+                                        edgeName.c_str());
                                 }
-                                if (type != std::abs(edgeType)) {
-                                    return 0L;
+                                if (std::abs(edgeType) != type) {
+                                    auto sit = edgeSchema.find(
+                                        direction_ ==
+                                        OverClause::Direction::kBackward ? -type : type);
+                                    if (sit == edgeSchema.end()) {
+                                        std::string errMsg = folly::stringPrintf(
+                                                "Can't find shcema for %s when get default.",
+                                                edgeName.c_str());
+                                        LOG(ERROR) << errMsg;
+                                        return Status::Error(errMsg);
+                                    }
+                                    return RowReader::getDefaultProp(sit->second.get(), prop);
                                 }
-                            }
-                            return dstId;
-                        };
-                        getters.getSrcTagProp = [&spaceId,
-                                                &tagData,
-                                                &tagSchema,
-                                                this] (const std::string &tag,
-                                                        const std::string &prop) -> OptVariantType {
-                            TagID tagId;
-                            auto found = expCtx_->getTagId(tag, tagId);
-                            if (!found) {
-                                return Status::Error(
-                                        "Get tag id for `%s' failed in getters.", tag.c_str());
-                            }
 
-                            auto it2 = std::find_if(tagData.cbegin(),
-                                                    tagData.cend(),
-                                                    [&tagId] (auto &td) {
-                                if (td.tag_id == tagId) {
-                                    return true;
+                                if (prop == _SRC) {
+                                    return srcId;
                                 }
-                                return false;
-                            });
-                            if (it2 == tagData.cend()) {
-                                auto ts = ectx()->schemaManager()->getTagSchema(spaceId, tagId);
-                                if (ts == nullptr) {
-                                    return Status::Error("No tag schema for %s", tag.c_str());
+                                DCHECK(reader != nullptr);
+                                auto res = RowReader::getPropByName(reader.get(), prop);
+                                if (!ok(res)) {
+                                    LOG(ERROR) << "Can't get prop for " << prop
+                                            << ", edge " << edgeName;
+                                    return Status::Error(
+                                            folly::sformat("get prop({}.{}) failed",
+                                                        edgeName,
+                                                        prop));
                                 }
-                                return RowReader::getDefaultProp(ts.get(), prop);
-                            }
-                            DCHECK(it2->__isset.data);
-                            auto vreader = RowReader::getRowReader(it2->data, tagSchema[tagId]);
-                            auto res = RowReader::getPropByName(vreader.get(), prop);
-                            if (!ok(res)) {
-                                return Status::Error(
-                                    folly::sformat("get prop({}.{}) failed", tag, prop));
-                            }
-                            return value(res);
-                        };
-                        // In reverse mode, it is used to get the src props.
-                        getters.getDstTagProp = [&spaceId,
-                                                &dstId,
-                                                this] (const std::string &tag,
-                                                        const std::string &prop) -> OptVariantType {
-                            TagID tagId;
-                            auto found = expCtx_->getTagId(tag, tagId);
-                            if (!found) {
-                                return Status::Error(
-                                        "Get tag id for `%s' failed in getters.", tag.c_str());
-                            }
-                            auto ret = vertexHolder_->get(dstId, tagId, prop);
-                            if (!ret.ok()) {
-                                auto ts = ectx()->schemaManager()->getTagSchema(spaceId, tagId);
-                                if (ts == nullptr) {
-                                    return Status::Error("No tag schema for %s", tag.c_str());
+                                return value(std::move(res));
+                            };  // getAliasProp
+                            // Evaluate filter
+                            if (whereWrapper_->filter_ != nullptr) {
+                                auto value = whereWrapper_->filter_->eval(getters);
+                                if (!value.ok()) {
+                                    doError(std::move(value).status());
+                                    return false;
                                 }
-                                return RowReader::getDefaultProp(ts.get(), prop);
-                            }
-                            return ret.value();
-                        };
-                        getters.getVariableProp = [&srcId,
-                                                    this] (const std::string &prop) {
-                            return getPropFromInterim(srcId, prop);
-                        };
-                        getters.getInputProp = [&srcId,
-                                                 this] (const std::string &prop) {
-                            return getPropFromInterim(srcId, prop);
-                        };
-
-                        std::unique_ptr<RowReader> reader;
-                        if (currEdgeSchema) {
-                            reader = RowReader::getRowReader(edge.props, currEdgeSchema);
-                        }
-
-                        // In reverse mode, we should handle _src
-                        getters.getAliasProp = [&reader,
-                                                &srcId,
-                                                &edgeType,
-                                                &edgeSchema,
-                                                this] (const std::string &edgeName,
-                                                    const std::string &prop) mutable
-                                                                    -> OptVariantType {
-                            EdgeType type;
-                            auto found = expCtx_->getEdgeType(edgeName, type);
-                            if (!found) {
-                                return Status::Error(
-                                    "Get edge type for `%s' failed in getters.", edgeName.c_str());
-                            }
-                            if (std::abs(edgeType) != type) {
-                                auto sit = edgeSchema.find(
-                                    direction_ == OverClause::Direction::kBackward ? -type : type);
-                                if (sit == edgeSchema.end()) {
-                                    std::string errMsg = folly::stringPrintf(
-                                            "Can't find shcema for %s when get default.",
-                                            edgeName.c_str());
-                                    LOG(ERROR) << errMsg;
-                                    return Status::Error(errMsg);
+                                if (!Expression::asBool(value.value())) {
+                                    continue;
                                 }
-                                return RowReader::getDefaultProp(sit->second.get(), prop);
                             }
-
-                            if (prop == _SRC) {
-                                return srcId;
+                            record.clear();
+                            for (auto *column : yields_) {
+                                auto *expr = column->expr();
+                                auto value = expr->eval(getters);
+                                if (!value.ok()) {
+                                    doError(std::move(value).status());
+                                    return false;
+                                }
+                                record.emplace_back(std::move(value.value()));
                             }
-                            DCHECK(reader != nullptr);
-                            auto res = RowReader::getPropByName(reader.get(), prop);
-                            if (!ok(res)) {
-                                LOG(ERROR) << "Can't get prop for " << prop
-                                        << ", edge " << edgeName;
-                                return Status::Error(
-                                        folly::sformat("get prop({}.{}) failed",
-                                                    edgeName,
-                                                    prop));
+                            // Check if duplicate
+                            if (distinct_) {
+                                auto ret = uniqResult->emplace(boost::hash_range(record.begin(),
+                                                                                record.end()));
+                                if (!ret.second) {
+                                    continue;
+                                }
                             }
-                            return value(std::move(res));
-                        };  // getAliasProp
-                        // Evaluate filter
-                        if (whereWrapper_->filter_ != nullptr) {
-                            auto value = whereWrapper_->filter_->eval(getters);
-                            if (!value.ok()) {
-                                doError(std::move(value).status());
+                            auto cbStatus = cb(std::move(record), colTypes);
+                            if (!cbStatus.ok()) {
+                                LOG(ERROR) << cbStatus;
+                                doError(std::move(cbStatus));
                                 return false;
                             }
-                            if (!Expression::asBool(value.value())) {
-                                continue;
-                            }
-                        }
-                        record.clear();
-                        for (auto *column : yields_) {
-                            auto *expr = column->expr();
-                            auto value = expr->eval(getters);
-                            if (!value.ok()) {
-                                doError(std::move(value).status());
-                                return false;
-                            }
-                            record.emplace_back(std::move(value.value()));
-                        }
-                        // Check if duplicate
-                        if (distinct_) {
-                            auto ret = uniqResult->emplace(boost::hash_range(record.begin(),
-                                                                            record.end()));
-                            if (!ret.second) {
-                                continue;
-                            }
-                        }
-                        auto cbStatus = cb(std::move(record), colTypes);
-                        if (!cbStatus.ok()) {
-                            LOG(ERROR) << cbStatus;
-                            doError(std::move(cbStatus));
-                            return false;
-                        }
-                    }  // for edges
-                }  // for edata
-            }   // for `vdata'
+                        }  // for edges
+                    }  // for edata
+                }   // for `vdata'
+            }  // extend input rows
         }   // for `resp'
     }
     return true;
@@ -1320,16 +1344,6 @@ void GoExecutor::VertexHolder::add(const storage::cpp2::QueryResponse &resp) {
         }
         data_[vdata.vertex_id] = std::move(m);
     }
-}
-
-OptVariantType GoExecutor::getPropFromInterim(VertexID id, const std::string &prop) const {
-    auto rootId = id;
-    if (backTracker_ != nullptr) {
-        DCHECK_NE(steps_ , 1u);
-        rootId = backTracker_->get(id);
-    }
-    DCHECK(index_ != nullptr);
-    return index_->getColumnWithVID(rootId, prop);
 }
 
 void GoExecutor::joinResp(RpcResponse &&resp) {

--- a/src/graph/GoExecutor.h
+++ b/src/graph/GoExecutor.h
@@ -77,6 +77,25 @@ private:
         return curStep_ >= recordFrom_ && curStep_ <= steps_;
     }
 
+    bool yieldInput() const {
+        for (const auto col : yields_) {
+            if (col->expr()->fromVarInput()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    VertexID getRoot(VertexID srcId, std::size_t record) const {
+        CHECK_GT(record, 0);
+        VertexID rootId = srcId;
+        if (record == 1) {
+            return rootId;
+        }
+        rootId = DCHECK_NOTNULL(backTracker_)->get(srcId);
+        return rootId;
+    }
+
     /**
      * To obtain the source ids from various places,
      * such as the literal id list, inputs from the pipeline or results of variable.
@@ -195,8 +214,6 @@ private:
     private:
          std::unordered_map<VertexID, VertexID>     mapping_;
     };
-
-    OptVariantType getPropFromInterim(VertexID id, const std::string &prop) const;
 
     enum FromType {
         kInstantExpr,

--- a/src/graph/InterimResult.cpp
+++ b/src/graph/InterimResult.cpp
@@ -217,7 +217,7 @@ InterimResult::buildIndex(const std::string &vidColumn) const {
                         return Status::Error("Get vid from interim failed.");
                     }
                     if (i == vidIndex) {
-                        index->vidToRowIndex_[v] = rowIndex++;
+                        index->vidToRowIndex_.emplace(v, rowIndex++);
                     }
                     row.emplace_back(v);
                     break;
@@ -273,14 +273,10 @@ InterimResult::buildIndex(const std::string &vidColumn) const {
     return index;
 }
 
-
-OptVariantType InterimResult::InterimResultIndex::getColumnWithVID(VertexID id,
-    const std::string &col) const {
-    uint32_t rowIndex = 0;
-    {
-        auto iter = vidToRowIndex_.find(id);
-        DCHECK(iter != vidToRowIndex_.end());
-        rowIndex = iter->second;
+OptVariantType
+InterimResult::InterimResultIndex::getColumnWithRow(std::size_t row, const std::string &col) const {
+    if (row >= rows_.size()) {
+        return Status::Error("Out of range");
     }
     uint32_t columnIndex = 0;
     {
@@ -291,9 +287,8 @@ OptVariantType InterimResult::InterimResultIndex::getColumnWithVID(VertexID id,
         }
         columnIndex = iter->second;
     }
-    return rows_[rowIndex][columnIndex];
+    return rows_[row][columnIndex];
 }
-
 
 nebula::cpp2::SupportedType InterimResult::getColumnType(
     const std::string &col) const {

--- a/src/graph/InterimResult.h
+++ b/src/graph/InterimResult.h
@@ -86,8 +86,11 @@ public:
 
     class InterimResultIndex final {
     public:
-        OptVariantType getColumnWithVID(VertexID id, const std::string &col) const;
+        OptVariantType getColumnWithRow(std::size_t row, const std::string &col) const;
         nebula::cpp2::SupportedType getColumnType(const std::string &col) const;
+        auto rowsOfVid(VertexID id) {
+            return vidToRowIndex_.equal_range(id);
+        }
 
     private:
         friend class InterimResult;
@@ -96,7 +99,7 @@ public:
         using SchemaPtr = std::shared_ptr<const meta::SchemaProviderIf>;
         SchemaPtr                                   schema_{nullptr};
         std::unordered_map<std::string, uint32_t>   columnToIndex_;
-        std::unordered_map<VertexID, uint32_t>      vidToRowIndex_;
+        std::multimap<VertexID, uint32_t>           vidToRowIndex_;
     };
 
 private:

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -115,7 +115,6 @@ TEST_P(GoTest, OneStepOutBound) {
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
-            {teams_["Spurs"].vid()},
             {teams_["Hornets"].vid()},
             {teams_["Trail Blazers"].vid()},
         };
@@ -137,7 +136,6 @@ TEST_P(GoTest, OneStepOutBound) {
         ASSERT_TRUE(verifyColNames(resp, expectedColNames));
 
         std::vector<std::tuple<int64_t>> expected = {
-            {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
@@ -656,7 +654,6 @@ TEST_P(GoTest, MULTI_EDGES) {
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
-            {teams_["Spurs"].vid()},
             {teams_["Hornets"].vid()},
             {teams_["Trail Blazers"].vid()},
         };
@@ -673,7 +670,6 @@ TEST_P(GoTest, MULTI_EDGES) {
         auto code  = client_->execute(query, resp);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
         std::vector<std::tuple<int64_t>> expected = {
-            {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
@@ -1009,7 +1005,6 @@ TEST_P(GoTest, ReturnTest) {
         ASSERT_TRUE(verifyColNames(resp, expectedColNames));
 
         std::vector<std::tuple<int64_t>> expected = {
-            {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Trail Blazers"].vid()},
             {teams_["Spurs"].vid()},
@@ -2662,10 +2657,6 @@ TEST_P(GoTest, issue2087_go_cover_input) {
             {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
             {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
             {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
-            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
-            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
-            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
-            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
         };
         ASSERT_TRUE(verifyResult(resp, expected));
     }
@@ -2679,10 +2670,6 @@ TEST_P(GoTest, issue2087_go_cover_input) {
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
 
         std::vector<std::tuple<int64_t, int64_t>> expected = {
-            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
-            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
-            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
-            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
             {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
             {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
             {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -115,6 +115,7 @@ TEST_P(GoTest, OneStepOutBound) {
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
+            {teams_["Spurs"].vid()},
             {teams_["Hornets"].vid()},
             {teams_["Trail Blazers"].vid()},
         };
@@ -136,6 +137,7 @@ TEST_P(GoTest, OneStepOutBound) {
         ASSERT_TRUE(verifyColNames(resp, expectedColNames));
 
         std::vector<std::tuple<int64_t>> expected = {
+            {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
@@ -654,6 +656,7 @@ TEST_P(GoTest, MULTI_EDGES) {
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
+            {teams_["Spurs"].vid()},
             {teams_["Hornets"].vid()},
             {teams_["Trail Blazers"].vid()},
         };
@@ -670,6 +673,7 @@ TEST_P(GoTest, MULTI_EDGES) {
         auto code  = client_->execute(query, resp);
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
         std::vector<std::tuple<int64_t>> expected = {
+            {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
@@ -1005,6 +1009,7 @@ TEST_P(GoTest, ReturnTest) {
         ASSERT_TRUE(verifyColNames(resp, expectedColNames));
 
         std::vector<std::tuple<int64_t>> expected = {
+            {teams_["Spurs"].vid()},
             {teams_["Spurs"].vid()},
             {teams_["Trail Blazers"].vid()},
             {teams_["Spurs"].vid()},
@@ -2662,6 +2667,14 @@ TEST_P(GoTest, issue2087_go_cover_input) {
              "Tim Duncan", "Tony Parker"},
             {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid(),
              "Tim Duncan", "Manu Ginobili"},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid(),
+             "Tim Duncan", "Tony Parker"},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid(),
+             "Tim Duncan", "Manu Ginobili"},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid(),
+             "Tim Duncan", "Tony Parker"},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid(),
+             "Tim Duncan", "Manu Ginobili"},
         };
         ASSERT_TRUE(verifyResult(resp, expected));
     }
@@ -2675,6 +2688,10 @@ TEST_P(GoTest, issue2087_go_cover_input) {
         ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
 
         std::vector<std::tuple<int64_t, int64_t>> expected = {
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
             {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
             {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
             {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
@@ -2699,6 +2716,11 @@ TEST_P(GoTest, issue2087_go_cover_input) {
             {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
             {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
             {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+
             {players_["Tim Duncan"].vid(), players_["Tim Duncan"].vid()},
             {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
             {players_["Tim Duncan"].vid(), players_["LaMarcus Aldridge"].vid()},
@@ -2730,6 +2752,15 @@ TEST_P(GoTest, issue2087_go_cover_input) {
              players_["Tony Parker"].vid(), 95},
             {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid(),
              players_["Manu Ginobili"].vid(), 95},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid(),
+             players_["Tony Parker"].vid(), 95},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid(),
+             players_["Manu Ginobili"].vid(), 95},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid(),
+             players_["Tony Parker"].vid(), 95},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid(),
+             players_["Manu Ginobili"].vid(), 95},
+
             {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid(),
              players_["Tim Duncan"].vid(), 95},
             {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid(),

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -4,7 +4,6 @@
  * attached with Common Clause Condition 1.0, found in the LICENSES directory.
  */
 
-#include <bits/stdint-intn.h>
 #include "base/Base.h"
 #include "graph/test/TestEnv.h"
 #include "graph/test/TestBase.h"

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -2647,6 +2647,51 @@ TEST_P(GoTest, ZeroStep) {
     }
 }
 
+TEST_P(GoTest, issue2087_go_cover_input) {
+    // input
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "GO FROM %ld OVER like YIELD like._src as src, like._dst as dst "
+            "| GO FROM $-.src OVER like YIELD $-.src as src, like._dst as dst";
+        auto query = folly::stringPrintf(fmt, players_["Tim Duncan"].vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+
+        std::vector<std::tuple<int64_t, int64_t>> expected = {
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+    // var
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "$a = GO FROM %ld OVER like YIELD like._src as src, like._dst as dst; "
+            "GO FROM $a.src OVER like YIELD $a.src as src, like._dst as dst";
+        auto query = folly::stringPrintf(fmt, players_["Tim Duncan"].vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+
+        std::vector<std::tuple<int64_t, int64_t>> expected = {
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Tony Parker"].vid()},
+            {players_["Tim Duncan"].vid(), players_["Manu Ginobili"].vid()},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+}
+
 INSTANTIATE_TEST_CASE_P(IfPushdownFilter, GoTest, ::testing::Bool());
 }   // namespace graph
 }   // namespace nebula

--- a/src/graph/test/GoTest.cpp
+++ b/src/graph/test/GoTest.cpp
@@ -2749,6 +2749,50 @@ TEST_P(GoTest, issue2087_go_cover_input) {
         };
         ASSERT_TRUE(verifyResult(resp, expected));
     }
+
+    // partial neighbors
+    // input
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "GO FROM %ld OVER like YIELD like._src AS src, like._dst AS dst "
+            "| GO FROM $-.dst OVER teammate YIELD $-.src AS src, $-.dst, teammate._dst AS dst";
+        auto query = folly::stringPrintf(fmt, players_["Danny Green"].vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+
+        std::vector<std::tuple<int64_t, int64_t, int64_t>> expected = {
+            {players_["Danny Green"].vid(), players_["Tim Duncan"].vid(),
+             players_["Tony Parker"].vid()},
+            {players_["Danny Green"].vid(), players_["Tim Duncan"].vid(),
+             players_["Manu Ginobili"].vid()},
+            {players_["Danny Green"].vid(), players_["Tim Duncan"].vid(),
+             players_["LaMarcus Aldridge"].vid()},
+            {players_["Danny Green"].vid(), players_["Tim Duncan"].vid(),
+             players_["Danny Green"].vid()},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+    // var
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "$a = GO FROM %ld OVER like YIELD like._src AS src, like._dst AS dst; "
+            "GO FROM $a.dst OVER teammate YIELD $a.src AS src, $a.dst, teammate._dst AS dst";
+        auto query = folly::stringPrintf(fmt, players_["Danny Green"].vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+
+        std::vector<std::tuple<int64_t, int64_t, int64_t>> expected = {
+            {players_["Danny Green"].vid(), players_["Tim Duncan"].vid(),
+             players_["Tony Parker"].vid()},
+            {players_["Danny Green"].vid(), players_["Tim Duncan"].vid(),
+             players_["Manu Ginobili"].vid()},
+            {players_["Danny Green"].vid(), players_["Tim Duncan"].vid(),
+             players_["LaMarcus Aldridge"].vid()},
+            {players_["Danny Green"].vid(), players_["Tim Duncan"].vid(),
+             players_["Danny Green"].vid()},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
 }
 
 INSTANTIATE_TEST_CASE_P(IfPushdownFilter, GoTest, ::testing::Bool());


### PR DESCRIPTION
[NG-141]

If not yield input this keep same with previous.
If yield input this will join input with current result.

And I fix a bug in previous that the initial start vertices don't dedup but the later steps done. This make the previous result(with duplicate initial start vertices) different(some duplicate row deleted). Had revert it, it's not related to this issue.