### PR TITLE
Fixed errors for NebulaStore.

### DIFF
--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -30,7 +30,7 @@ namespace kvstore {
         auto s = (__VA_ARGS__);                                                                    \
         if (!ok(s)) {                                                                              \
             if (spaceRet.left() == ResultCode::ERR_SPACE_NOT_FOUND) {                              \
-                LOG(INFO) << "Space " << spaceId << " dis not exist, skip it.";                    \
+                LOG(INFO) << "Space " << spaceId << " does not exist, skip it.";                   \
                 return ResultCode::SUCCEEDED;                                                      \
             }                                                                                      \
             return error(s);                                                                       \

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -38,6 +38,7 @@ class NebulaStore : public KVStore, public Handler {
     FRIEND_TEST(NebulaStoreTest, TransLeaderTest);
     FRIEND_TEST(NebulaStoreTest, CheckpointTest);
     FRIEND_TEST(NebulaStoreTest, ThreeCopiesCheckpointTest);
+    FRIEND_TEST(NebulaStoreTest, DifferentSpaceStructureTest);
 
 public:
     NebulaStore(KVOptions options,

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -91,6 +91,7 @@ class MemPartManager final : public PartManager {
     FRIEND_TEST(NebulaStoreTest, CheckpointTest);
     FRIEND_TEST(NebulaStoreTest, ThreeCopiesCheckpointTest);
     FRIEND_TEST(NebulaStoreTest, AtomicOpBatchTest);
+    FRIEND_TEST(NebulaStoreTest, DifferentSpaceStructureTest);
 
 public:
     MemPartManager() = default;


### PR DESCRIPTION
Recreate step : 
```
CREATE SPACE space1(partition_num=1, replica_factor=1);
CREATE SPACE space2(partition_num=2, replica_factor=3);
USE space1;
CREATE TAG t1(c1 string, c2 int);
INSERT VERTEX t1(c1, c2) VALUES hash("Tom"):("Tom", "2");
USE space2;
CREATE TAG t2(c1 string, c2 int);
INSERT VERTEX t2(c1, c2) VALUES hash("Tom"):("Tom", "2");
```

This error will occur after execute flush、compact、checkpoint and setDBOption.

Error reason : Maybe some space doesn't exist NebulaStore::spaces_ . for example : 
The cluster has three storage nodes ：s1, s2, s3 , Space (partition_num=1, replica_factor=1) ，It can only be in one of them.
