### PR TITLE
Try to use whole key bloom filter when insert data with index

### DIFF
--- a/src/storage/BaseProcessor.h
+++ b/src/storage/BaseProcessor.h
@@ -24,6 +24,8 @@
 #include "stats/StatsManager.h"
 #include "stats/Stats.h"
 
+DECLARE_bool(enable_multi_versions);
+
 namespace nebula {
 namespace storage {
 
@@ -56,6 +58,11 @@ protected:
         this->promise_.setValue(std::move(this->resp_));
         delete this;
     }
+
+    kvstore::ResultCode doGetFirstRecord(GraphSpaceID spaceId,
+                                         PartitionID partId,
+                                         std::string& key,
+                                         std::string* value);
 
     void doPut(GraphSpaceID spaceId, PartitionID partId, std::vector<kvstore::KV> data);
 

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -148,15 +148,10 @@ std::string AddEdgesProcessor::findObsoleteIndex(PartitionID partId,
                                              NebulaKeyUtils::getEdgeType(rawKey),
                                              NebulaKeyUtils::getRank(rawKey),
                                              NebulaKeyUtils::getDstId(rawKey));
-    std::unique_ptr<kvstore::KVIterator> iter;
-    auto ret = kvstore_->prefix(this->spaceId_, partId, prefix, &iter);
-    if (ret != kvstore::ResultCode::SUCCEEDED) {
-        LOG(ERROR) << "Error! ret = " << static_cast<int32_t>(ret)
-                   << ", spaceId " << this->spaceId_;
-        return "";
-    }
-    if (iter && iter->valid()) {
-        return iter->val().str();
+    std::string value;
+    auto ret = doGetFirstRecord(spaceId_, partId, prefix, &value);
+    if (ret == kvstore::ResultCode::SUCCEEDED) {
+        return value;
     }
     return "";
 }

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -158,15 +158,10 @@ std::string AddVerticesProcessor::findObsoleteIndex(PartitionID partId,
                                                     VertexID vId,
                                                     TagID tagId) {
     auto prefix = NebulaKeyUtils::vertexPrefix(partId, vId, tagId);
-    std::unique_ptr<kvstore::KVIterator> iter;
-    auto ret = kvstore_->prefix(this->spaceId_, partId, prefix, &iter);
-    if (ret != kvstore::ResultCode::SUCCEEDED) {
-        LOG(ERROR) << "Error! ret = " << static_cast<int32_t>(ret)
-                   << ", spaceId " << this->spaceId_;
-        return "";
-    }
-    if (iter && iter->valid()) {
-        return iter->val().str();
+    std::string value;
+    auto ret = doGetFirstRecord(spaceId_, partId, prefix, &value);
+    if (ret == kvstore::ResultCode::SUCCEEDED) {
+        return value;
     }
     return "";
 }


### PR DESCRIPTION
As title, since the default value of enable_multi_versions is false, we could use the bloom filter to avoid extra disk read if the newly insert data does not exist.