### PR TITLE
fix double quote in index

### DIFF
--- a/src/tools/spark-sstfile-generator/src/main/scala/com/vesoft/nebula/tools/generator/v2/SparkClientGenerator.scala
+++ b/src/tools/spark-sstfile-generator/src/main/scala/com/vesoft/nebula/tools/generator/v2/SparkClientGenerator.scala
@@ -297,7 +297,6 @@ object SparkClientGenerator {
           fields.asScala.keys.toList
         }
 
-        val vertexIndex      = sourceProperties.indexOf(vertex)
         val nebulaProperties = properties.mkString(",")
         val data             = createDataSource(spark, pathOpt, tagConfig)
 
@@ -310,7 +309,11 @@ object SparkClientGenerator {
               val values = (for {
                 property <- valueProperties if property.trim.length != 0
               } yield extraValue(row, property)).mkString(",")
-              (String.valueOf(extraValue(row, vertex)), values)
+              (if (String.valueOf(extraValue(row, vertex)).startsWith("\"") && String.valueOf(extraValue(row, vertex)).endsWith("\"")) {
+                String.valueOf(extraValue(row, vertex)).slice(1,-1)
+              } else {
+                String.valueOf(extraValue(row, vertex))
+              }, values)
             }(Encoders.tuple(Encoders.STRING, Encoders.STRING))
             .foreachPartition { iterator: Iterator[(String, String)] =>
               val service      = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(1))


### PR DESCRIPTION
What changes were proposed in this pull request?
fix SparkClientGenerator. The function extraValue add duplicate double quote to index.

Why are the changes needed?
When using extraValue to transfrom index, double quote  was added. The change fixes the logic to delete duplicate double quote.
before: duplicate double quote
after: delete duplicate double quote

Does this PR introduce any user-facing change?
No.

How was this patch tested?
Built jar and test in production environment.