### PR TITLE
Fix missing debug info of libstdc++ when build with Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,9 @@ endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--compress-debug-sections=zlib")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        add_compile_options(-fno-limit-debug-info)
+    endif()
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION
Clang omit debug info of libstdc++ to reduce the binary size, hoping the debug info could be retrieved from the debuginfo file shipped along with libstdc++.so, which is not available in our case.