### PR TITLE
Yet another fix in raft election

### DIFF
--- a/src/interface/raftex.thrift
+++ b/src/interface/raftex.thrift
@@ -51,6 +51,7 @@ struct AskForVoteRequest {
     5: TermID              term;               // Proposed term
     6: LogID               last_log_id;        // The last received log id
     7: TermID              last_log_term;      // The term receiving the last log
+    8: bool                is_pre_vote;        // Is pre vote or not
 }
 
 

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -336,19 +336,20 @@ private:
 
     // The method sends out AskForVote request
     // It return true if a leader is elected, otherwise returns false
-    bool leaderElection();
+    bool leaderElection(bool isPreVote);
 
     // The method will fill up the request object and return TRUE
     // if the election should continue. Otherwise the method will
     // return FALSE
-    bool prepareElectionRequest(
-        cpp2::AskForVoteRequest& req,
-        std::vector<std::shared_ptr<Host>>& hosts);
+    bool prepareElectionRequest(cpp2::AskForVoteRequest& req,
+                                std::vector<std::shared_ptr<Host>>& hosts,
+                                bool isPreVote);
 
-    // The method returns the partition's role after the election
-    Role processElectionResponses(const ElectionResponses& results,
+    // The method returns how many votes we are granted
+    bool processElectionResponses(const ElectionResponses& results,
                                   std::vector<std::shared_ptr<Host>> hosts,
-                                  TermID proposedTerm);
+                                  TermID proposedTerm,
+                                  bool isPreVote);
 
     // Check whether new logs can be appended
     // Pre-condition: The caller needs to hold the raftLock_

--- a/src/kvstore/raftex/test/RaftexTestBase.cpp
+++ b/src/kvstore/raftex/test/RaftexTestBase.cpp
@@ -296,7 +296,7 @@ void checkConsensus(std::vector<std::shared_ptr<test::TestShard>>& copies,
                     size_t start, size_t end,
                     std::vector<std::string>& msgs) {
     // Sleep a while to make sure the last log has been committed on followers
-    sleep(FLAGS_raft_heartbeat_interval_secs);
+    sleep(FLAGS_raft_heartbeat_interval_secs + 1);
 
     // Check every copy
     for (auto& c : copies) {


### PR DESCRIPTION
2 phase commit in election.

| | lastLogId | lastLogTerm | currentTerm |
|-|-----------|-------------|-------------|
|A|   100     |     15      |     15      |
|B|    90      |     15      |     15      |

We restart service, A start election with `proposed term` = `currentTerm` + 1 = 16, B will vote for A, B will set `currentTerm` to 16. However, the response is timeout. 

After that no one will win election. B's term is higher, so B won't vote for A. On the other hand, since `lastLogTerm` is same, but A's `lastLogId` is bigger, A won't vote for B.