### PR TITLE
fix double quote in index

### DIFF
--- a/src/tools/spark-sstfile-generator/src/main/scala/com/vesoft/nebula/tools/generator/v2/SparkClientGenerator.scala
+++ b/src/tools/spark-sstfile-generator/src/main/scala/com/vesoft/nebula/tools/generator/v2/SparkClientGenerator.scala
@@ -51,8 +51,8 @@ object SparkClientGenerator {
 
   private[this] val BATCH_INSERT_TEMPLATE                           = "INSERT %s %s(%s) VALUES %s"
   private[this] val INSERT_VALUE_TEMPLATE                           = "%s: (%s)"
-  private[this] val INSERT_VALUE_TEMPLATE_WITH_POLICY               = "%s(\"%s\"): (%s)"
-  private[this] val ENDPOINT_TEMPLATE                               = "%s(\"%s\")"
+  private[this] val INSERT_VALUE_TEMPLATE_WITH_POLICY               = "%s(%s): (%s)"
+  private[this] val ENDPOINT_TEMPLATE                               = "%s(%s)"
   private[this] val EDGE_VALUE_WITHOUT_RANKING_TEMPLATE             = "%s->%s: (%s)"
   private[this] val EDGE_VALUE_WITHOUT_RANKING_TEMPLATE_WITH_POLICY = "%s->%s: (%s)"
   private[this] val EDGE_VALUE_TEMPLATE                             = "%s->%s@%d: (%s)"
@@ -297,7 +297,6 @@ object SparkClientGenerator {
           fields.asScala.keys.toList
         }
 
-        val vertexIndex      = sourceProperties.indexOf(vertex)
         val nebulaProperties = properties.mkString(",")
         val data             = createDataSource(spark, pathOpt, tagConfig)
 


### PR DESCRIPTION
What changes were proposed in this pull request?
fix SparkClientGenerator. The function extraValue add duplicate double quote to index. Remove the quote in `INSERT_VALUE_TEMPLATE_WITH_POLICY` and `ENDPOINT_TEMPLATE`. Refers to #2250 #2245 

Why are the changes needed?
When using extraValue to transfrom index, double quote was added. 
before: duplicate double quote
after: aviod duplicate double quote

Does this PR introduce any user-facing change?
No.

How was this patch tested?
Built jar and test in production environment.
