### PR TITLE
add a flag to control whether delete data of dropped space when restart

### DIFF
--- a/src/graph/DropSpaceExecutor.cpp
+++ b/src/graph/DropSpaceExecutor.cpp
@@ -40,7 +40,9 @@ void DropSpaceExecutor::execute() {
         if (*spaceName_ == ectx()->rctx()->session()->spaceName()) {
             ectx()->rctx()->session()->setSpace("", -1);
         }
-        ectx()->addWarningMsg("Data will be deleted completely after restarting the services");
+        ectx()->addWarningMsg("If auto_remove_invalid_space is true, data will be deleted "
+                              "completely after restarting the storage services, else you "
+                              "need to remove data by manual");
 
         doFinish(Executor::ProcessControl::kNext);
     };

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -77,7 +77,7 @@ bool NebulaStore::init() {
                             // TODO We might want to have a second thought here.
                             // Removing the data directly feels a little strong
                             LOG(INFO) << "Space " << spaceId
-                                    << " does not exist any more, remove the data!";
+                                      << " does not exist any more, remove the data!";
                             auto dataPath = folly::stringPrintf("%s/%s",
                                                                 rootPath.c_str(),
                                                                 dir.c_str());

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -21,6 +21,7 @@ DEFINE_int32(custom_filter_interval_secs, 24 * 3600,
 DEFINE_int32(num_workers, 4, "Number of worker threads");
 DEFINE_bool(check_leader, true, "Check leader or not");
 DEFINE_int32(clean_wal_interval_secs, 600, "inerval to trigger clean expired wal");
+DEFINE_bool(auto_remove_invalid_space, false, "whether remove data of invalid space when restart");
 
 DECLARE_bool(rocksdb_disable_wal);
 
@@ -72,14 +73,16 @@ bool NebulaStore::init() {
                     }
 
                     if (!options_.partMan_->spaceExist(storeSvcAddr_, spaceId).ok()) {
-                        // TODO We might want to have a second thought here.
-                        // Removing the data directly feels a little strong
-                        LOG(INFO) << "Space " << spaceId
-                                  << " does not exist any more, remove the data!";
-                        auto dataPath = folly::stringPrintf("%s/%s",
-                                                            rootPath.c_str(),
-                                                            dir.c_str());
-                        CHECK(fs::FileUtils::remove(dataPath.c_str(), true));
+                        if (FLAGS_auto_remove_invalid_space) {
+                            // TODO We might want to have a second thought here.
+                            // Removing the data directly feels a little strong
+                            LOG(INFO) << "Space " << spaceId
+                                    << " does not exist any more, remove the data!";
+                            auto dataPath = folly::stringPrintf("%s/%s",
+                                                                rootPath.c_str(),
+                                                                dir.c_str());
+                            CHECK(fs::FileUtils::remove(dataPath.c_str(), true));
+                        }
                         continue;
                     }
 

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -1563,6 +1563,15 @@ void RaftPart::processAppendLogRequest(
         resp.set_error_code(cpp2::ErrorCode::E_LOG_GAP);
         return;
     } else if (req.get_last_log_id_sent() < lastLogId_) {
+        // TODO(doodle): This is a potential bug which would cause data not in consensus. In most
+        // case, we would hit this path when leader append logs to follower and timeout (leader
+        // would set lastLogIdSent_ = logIdToSend_ - 1 in Host). **But follower actually received
+        // it successfully**. Which will explain when leader retry to append these logs, the LOG
+        // belows is printed, and lastLogId_ == req.get_last_log_id_sent() + 1 in the LOG.
+        //
+        // In fact we should always rollback to req.get_last_log_id_sent(), and append the logs from
+        // leader (we can't make promise that the logs in range [req.get_last_log_id_sent() + 1,
+        // lastLogId_] is same with follower). However, this makes no difference in the above case.
         LOG(INFO) << idStr_ << "Stale log! Local lastLogId " << lastLogId_
                   << ", lastLogTerm " << lastLogTerm_
                   << ", lastLogIdSent " << req.get_last_log_id_sent()


### PR DESCRIPTION
1. Add a flag to control whether delete data of dropped space when restart
2. Identify a potential bug in raft, we don't modify in 1.0 for safety