### PR TITLE
fix update after alter

### DIFF
--- a/src/graph/test/UpdateTest.cpp
+++ b/src/graph/test/UpdateTest.cpp
@@ -772,6 +772,133 @@ TEST_F(UpdateTest, UpsertThenInsert) {
     }
 }
 
+TEST_F(UpdateTest, UpsertAfterAlterSchema) {
+    // Test upsert tag after alter schema
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "INSERT VERTEX building(name) VALUES 100: (\"No1\")";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "ALTER TAG building ADD (new_field string default \"123\")";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    sleep(FLAGS_heartbeat_interval_secs + 1);
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "UPSERT VERTEX 100 SET building.name = \"No2\"";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "FETCH PROP on building 100";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<int64_t, std::string, std::string>> expected = {
+            {100, "No2", "123"},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "UPSERT VERTEX 100 SET building.name = \"No3\", building.new_field = \"321\"";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "FETCH PROP on building 100";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<int64_t, std::string, std::string>> expected = {
+            {100, "No3", "321"},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "UPSERT VERTEX 101 SET building.name = \"No1\", building.new_field = \"No2\"";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "FETCH PROP on building 101";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<int64_t, std::string, std::string>> expected = {
+            {101, "No1", "No2"},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+    // Test upsert edge after alter schema
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "INSERT EDGE like(likeness) VALUES 1 -> 100:(1.0)";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "ALTER EDGE like ADD (new_field string default \"123\")";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    sleep(FLAGS_heartbeat_interval_secs + 1);
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "UPSERT EDGE 1->100 of like SET likeness = 2.0";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "FETCH PROP on like 1->100@0";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<int64_t, int64_t, int64_t, double, std::string>> expected = {
+            {1, 100, 0, 2.0, "123"},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "UPSERT EDGE 1->100 of like SET likeness = 3.0, new_field = \"321\"";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "FETCH PROP on like 1->100@0";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<int64_t, int64_t, int64_t, double, std::string>> expected = {
+            {1, 100, 0, 3.0, "321"},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "UPSERT EDGE 1->101 of like SET likeness = 1.0, new_field = \"111\"";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto query = "FETCH PROP on like 1->101@0";
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code);
+        std::vector<std::tuple<int64_t, int64_t, int64_t, double, std::string>> expected = {
+            {1, 101, 0, 1.0, "111"},
+        };
+        ASSERT_TRUE(verifyResult(resp, expected));
+    }
+}
+
 // Above cases behavior different with UPDATE for UPSERT insert data when not exists
 
 }   // namespace graph

--- a/src/storage/mutate/UpdateEdgeProcessor.cpp
+++ b/src/storage/mutate/UpdateEdgeProcessor.cpp
@@ -132,8 +132,8 @@ kvstore::ResultCode UpdateEdgeProcessor::collectVertexProps(
             if (!ok(res)) {
                 auto defaultVal = schema->getDefaultValue(prop.prop_.name);
                 if (!defaultVal.ok()) {
-                    VLOG(1) << "No default value of "
-                            << tagId << ", prop " << prop.prop_.name;
+                    LOG(WARNING) << "No default value of "
+                                 << tagId << ", prop " << prop.prop_.name;
                     return kvstore::ResultCode::ERR_TAG_NOT_FOUND;
                 }
                 v = std::move(defaultVal).value();
@@ -192,15 +192,15 @@ kvstore::ResultCode UpdateEdgeProcessor::collectEdgesProps(
             if (!ok(res)) {
                 auto defaultVal = constSchema->getDefaultValue(propName);
                 if (!defaultVal.ok()) {
-                    VLOG(1) << "No default value of "
-                            << edgeKey.edge_type << ", prop " << propName;
+                    LOG(WARNING) << "No default value of "
+                                 << edgeKey.edge_type << ", prop " << propName;
                     return kvstore::ResultCode::ERR_EDGE_NOT_FOUND;
                 }
                 v = std::move(defaultVal).value();
             } else {
                 v = value(std::move(res));
             }
-            edgeFilters_.emplace(propName, v);
+            edgeFilters_.emplace(propName, std::move(v));
         }
         updater_ = std::unique_ptr<RowUpdater>(new RowUpdater(std::move(reader), constSchema));
     } else if (insertable_) {

--- a/src/storage/mutate/UpdateVertexProcessor.cpp
+++ b/src/storage/mutate/UpdateVertexProcessor.cpp
@@ -128,8 +128,8 @@ kvstore::ResultCode UpdateVertexProcessor::collectVertexProps(
             if (!ok(res)) {
                 auto defaultVal = schema->getDefaultValue(prop.prop_.name);
                 if (!defaultVal.ok()) {
-                    VLOG(1) << "No default value of "
-                            << tagId << ", prop " << prop.prop_.name;
+                    LOG(WARNING) << "No default value of "
+                                 << tagId << ", prop " << prop.prop_.name;
                     return kvstore::ResultCode::ERR_TAG_NOT_FOUND;
                 }
                 v = std::move(defaultVal).value();


### PR DESCRIPTION
Fix problems about upsert after alter schema, the default value not found.

```
CREATE TAG building(name string)
INSERT VERTEX building(name) VALUES 100: ("No1")
ALTER TAG building ADD (new_field string default "123")
FETCH PROP on building 100
UPSERT VERTEX 100 SET building.name = "No3", building.new_field = "321"
FETCH PROP on building 100
```

Known issue: when go/fetch data of old schema versions, the default value in new schema won't work, still use int as 0, string as "".