### PR TITLE
Split Storaged's RPC into multiple threadpools according to their priority

### DIFF
--- a/cmake/ThriftGenerate.cmake
+++ b/cmake/ThriftGenerate.cmake
@@ -81,7 +81,7 @@ add_custom_command(
   COMMAND ${THRIFT1}
     --strict "--allow-neg-enum-vals"
     --templates ${THRIFT_TEMPLATES}
-    --gen "mstch_cpp2:include_prefix=${include_prefix},process_in_event_base,stack_arguments"
+    --gen "mstch_cpp2:include_prefix=${include_prefix},stack_arguments"
     --gen "py"
     --gen "java:hashcode"
     --gen "go:thrift_import=github.com/facebook/fbthrift/thrift/lib/go/thrift,package_prefix=github.com/vesoft-inc/nebula-go/"

--- a/src/interface/graph.thrift
+++ b/src/interface/graph.thrift
@@ -127,9 +127,9 @@ struct AuthResponse {
 
 
 service GraphService {
-    AuthResponse authenticate(1: string username, 2: string password)
+    AuthResponse authenticate(1: string username, 2: string password) (thread = "eb")
 
-    oneway void signout(1: i64 sessionId)
+    oneway void signout(1: i64 sessionId) (thread = "eb")
 
-    ExecutionResponse execute(1: i64 sessionId, 2: string stmt)
+    ExecutionResponse execute(1: i64 sessionId, 2: string stmt) (thread = "eb")
 }

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -688,70 +688,70 @@ struct ListIndexStatusResp {
 }
 
 service MetaService {
-    ExecResp createSpace(1: CreateSpaceReq req);
-    ExecResp dropSpace(1: DropSpaceReq req);
-    GetSpaceResp getSpace(1: GetSpaceReq req);
-    ListSpacesResp listSpaces(1: ListSpacesReq req);
+    ExecResp createSpace(1: CreateSpaceReq req) (thread = "eb")
+    ExecResp dropSpace(1: DropSpaceReq req) (thread = "eb")
+    GetSpaceResp getSpace(1: GetSpaceReq req) (thread = "eb")
+    ListSpacesResp listSpaces(1: ListSpacesReq req) (thread = "eb")
 
-    ExecResp createTag(1: CreateTagReq req);
-    ExecResp alterTag(1: AlterTagReq req);
-    ExecResp dropTag(1: DropTagReq req);
-    GetTagResp getTag(1: GetTagReq req);
-    ListTagsResp listTags(1: ListTagsReq req);
+    ExecResp createTag(1: CreateTagReq req) (thread = "eb")
+    ExecResp alterTag(1: AlterTagReq req) (thread = "eb")
+    ExecResp dropTag(1: DropTagReq req) (thread = "eb")
+    GetTagResp getTag(1: GetTagReq req) (thread = "eb")
+    ListTagsResp listTags(1: ListTagsReq req) (thread = "eb")
 
-    ExecResp createEdge(1: CreateEdgeReq req);
-    ExecResp alterEdge(1: AlterEdgeReq req);
-    ExecResp dropEdge(1: DropEdgeReq req);
-    GetEdgeResp getEdge(1: GetEdgeReq req);
-    ListEdgesResp listEdges(1: ListEdgesReq req);
+    ExecResp createEdge(1: CreateEdgeReq req) (thread = "eb")
+    ExecResp alterEdge(1: AlterEdgeReq req) (thread = "eb")
+    ExecResp dropEdge(1: DropEdgeReq req) (thread = "eb")
+    GetEdgeResp getEdge(1: GetEdgeReq req) (thread = "eb")
+    ListEdgesResp listEdges(1: ListEdgesReq req) (thread = "eb")
 
-    ListHostsResp listHosts(1: ListHostsReq req);
+    ListHostsResp listHosts(1: ListHostsReq req) (thread = "eb")
 
-    GetPartsAllocResp getPartsAlloc(1: GetPartsAllocReq req);
-    ListPartsResp listParts(1: ListPartsReq req);
+    GetPartsAllocResp getPartsAlloc(1: GetPartsAllocReq req) (thread = "eb")
+    ListPartsResp listParts(1: ListPartsReq req) (thread = "eb")
 
-    ExecResp multiPut(1: MultiPutReq req);
-    GetResp get(1: GetReq req);
-    MultiGetResp multiGet(1: MultiGetReq req);
-    ExecResp remove(1: RemoveReq req);
-    ExecResp removeRange(1: RemoveRangeReq req);
-    ScanResp scan(1: ScanReq req);
+    ExecResp multiPut(1: MultiPutReq req) (thread = "eb")
+    GetResp get(1: GetReq req) (thread = "eb")
+    MultiGetResp multiGet(1: MultiGetReq req) (thread = "eb")
+    ExecResp remove(1: RemoveReq req) (thread = "eb")
+    ExecResp removeRange(1: RemoveRangeReq req) (thread = "eb")
+    ScanResp scan(1: ScanReq req) (thread = "eb")
 
-    ExecResp             createTagIndex(1: CreateTagIndexReq req);
-    ExecResp             dropTagIndex(1: DropTagIndexReq req );
-    GetTagIndexResp      getTagIndex(1: GetTagIndexReq req);
-    ListTagIndexesResp   listTagIndexes(1:ListTagIndexesReq req);
-    ExecResp             rebuildTagIndex(1: RebuildIndexReq req);
-    ListIndexStatusResp  listTagIndexStatus(1: ListIndexStatusReq req);
-    ExecResp             createEdgeIndex(1: CreateEdgeIndexReq req);
-    ExecResp             dropEdgeIndex(1: DropEdgeIndexReq req );
-    GetEdgeIndexResp     getEdgeIndex(1: GetEdgeIndexReq req);
-    ListEdgeIndexesResp  listEdgeIndexes(1: ListEdgeIndexesReq req);
-    ExecResp             rebuildEdgeIndex(1: RebuildIndexReq req);
-    ListIndexStatusResp  listEdgeIndexStatus(1: ListIndexStatusReq req);
+    ExecResp             createTagIndex(1: CreateTagIndexReq req) (thread = "eb")
+    ExecResp             dropTagIndex(1: DropTagIndexReq req ) (thread = "eb")
+    GetTagIndexResp      getTagIndex(1: GetTagIndexReq req) (thread = "eb")
+    ListTagIndexesResp   listTagIndexes(1:ListTagIndexesReq req) (thread = "eb")
+    ExecResp             rebuildTagIndex(1: RebuildIndexReq req) (thread = "eb")
+    ListIndexStatusResp  listTagIndexStatus(1: ListIndexStatusReq req) (thread = "eb")
+    ExecResp             createEdgeIndex(1: CreateEdgeIndexReq req) (thread = "eb")
+    ExecResp             dropEdgeIndex(1: DropEdgeIndexReq req ) (thread = "eb")
+    GetEdgeIndexResp     getEdgeIndex(1: GetEdgeIndexReq req) (thread = "eb")
+    ListEdgeIndexesResp  listEdgeIndexes(1: ListEdgeIndexesReq req) (thread = "eb")
+    ExecResp             rebuildEdgeIndex(1: RebuildIndexReq req) (thread = "eb")
+    ListIndexStatusResp  listEdgeIndexStatus(1: ListIndexStatusReq req) (thread = "eb")
 
-    ExecResp createUser(1: CreateUserReq req);
-    ExecResp dropUser(1: DropUserReq req);
-    ExecResp alterUser(1: AlterUserReq req);
-    ExecResp grantRole(1: GrantRoleReq req);
-    ExecResp revokeRole(1: RevokeRoleReq req);
-    ListUsersResp listUsers(1: ListUsersReq req);
-    ListRolesResp listRoles(1: ListRolesReq req);
-    ListRolesResp getUserRoles(1: GetUserRolesReq req);
-    ExecResp changePassword(1: ChangePasswordReq req);
+    ExecResp createUser(1: CreateUserReq req) (thread = "eb")
+    ExecResp dropUser(1: DropUserReq req) (thread = "eb")
+    ExecResp alterUser(1: AlterUserReq req) (thread = "eb")
+    ExecResp grantRole(1: GrantRoleReq req) (thread = "eb")
+    ExecResp revokeRole(1: RevokeRoleReq req) (thread = "eb")
+    ListUsersResp listUsers(1: ListUsersReq req) (thread = "eb")
+    ListRolesResp listRoles(1: ListRolesReq req) (thread = "eb")
+    ListRolesResp getUserRoles(1: GetUserRolesReq req) (thread = "eb")
+    ExecResp changePassword(1: ChangePasswordReq req) (thread = "eb")
 
-    HBResp           heartBeat(1: HBReq req);
-    BalanceResp      balance(1: BalanceReq req);
-    ExecResp         leaderBalance(1: LeaderBalanceReq req);
+    HBResp           heartBeat(1: HBReq req) (thread = "eb")
+    BalanceResp      balance(1: BalanceReq req) (thread = "eb")
+    ExecResp         leaderBalance(1: LeaderBalanceReq req) (thread = "eb")
 
-    ExecResp regConfig(1: RegConfigReq req);
-    GetConfigResp getConfig(1: GetConfigReq req);
-    ExecResp setConfig(1: SetConfigReq req);
-    ListConfigsResp listConfigs(1: ListConfigsReq req);
+    ExecResp regConfig(1: RegConfigReq req) (thread = "eb")
+    GetConfigResp getConfig(1: GetConfigReq req) (thread = "eb")
+    ExecResp setConfig(1: SetConfigReq req) (thread = "eb")
+    ListConfigsResp listConfigs(1: ListConfigsReq req) (thread = "eb")
 
-    ExecResp createSnapshot(1: CreateSnapshotReq req);
-    ExecResp dropSnapshot(1: DropSnapshotReq req);
-    ListSnapshotsResp listSnapshots(1: ListSnapshotsReq req);
-    AdminJobResp runAdminJob(1: AdminJobReq req);
+    ExecResp createSnapshot(1: CreateSnapshotReq req) (thread = "eb")
+    ExecResp dropSnapshot(1: DropSnapshotReq req) (thread = "eb")
+    ListSnapshotsResp listSnapshots(1: ListSnapshotsReq req) (thread = "eb")
+    AdminJobResp runAdminJob(1: AdminJobReq req) (thread = "eb")
 }
 

--- a/src/interface/raftex.thrift
+++ b/src/interface/raftex.thrift
@@ -136,9 +136,9 @@ struct SendSnapshotResponse {
 }
 
 service RaftexService {
-    AskForVoteResponse askForVote(1: AskForVoteRequest req);
-    AppendLogResponse appendLog(1: AppendLogRequest req);
-    SendSnapshotResponse  sendSnapshot(1: SendSnapshotRequest req);
+    AskForVoteResponse askForVote(1: AskForVoteRequest req) (priority = "HIGH")
+    AppendLogResponse appendLog(1: AppendLogRequest req) (priority = "HIGH")
+    SendSnapshotResponse  sendSnapshot(1: SendSnapshotRequest req) (priority = "HIGH")
 }
 
 

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -462,53 +462,52 @@ struct LookUpIndexResp {
 }
 
 service StorageService {
-    QueryResponse getBound(1: GetNeighborsRequest req)
-
-    QueryStatsResponse boundStats(1: GetNeighborsRequest req)
+    QueryResponse getBound(1: GetNeighborsRequest req) (priority = "IMPORTANT")
+    QueryStatsResponse boundStats(1: GetNeighborsRequest req) (priority = "IMPORTANT")
 
     // When return_columns is empty, return all properties
-    QueryResponse getProps(1: VertexPropRequest req);
-    EdgePropResponse getEdgeProps(1: EdgePropRequest req)
+    QueryResponse getProps(1: VertexPropRequest req) (priority = "IMPORTANT")
+    EdgePropResponse getEdgeProps(1: EdgePropRequest req) (priority = "IMPORTANT")
 
-    ExecResponse addVertices(1: AddVerticesRequest req);
-    ExecResponse addEdges(1: AddEdgesRequest req);
+    ExecResponse addVertices(1: AddVerticesRequest req) (priority = "NORMAL")
+    ExecResponse addEdges(1: AddEdgesRequest req) (priority = "NORMAL")
 
-    ExecResponse deleteEdges(1: DeleteEdgesRequest req);
-    ExecResponse deleteVertices(1: DeleteVerticesRequest req);
+    ExecResponse deleteEdges(1: DeleteEdgesRequest req) (priority = "NORMAL")
+    ExecResponse deleteVertices(1: DeleteVerticesRequest req) (priority = "NORMAL")
 
-    UpdateResponse updateVertex(1: UpdateVertexRequest req)
-    UpdateResponse updateEdge(1: UpdateEdgeRequest req)
+    UpdateResponse updateVertex(1: UpdateVertexRequest req) (priority = "NORMAL")
+    UpdateResponse updateEdge(1: UpdateEdgeRequest req) (priority = "NORMAL")
 
-    ScanEdgeResponse scanEdge(1: ScanEdgeRequest req)
-    ScanVertexResponse scanVertex(1: ScanVertexRequest req)
+    ScanEdgeResponse scanEdge(1: ScanEdgeRequest req) (priority = "IMPORTANT")
+    ScanVertexResponse scanVertex(1: ScanVertexRequest req) (priority = "IMPORTANT")
 
     // Interfaces for admin operations
-    AdminExecResp transLeader(1: TransLeaderReq req);
-    AdminExecResp addPart(1: AddPartReq req);
-    AdminExecResp addLearner(1: AddLearnerReq req);
-    AdminExecResp waitingForCatchUpData(1: CatchUpDataReq req);
-    AdminExecResp removePart(1: RemovePartReq req);
-    AdminExecResp memberChange(1: MemberChangeReq req);
-    AdminExecResp checkPeers(1: CheckPeersReq req);
-    GetLeaderResp getLeaderPart(1: GetLeaderReq req);
+    AdminExecResp transLeader(1: TransLeaderReq req) (priority = "HIGH")
+    AdminExecResp addPart(1: AddPartReq req) (priority = "HIGH")
+    AdminExecResp addLearner(1: AddLearnerReq req) (priority = "HIGH")
+    AdminExecResp waitingForCatchUpData(1: CatchUpDataReq req) (priority = "HIGH")
+    AdminExecResp removePart(1: RemovePartReq req) (priority = "HIGH")
+    AdminExecResp memberChange(1: MemberChangeReq req) (priority = "HIGH")
+    AdminExecResp checkPeers(1: CheckPeersReq req) (priority = "HIGH")
+    GetLeaderResp getLeaderPart(1: GetLeaderReq req) (priority = "HIGH")
 
     // Interfaces for manage checkpoint
-    AdminExecResp createCheckpoint(1: CreateCPRequest req);
-    AdminExecResp dropCheckpoint(1: DropCPRequest req);
-    AdminExecResp blockingWrites(1: BlockingSignRequest req);
+    AdminExecResp createCheckpoint(1: CreateCPRequest req) (priority = "BEST_EFFORT")
+    AdminExecResp dropCheckpoint(1: DropCPRequest req) (priority = "BEST_EFFORT")
+    AdminExecResp blockingWrites(1: BlockingSignRequest req) (priority = "BEST_EFFORT")
 
     // Interfaces for rebuild index
-    AdminExecResp rebuildTagIndex(1: RebuildIndexRequest req);
-    AdminExecResp rebuildEdgeIndex(1: RebuildIndexRequest req);
+    AdminExecResp rebuildTagIndex(1: RebuildIndexRequest req) (priority = "BEST_EFFORT")
+    AdminExecResp rebuildEdgeIndex(1: RebuildIndexRequest req) (priority = "BEST_EFFORT")
 
     // Interfaces for key-value storage
-    ExecResponse      put(1: PutRequest req);
-    GeneralResponse   get(1: GetRequest req);
-    ExecResponse      remove(1: RemoveRequest req);
-    ExecResponse      removeRange(1: RemoveRangeRequest req);
+    ExecResponse      put(1: PutRequest req) (priority = "NORMAL")
+    GeneralResponse   get(1: GetRequest req) (priority = "IMPORTANT")
+    ExecResponse      remove(1: RemoveRequest req) (priority = "NORMAL")
+    ExecResponse      removeRange(1: RemoveRangeRequest req) (priority = "NORMAL")
 
-    GetUUIDResp getUUID(1: GetUUIDReq req);
+    GetUUIDResp getUUID(1: GetUUIDReq req) (priority = "IMPORTANT")
 
     // Interfaces for edge and vertex index scan
-    LookUpIndexResp   lookUpIndex(1: LookUpIndexRequest req);
+    LookUpIndexResp   lookUpIndex(1: LookUpIndexRequest req) (priority = "IMPORTANT")
 }


### PR DESCRIPTION
_StorageServer_ use _PriorityThreadManager_ as the thread manager, but currently all RPC request are treat as _NORMAL_ priority. In write heavy scenario, read requests may be blocked because there are no idle thread to process it. 

So we'd better split RPC requests into different priorities. To implements this, we should remove the **process_in_event_base** declaration in ThriftGenerate.cmake and introduce **priority** annotation for each method.