### PR TITLE
Enhance update/upsert  in nebula 1.0

### DIFF
--- a/src/storage/mutate/UpdateEdgeProcessor.h
+++ b/src/storage/mutate/UpdateEdgeProcessor.h
@@ -51,6 +51,16 @@ private:
                             const TagID tagId,
                             const std::vector<PropContext>& props);
 
+    kvstore::ResultCode checkField(const std::string& edgeName, const std::string& propName,
+                                   const meta::SchemaProviderIf* schema);
+
+    kvstore::ResultCode checkAndGetDefault(const std::string& edgeName,
+                                           const std::string& propNamem,
+                                           const meta::SchemaProviderIf* schema);
+
+    kvstore::ResultCode buildDependProps(const cpp2::EdgeKey& edgeKey,
+                                         const meta::SchemaProviderIf* schema);
+
     kvstore::ResultCode collectEdgesProps(const PartitionID partId,
                                           const cpp2::EdgeKey& edgeKey);
 
@@ -71,6 +81,15 @@ private:
     meta::IndexManager*                                             indexMan_{nullptr};
     std::vector<std::shared_ptr<nebula::cpp2::IndexItem>>           indexes_;
     std::atomic<cpp2::ErrorCode>                          filterResult_{cpp2::ErrorCode::SUCCEEDED};
+
+    // Each UpdateItem in updateItems_ depend props in value expression
+    // <edgename, propNmae> -> unordered_set<edgename,propNmae>
+    using PropPair = std::pair<std::string, std::string>;
+    std::vector<std::pair<PropPair, std::unordered_set<PropPair>>>  depPropMap_;
+
+
+    // Checked props
+    std::unordered_set<std::string>                                 checkedProp_;
 };
 
 }  // namespace storage

--- a/src/storage/mutate/UpdateVertexProcessor.h
+++ b/src/storage/mutate/UpdateVertexProcessor.h
@@ -52,6 +52,10 @@ private:
 
     cpp2::ErrorCode checkAndBuildContexts(const cpp2::UpdateVertexRequest& req);
 
+    kvstore::ResultCode checkField(const std::string& tagName, const std::string& propName);
+
+    kvstore::ResultCode checkAndGetDefault(const std::string& tagName, const std::string& propName);
+
     kvstore::ResultCode collectVertexProps(
                             const PartitionID partId,
                             const VertexID vId,
@@ -72,6 +76,13 @@ private:
     meta::IndexManager*                                             indexMan_{nullptr};
     std::vector<std::shared_ptr<nebula::cpp2::IndexItem>>           indexes_;
     std::atomic<cpp2::ErrorCode>                          filterResult_{cpp2::ErrorCode::SUCCEEDED};
+
+    // updateItems_ dependent props in value expression
+    // <tagname,propNmae> -> set<tagname,propNmae>
+    using PropPair = std::pair<std::string, std::string>;
+    std::vector<std::pair<PropPair, std::unordered_set<PropPair>>>  depPropMap_;
+    const meta::SchemaProviderIf*                                   schema_{nullptr};
+    TagID                                                           tagId_;
 };
 
 }  // namespace storage

--- a/src/storage/mutate/UpdateVertexProcessor.h
+++ b/src/storage/mutate/UpdateVertexProcessor.h
@@ -56,6 +56,8 @@ private:
 
     kvstore::ResultCode checkAndGetDefault(const std::string& tagName, const std::string& propName);
 
+    kvstore::ResultCode buildDependProps();
+
     kvstore::ResultCode collectVertexProps(
                             const PartitionID partId,
                             const VertexID vId,
@@ -77,10 +79,15 @@ private:
     std::vector<std::shared_ptr<nebula::cpp2::IndexItem>>           indexes_;
     std::atomic<cpp2::ErrorCode>                          filterResult_{cpp2::ErrorCode::SUCCEEDED};
 
-    // updateItems_ dependent props in value expression
-    // <tagname,propNmae> -> set<tagname,propNmae>
+    // The following variables are only used when upsert
+    // Each UpdateItem in updateItems_ depend props in value expression
+    // <tagname,propNmae> -> unordered_set<tagname,propNmae>
     using PropPair = std::pair<std::string, std::string>;
     std::vector<std::pair<PropPair, std::unordered_set<PropPair>>>  depPropMap_;
+
+    // Checked props
+    std::unordered_set<std::pair<std::string, std::string>>         checkedProp_;
+    bool                                                            checked_{false};
     const meta::SchemaProviderIf*                                   schema_{nullptr};
     TagID                                                           tagId_;
 };

--- a/src/storage/query/QueryBaseProcessor.h
+++ b/src/storage/query/QueryBaseProcessor.h
@@ -112,7 +112,9 @@ protected:
 
     int32_t getBucketsNum(int32_t verticesNum, int32_t minVerticesPerBucket, int32_t handlerNum);
 
-    bool checkExp(const Expression* exp);
+    // updated whether it is the set clause of update
+    // updateEdge whether it is an update edge
+    bool checkExp(const Expression* exp, bool updated = false, bool updateEdge = false);
 
     void buildTTLInfoAndRespSchema();
 
@@ -143,6 +145,9 @@ protected:
     std::unordered_map<EdgeType, std::pair<std::string, int64_t>> edgeTTLInfo_;
 
     std::unordered_map<TagID, std::pair<std::string, int64_t>> tagTTLInfo_;
+
+    // Collect dependent props of one prop in value expression in upsert set clause
+    std::unordered_set<std::pair<std::string, std::string>>    valueProps_;
 };
 
 }  // namespace storage


### PR DESCRIPTION
fix issue #2256
three questions in nebula 1.0

```
case 1
create tag t1 (a int , b int default 1);
upsert vertex 5 set t1.a = 1, t1.b = $^.t1.a + 1;
The upsert statement should be executed successfully, but currently it has failed
The reason is that` b = $^.t1.a + 1 `requires `a` to have a default value, which is wrong

case 2
create edge e1 (c  int , d int default 1);
upsert edge  111 -> 222@0 of e1  set  c= 3,  d = e1.c+ 10;
The upsert statement should be executed successfully, but currently it has failed
The reason is that` d = e1.c+ 10 `  requires` c`  to have a default value, which is wrong

case 3
update/upsert edge 111->333 @0 of e1 set  c = 1,  d = $^.t1.a; 
$^ is different in the forward edge and the reverse edge
$^ in the positive edge is 5
$^ in the reverse edge is 10002
Cause the properties of the forward and reverse edges to be inconsistent.
Therefore, tag properties are not allowed in the` set clause` and `when clause` in update edge

case 1 and case 2  case 3   are ok in   2.0 
```