### PR TITLE
bug fix: delete vertices processor may core, if this vertex also have edges and index

### DIFF
--- a/src/common/utils/NebulaKeyUtils.h
+++ b/src/common/utils/NebulaKeyUtils.h
@@ -137,11 +137,8 @@ public:
             msg << " rawKey.size() != kVertexLen."
                 << "\nrawKey.size()=" << rawKey.size()
                 << "\nkVertexLen=" << kVertexLen
-                << "\nrawkey string format=" << rawKey
-                << "\nrawkey dec format:";
-            for (auto i = 0U; i != rawKey.size(); ++i) {
-                msg << "\nrawKey[" << i << "]=" << static_cast<int>(rawKey[i]);
-            }
+                << "\nhexDump:\n"
+                << folly::hexDump(rawKey.data(), rawKey.size());
             LOG(FATAL) << msg.str();
         }
         auto offset = sizeof(PartitionID) + sizeof(VertexID);

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -96,14 +96,13 @@ DeleteVerticesProcessor::deleteVertices(GraphSpaceID spaceId,
         while (iter->valid()) {
             auto key = iter->key();
             if (!NebulaKeyUtils::isVertex(key)) {
-                break;  // there isn't any version of curr vertex, go to next
+                iter->next();
+                continue;
             }
             auto tagId = NebulaKeyUtils::getTagId(key);
             if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
-                if (NebulaKeyUtils::isVertex(key)) {
-                    VLOG(3) << "Evict vertex cache for vertex ID " << vertex << ", tagId " << tagId;
-                    vertexCache_->evict(std::make_pair(vertex, tagId));
-                }
+                VLOG(3) << "Evict vertex cache for vertex ID " << vertex << ", tagId " << tagId;
+                vertexCache_->evict(std::make_pair(vertex, tagId));
             }
 
             /**

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -95,6 +95,9 @@ DeleteVerticesProcessor::deleteVertices(GraphSpaceID spaceId,
         TagID latestVVId = -1;
         while (iter->valid()) {
             auto key = iter->key();
+            if (!NebulaKeyUtils::isVertex(key)) {
+                break;  // there isn't any version of curr vertex, go to next
+            }
             auto tagId = NebulaKeyUtils::getTagId(key);
             if (FLAGS_enable_vertex_cache && vertexCache_ != nullptr) {
                 if (NebulaKeyUtils::isVertex(key)) {

--- a/src/storage/test/DeleteVerticesTest.cpp
+++ b/src/storage/test/DeleteVerticesTest.cpp
@@ -10,7 +10,9 @@
 #include "fs/TempDir.h"
 #include "storage/test/TestUtils.h"
 #include "storage/mutate/DeleteVerticesProcessor.h"
+#include "storage/mutate/DeleteEdgesProcessor.h"
 #include "storage/mutate/AddVerticesProcessor.h"
+#include "storage/mutate/AddEdgesProcessor.h"
 #include "utils/NebulaKeyUtils.h"
 
 
@@ -86,6 +88,102 @@ TEST(DeleteVerticesTest, SimpleTest) {
             std::unique_ptr<kvstore::KVIterator> iter;
             EXPECT_EQ(kvstore::ResultCode::SUCCEEDED, kv->prefix(0, partId, prefix, &iter));
             CHECK(!iter->valid());
+        }
+    }
+}
+
+TEST(DeleteVerticesTest, DeleteVerticesMayCoreIfThereAreEdges) {
+    fs::TempDir rootPath("/tmp/DeleteVertexTest.XXXXXX");
+    std::unique_ptr<kvstore::KVStore> kv(TestUtils::initKV(rootPath.path()));
+    auto schemaMan = TestUtils::mockSchemaMan();
+    auto indexMan = TestUtils::mockIndexMan();
+    // Add vertices
+    {
+        auto* processor = AddVerticesProcessor::instance(kv.get(),
+                                                         schemaMan.get(),
+                                                         indexMan.get(),
+                                                         nullptr);
+        cpp2::AddVerticesRequest req;
+        req.space_id = 0;
+        req.overwritable = false;
+        // partId => List<Vertex>
+        for (PartitionID partId = 0; partId < 3; partId++) {
+            auto vertices = TestUtils::setupVertices(partId, partId * 10, 10 * (partId + 1));
+            req.parts.emplace(partId, std::move(vertices));
+        }
+
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_codes.size());
+
+        for (PartitionID partId = 0; partId < 3; partId++) {
+            for (VertexID vertexId = 10 * partId; vertexId < 10 * (partId + 1); vertexId++) {
+                auto prefix = NebulaKeyUtils::vertexPrefix(partId, vertexId);
+                std::unique_ptr<kvstore::KVIterator> iter;
+                EXPECT_EQ(kvstore::ResultCode::SUCCEEDED, kv->prefix(0, partId, prefix, &iter));
+                TagID tagId = 0;
+                while (iter->valid()) {
+                    EXPECT_EQ(TestUtils::encodeValue(partId, vertexId, tagId), iter->val());
+                    tagId++;
+                    iter->next();
+                }
+                EXPECT_EQ(10, tagId);
+            }
+        }
+    }
+
+    // Add edges
+    {
+        auto* processor = AddEdgesProcessor::instance(kv.get(),
+                                                      schemaMan.get(),
+                                                      indexMan.get(),
+                                                      nullptr);
+        cpp2::AddEdgesRequest req;
+        req.space_id = 0;
+        req.overwritable = true;
+        for (PartitionID partId = 1; partId <= 3; partId++) {
+            auto edges = TestUtils::setupEdges(partId, partId * 10, 10 * (partId + 1));
+            req.parts.emplace(partId, std::move(edges));
+        }
+
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_codes.size());
+    }
+
+    // Delete vertices
+    {
+        cpp2::DeleteVerticesRequest req;
+        req.set_space_id(0);
+        for (PartitionID partId = 0; partId < 3; partId++) {
+            std::vector<VertexID> vertices;
+            for (VertexID vertexId = 10 * partId; vertexId < 10 * (partId + 1); vertexId++) {
+                vertices.emplace_back(vertexId);
+            }
+            req.parts.emplace(partId, std::move(vertices));
+        }
+
+        auto* processor = DeleteVerticesProcessor::instance(kv.get(),
+                                                            schemaMan.get(),
+                                                            indexMan.get(),
+                                                            nullptr);
+
+        // pretend there are some index
+
+        auto fut = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(fut).get();
+        EXPECT_EQ(0, resp.result.failed_codes.size());
+    }
+
+    for (PartitionID partId = 0; partId < 3; partId++) {
+        for (VertexID vertexId = 10 * partId; vertexId < 10 * (partId + 1); vertexId++) {
+            auto prefix = NebulaKeyUtils::vertexPrefix(partId, vertexId);
+            std::unique_ptr<kvstore::KVIterator> iter;
+            EXPECT_EQ(kvstore::ResultCode::SUCCEEDED, kv->prefix(0, partId, prefix, &iter));
+            CHECK(!NebulaKeyUtils::isVertex(iter->key()));
         }
     }
 }


### PR DESCRIPTION
get one core screen from BBS. 

https://discuss.nebula-graph.com.cn/t/topic/1123/8

check all reference to getTagId, 
find deleteVerticesProcessor call this without check if it is a vertex first. 