### PR TITLE
modify some log level when get default value

### DIFF
--- a/src/dataman/ResultSchemaProvider.cpp
+++ b/src/dataman/ResultSchemaProvider.cpp
@@ -158,7 +158,7 @@ const StatusOr<VariantType>
 ResultSchemaProvider::getDefaultValue(const folly::StringPiece name) const {
     auto index = getFieldIndex(name);
     if (index < 0 || index >= static_cast<int64_t>(columns_.size())) {
-        LOG(ERROR) << "Unknown field \"" << name.toString() << "\"";
+        VLOG(2) << "Unknown field \"" << name.toString() << "\"";
         return Status::Error("Unknown field \"%s\"", name.toString().c_str());
     }
     return getDefaultValue(index);

--- a/src/dataman/RowReader.h
+++ b/src/dataman/RowReader.h
@@ -178,7 +178,7 @@ public:
                 return v.toString();
             }
             default:
-                LOG(ERROR) << "Unknown type: " << static_cast<int32_t>(vType.type);
+                VLOG(2) << "Unknown type: " << static_cast<int32_t>(vType.type);
                 return ResultType::E_DATA_INVALID;
         }
     }
@@ -238,7 +238,7 @@ public:
                 return v.toString();
             }
             default:
-                LOG(ERROR) << "Unknown type: " << static_cast<int32_t>(vType.get_type());
+                VLOG(2) << "Unknown type: " << static_cast<int32_t>(vType.get_type());
                 return ResultType::E_DATA_INVALID;
         }
     }

--- a/src/jni/src/datamanlite/NebulaSchemaProvider.cpp
+++ b/src/jni/src/datamanlite/NebulaSchemaProvider.cpp
@@ -52,7 +52,7 @@ const ValueType& NebulaSchemaProvider::getFieldType(int64_t index) const {
 const ValueType& NebulaSchemaProvider::getFieldType(const Slice& name) const {
     auto it = fieldNameIndex_.find(name.toString());
     if (fieldNameIndex_.end() == it) {
-        LOG(ERROR) << "Unknown field \"" << name.toString() << "\"";
+        VLOG(2) << "Unknown field \"" << name.toString() << "\"";
         return kUnknown;
     }
 

--- a/src/meta/NebulaSchemaProvider.cpp
+++ b/src/meta/NebulaSchemaProvider.cpp
@@ -49,7 +49,7 @@ const cpp2::ValueType& NebulaSchemaProvider::getFieldType(int64_t index) const {
 const cpp2::ValueType& NebulaSchemaProvider::getFieldType(const folly::StringPiece name) const {
     auto it = fieldNameIndex_.find(name.toString());
     if (UNLIKELY(fieldNameIndex_.end() == it)) {
-        LOG(ERROR) << "Unknown field \"" << name.toString() << "\"";
+        VLOG(2) << "Unknown field \"" << name.toString() << "\"";
         return CommonConstants::kInvalidValueType();
     }
 
@@ -132,7 +132,7 @@ const StatusOr<VariantType>
 NebulaSchemaProvider::getDefaultValue(const folly::StringPiece name) const {
     auto it = fieldNameIndex_.find(name.toString());
     if (UNLIKELY(fieldNameIndex_.end() == it)) {
-        LOG(ERROR) << "Unknown field \"" << name.toString() << "\"";
+        VLOG(2) << "Unknown field \"" << name.toString() << "\"";
         return Status::Error("Unknown field \"%s\"", name.toString().c_str());
     }
     return getDefaultValue(it->second);


### PR DESCRIPTION
After alter schema, when we read data of old schemas, it will keeps printing some logs like `Unknown field` and `Unknown type`.