### PR TITLE
Support to enable rocksdbs statistics

### DIFF
--- a/etc/nebula-storaged.conf.default
+++ b/etc/nebula-storaged.conf.default
@@ -65,6 +65,17 @@
 # In order to disable compression for level 0/1, set it to "no:no"
 --rocksdb_compression_per_level=
 
+# Whether or not to enable rocksdb's statistics, disabled by default
+--enable_rocksdb_statistics=false
+
+# Statslevel used by rocksdb to collection statistics, optional values are
+#   * kExceptHistogramOrTimers, disable timer stats, and skip histogram stats
+#   * kExceptTimers, Skip timer stats
+#   * kExceptDetailedTimers, Collect all stats except time inside mutex lock AND time spent on compression.
+#   * kExceptTimeForMutex, Collect all stats except the counters requiring to get time inside the mutex lock.
+#   * kAll, Collect all stats
+--rocksdb_stats_level=kExceptHistogramOrTimers
+
 ############## rocksdb Options ##############
 # rocksdb DBOptions in json, each name and value of option is a string, given as "option_name":"option_value" separated by comma
 --rocksdb_db_options={"max_subcompactions":"1","max_background_jobs":"1"}

--- a/etc/nebula-storaged.conf.production
+++ b/etc/nebula-storaged.conf.production
@@ -73,6 +73,17 @@
 # rocksdb BlockBasedTableOptions in json, each name and value of option is string, given as "option_name":"option_value" separated by comma
 --rocksdb_block_based_table_options={"block_size":"8192"}
 
+# Whether or not to enable rocksdb's statistics, disabled by default
+--enable_rocksdb_statistics=false
+
+# Statslevel used by rocksdb to collection statistics, optional values are
+#   * kExceptHistogramOrTimers, disable timer stats, and skip histogram stats
+#   * kExceptTimers, Skip timer stats
+#   * kExceptDetailedTimers, Collect all stats except time inside mutex lock AND time spent on compression.
+#   * kExceptTimeForMutex, Collect all stats except the counters requiring to get time inside the mutex lock.
+#   * kAll, Collect all stats
+--rocksdb_stats_level=kExceptHistogramOrTimers
+
 ############### misc ####################
 --max_handlers_per_req=1
 --heartbeat_interval_secs=10

--- a/src/kvstore/RocksEngineConfig.h
+++ b/src/kvstore/RocksEngineConfig.h
@@ -40,6 +40,8 @@ DECLARE_string(part_man_type);
 DECLARE_string(rocksdb_compression_per_level);
 DECLARE_string(rocksdb_compression);
 
+DECLARE_bool(enable_rocksdb_statistics);
+DECLARE_string(rocksdb_stats_level);
 
 namespace nebula {
 namespace kvstore {
@@ -47,6 +49,8 @@ namespace kvstore {
 rocksdb::Status initRocksdbOptions(rocksdb::Options &baseOpts);
 
 bool loadOptionsMap(std::unordered_map<std::string, std::string> &map, const std::string& gflags);
+
+std::shared_ptr<rocksdb::Statistics> getDBStatistics();
 
 }  // namespace kvstore
 }  // namespace nebula

--- a/src/kvstore/test/RocksEngineConfigTest.cpp
+++ b/src/kvstore/test/RocksEngineConfigTest.cpp
@@ -88,6 +88,25 @@ TEST(RocksEngineConfigTest, createOptionsTest) {
     FLAGS_rocksdb_db_options = "{}";
 }
 
+TEST(RocksEngineConfigTest, StatisticsConfigTest) {
+    {
+        FLAGS_enable_rocksdb_statistics = false;
+        rocksdb::Options options;
+        auto status = initRocksdbOptions(options);
+        ASSERT_TRUE(status.ok()) << status.ToString();
+        ASSERT_EQ(nullptr, getDBStatistics());
+    }
+
+    {
+        FLAGS_enable_rocksdb_statistics = true;
+        FLAGS_rocksdb_stats_level = "kExceptTimers";
+        rocksdb::Options options;
+        auto status = initRocksdbOptions(options);
+        ASSERT_TRUE(status.ok()) << status.ToString();
+        std::shared_ptr<rocksdb::Statistics> stats = getDBStatistics();
+        ASSERT_EQ(rocksdb::StatsLevel::kExceptTimers, stats->get_stats_level());
+    }
+}
 
 TEST(RocksEngineConfigTest, CompressionConfigTest) {
     {


### PR DESCRIPTION
I think there is a need to enable rocksdb's statistics, so we can dump some metrics to the log, and use it to find bottleneck.
We can enable this by specify --rocksdb_statistics_enable=true in nebula-storaged.conf, and declare the stats level through --rocksdb_stats_level(default value is kExceptHistogramOrTimers)