### PR TITLE
fix lookup_index_selection_abnormal

### DIFF
--- a/src/graph/LookupExecutor.cpp
+++ b/src/graph/LookupExecutor.cpp
@@ -300,7 +300,8 @@ LookupExecutor::findValidIndex() {
         for (const auto& field : index->get_fields()) {
             auto it = std::find_if(filters_.begin(), filters_.end(),
                                    [field](const auto &rel) {
-                                       return rel.second == RelationalExpression::EQ;
+                                       return rel.second == RelationalExpression::EQ
+                                       && rel.first == field.get_name();
                                    });
             if (it == filters_.end()) {
                 break;


### PR DESCRIPTION
<!--
Thank you for contributing to **Nebula Graph**! Please read the [CONTRIBUTING](https://github.com/vesoft-inc/nebula/blob/master/docs/manual-EN/4.contributions/how-to-contribute.md
) document **BEFORE** filing this PR.
-->

### What changes were proposed in this pull request?
Fix the abnormal index selection in LookupExecutor.


### Why are the changes needed?
There is a problem with the index selection, and the selection logic declared in the comment is not implemented.
The code in line 303 is not valid. It is meaningless to only judge where the operator is eq. On this basis, it is necessary to judge whether the field of index is equal to the field of filters_.

For example:
        CREATE TAG multi_int(val1 int, val2 int);
        INSERT VERTEX multi_int(val1, val2) VALUES 10000:(1, 2);
        CREATE TAG INDEX i_multi_int_val2_val1 on multi_int(val2, val1);     <--- index1
        CREATE TAG INDEX i_multi_int_val1_val2 on multi_int(val1, val2);     <--- index2
For query "Lookup on multi_int where multi_int.val1 == 1 and multi_int.val2 >= 2;", index2 is better, but result uses index1.


### Will break the compatibility? How if so?
No.


### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
Create tag and corresponding batch of indexes, and judge whether the selected index meets expectations.
If necessary, we can add a log line at the end of the function LookupExecutor::optimize to print out the selected index. (I'm gdb single-step debugging here to see the selected index.)


### Checklist
<!--Tick the checkbox(es) below to choose what you have done.-->

- [ - ] I've run the tests to see all new and existing tests pass
No new single test cases. Because need check selected index's ID, and the function LookupExecutor::optimize is private, so according to the current test logic, if don't change private to public (like: #define private public ) in single test code, then it may not be very intuitive to write single tests.
- [ No ] If this Pull Request resolves an issue, I linked to the issue in the text above
- [ No ] I've informed the technical writer about the documentation change if necessary
