### PR TITLE
Support no username and password are required

### DIFF
--- a/src/console/CMakeLists.txt
+++ b/src/console/CMakeLists.txt
@@ -17,6 +17,7 @@ nebula_add_executable(
         $<TARGET_OBJECTS:graph_thrift_obj>
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:network_obj>
     LIBRARIES
         ${THRIFT_LIBRARIES}
         wangle

--- a/src/console/CliManager.cpp
+++ b/src/console/CliManager.cpp
@@ -13,7 +13,10 @@
 #include "console/CliManager.h"
 #include "client/cpp/GraphClient.h"
 #include "fs/FileUtils.h"
+#include "network/NetworkUtils.h"
 
+DECLARE_string(addr);
+DECLARE_int32(port);
 DECLARE_string(u);
 DECLARE_string(p);
 DEFINE_bool(enable_history, false, "Whether to force saving the command history");
@@ -21,7 +24,6 @@ DEFINE_bool(enable_history, false, "Whether to force saving the command history"
 namespace nebula {
 namespace graph {
 
-const int32_t kMaxAuthInfoRetries = 3;
 const int32_t kMaxUsernameLen = 16;
 const int32_t kMaxPasswordLen = 24;
 
@@ -45,64 +47,27 @@ CliManager::CliManager() {
 }
 
 
-bool CliManager::connect(const std::string& addr,
-                         uint16_t port,
-                         const std::string& username,
-                         const std::string& password) {
-    char user[kMaxUsernameLen + 1];
-    char pass[kMaxPasswordLen + 1];
-
-    strncpy(user, username.c_str(), kMaxUsernameLen);
-    user[kMaxUsernameLen] = '\0';
-    strncpy(pass, password.c_str(), kMaxPasswordLen);
-    pass[kMaxPasswordLen] = '\0';
-
-    // Make sure username is not empty
-    if (FLAGS_u.empty()) {
-        for (int32_t i = 0; i < kMaxAuthInfoRetries && !strlen(user); i++) {
-            // Need to interactively get the username
-            std::cout << "Username: ";
-            std::cin.getline(user, kMaxUsernameLen);
-            user[kMaxUsernameLen] = '\0';
-        }
-    } else {
-        strcpy(user, FLAGS_u.c_str());  // NOLINT
+bool CliManager::connect() {
+    addr_ = FLAGS_addr;
+    port_ = FLAGS_port;
+    username_ = FLAGS_u.empty() ? "root" : FLAGS_u;
+    std::string passwd = FLAGS_p;
+    if (username_.size() > kMaxUsernameLen) {
+        username_.erase(username_.begin() + kMaxUsernameLen, username_.end());
     }
-    if (!strlen(user)) {
-        std::cout << "Authentication failed: "
-                     "Need a valid username to authenticate\n\n";
+
+    if (passwd.size() > kMaxPasswordLen) {
+        passwd.erase(passwd.begin() + kMaxPasswordLen, passwd.end());
+    }
+
+    IPv4 temp;
+    if (!network::NetworkUtils::ipv4ToInt(addr_, temp)) {
+        std::cout << "Invalid ip string\n";
         return false;
     }
-
-    // Make sure password is not empty
-    if (FLAGS_p.empty()) {
-        for (int32_t i = 0; i < kMaxAuthInfoRetries && !strlen(pass); i++) {
-            // Need to interactively get the password
-            std::cout << "Password: ";
-            termios oldTerminal;
-            tcgetattr(STDIN_FILENO, &oldTerminal);
-            termios newTerminal = oldTerminal;
-            newTerminal.c_lflag &= ~ECHO;
-            tcsetattr(STDIN_FILENO, TCSANOW, &newTerminal);
-            std::cin.getline(pass, kMaxPasswordLen);
-            pass[kMaxPasswordLen] = '\0';
-            tcsetattr(STDIN_FILENO, TCSANOW, &oldTerminal);
-        }
-    } else {
-        strcpy(pass, FLAGS_p.c_str());  // NOLINT
-    }
-    if (!strlen(pass)) {
-        std::cout << "Authentication failed: "
-                     "Need a valid password\n\n";
-        return false;
-    }
-
-    addr_ = addr;
-    port_ = port;
-    username_ = user;
 
     auto client = std::make_unique<GraphClient>(addr_, port_);
-    cpp2::ErrorCode res = client->connect(user, pass);
+    cpp2::ErrorCode res = client->connect(username_, passwd);
     if (res == cpp2::ErrorCode::SUCCEEDED) {
 #if defined(NEBULA_BUILD_VERSION)
         std::cerr << "\nWelcome to Nebula Graph (Version "

--- a/src/console/CliManager.cpp
+++ b/src/console/CliManager.cpp
@@ -24,9 +24,6 @@ DEFINE_bool(enable_history, false, "Whether to force saving the command history"
 namespace nebula {
 namespace graph {
 
-const int32_t kMaxUsernameLen = 16;
-const int32_t kMaxPasswordLen = 24;
-
 CliManager::CliManager() {
     if (!fs::FileUtils::isStdinTTY()) {
         enableHistroy_ = false;
@@ -50,15 +47,8 @@ CliManager::CliManager() {
 bool CliManager::connect() {
     addr_ = FLAGS_addr;
     port_ = FLAGS_port;
-    username_ = FLAGS_u.empty() ? "root" : FLAGS_u;
+    username_ = FLAGS_u;
     std::string passwd = FLAGS_p;
-    if (username_.size() > kMaxUsernameLen) {
-        username_.erase(username_.begin() + kMaxUsernameLen, username_.end());
-    }
-
-    if (passwd.size() > kMaxPasswordLen) {
-        passwd.erase(passwd.begin() + kMaxPasswordLen, passwd.end());
-    }
 
     IPv4 temp;
     if (!network::NetworkUtils::ipv4ToInt(addr_, temp)) {

--- a/src/console/CliManager.h
+++ b/src/console/CliManager.h
@@ -18,10 +18,7 @@ public:
     CliManager();
     ~CliManager() = default;
 
-    bool connect(const std::string& addr,
-                 uint16_t port,
-                 const std::string& username,
-                 const std::string& password);
+    bool connect();
 
     void batch(const std::string& filename);
 

--- a/src/console/NebulaConsole.cpp
+++ b/src/console/NebulaConsole.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
     }
 
     CliManager cli;
-    if (!cli.connect(FLAGS_addr, FLAGS_port, FLAGS_u, FLAGS_p)) {
+    if (!cli.connect()) {
         return EXIT_FAILURE;
     }
 

--- a/src/console/NebulaConsole.cpp
+++ b/src/console/NebulaConsole.cpp
@@ -10,7 +10,7 @@
 
 DEFINE_string(addr, "127.0.0.1", "Nebula daemon IP address");
 DEFINE_int32(port, 0, "Nebula daemon listening port");
-DEFINE_string(u, "", "Username used to authenticate");
+DEFINE_string(u, "root", "Username used to authenticate");
 DEFINE_string(p, "", "Password used to authenticate");
 
 


### PR DESCRIPTION
@Amber1990Zhang need to modify all docs about use console. the `user` and `password` need to delete.
if `enable_authorize` is false, can directly use console without input username and password, and the default user name is `root`

