### PR TITLE
[RAFT] Add keepAlive heartBeat to keep the leader stable

### DIFF
--- a/src/interface/raftex.thrift
+++ b/src/interface/raftex.thrift
@@ -103,6 +103,7 @@ struct AppendLogRequest {
     11: list<LogEntry> log_str_list;
 
     12: bool sending_snapshot;
+    13: bool keep_alive;
 }
 
 

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -92,6 +92,8 @@ public:
         return addr_;
     }
 
+    void keepAlive(folly::EventBase* eb, TermID term, LogID lastLogId, TermID lastLogTerm);
+
 private:
     cpp2::ErrorCode checkStatus() const;
 

--- a/src/kvstore/raftex/RaftexService.h
+++ b/src/kvstore/raftex/RaftexService.h
@@ -83,6 +83,8 @@ private:
     folly::RWSpinLock partsLock_;
     std::unordered_map<std::pair<GraphSpaceID, PartitionID>,
                        std::shared_ptr<RaftPart>> parts_;
+
+    std::shared_ptr<folly::IOThreadPoolExecutor> hbThreads_;
 };
 
 }  // namespace raftex

--- a/src/kvstore/raftex/SnapshotManager.h
+++ b/src/kvstore/raftex/SnapshotManager.h
@@ -39,7 +39,8 @@ public:
 
     // Send snapshot for spaceId, partId to host dst.
     folly::Future<Status> sendSnapshot(std::shared_ptr<RaftPart> part,
-                                       const HostAddr& dst);
+                                       const HostAddr& dst,
+                                       std::pair<LogID, TermID> commitLogIdAndTerm);
 
 private:
     folly::Future<raftex::cpp2::SendSnapshotResponse> send(

--- a/src/kvstore/raftex/test/MemberChangeTest.cpp
+++ b/src/kvstore/raftex/test/MemberChangeTest.cpp
@@ -36,14 +36,14 @@ TEST(MemberChangeTest, AddRemovePeerTest) {
     // Check all hosts agree on the same leader
     checkLeadership(copies, leader);
 
-    CHECK_EQ(2, leader->hosts_.size());
+    CHECK_EQ(2, leader->hosts_->size());
 
     {
         auto f = leader->sendCommandAsync(test::encodeAddPeer(allHosts[3]));
         f.wait();
 
         for (auto& c : copies) {
-            CHECK_EQ(3, c->hosts_.size());
+            CHECK_EQ(3, c->hosts_->size());
         }
     }
     std::vector<std::string> msgs;
@@ -62,7 +62,7 @@ TEST(MemberChangeTest, AddRemovePeerTest) {
         // sleep a while to ensure the learner receive the command.
         sleep(1);
         for (auto& c : copies) {
-            CHECK_EQ(3, c->hosts_.size());
+            CHECK_EQ(3, c->hosts_->size());
         }
     }
     {
@@ -72,7 +72,7 @@ TEST(MemberChangeTest, AddRemovePeerTest) {
         // sleep a while to ensure the learner receive the command.
         sleep(1);
         for (size_t i = 0; i < copies.size() - 1; i++) {
-            CHECK_EQ(2, copies[i]->hosts_.size());
+            CHECK_EQ(2, copies[i]->hosts_->size());
         }
 //        CHECK(copies[3]->isStopped());
     }
@@ -94,7 +94,7 @@ TEST(MemberChangeTest, RemoveLeaderTest) {
     // Check all hosts agree on the same leader
     auto leaderIndex = checkLeadership(copies, leader);
 
-    CHECK_EQ(3, leader->hosts_.size());
+    CHECK_EQ(3, leader->hosts_->size());
 
     {
         LOG(INFO) << "Send remove peer request, remove " << allHosts[leaderIndex];
@@ -106,7 +106,7 @@ TEST(MemberChangeTest, RemoveLeaderTest) {
 //        CHECK(copies[leaderIndex]->isStopped());
         for (size_t i = 0; i < copies.size(); i++) {
             if (static_cast<int>(i) != leaderIndex) {
-                CHECK_EQ(2, copies[i]->hosts_.size());
+                CHECK_EQ(2, copies[i]->hosts_->size());
             }
         }
     }

--- a/src/meta/processors/admin/BalancePlan.cpp
+++ b/src/meta/processors/admin/BalancePlan.cpp
@@ -50,8 +50,10 @@ void BalancePlan::invoke() {
     dispatchTasks();
     for (size_t i = 0; i < buckets_.size(); i++) {
         for (size_t j = 0; j < buckets_[i].size(); j++) {
+            LOG(INFO) << "Bucket index " << i << ", total tasks in bucket " << buckets_[i].size();
             auto taskIndex = buckets_[i][j];
             tasks_[taskIndex].onFinished_ = [this, i, j]() {
+                LOG(INFO) << "The " << j << " task in bucket " << i << " finished!";
                 bool finished = false;
                 bool stopped = false;
                 {
@@ -77,10 +79,12 @@ void BalancePlan::invoke() {
                     if (stopped) {
                         task.ret_ = BalanceTask::Result::INVALID;
                     }
+                    LOG(INFO) << "Schedule the " << j + 1 << " task in bucket " << i;
                     task.invoke();
                 }
             };  // onFinished
             tasks_[taskIndex].onError_ = [this, i, j, taskIndex]() {
+                LOG(INFO) << "The " << j << " task in bucket " << i << " finished!";
                 bool finished = false;
                 bool stopped = false;
                 {
@@ -109,6 +113,7 @@ void BalancePlan::invoke() {
                     if (stopped) {
                         task.ret_ = BalanceTask::Result::INVALID;
                     }
+                    LOG(INFO) << "Schedule the " << j + 1 << " task in bucket " << i;
                     task.invoke();
                 }
             };  // onError


### PR DESCRIPTION
Currently, we use an empty log as heartBeat to keep alive for leader. 

In some cases,  appendLog request maybe blocked (for example,  writing stalll when doing compaction).  So we use a short path without writing wal and commiting to state machine to keep alive for leader.

In most sutiation,  we only need to send the light-weight keep-alive heartbeat because writing request is always on going.
But in some cases, we need the original way,  for example in metad there are few writes coming from outside. 

The pr is still in testing