### PR TITLE
Support TTL cache inside ConcurrentLRUCache

### DIFF
--- a/src/common/base/CMakeLists.txt
+++ b/src/common/base/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(
     SanitizerOptions.cpp
     SignalHandler.cpp
     SlowOpTracker.cpp
+    ConcurrentLRUCache.cpp
 )
 
 IF(${PCHSupport_FOUND})

--- a/src/common/base/ConcurrentLRUCache.cpp
+++ b/src/common/base/ConcurrentLRUCache.cpp
@@ -1,0 +1,15 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/ConcurrentLRUCache.h"
+
+DEFINE_int64(cache_ttl_ms, -1, "TTL for cache entry, only valid for MapTTLCache");
+
+namespace nebula {
+
+}  // namespace nebula
+
+

--- a/src/common/base/ConcurrentLRUCache.h
+++ b/src/common/base/ConcurrentLRUCache.h
@@ -348,7 +348,8 @@ public:
                                          time::WallClock::fastNowInMilliSec()));
         } else {
             // Overwrite the value
-            std::get<0>(it->second) = std::move(value);
+            it->second = std::make_tuple(std::move(value),
+                                         time::WallClock::fastNowInMilliSec());
         }
     }
 

--- a/src/common/base/test/CMakeLists.txt
+++ b/src/common/base/test/CMakeLists.txt
@@ -92,8 +92,19 @@ nebula_add_test(
 nebula_add_test(
     NAME lru_test
     SOURCES ConcurrentLRUCacheTest.cpp
-    OBJECTS $<TARGET_OBJECTS:base_obj>
+    OBJECTS
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:time_obj>
     LIBRARIES gtest gtest_main
+)
+
+nebula_add_executable(
+    NAME cache_bm
+    SOURCES CacheBenchmark.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:time_obj>
+    LIBRARIES follybenchmark boost_regex
 )
 
 nebula_add_executable(

--- a/src/common/base/test/CacheBenchmark.cpp
+++ b/src/common/base/test/CacheBenchmark.cpp
@@ -1,0 +1,71 @@
+/* Copyright (c) 2019 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+#include <folly/init/Init.h>
+#include <folly/Benchmark.h>
+#include <algorithm>
+#include <vector>
+#include "base/ConcurrentLRUCache.h"
+
+const int32_t kTotal = 1 << 12;
+using Cache = nebula::ConcurrentLRUCache<std::pair<int64_t, int32_t>, std::string>;
+using ConMapCache = nebula::ConcurrentLRUCache<std::pair<int64_t, int32_t>,
+                                               std::string,
+                                               nebula::MapTTLCache<std::pair<int64_t, int32_t>,
+                                                                   std::string>>;
+
+BENCHMARK(LruCache1024Buckets) {
+    std::unique_ptr<Cache> cache;
+    BENCHMARK_SUSPEND {
+        cache = std::make_unique<Cache>(kTotal, 10);
+        for (int32_t i = 0; i < kTotal; i++) {
+            cache->insert(std::make_pair(i, 0), std::to_string(i));
+        }
+    }
+    for (int32_t i = 0; i < kTotal; i++) {
+        auto val = cache->get(std::make_pair(i, 0));
+        folly::doNotOptimizeAway(val);
+    }
+    BENCHMARK_SUSPEND {
+        cache.reset();
+    }
+}
+
+BENCHMARK_RELATIVE(MapCache1024Buckets) {
+    std::unique_ptr<ConMapCache> cache;
+    BENCHMARK_SUSPEND {
+        cache = std::make_unique<ConMapCache>(kTotal, 10);
+        for (int32_t i = 0; i < kTotal; i++) {
+            cache->insert(std::make_pair(i, 0), std::to_string(i));
+        }
+    }
+    for (int32_t i = 0; i < kTotal; i++) {
+        auto val = cache->get(std::make_pair(i, 0));
+        folly::doNotOptimizeAway(val);
+    }
+    BENCHMARK_SUSPEND {
+        cache.reset();
+    }
+}
+
+int main(int argc, char** argv) {
+    folly::init(&argc, &argv, true);
+    folly::runBenchmarks();
+    return 0;
+}
+
+
+/*
+Intel(R) Xeon(R) CPU E5-2690 v2 @ 3.00GHz*
+
+-O2
+============================================================================
+CacheBenchmark.cpprelative                                  time/iter  iters/s
+============================================================================
+LruCache1024Buckets                                        446.91us    2.24K
+MapCache1024Buckets                              260.43%   171.60us    5.83K
+============================================================================
+*/
+


### PR DESCRIPTION
In many cases,  users could load all vertices.  
LRU is not suitable,  so we support Map cache for all data with TTL feature. 
The performance has been improved by 2.7x compare to LRU cache. 