### PR TITLE
fix bugs for "graph_update_vertex_error_qps"

### DIFF
--- a/src/graph/UpdateVertexExecutor.cpp
+++ b/src/graph/UpdateVertexExecutor.cpp
@@ -68,7 +68,7 @@ Status UpdateVertexExecutor::prepareData() {
         }
     } while (false);
 
-    if (status.ok()) {
+    if (!status.ok()) {
         stats::Stats::addStatsValue(stats_.get(), false, duration().elapsedInUSec());
     }
     return status;


### PR DESCRIPTION
Statistics of `graph_update_vertex_error_qps` is incorrect. This stats should be added when status is NOT ok. #2269 