### PR TITLE
fix multi daemon can't start on same node

### DIFF
--- a/src/daemons/GraphDaemon.cpp
+++ b/src/daemons/GraphDaemon.cpp
@@ -56,8 +56,7 @@ int main(int argc, char *argv[]) {
         return EXIT_FAILURE;
     }
 
-    folly::SingletonVault::singleton()->registrationComplete();
-    google::InitGoogleLogging(argv[0]);
+    folly::init(&argc, &argv, true);
 
     if (FLAGS_flagfile.empty()) {
         printHelp(argv[0]);

--- a/src/daemons/GraphDaemon.cpp
+++ b/src/daemons/GraphDaemon.cpp
@@ -33,16 +33,6 @@ static void printHelp(const char *prog);
 DECLARE_string(flagfile);
 
 int main(int argc, char *argv[]) {
-    // Detect if the server has already been started
-    // Check pid before glog init, in case of user may start daemon twice
-    // the 2nd will make the 1st failed to output log anymore
-    auto pidPath = FLAGS_pid_file;
-    auto status = ProcessUtils::isPidAvailable(pidPath);
-    if (!status.ok()) {
-        LOG(ERROR) << status;
-        return EXIT_FAILURE;
-    }
-
     google::SetVersionString(nebula::versionString());
     if (argc == 1) {
         printHelp(argv[0]);
@@ -55,7 +45,19 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    folly::init(&argc, &argv, true);
+    // Detect if the server has already been started
+    // Check pid before glog init, in case of user may start daemon twice
+    // the 2nd will make the 1st failed to output log anymore
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+    auto pidPath = FLAGS_pid_file;
+    auto status = ProcessUtils::isPidAvailable(pidPath);
+    if (!status.ok()) {
+        LOG(ERROR) << status;
+        return EXIT_FAILURE;
+    }
+
+    folly::SingletonVault::singleton()->registrationComplete();
+    google::InitGoogleLogging(argv[0]);
 
     if (FLAGS_flagfile.empty()) {
         printHelp(argv[0]);

--- a/src/daemons/MetaDaemon.cpp
+++ b/src/daemons/MetaDaemon.cpp
@@ -171,8 +171,7 @@ int main(int argc, char *argv[]) {
     }
 
     google::SetVersionString(nebula::versionString());
-    folly::SingletonVault::singleton()->registrationComplete();
-    google::InitGoogleLogging(argv[0]);
+    folly::init(&argc, &argv, true);
     if (FLAGS_data_path.empty()) {
         LOG(ERROR) << "Meta Data Path should not empty";
         return EXIT_FAILURE;

--- a/src/daemons/MetaDaemon.cpp
+++ b/src/daemons/MetaDaemon.cpp
@@ -162,6 +162,7 @@ int main(int argc, char *argv[]) {
     // Detect if the server has already been started
     // Check pid before glog init, in case of user may start daemon twice
     // the 2nd will make the 1st failed to output log anymore
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
     auto pidPath = FLAGS_pid_file;
     auto status = ProcessUtils::isPidAvailable(pidPath);
     if (!status.ok()) {
@@ -170,7 +171,8 @@ int main(int argc, char *argv[]) {
     }
 
     google::SetVersionString(nebula::versionString());
-    folly::init(&argc, &argv, true);
+    folly::SingletonVault::singleton()->registrationComplete();
+    google::InitGoogleLogging(argv[0]);
     if (FLAGS_data_path.empty()) {
         LOG(ERROR) << "Meta Data Path should not empty";
         return EXIT_FAILURE;

--- a/src/daemons/StorageDaemon.cpp
+++ b/src/daemons/StorageDaemon.cpp
@@ -36,6 +36,7 @@ int main(int argc, char *argv[]) {
     // Detect if the server has already been started
     // Check pid before glog init, in case of user may start daemon twice
     // the 2nd will make the 1st failed to output log anymore
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
     auto pidPath = FLAGS_pid_file;
     auto status = ProcessUtils::isPidAvailable(pidPath);
     if (!status.ok()) {
@@ -44,7 +45,8 @@ int main(int argc, char *argv[]) {
     }
 
     google::SetVersionString(nebula::versionString());
-    folly::init(&argc, &argv, true);
+    folly::SingletonVault::singleton()->registrationComplete();
+    google::InitGoogleLogging(argv[0]);
     if (FLAGS_daemonize) {
         google::SetStderrLogging(google::FATAL);
     } else {

--- a/src/daemons/StorageDaemon.cpp
+++ b/src/daemons/StorageDaemon.cpp
@@ -45,8 +45,7 @@ int main(int argc, char *argv[]) {
     }
 
     google::SetVersionString(nebula::versionString());
-    folly::SingletonVault::singleton()->registrationComplete();
-    google::InitGoogleLogging(argv[0]);
+    folly::init(&argc, &argv, true);
     if (FLAGS_daemonize) {
         google::SetStderrLogging(google::FATAL);
     } else {


### PR DESCRIPTION
Introduced in #2278, if we want to start multiple daemon with different flag file, the `FLAGS_pid_file` is the same because we have not init `gflags` yet. (all of them is the default value of `FLAGS_pid_file`, not the one in flag file)

So we need to init `gflags`, `glogs` by manual instead of `folly::init`.