### PR TITLE
Exposing rocksdb statistics through webservice

### DIFF
--- a/src/kvstore/RocksEngineConfig.cpp
+++ b/src/kvstore/RocksEngineConfig.cpp
@@ -129,6 +129,7 @@ rocksdb::Status initRocksdbOptions(rocksdb::Options &baseOpts) {
     std::shared_ptr<rocksdb::Statistics> stats = getDBStatistics();
     if (stats) {
         dbOpts.statistics = std::move(stats);
+        dbOpts.stats_dump_period_sec = 0;  // exposing statistics ourself
     }
     dbOpts.listeners.emplace_back(new EventListener());
 

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -33,6 +33,7 @@ nebula_add_library(
     http/StorageHttpIngestHandler.cpp
     http/StorageHttpDownloadHandler.cpp
     http/StorageHttpAdminHandler.cpp
+    http/StorageHttpStatsHandler.cpp
 )
 
 nebula_add_library(

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -8,6 +8,7 @@
 #include "network/NetworkUtils.h"
 #include "storage/StorageFlags.h"
 #include "storage/StorageServiceHandler.h"
+#include "storage/http/StorageHttpStatsHandler.h"
 #include "storage/http/StorageHttpDownloadHandler.h"
 #include "storage/http/StorageHttpIngestHandler.h"
 #include "storage/http/StorageHttpAdminHandler.h"
@@ -86,6 +87,9 @@ bool StorageServer::initWebService() {
     });
     router.get("/admin").handler([this](web::PathParams&&) {
         return new storage::StorageHttpAdminHandler(schemaMan_.get(), kvstore_.get());
+    });
+    router.get("/rocksdb_stats").handler([](web::PathParams&&) {
+        return new storage::StorageHttpStatsHandler();
     });
 
     auto status = webSvc_->start();

--- a/src/storage/http/StorageHttpStatsHandler.cpp
+++ b/src/storage/http/StorageHttpStatsHandler.cpp
@@ -1,0 +1,58 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/Base.h"
+#include "kvstore/RocksEngineConfig.h"
+#include "storage/http/StorageHttpStatsHandler.h"
+#include <proxygen/lib/http/ProxygenErrorEnum.h>
+
+namespace nebula {
+namespace storage {
+
+using proxygen::ProxygenError;
+
+void StorageHttpStatsHandler::onError(ProxygenError err) noexcept {
+    LOG(ERROR) << "Web service StorageHttpStatsHandler got error: "
+               << proxygen::getErrorString(err);
+    delete this;
+}
+
+folly::dynamic StorageHttpStatsHandler::getStats() const {
+    auto stats = folly::dynamic::array();
+    std::shared_ptr<rocksdb::Statistics> statistics = kvstore::getDBStatistics();
+    if (statistics) {
+        std::map<std::string, uint64_t> stats_map;
+        if (statistics->getTickerMap(&stats_map)) {
+            for (const auto& stat : stats_map) {
+                if (!statFiltered(stat.first)) {
+                    addOneStat(stats, stat.first, stat.second);
+                }
+            }
+        }
+        if (statistics->get_stats_level() > rocksdb::StatsLevel::kExceptHistogramOrTimers) {
+            for (const auto& h : rocksdb::HistogramsNameMap) {
+                if (!statFiltered(h.second)) {
+                    rocksdb::HistogramData hData;
+                    statistics->histogramData(h.first, &hData);
+                    addOneStat(stats, h.second + ".p50", hData.average);
+                    addOneStat(stats, h.second + ".p95", hData.percentile95);
+                    addOneStat(stats, h.second + ".p99", hData.percentile99);
+                }
+            }
+        }
+    }
+    return stats;
+}
+
+bool StorageHttpStatsHandler::statFiltered(const std::string& stat) const {
+    if (statNames_.empty()) {
+        return false;
+    }
+    return std::find(statNames_.begin(), statNames_.end(), stat) == statNames_.end();
+}
+
+}  // namespace storage
+}  // namespace nebula

--- a/src/storage/http/StorageHttpStatsHandler.h
+++ b/src/storage/http/StorageHttpStatsHandler.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#ifndef STORAGE_HTTP_STORAGEHTTPSTATSHANDLER_H_
+#define STORAGE_HTTP_STORAGEHTTPSTATSHANDLER_H_
+
+#include "base/Base.h"
+#include "webservice/GetStatsHandler.h"
+
+namespace nebula {
+namespace storage {
+
+class StorageHttpStatsHandler : public nebula::GetStatsHandler {
+public:
+    StorageHttpStatsHandler() = default;
+    void onError(proxygen::ProxygenError err) noexcept override;
+    folly::dynamic getStats() const override;
+
+private:
+    bool statFiltered(const std::string& stat) const;
+};
+
+}  // namespace storage
+}  // namespace nebula
+#endif  // STORAGE_HTTP_STORAGEHTTPSTATSHANDLER_H_

--- a/src/storage/test/CMakeLists.txt
+++ b/src/storage/test/CMakeLists.txt
@@ -261,6 +261,27 @@ nebula_add_test(
 
 nebula_add_test(
     NAME
+        storage_http_stats_test
+    SOURCES
+        StorageHttpStatsHandlerTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:storage_http_handler>
+        $<TARGET_OBJECTS:http_client_obj>
+        $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:ws_common_obj>
+        $<TARGET_OBJECTS:process_obj>
+        ${storage_test_deps}
+    LIBRARIES
+        proxygenhttpserver
+        proxygenlib
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
         compaction_test
     SOURCES
         CompactionTest.cpp

--- a/src/storage/test/StorageHttpStatsHandlerTest.cpp
+++ b/src/storage/test/StorageHttpStatsHandlerTest.cpp
@@ -1,0 +1,96 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/Base.h"
+#include <gtest/gtest.h>
+#include <folly/json.h>
+#include "kvstore/RocksEngineConfig.h"
+#include "webservice/Router.h"
+#include "webservice/WebService.h"
+#include "webservice/test/TestUtils.h"
+#include "storage/http/StorageHttpStatsHandler.h"
+#include "storage/test/TestUtils.h"
+#include "fs/TempDir.h"
+
+namespace nebula {
+namespace storage {
+
+using nebula::storage::TestUtils;
+using nebula::fs::TempDir;
+
+class StorageHttpStatsHandlerTestEnv : public ::testing::Environment {
+public:
+    void SetUp() override {
+        FLAGS_ws_http_port = 0;
+        FLAGS_ws_h2_port = 0;
+        FLAGS_enable_rocksdb_statistics = true;
+        rootPath_ = std::make_unique<fs::TempDir>("/tmp/StorageHttpStatsHandler.XXXXXX");
+        kv_ = TestUtils::initKV(rootPath_->path());
+
+        VLOG(1) << "Starting web service...";
+        webSvc_ = std::make_unique<WebService>();
+        auto& router = webSvc_->router();
+        router.get("/rocksdb_stats").handler([this](nebula::web::PathParams&&) {
+            return new storage::StorageHttpStatsHandler();
+        });
+        auto status = webSvc_->start();
+        ASSERT_TRUE(status.ok()) << status;
+    }
+
+    void TearDown() override {
+        webSvc_.reset();
+        kv_.reset();
+        rootPath_.reset();
+        VLOG(1) << "Web service stopped";
+    }
+
+protected:
+    std::unique_ptr<WebService> webSvc_;
+    std::unique_ptr<kvstore::KVStore> kv_;
+    std::unique_ptr<fs::TempDir> rootPath_;
+};
+
+TEST(StorageHttpStatsHandlerTest, GetStatsTest) {
+    {
+        auto url = "/rocksdb_stats";
+        auto request = folly::stringPrintf("http://%s:%d%s", FLAGS_ws_ip.c_str(),
+                FLAGS_ws_http_port, url);
+        auto resp = http::HttpClient::get(request);
+        ASSERT_TRUE(resp.ok());
+    }
+    {
+        auto url = "/rocksdb_stats?stats=rocksdb.bytes.read";
+        auto request = folly::stringPrintf("http://%s:%d%s", FLAGS_ws_ip.c_str(),
+                FLAGS_ws_http_port, url);
+        auto resp = http::HttpClient::get(request);
+        ASSERT_TRUE(resp.ok());
+        const std::string expect = "rocksdb.bytes.read=0\n";
+        ASSERT_STREQ(expect.c_str(), resp.value().c_str());
+    }
+    {
+        auto url = "/rocksdb_stats?stats=rocksdb.bytes.read,rocksdb.block.cache.add&returnjson";
+        auto request = folly::stringPrintf("http://%s:%d%s", FLAGS_ws_ip.c_str(),
+                FLAGS_ws_http_port, url);
+        auto resp = http::HttpClient::get(request);
+        ASSERT_TRUE(resp.ok());
+        const std::string expect = "[{\"value\":0,\"name\":\"rocksdb.block.cache.add\"},"
+                "{\"value\":0,\"name\":\"rocksdb.bytes.read\"}]";
+        ASSERT_STREQ(expect.c_str(), resp.value().c_str());
+    }
+}
+
+}  // namespace storage
+}  // namespace nebula
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    folly::init(&argc, &argv, true);
+    google::SetStderrLogging(google::INFO);
+
+    ::testing::AddGlobalTestEnvironment(new nebula::storage::StorageHttpStatsHandlerTestEnv());
+
+    return RUN_ALL_TESTS();
+}

--- a/src/storage/test/StorageHttpStatsHandlerTest.cpp
+++ b/src/storage/test/StorageHttpStatsHandlerTest.cpp
@@ -33,7 +33,7 @@ public:
         VLOG(1) << "Starting web service...";
         webSvc_ = std::make_unique<WebService>();
         auto& router = webSvc_->router();
-        router.get("/rocksdb_stats").handler([this](nebula::web::PathParams&&) {
+        router.get("/rocksdb_stats").handler([](nebula::web::PathParams&&) {
             return new storage::StorageHttpStatsHandler();
         });
         auto status = webSvc_->start();

--- a/src/webservice/GetStatsHandler.h
+++ b/src/webservice/GetStatsHandler.h
@@ -31,8 +31,8 @@ public:
 
     void onError(proxygen::ProxygenError err) noexcept override;
 
-private:
-    folly::dynamic getStats() const;
+protected:
+    virtual folly::dynamic getStats() const;
     void addOneStat(folly::dynamic& vals, const std::string& statName,
                     int64_t statValue) const;
     void addOneStat(folly::dynamic& vals,
@@ -40,7 +40,7 @@ private:
                     const std::string& error) const;
     std::string toStr(folly::dynamic& vals) const;
 
-private:
+protected:
     HttpCode err_{HttpCode::SUCCEEDED};
     bool returnJson_{false};
     std::vector<std::string> statNames_;


### PR DESCRIPTION
After #2243, rocksdb’s statistics can be enabled by specify --enable_rocksdb_statistics=true, And the statistics info will be dumped into each DB’s log file periodically.
Since all DB instances share the same Statistics obj, there is no need to dump it every where.
So it's better to manage it ourself, and exposing the statistics through webservice.
usage example:
(1) get all stats
http://host:prot/rocksdb_stats
(2) get specify stats
http://host:prot/rocksdb_stats?stats=rocksdb.bytes.read,rocksdb.block.cache.add
(3) return json format
http://host:prot/rocksdb_stats?stats=rocksdb.bytes.read,rocksdb.block.cache.add&returnjson