### PR TITLE
Remove lock in FunctionManager

### DIFF
--- a/src/common/filter/FunctionManager.cpp
+++ b/src/common/filter/FunctionManager.cpp
@@ -566,7 +566,6 @@ FunctionManager::get(const std::string &func, size_t arity) {
 StatusOr<FunctionManager::Function>
 FunctionManager::getInternal(const std::string &func, size_t arity) const {
     auto status = Status::OK();
-    folly::RWSpinLock::ReadHolder holder(lock_);
     // check existence
     auto iter = functions_.find(func);
     if (iter == functions_.end()) {

--- a/src/common/filter/FunctionManager.h
+++ b/src/common/filter/FunctionManager.h
@@ -60,7 +60,6 @@ private:
         Function                body_;
     };
 
-    mutable folly::RWSpinLock                           lock_;
     std::unordered_map<std::string, FunctionAttributes> functions_;
 };
 


### PR DESCRIPTION
atomic operation acts like dead lock, and can not go out of the while loop if multi-thread access it frequently.

![image](https://user-images.githubusercontent.com/6092236/89388675-eba6bb80-d736-11ea-924f-7fa20c4a3a33.png)
