### PR TITLE
Fix vertex_holder_'s abnormal memory usage in GoExecutor

### DIFF
--- a/src/graph/GoExecutor.cpp
+++ b/src/graph/GoExecutor.cpp
@@ -1380,13 +1380,17 @@ void GoExecutor::VertexHolder::add(const storage::cpp2::QueryResponse &resp) {
     if (vertexSchema == nullptr) {
         return;
     }
+    std::unordered_map<nebula::cpp2::TagID, std::shared_ptr<ResultSchemaProvider>> tagSchemaPtrs;
+    for (auto &it : *vertexSchema) {
+        tagSchemaPtrs[it.first] = std::make_shared<ResultSchemaProvider>(it.second);
+    }
     for (auto &vdata : *vertices) {
         std::unordered_map<TagID, VData> m;
         for (auto &td : vdata.tag_data) {
             DCHECK(td.__isset.data);
-            auto it = vertexSchema->find(td.tag_id);
-            DCHECK(it != vertexSchema->end());
-            m[td.tag_id] = {std::make_shared<ResultSchemaProvider>(it->second), td.data};
+            auto it = tagSchemaPtrs.find(td.tag_id);
+            DCHECK(it != tagSchemaPtrs.end());
+            m[td.tag_id] = {it->second, td.data};
         }
         data_[vdata.vertex_id] = std::move(m);
     }


### PR DESCRIPTION
<!--
Thank you for contributing to **Nebula Graph**! Please read the [CONTRIBUTING](https://github.com/vesoft-inc/nebula/blob/master/docs/manual-EN/4.contributions/how-to-contribute.md
) document **BEFORE** filing this PR.
-->

### What changes were proposed in this pull request?
Fix a memory abuse problem in GoExecutor.


### Why are the changes needed?
I found GoExecutor has a memory bug that can cause memory abuse.
In my test case, 18MB is enough, but actually used 2.9GB !

The problem occurs on 1389 line of the file GoExecutor.cpp. Here not using std::shared_ptr correctly because of new ResultSchemaProvider many times but once is enough for a clear TAG.
In my test case, I will get 171639 destination nodes on the one TAG and 1389 line will new ResultSchemaProvider 171639 times!
Per ResultSchemaProvider's size is 17787B.


### Will break the compatibility? How if so?
No.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Use the GO statement, use the keyword YIELD, and YIELD needs to be some properties of the TAG, not EDGE.
For example:
GO FROM 1 OVER EDGE1 YIELD TAG1.props1 as tag1_props1, TAG1.props2 as tag1_props2;

At the same time, run this test go statement query on the two sets of codes before and after the bug is fixed, and observe the memory growth. The more destination nodes, the more memory optimization. In my test case, the number of destination nodes is 171639  and memory usage can optimized from 2.9GB to 18MB.

### Checklist
<!--Tick the checkbox(es) below to choose what you have done.-->

- [ - ] I've run the tests to see all new and existing tests pass
No need to write new test cases, existing cases can cover this change.
- [ No ] If this Pull Request resolves an issue, I linked to the issue in the text above
- [ No ] I've informed the technical writer about the documentation change if necessary
