### PR TITLE
[RAFT] fix raft snapshot by mistake

### DIFF
--- a/src/common/base/Logging.h
+++ b/src/common/base/Logging.h
@@ -157,9 +157,6 @@
 
 #undef LOG_EVERY_N
 #define LOG_EVERY_N(severity, n) \
-  GOOGLE_GLOG_COMPILE_ASSERT(google::GLOG_ ## severity < \
-                             google::NUM_SEVERITIES,     \
-                             INVALID_REQUESTED_LOG_SEVERITY);           \
   SOME_KIND_OF_LOG_EVERY_N(severity, (n), google::LogMessage::SendToLog)
 
 #undef LOG_IF_EVERY_N

--- a/src/kvstore/EventListner.h
+++ b/src/kvstore/EventListner.h
@@ -13,6 +13,22 @@ namespace kvstore {
 
 class EventListener : public rocksdb::EventListener {
 public:
+    void OnStallConditionsChanged(const rocksdb::WriteStallInfo& info) override {
+        LOG(INFO) << "Rocksdb write stall condition changed, column family: " << info.cf_name
+                  << ", pre " << static_cast<int32_t>(info.condition.prev)
+                  << ", cur " << static_cast<int32_t>(info.condition.cur);
+    }
+
+    void OnCompactionBegin(rocksdb::DB*, const rocksdb::CompactionJobInfo& info) override {
+        LOG(INFO) << "Rocksdb compact column family: " << info.cf_name
+                  << " because of " << static_cast<int32_t>(info.compaction_reason)
+                  << ", status: " << info.status.ToString()
+                  << ", compacted " << info.input_files.size()
+                  << " files into " << info.output_files.size()
+                  << ", base level is " << info.base_input_level
+                  << ", output level is " << info.output_level;
+    }
+
     void OnCompactionCompleted(rocksdb::DB*, const rocksdb::CompactionJobInfo& info) override {
         LOG(INFO) << "Rocksdb compact column family: " << info.cf_name
                   << " because of " << static_cast<int32_t>(info.compaction_reason)

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -431,6 +431,9 @@ ResultCode Part::toResultCode(raftex::AppendLogResult res) {
             return ResultCode::ERR_WRITE_BLOCK_ERROR;
         case raftex::AppendLogResult::E_ATOMIC_OP_FAILURE:
             return ResultCode::ERR_ATOMIC_OP_FAILED;
+        case raftex::AppendLogResult::E_BUFFER_OVERFLOW:
+            PLOG_EVERY_N(ERROR, 100) << idStr_ << "RaftPart buffer is full";
+            return ResultCode::ERR_CONSENSUS_ERROR;
         default:
             LOG(ERROR) << idStr_ << "Consensus error "
                        << static_cast<int32_t>(res);

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -432,7 +432,7 @@ ResultCode Part::toResultCode(raftex::AppendLogResult res) {
         case raftex::AppendLogResult::E_ATOMIC_OP_FAILURE:
             return ResultCode::ERR_ATOMIC_OP_FAILED;
         case raftex::AppendLogResult::E_BUFFER_OVERFLOW:
-            PLOG_EVERY_N(ERROR, 100) << idStr_ << "RaftPart buffer is full";
+            LOG_EVERY_N(ERROR, 100) << idStr_ << "RaftPart buffer is full";
             return ResultCode::ERR_CONSENSUS_ERROR;
         default:
             LOG(ERROR) << idStr_ << "Consensus error "

--- a/src/kvstore/raftex/Host.cpp
+++ b/src/kvstore/raftex/Host.cpp
@@ -125,8 +125,7 @@ folly::Future<cpp2::AppendLogResponse> Host::appendLogs(
                                               committedLogId);
                 return cachingPromise_.getFuture();
             } else {
-                PLOG_EVERY_N(INFO, 200) << idStr_
-                          << "Too many requests are waiting, return error";
+                LOG_EVERY_N(INFO, 200) << idStr_ << "Too many requests are waiting, return error";
                 cpp2::AppendLogResponse r;
                 r.set_error_code(cpp2::ErrorCode::E_TOO_MANY_REQUESTS);
                 return r;
@@ -386,7 +385,7 @@ void Host::appendLogsInternal(folly::EventBase* eb,
                 return;
             }
             default: {
-                PLOG_EVERY_N(ERROR, 100)
+                LOG_EVERY_N(ERROR, 100)
                            << self->idStr_
                            << "Failed to append logs to the host (Err: "
                            << static_cast<int32_t>(resp.get_error_code())
@@ -463,7 +462,7 @@ Host::prepareAppendLogRequest() {
                 self->sendingSnapshot_ = false;
             });
         } else {
-            PLOG_EVERY_N(INFO, 30) << idStr_
+            LOG_EVERY_N(INFO, 30) << idStr_
                                    << "The snapshot req is in queue, please wait for a moment";
         }
     }

--- a/src/kvstore/raftex/Host.cpp
+++ b/src/kvstore/raftex/Host.cpp
@@ -449,7 +449,10 @@ Host::prepareAppendLogRequest() {
         req->set_sending_snapshot(true);
         if (!sendingSnapshot_) {
             LOG(INFO) << idStr_ << "Can't find log " << lastLogIdSent_ + 1
-                      << " in wal, send the snapshot";
+                      << " in wal, send the snapshot"
+                      << ", logIdToSend = " << logIdToSend_
+                      << ", firstLogId in wal = " << part_->wal()->firstLogId()
+                      << ", lastLogId in wal = " << part_->wal()->lastLogId();
             sendingSnapshot_ = true;
             part_->snapshot_->sendSnapshot(part_, addr_)
                 .thenValue([self = shared_from_this()] (Status&& status) {

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -53,6 +53,18 @@ public:
         stopped_ = true;
     }
 
+    void reset() {
+        std::unique_lock<std::mutex> g(lock_);
+        noMoreRequestCV_.wait(g, [this] { return !requestOnGoing_; });
+        logIdToSend_ = 0;
+        logTermToSend_ = 0;
+        lastLogIdSent_ = 0;
+        lastLogTermSent_ = 0;
+        committedLogId_ = 0;
+        sendingSnapshot_ = false;
+        followerCommittedLogId_ = 0;
+    }
+
     void waitForStop();
 
     bool isLearner() const {

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -562,7 +562,7 @@ folly::Future<AppendLogResult> RaftPart::appendLogAsync(ClusterID source,
     auto retFuture = folly::Future<AppendLogResult>::makeEmpty();
 
     if (bufferOverFlow_) {
-        PLOG_EVERY_N(WARNING, 30) << idStr_
+        PLOG_EVERY_N(WARNING, 100) << idStr_
                      << "The appendLog buffer is full."
                         " Please slow down the log appending rate."
                      << "replicatingLogs_ :" << replicatingLogs_;
@@ -1163,6 +1163,9 @@ bool RaftPart::leaderElection() {
                 std::lock_guard<std::mutex> g(raftLock_);
                 if (status_ == Status::RUNNING) {
                     leader_ = addr_;
+                    for (auto& host : hosts_) {
+                        host->reset();
+                    }
                     bgWorkers_->addTask([self = shared_from_this(),
                                        term = voteReq.get_term()] {
                         self->onElected(term);

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -362,7 +362,7 @@ AppendLogResult RaftPart::canAppendLogs() {
         return AppendLogResult::E_STOPPED;
     }
     if (role_ != Role::LEADER) {
-        PLOG_EVERY_N(ERROR, 100) << idStr_ << "The partition is not a leader";
+        LOG_EVERY_N(ERROR, 100) << idStr_ << "The partition is not a leader";
         return AppendLogResult::E_NOT_A_LEADER;
     }
 
@@ -562,7 +562,7 @@ folly::Future<AppendLogResult> RaftPart::appendLogAsync(ClusterID source,
     auto retFuture = folly::Future<AppendLogResult>::makeEmpty();
 
     if (bufferOverFlow_) {
-        PLOG_EVERY_N(WARNING, 100) << idStr_
+        LOG_EVERY_N(WARNING, 100) << idStr_
                      << "The appendLog buffer is full."
                         " Please slow down the log appending rate."
                      << "replicatingLogs_ :" << replicatingLogs_;
@@ -630,7 +630,7 @@ folly::Future<AppendLogResult> RaftPart::appendLogAsync(ClusterID source,
 
     if (!checkAppendLogResult(res)) {
         // Mosy likely failed because the parttion is not leader
-        PLOG_EVERY_N(ERROR, 100) << idStr_ << "Cannot append logs, clean the buffer";
+        LOG_EVERY_N(ERROR, 100) << idStr_ << "Cannot append logs, clean the buffer";
         return res;
     }
     // Replicate buffered logs to all followers
@@ -952,8 +952,8 @@ void RaftPart::processAppendLogResponses(
         this->appendLogsInternal(std::move(iter), currTerm);
     } else {
         // Not enough hosts accepted the log, re-try
-        LOG(WARNING) << idStr_ << "Only " << numSucceeded
-                     << " hosts succeeded, Need to try again";
+        LOG_EVERY_N(WARNING, 100) << idStr_ << "Only " << numSucceeded
+                                  << " hosts succeeded, Need to try again";
         replicateLogs(eb,
                       std::move(iter),
                       currTerm,
@@ -1664,10 +1664,10 @@ cpp2::ErrorCode RaftPart::verifyLeader(
 
     // Make sure the remote term is greater than local's
     if (req.get_current_term() < term_) {
-        PLOG_EVERY_N(ERROR, 100) << idStr_
-                                 << "The current role is " << roleStr(role_)
-                                 << ". The local term is " << term_
-                                 << ". The remote term is not newer";
+        LOG_EVERY_N(ERROR, 100) << idStr_
+                                << "The current role is " << roleStr(role_)
+                                << ". The local term is " << term_
+                                << ". The remote term is not newer";
         return cpp2::ErrorCode::E_TERM_OUT_OF_DATE;
     }
     if (role_ == Role::FOLLOWER || role_ == Role::LEARNER) {


### PR DESCRIPTION
1. When elected as leader, we need to reset all info in `Host`, which may trigger snapshot by mistake. Otherwise, if it is elected as leader more than once, the info in host is outdated.
2. Add more EventListener

@sherman-the-tank, we will open another PR to fix election problem.