### PR TITLE
Exposing some metrics about ThreadManager

### DIFF
--- a/src/common/http/test/CMakeLists.txt
+++ b/src/common/http/test/CMakeLists.txt
@@ -12,9 +12,11 @@ nebula_add_test(
         $<TARGET_OBJECTS:stats_obj>
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_manager_obj>
     LIBRARIES
         proxygenhttpserver
         proxygenlib
+        ${THRIFT_LIBRARIES}
         wangle
         gtest
         gtest_main

--- a/src/common/thread/CMakeLists.txt
+++ b/src/common/thread/CMakeLists.txt
@@ -5,4 +5,9 @@ nebula_add_library(
     GenericThreadPool.cpp
 )
 
+nebula_add_library(
+    thread_manager_obj OBJECT
+    ThreadManager.cpp
+)
+
 nebula_add_subdirectory(test)

--- a/src/common/thread/ThreadManager.cpp
+++ b/src/common/thread/ThreadManager.cpp
@@ -1,0 +1,68 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "thread/ThreadManager.h"
+
+DEFINE_string(num_threads_per_priority, "",
+        "Number of worker threads for each request priority.");
+DEFINE_int32(num_worker_threads, 0, "Number of threads to execute user queries");
+
+namespace nebula {
+namespace thread {
+
+static std::shared_ptr<apache::thrift::concurrency::PriorityThreadManager>
+createPriorityThreadManager() {
+    std::vector<size_t> threadNums;
+    folly::split(":", FLAGS_num_threads_per_priority, threadNums, false);
+    if (threadNums.size() != apache::thrift::concurrency::N_PRIORITIES) {
+        LOG(WARNING) << "num_threads_per_priority does not declare all priorities,"
+                << " it's value is " << FLAGS_num_threads_per_priority;
+        threadNums.resize(apache::thrift::concurrency::N_PRIORITIES);
+    }
+    std::shared_ptr<apache::thrift::concurrency::PriorityThreadManager> workers(
+            apache::thrift::concurrency::PriorityThreadManager::newPriorityThreadManager(
+                    {{
+                        threadNums[apache::thrift::concurrency::HIGH_IMPORTANT],
+                        threadNums[apache::thrift::concurrency::HIGH],
+                        threadNums[apache::thrift::concurrency::IMPORTANT],
+                        threadNums[apache::thrift::concurrency::NORMAL],
+                        threadNums[apache::thrift::concurrency::BEST_EFFORT]
+                    }}, false /*stats*/));
+    workers->setNamePrefix("priority_executor");
+    workers->start();
+    return workers;
+}
+
+static std::shared_ptr<apache::thrift::concurrency::ThreadManager>
+createSimpleThreadManager() {
+    if (FLAGS_num_worker_threads == 0) {
+        FLAGS_num_worker_threads = std::thread::hardware_concurrency();
+    }
+    LOG(INFO) << "Number of worker threads: " << FLAGS_num_worker_threads;
+    std::shared_ptr<apache::thrift::concurrency::ThreadManager> workers(
+            apache::thrift::concurrency::ThreadManager::newSimpleThreadManager(
+                    FLAGS_num_worker_threads));
+    auto threadFactory = std::make_shared<apache::thrift::concurrency::PosixThreadFactory>();
+    workers->threadFactory(threadFactory);
+    workers->setNamePrefix("simple_executor");
+    workers->start();
+    return workers;
+}
+
+std::shared_ptr<apache::thrift::concurrency::ThreadManager> getThreadManager() {
+    if (!FLAGS_num_threads_per_priority.empty()) {
+        static std::shared_ptr<apache::thrift::concurrency::PriorityThreadManager> priorityMgr(
+                createPriorityThreadManager());
+        return priorityMgr;
+    } else {
+        static std::shared_ptr<apache::thrift::concurrency::ThreadManager> simpleMgr(
+                createSimpleThreadManager());
+        return simpleMgr;
+    }
+}
+
+}   // namespace thread
+}   // namespace nebula

--- a/src/common/thread/ThreadManager.h
+++ b/src/common/thread/ThreadManager.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+#ifndef COMMON_THREAD_THREADMANAGER_H_
+#define COMMON_THREAD_THREADMANAGER_H_
+
+#include "base/Base.h"
+#include <thrift/lib/cpp/concurrency/ThreadManager.h>
+
+DECLARE_string(num_threads_per_priority);
+DECLARE_int32(num_worker_threads);
+
+namespace nebula {
+namespace thread {
+
+std::shared_ptr<apache::thrift::concurrency::ThreadManager> getThreadManager();
+
+}   // namespace thread
+}   // namespace nebula
+
+#endif /* COMMON_THREAD_THREADMANAGER_H_ */

--- a/src/common/thread/test/CMakeLists.txt
+++ b/src/common/thread/test/CMakeLists.txt
@@ -13,3 +13,15 @@ nebula_add_test(
         gtest
         gtest_main
 )
+
+nebula_add_test(
+    NAME
+        thread_manager_test
+    SOURCES
+        ThreadManagerTest.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:thread_manager_obj>
+    LIBRARIES
+        ${THRIFT_LIBRARIES}
+        gtest
+)

--- a/src/common/thread/test/ThreadManagerTest.cpp
+++ b/src/common/thread/test/ThreadManagerTest.cpp
@@ -1,0 +1,52 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "base/Base.h"
+#include <gtest/gtest.h>
+#include "thread/ThreadManager.h"
+
+namespace nebula {
+namespace thread {
+
+TEST(ThreadManagerTest, GenericTests) {
+    using namespace apache::thrift::concurrency;
+    {
+        FLAGS_num_threads_per_priority = "";
+        FLAGS_num_worker_threads = 1;
+        std::shared_ptr<ThreadManager> workers(nebula::thread::getThreadManager());
+        ASSERT_NE(nullptr, workers);
+        ASSERT_EQ(typeid(*workers), typeid(SimpleThreadManager<folly::LifoSem>));
+    }
+
+    {
+        FLAGS_num_threads_per_priority = "0:1:2:2";
+        std::shared_ptr<ThreadManager> workers(nebula::thread::getThreadManager());
+        ASSERT_NE(nullptr, workers);
+        ASSERT_EQ(typeid(*workers), typeid(PriorityThreadManager::PriorityImplT<folly::LifoSem>));
+        std::shared_ptr<PriorityThreadManager> ptm =
+                std::dynamic_pointer_cast<PriorityThreadManager>(workers);
+        int8_t count = ptm->workerCount(apache::thrift::concurrency::HIGH_IMPORTANT);
+        EXPECT_EQ(0, count);
+        count = ptm->workerCount(apache::thrift::concurrency::HIGH);
+        EXPECT_EQ(1, count);
+        count = ptm->workerCount(apache::thrift::concurrency::IMPORTANT);
+        EXPECT_EQ(2, count);
+        count = ptm->workerCount(apache::thrift::concurrency::NORMAL);
+        EXPECT_EQ(2, count);
+        count = ptm->workerCount(apache::thrift::concurrency::BEST_EFFORT);
+        EXPECT_EQ(0, count);
+    }
+}
+
+}   // namespace thread
+}   // namespace nebula
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    folly::init(&argc, &argv, true);
+    google::SetStderrLogging(google::INFO);
+    return RUN_ALL_TESTS();
+}

--- a/src/daemons/CMakeLists.txt
+++ b/src/daemons/CMakeLists.txt
@@ -29,6 +29,7 @@ nebula_add_executable(
         $<TARGET_OBJECTS:stats_obj>
         $<TARGET_OBJECTS:charset_obj>
         $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:thread_manager_obj>
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:base_obj>
         $<TARGET_OBJECTS:concurrent_obj>
@@ -79,6 +80,7 @@ nebula_add_executable(
         $<TARGET_OBJECTS:ws_obj>
         $<TARGET_OBJECTS:ws_common_obj>
         $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:thread_manager_obj>
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:stats_obj>
         $<TARGET_OBJECTS:base_obj>
@@ -123,6 +125,7 @@ nebula_add_executable(
         $<TARGET_OBJECTS:gflags_man_obj>
         $<TARGET_OBJECTS:network_obj>
         $<TARGET_OBJECTS:thread_obj>
+        $<TARGET_OBJECTS:thread_manager_obj>
         $<TARGET_OBJECTS:stats_obj>
         $<TARGET_OBJECTS:charset_obj>
         $<TARGET_OBJECTS:fs_obj>

--- a/src/daemons/MetaDaemon.cpp
+++ b/src/daemons/MetaDaemon.cpp
@@ -18,6 +18,7 @@
 #include "hdfs/HdfsHelper.h"
 #include "hdfs/HdfsCommandHelper.h"
 #include "thread/GenericThreadPool.h"
+#include "thread/ThreadManager.h"
 #include "kvstore/PartManager.h"
 #include "meta/ClusterIdMan.h"
 #include "kvstore/NebulaStore.h"
@@ -41,7 +42,6 @@ DEFINE_string(meta_server_addrs,
 DEFINE_string(local_ip, "", "Local ip specified for NetworkUtils::getLocalIP");
 DEFINE_int32(num_io_threads, 16, "Number of IO threads");
 DEFINE_int32(meta_http_thread_num, 3, "Number of meta daemon's http thread");
-DEFINE_int32(num_worker_threads, 32, "Number of workers");
 
 DEFINE_string(pid_file, "pids/nebula-metad.pid", "File to hold the process id");
 DEFINE_bool(daemonize, true, "Whether run as a daemon process");
@@ -71,10 +71,7 @@ std::unique_ptr<nebula::kvstore::KVStore> initKV(std::vector<nebula::HostAddr> p
     // folly IOThreadPoolExecutor
     auto ioPool = std::make_shared<folly::IOThreadPoolExecutor>(FLAGS_num_io_threads);
     std::shared_ptr<apache::thrift::concurrency::ThreadManager> threadManager(
-        apache::thrift::concurrency::PriorityThreadManager::newPriorityThreadManager(
-                                 FLAGS_num_worker_threads, true /*stats*/));
-    threadManager->setNamePrefix("executor");
-    threadManager->start();
+            nebula::thread::getThreadManager());
     // On metad, we are allowed to read on follower
     FLAGS_check_leader = false;
     nebula::kvstore::KVOptions options;

--- a/src/graph/GraphFlags.cpp
+++ b/src/graph/GraphFlags.cpp
@@ -15,7 +15,6 @@ DEFINE_int32(session_reclaim_interval_secs, 10, "Period we try to reclaim expire
 DEFINE_int32(num_netio_threads, 0,
                 "Number of networking threads, 0 for number of physical CPU cores");
 DEFINE_int32(num_accept_threads, 1, "Number of threads to accept incoming connections");
-DEFINE_int32(num_worker_threads, 0, "Number of threads to execute user queries");
 DEFINE_bool(reuse_port, true, "Whether to turn on the SO_REUSEPORT option");
 DEFINE_int32(listen_backlog, 1024, "Backlog of the listen socket");
 DEFINE_string(listen_netdev, "any", "The network device to listen on");

--- a/src/graph/GraphFlags.h
+++ b/src/graph/GraphFlags.h
@@ -15,7 +15,6 @@ DECLARE_int32(session_idle_timeout_secs);
 DECLARE_int32(session_reclaim_interval_secs);
 DECLARE_int32(num_netio_threads);
 DECLARE_int32(num_accept_threads);
-DECLARE_int32(num_worker_threads);
 DECLARE_bool(reuse_port);
 DECLARE_int32(listen_backlog);
 DECLARE_string(listen_netdev);

--- a/src/meta/test/CMakeLists.txt
+++ b/src/meta/test/CMakeLists.txt
@@ -19,6 +19,7 @@ set(meta_test_deps
     $<TARGET_OBJECTS:time_obj>
     $<TARGET_OBJECTS:network_obj>
     $<TARGET_OBJECTS:thread_obj>
+    $<TARGET_OBJECTS:thread_manager_obj>
     $<TARGET_OBJECTS:base_obj>
     $<TARGET_OBJECTS:kvstore_storage_utils_obj>
 )

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -18,13 +18,11 @@
 #include "storage/CompactionFilter.h"
 #include "hdfs/HdfsCommandHelper.h"
 #include "thread/GenericThreadPool.h"
-#include <thrift/lib/cpp/concurrency/ThreadManager.h>
-
+#include "thread/ThreadManager.h"
 
 DEFINE_int32(port, 44500, "Storage daemon listening port");
 DEFINE_bool(reuse_port, true, "Whether to turn on the SO_REUSEPORT option");
 DEFINE_int32(num_io_threads, 16, "Number of IO threads");
-DEFINE_int32(num_worker_threads, 32, "Number of workers");
 DEFINE_int32(storage_http_thread_num, 3, "Number of storage daemon's http thread");
 DEFINE_bool(local_config, false, "meta client will not retrieve latest configuration from meta");
 
@@ -98,10 +96,7 @@ bool StorageServer::initWebService() {
 
 bool StorageServer::start() {
     ioThreadPool_ = std::make_shared<folly::IOThreadPoolExecutor>(FLAGS_num_io_threads);
-    workers_ = apache::thrift::concurrency::PriorityThreadManager::newPriorityThreadManager(
-                                 FLAGS_num_worker_threads, true /*stats*/);
-    workers_->setNamePrefix("executor");
-    workers_->start();
+    workers_ = nebula::thread::getThreadManager();
 
     // Meta client
     meta::MetaClientOptions options;

--- a/src/storage/test/CMakeLists.txt
+++ b/src/storage/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(storage_test_deps
     $<TARGET_OBJECTS:base_obj>
     $<TARGET_OBJECTS:thrift_obj>
     $<TARGET_OBJECTS:thread_obj>
+    $<TARGET_OBJECTS:thread_manager_obj>
     $<TARGET_OBJECTS:time_obj>
     $<TARGET_OBJECTS:fs_obj>
     $<TARGET_OBJECTS:network_obj>

--- a/src/webservice/GetStatsHandler.h
+++ b/src/webservice/GetStatsHandler.h
@@ -40,6 +40,9 @@ protected:
                     const std::string& error) const;
     std::string toStr(folly::dynamic& vals) const;
 
+private:
+    std::unordered_map<std::string, std::function<size_t()>> getFunctionMap() const;
+
 protected:
     HttpCode err_{HttpCode::SUCCEEDED};
     bool returnJson_{false};

--- a/src/webservice/test/CMakeLists.txt
+++ b/src/webservice/test/CMakeLists.txt
@@ -12,9 +12,11 @@ nebula_add_test(
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:stats_obj>
         $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:thread_manager_obj>
     LIBRARIES
         proxygenhttpserver
         proxygenlib
+        ${THRIFT_LIBRARIES}
         wangle
         gtest
 )
@@ -34,9 +36,11 @@ nebula_add_test(
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:stats_obj>
         $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:thread_manager_obj>
     LIBRARIES
         proxygenhttpserver
         proxygenlib
+        ${THRIFT_LIBRARIES}
         wangle
         gtest
 )
@@ -55,9 +59,11 @@ nebula_add_test(
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:stats_obj>
         $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:thread_manager_obj>
     LIBRARIES
         proxygenhttpserver
         proxygenlib
+        ${THRIFT_LIBRARIES}
         wangle
         gtest
 )
@@ -76,9 +82,11 @@ nebula_add_test(
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:thread_manager_obj>
     LIBRARIES
         proxygenhttpserver
         proxygenlib
+        ${THRIFT_LIBRARIES}
         wangle
         gtest
 )


### PR DESCRIPTION
Sometimes we don't know if the setting of num_worker_threads are suitable, or whether the threadpool’s usage is saturated.
We’d better exposing some metrics about the ThreadManager in order to get a feedback.

PR mainly do the following thing
(1) declare nebula:: thread::getThreadManager() in ThreadManager.cpp in order to build ThreadManager instance that can be used by metad, graphd and storaged.
(2) Exposing some metrics about ThreadManager, in order to get feedback on how many threads we should run with