### PR TITLE
remove lru partid as hint.

### DIFF
--- a/src/storage/index/IndexExecutor.inl
+++ b/src/storage/index/IndexExecutor.inl
@@ -182,7 +182,7 @@ kvstore::ResultCode IndexExecutor<RESP>::getVertexRow(PartitionID partId,
         return kvstore::ResultCode::SUCCEEDED;
     }
     if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
-        auto result = vertexCache_->get(std::make_pair(vId, tagOrEdge_), partId);
+        auto result = vertexCache_->get(std::make_pair(vId, tagOrEdge_));
         if (result.ok()) {
             auto v = std::move(result).value();
             auto reader = RowReader::getTagPropReader(schemaMan_, v, spaceId_, tagOrEdge_);
@@ -216,7 +216,7 @@ kvstore::ResultCode IndexExecutor<RESP>::getVertexRow(PartitionID partId,
         data->set_props(std::move(row));
         if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
             vertexCache_->insert(std::make_pair(vId, tagOrEdge_),
-                                 iter->val().str(), partId);
+                                 iter->val().str());
             VLOG(3) << "Insert cache for vId " << vId << ", tagId " << tagOrEdge_;
         }
     } else {

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -44,7 +44,7 @@ void AddVerticesProcessor::process(const cpp2::AddVerticesRequest& req) {
                                                          tag.get_tag_id(), version);
                     data.emplace_back(std::move(key), std::move(tag.get_props()));
                     if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
-                        vertexCache_->evict(std::make_pair(v.get_id(), tag.get_tag_id()), partId);
+                        vertexCache_->evict(std::make_pair(v.get_id(), tag.get_tag_id()));
                         VLOG(3) << "Evict cache for vId " << v.get_id()
                                 << ", tagId " << tag.get_tag_id();
                     }
@@ -95,7 +95,7 @@ std::string AddVerticesProcessor::addVertices(int64_t version, PartitionID partI
             auto key = NebulaKeyUtils::vertexKey(partId, vId, tagId, version);
             newVertices[key] = std::move(prop);
             if (FLAGS_enable_vertex_cache && this->vertexCache_ != nullptr) {
-                this->vertexCache_->evict(std::make_pair(vId, tagId), partId);
+                this->vertexCache_->evict(std::make_pair(vId, tagId));
                 VLOG(3) << "Evict cache for vId " << vId << ", tagId " << tagId;
             }
         });

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -49,7 +49,7 @@ void DeleteVerticesProcessor::process(const cpp2::DeleteVerticesRequest& req) {
                         // Evict vertices from cache
                         if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
                             VLOG(3) << "Evict vertex cache for VID " << *v << ", TagID " << tag;
-                            vertexCache_->evict(std::make_pair(*v, tag), part);
+                            vertexCache_->evict(std::make_pair(*v, tag));
                         }
                         keys.emplace_back(key.str());
                     }
@@ -99,7 +99,7 @@ DeleteVerticesProcessor::deleteVertices(GraphSpaceID spaceId,
             if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
                 if (NebulaKeyUtils::isVertex(key)) {
                     VLOG(3) << "Evict vertex cache for vertex ID " << vertex << ", tagId " << tagId;
-                    vertexCache_->evict(std::make_pair(vertex, tagId), partId);
+                    vertexCache_->evict(std::make_pair(vertex, tagId));
                 }
             }
 

--- a/src/storage/mutate/UpdateVertexProcessor.cpp
+++ b/src/storage/mutate/UpdateVertexProcessor.cpp
@@ -491,7 +491,6 @@ cpp2::ErrorCode UpdateVertexProcessor::checkAndBuildContexts(
         }
     }
     auto vId = req.get_vertex_id();
-    auto partId = req.get_part_id();
     // build context of the update items
     for (auto& item : req.get_update_items()) {
         const auto &name = item.get_name();
@@ -510,7 +509,7 @@ cpp2::ErrorCode UpdateVertexProcessor::checkAndBuildContexts(
         auto tagId = tagRet.value();
         if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
             VLOG(3) << "Evict cache for vId " << vId << ", tagId " << tagId;
-            vertexCache_->evict(std::make_pair(req.get_vertex_id(), tagId), partId);
+            vertexCache_->evict(std::make_pair(req.get_vertex_id(), tagId));
         }
         updateTagIds_.emplace(tagId);
         auto exp = Expression::decode(item.get_value());

--- a/src/storage/query/QueryBaseProcessor.inl
+++ b/src/storage/query/QueryBaseProcessor.inl
@@ -408,7 +408,7 @@ kvstore::ResultCode QueryBaseProcessor<REQ, RESP>::collectVertexProps(
                             Collector* collector) {
     auto schema = this->schemaMan_->getTagSchema(spaceId_, tagId);
     if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
-        auto result = vertexCache_->get(std::make_pair(vId, tagId), partId);
+        auto result = vertexCache_->get(std::make_pair(vId, tagId));
         if (result.ok()) {
             auto v = std::move(result).value();
             auto reader = RowReader::getTagPropReader(this->schemaMan_, v, spaceId_, tagId);
@@ -465,7 +465,7 @@ kvstore::ResultCode QueryBaseProcessor<REQ, RESP>::collectVertexProps(
         this->collectProps(reader.get(), iter->key(), props, fcontext, collector);
         if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
             vertexCache_->insert(std::make_pair(vId, tagId),
-                                 iter->val().str(), partId);
+                                 iter->val().str());
             VLOG(3) << "Insert cache for vId " << vId << ", tagId " << tagId;
         }
     } else {

--- a/src/storage/query/QueryVertexPropsProcessor.cpp
+++ b/src/storage/query/QueryVertexPropsProcessor.cpp
@@ -150,8 +150,7 @@ kvstore::ResultCode QueryVertexPropsProcessor::collectVertexProps(
         }
         auto valStr = val.str();
         if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
-            vertexCache_->insert(std::make_pair(vId, tagId),
-                                 valStr, partId);
+            vertexCache_->insert(std::make_pair(vId, tagId), valStr);
             VLOG(3) << "Insert cache for vId " << vId << ", tagId " << tagId;
         }
         cpp2::TagData td;


### PR DESCRIPTION
Use partId as hint of LRU cache is a bad idea, as a machine only has some of the partitions. This will cause lock conflict a big performance issue.

PS:
Hash a limited num stored in the L1 cache of CPU, has little impact on the performance, as the access to the memory cost hundreds of CPU cycle.