### PR TITLE
fix compaction filter doesn't work in manual compaction

### DIFF
--- a/share/resources/gflags.json
+++ b/share/resources/gflags.json
@@ -7,7 +7,8 @@
         "meta_client_retry_times",
         "slow_op_threshhold_ms",
         "wal_ttl",
-        "enable_reservoir_sampling"
+        "enable_reservoir_sampling",
+        "custom_filter_interval_secs"
     ],
     "NESTED": [
         "rocksdb_db_options",

--- a/share/resources/gflags.json
+++ b/share/resources/gflags.json
@@ -8,7 +8,8 @@
         "slow_op_threshhold_ms",
         "wal_ttl",
         "enable_reservoir_sampling",
-        "custom_filter_interval_secs"
+        "custom_filter_interval_secs",
+        "enable_multi_versions"
     ],
     "NESTED": [
         "rocksdb_db_options",

--- a/src/graph/test/TestEnv.h
+++ b/src/graph/test/TestEnv.h
@@ -14,6 +14,7 @@
 #include <gtest/gtest.h>
 #include "TestUtils.h"
 #include "graph/GraphFlags.h"
+#include "storage/StorageFlags.h"
 
 namespace nebula {
 namespace graph {

--- a/src/kvstore/CompactionFilter.h
+++ b/src/kvstore/CompactionFilter.h
@@ -13,6 +13,8 @@
 #include "time/WallClock.h"
 #include "kvstore/Common.h"
 
+DECLARE_int32(custom_filter_interval_secs);
+
 namespace nebula {
 namespace kvstore {
 
@@ -44,21 +46,20 @@ private:
 
 class KVCompactionFilterFactory : public rocksdb::CompactionFilterFactory {
 public:
-    KVCompactionFilterFactory(GraphSpaceID spaceId, int32_t customFilterIntervalSecs):
-        spaceId_(spaceId), customFilterIntervalSecs_(customFilterIntervalSecs) {}
+    explicit KVCompactionFilterFactory(GraphSpaceID spaceId) : spaceId_(spaceId) {}
 
     virtual ~KVCompactionFilterFactory() = default;
 
     std::unique_ptr<rocksdb::CompactionFilter>
     CreateCompactionFilter(const rocksdb::CompactionFilter::Context& context) override {
         auto now = time::WallClock::fastNowInSec();
-        if (context.is_full_compaction) {
-            LOG(INFO) << "Do full compaction!";
+        if (context.is_full_compaction || context.is_manual_compaction) {
+            LOG(INFO) << "Do full/manual compaction!";
             lastRunCustomFilterTimeSec_ = now;
             return std::make_unique<KVCompactionFilter>(spaceId_, createKVFilter());
         } else {
-            if (customFilterIntervalSecs_ >= 0
-                    && now - lastRunCustomFilterTimeSec_ > customFilterIntervalSecs_) {
+            if (FLAGS_custom_filter_interval_secs >= 0
+                    && now - lastRunCustomFilterTimeSec_ > FLAGS_custom_filter_interval_secs) {
                 LOG(INFO) << "Do custom minor compaction!";
                 lastRunCustomFilterTimeSec_ = now;
                 return std::make_unique<KVCompactionFilter>(spaceId_, createKVFilter());
@@ -76,9 +77,6 @@ public:
 
 private:
     GraphSpaceID spaceId_;
-    // -1 means always do default minor compaction.
-    // 0 means always do custom minor compaction
-    int32_t customFilterIntervalSecs_ = 0;
     int32_t lastRunCustomFilterTimeSec_ = 0;
 };
 
@@ -89,7 +87,7 @@ public:
     virtual ~CompactionFilterFactoryBuilder() = default;
 
     virtual std::shared_ptr<KVCompactionFilterFactory>
-    buildCfFactory(GraphSpaceID spaceId, int32_t customFilterIntervalSecs) = 0;
+    buildCfFactory(GraphSpaceID spaceId) = 0;
 };
 
 }   // namespace kvstore

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -16,7 +16,8 @@
 #include <folly/ScopeGuard.h>
 
 DEFINE_string(engine_type, "rocksdb", "rocksdb, memory...");
-DEFINE_int32(custom_filter_interval_secs, 24 * 3600, "interval to trigger custom compaction");
+DEFINE_int32(custom_filter_interval_secs, 24 * 3600,
+             "interval to trigger custom compaction, < 0 means always do default minor compaction");
 DEFINE_int32(num_workers, 4, "Number of worker threads");
 DEFINE_bool(check_leader, true, "Check leader or not");
 DEFINE_int32(clean_wal_interval_secs, 600, "inerval to trigger clean expired wal");
@@ -207,8 +208,7 @@ std::unique_ptr<KVEngine> NebulaStore::newEngine(GraphSpaceID spaceId,
     if (FLAGS_engine_type == "rocksdb") {
         std::shared_ptr<KVCompactionFilterFactory> cfFactory = nullptr;
         if (options_.cffBuilder_ != nullptr) {
-            cfFactory = options_.cffBuilder_->buildCfFactory(spaceId,
-                                                             FLAGS_custom_filter_interval_secs);
+            cfFactory = options_.cffBuilder_->buildCfFactory(spaceId);
         }
         return std::make_unique<RocksEngine>(spaceId,
                                              path,

--- a/src/storage/CompactionFilter.h
+++ b/src/storage/CompactionFilter.h
@@ -185,9 +185,8 @@ class StorageCompactionFilterFactory final : public kvstore::KVCompactionFilterF
 public:
     StorageCompactionFilterFactory(meta::SchemaManager* schemaMan,
                                    meta::IndexManager* indexMan,
-                                   GraphSpaceID spaceId,
-                                   int32_t customFilterIntervalSecs):
-        KVCompactionFilterFactory(spaceId, customFilterIntervalSecs),
+                                   GraphSpaceID spaceId):
+        KVCompactionFilterFactory(spaceId),
         schemaMan_(schemaMan),
         indexMan_(indexMan) {}
 
@@ -214,11 +213,10 @@ public:
     virtual ~StorageCompactionFilterFactoryBuilder() = default;
 
     std::shared_ptr<kvstore::KVCompactionFilterFactory>
-    buildCfFactory(GraphSpaceID spaceId, int32_t customFilterIntervalSecs) override {
+    buildCfFactory(GraphSpaceID spaceId) override {
         return std::make_shared<StorageCompactionFilterFactory>(schemaMan_,
                                                                 indexMan_,
-                                                                spaceId,
-                                                                customFilterIntervalSecs);
+                                                                spaceId);
     }
 
 private:

--- a/src/storage/StorageFlags.cpp
+++ b/src/storage/StorageFlags.cpp
@@ -18,3 +18,5 @@ DEFINE_int32(waiting_new_leader_interval_in_secs, 5,
              "interval between two requests for catching up state");
 DEFINE_int32(rebuild_index_batch_num, 1024,
              "The batch size when rebuild index");
+DEFINE_bool(enable_multi_versions, false, "If true, the insert timestamp will be the wall clock. "
+                                          "If false, always has the same timestamp of max");

--- a/src/storage/StorageFlags.h
+++ b/src/storage/StorageFlags.h
@@ -21,4 +21,6 @@ DECLARE_int32(waiting_new_leader_interval_in_secs);
 
 DECLARE_int32(rebuild_index_batch_num);
 
+DECLARE_bool(enable_multi_versions);
+
 #endif  // STORAGE_STORAGEFLAGS_H_

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -15,8 +15,7 @@ namespace storage {
 void AddEdgesProcessor::process(const cpp2::AddEdgesRequest& req) {
     spaceId_ = req.get_space_id();
     auto version = FLAGS_enable_multi_versions ?
-        std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() :
-        std::numeric_limits<int64_t>::max();
+        std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() : 0L;
     // Switch version to big-endian, make sure the key is in ordered.
     version = folly::Endian::big(version);
 

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -14,8 +14,9 @@ namespace storage {
 
 void AddEdgesProcessor::process(const cpp2::AddEdgesRequest& req) {
     spaceId_ = req.get_space_id();
-    auto version =
-        std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec();
+    auto version = FLAGS_enable_multi_versions ?
+        std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() :
+        std::numeric_limits<int64_t>::max();
     // Switch version to big-endian, make sure the key is in ordered.
     version = folly::Endian::big(version);
 

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -17,8 +17,7 @@ namespace storage {
 
 void AddVerticesProcessor::process(const cpp2::AddVerticesRequest& req) {
     auto version = FLAGS_enable_multi_versions ?
-        std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() :
-        std::numeric_limits<int64_t>::max();
+        std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() : 0L;
     // Switch version to big-endian, make sure the key is in ordered.
     version = folly::Endian::big(version);
 

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -16,8 +16,9 @@ namespace nebula {
 namespace storage {
 
 void AddVerticesProcessor::process(const cpp2::AddVerticesRequest& req) {
-    auto version =
-        std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec();
+    auto version = FLAGS_enable_multi_versions ?
+        std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() :
+        std::numeric_limits<int64_t>::max();
     // Switch version to big-endian, make sure the key is in ordered.
     version = folly::Endian::big(version);
 

--- a/src/storage/mutate/UpdateEdgeProcessor.cpp
+++ b/src/storage/mutate/UpdateEdgeProcessor.cpp
@@ -179,10 +179,13 @@ kvstore::ResultCode UpdateEdgeProcessor::collectEdgesProps(
         updater_ = std::unique_ptr<RowUpdater>(new RowUpdater(std::move(reader), constSchema));
     } else if (insertable_) {
         resp_.set_upsert(true);
-        int64_t ms = time::WallClock::fastNowInMicroSec();
-        auto now = std::numeric_limits<int64_t>::max() - ms;
+        auto version = FLAGS_enable_multi_versions ?
+            std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() :
+            std::numeric_limits<int64_t>::max();
+        // Switch version to big-endian, make sure the key is in ordered.
+        version = folly::Endian::big(version);
         key_ = NebulaKeyUtils::edgeKey(partId, edgeKey.src, edgeKey.edge_type,
-                                       edgeKey.ranking, edgeKey.dst, now);
+                                       edgeKey.ranking, edgeKey.dst, version);
         const auto constSchema = this->schemaMan_->getEdgeSchema(this->spaceId_,
                                                                  std::abs(edgeKey.edge_type));
         if (constSchema == nullptr) {

--- a/src/storage/mutate/UpdateEdgeProcessor.cpp
+++ b/src/storage/mutate/UpdateEdgeProcessor.cpp
@@ -180,8 +180,7 @@ kvstore::ResultCode UpdateEdgeProcessor::collectEdgesProps(
     } else if (insertable_) {
         resp_.set_upsert(true);
         auto version = FLAGS_enable_multi_versions ?
-            std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() :
-            std::numeric_limits<int64_t>::max();
+            std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() : 0L;
         // Switch version to big-endian, make sure the key is in ordered.
         version = folly::Endian::big(version);
         key_ = NebulaKeyUtils::edgeKey(partId, edgeKey.src, edgeKey.edge_type,

--- a/src/storage/mutate/UpdateEdgeProcessor.h
+++ b/src/storage/mutate/UpdateEdgeProcessor.h
@@ -10,6 +10,7 @@
 #include "storage/query/QueryBaseProcessor.h"
 #include "dataman/RowReader.h"
 #include "dataman/RowUpdater.h"
+#include "storage/StorageFlags.h"
 
 namespace nebula {
 namespace storage {

--- a/src/storage/mutate/UpdateVertexProcessor.cpp
+++ b/src/storage/mutate/UpdateVertexProcessor.cpp
@@ -205,9 +205,12 @@ kvstore::ResultCode UpdateVertexProcessor::collectVertexProps(
         }
         tagUpdaters_[tagId] = std::make_unique<KeyUpdaterPair>();
         auto& tagUpdater = tagUpdaters_[tagId];
-        int64_t ms = time::WallClock::fastNowInMicroSec();
-        auto now = std::numeric_limits<int64_t>::max() - ms;
-        auto key = NebulaKeyUtils::vertexKey(partId, vId, tagId, now);
+        auto version = FLAGS_enable_multi_versions ?
+            std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() :
+            std::numeric_limits<int64_t>::max();
+        // Switch version to big-endian, make sure the key is in ordered.
+        version = folly::Endian::big(version);
+        auto key = NebulaKeyUtils::vertexKey(partId, vId, tagId, version);
         tagUpdater->kv = std::make_pair(std::move(key), "");
         tagUpdater->updater = std::move(updater);
     } else {

--- a/src/storage/mutate/UpdateVertexProcessor.cpp
+++ b/src/storage/mutate/UpdateVertexProcessor.cpp
@@ -206,8 +206,7 @@ kvstore::ResultCode UpdateVertexProcessor::collectVertexProps(
         tagUpdaters_[tagId] = std::make_unique<KeyUpdaterPair>();
         auto& tagUpdater = tagUpdaters_[tagId];
         auto version = FLAGS_enable_multi_versions ?
-            std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() :
-            std::numeric_limits<int64_t>::max();
+            std::numeric_limits<int64_t>::max() - time::WallClock::fastNowInMicroSec() : 0L;
         // Switch version to big-endian, make sure the key is in ordered.
         version = folly::Endian::big(version);
         auto key = NebulaKeyUtils::vertexKey(partId, vId, tagId, version);

--- a/src/storage/mutate/UpdateVertexProcessor.h
+++ b/src/storage/mutate/UpdateVertexProcessor.h
@@ -10,6 +10,7 @@
 #include "storage/query/QueryBaseProcessor.h"
 #include "dataman/RowReader.h"
 #include "dataman/RowUpdater.h"
+#include "storage/StorageFlags.h"
 
 namespace nebula {
 namespace storage {

--- a/src/storage/test/DeleteEdgesTest.cpp
+++ b/src/storage/test/DeleteEdgesTest.cpp
@@ -18,6 +18,7 @@ namespace nebula {
 namespace storage {
 
 TEST(DeleteEdgesTest, SimpleTest) {
+    FLAGS_enable_multi_versions = true;
     fs::TempDir rootPath("/tmp/DeleteEdgesTest.XXXXXX");
     std::unique_ptr<kvstore::KVStore> kv(TestUtils::initKV(rootPath.path()));
     auto schemaMan = TestUtils::mockSchemaMan();


### PR DESCRIPTION
1. As title
2. Make `custom_filter_interval_secs` could be updated via console.
3. Add a flag to control whether support multi-version of same key (the timestamp field in key). `enable_multi_versions`, If true, will use wall clock when insert data. If false, always insert as newest data.
4. However, there is a bug in previous `update`........ because the timestamp in `update` is wrong... @jude-zhu release a bug fix version?

```
CREATE TAG building(name string)
UPSERT VERTEX 100 SET building.name = "No1"
FETCH PROP on building 100
INSERT VERTEX building(name) VALUES 100: ("No2")
FETCH PROP on building 100
```


