### PR TITLE
Ignore existed index

### DIFF
--- a/src/graph/InsertEdgeExecutor.cpp
+++ b/src/graph/InsertEdgeExecutor.cpp
@@ -37,6 +37,7 @@ Status InsertEdgeExecutor::check() {
 
     spaceId_ = ectx()->rctx()->session()->space();
     overwritable_ = sentence_->overwritable();
+    ignoreExistedIndex_ = sentence_->ignoreExistedIndex();
     auto edgeStatus = ectx()->schemaManager()->toEdgeType(spaceId_, *sentence_->edge());
     if (!edgeStatus.ok()) {
         status = edgeStatus.status();
@@ -247,7 +248,8 @@ void InsertEdgeExecutor::execute() {
 
     auto future = ectx()->getStorageClient()->addEdges(spaceId_,
                                                        std::move(result).value(),
-                                                       overwritable_);
+                                                       overwritable_,
+                                                       ignoreExistedIndex_);
     auto *runner = ectx()->rctx()->runner();
 
     auto cb = [this] (auto &&resp) {

--- a/src/graph/InsertEdgeExecutor.h
+++ b/src/graph/InsertEdgeExecutor.h
@@ -35,6 +35,7 @@ private:
     InsertEdgeSentence                               *sentence_{nullptr};
     std::unique_ptr<ExpressionContext>                expCtx_;
     bool                                              overwritable_{true};
+    bool                                              ignoreExistedIndex_{false};
     EdgeType                                          edgeType_{0};
     EdgeSchema                                        schema_;
     std::vector<std::string*>                         props_;

--- a/src/graph/InsertVertexExecutor.cpp
+++ b/src/graph/InsertVertexExecutor.cpp
@@ -41,6 +41,7 @@ Status InsertVertexExecutor::check() {
 
     auto tagItems = sentence_->tagItems();
     overwritable_ = sentence_->overwritable();
+    ignoreExistedIndex_ = sentence_->ignoreExistedIndex();
     spaceId_ = ectx()->rctx()->session()->space();
 
     tagIds_.reserve(tagItems.size());
@@ -237,7 +238,8 @@ void InsertVertexExecutor::execute() {
     }
     auto future = ectx()->getStorageClient()->addVertices(spaceId_,
                                                           std::move(result).value(),
-                                                          overwritable_);
+                                                          overwritable_,
+                                                          ignoreExistedIndex_);
     auto *runner = ectx()->rctx()->runner();
 
     auto cb = [this] (auto &&resp) {

--- a/src/graph/InsertVertexExecutor.h
+++ b/src/graph/InsertVertexExecutor.h
@@ -35,6 +35,7 @@ private:
     InsertVertexSentence                                  *sentence_{nullptr};
     std::unique_ptr<ExpressionContext>                     expCtx_;
     bool                                                   overwritable_{true};
+    bool                                                   ignoreExistedIndex_{false};
     std::vector<VertexRowItem*>                            rows_;
     std::vector<TagID>                                     tagIds_;
     std::vector<TagSchema>                                 schemas_;

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -207,6 +207,8 @@ struct AddVerticesRequest {
     2: map<common.PartitionID, list<Vertex>>(cpp.template = "std::unordered_map") parts,
     // If true, it equals an upsert operation.
     3: bool overwritable,
+    // If true, existed index won't be removed
+    4: bool ignore_existed_index = false,
 }
 
 struct AddEdgesRequest {
@@ -215,6 +217,8 @@ struct AddEdgesRequest {
     2: map<common.PartitionID, list<Edge>>(cpp.template = "std::unordered_map") parts,
     // If true, it equals an upsert operation.
     3: bool overwritable,
+    // If true, existed index won't be removed
+    4: bool ignore_existed_index = false,
 }
 
 struct DeleteVerticesRequest {

--- a/src/parser/MutateSentences.h
+++ b/src/parser/MutateSentences.h
@@ -160,15 +160,21 @@ class InsertVertexSentence final : public Sentence {
 public:
     InsertVertexSentence(VertexTagList *tagList,
                          VertexRowList *rows,
-                         bool overwritable = true) {
+                         bool overwritable = true,
+                         bool ignoreExistedIndex = false) {
         tagList_.reset(tagList);
         rows_.reset(rows);
         overwritable_ = overwritable;
+        ignoreExistedIndex_ = ignoreExistedIndex;
         kind_ = Kind::kInsertVertex;
     }
 
     bool overwritable() const {
         return overwritable_;
+    }
+
+    bool ignoreExistedIndex() const {
+        return ignoreExistedIndex_;
     }
 
     auto tagItems() const {
@@ -183,6 +189,7 @@ public:
 
 private:
     bool                                        overwritable_{true};
+    bool                                        ignoreExistedIndex_{false};
     std::unique_ptr<VertexTagList>              tagList_;
     std::unique_ptr<VertexRowList>              rows_;
 };
@@ -252,28 +259,29 @@ private:
 
 class InsertEdgeSentence final : public Sentence {
 public:
-    InsertEdgeSentence() {
-        kind_ = Kind::kInsertEdge;
-    }
-
-    void setOverwrite(bool overwritable) {
+    InsertEdgeSentence(std::string *edge,
+                       PropertyList *props,
+                       EdgeRowList *rows,
+                       bool overwritable = true,
+                       bool ignoreExistedIndex = false) {
+        edge_.reset(edge);
+        properties_.reset(props);
+        rows_.reset(rows);
         overwritable_ = overwritable;
+        ignoreExistedIndex_ = ignoreExistedIndex;
+        kind_ = Kind::kInsertEdge;
     }
 
     bool overwritable() const {
         return overwritable_;
     }
 
-    void setEdge(std::string *edge) {
-        edge_.reset(edge);
+    bool ignoreExistedIndex() const {
+        return ignoreExistedIndex_;
     }
 
     const std::string* edge() const {
         return edge_.get();
-    }
-
-    void setProps(PropertyList *props) {
-        properties_.reset(props);
     }
 
     std::vector<std::string*> properties() const {
@@ -281,10 +289,6 @@ public:
             return {};
         }
         return properties_->properties();
-    }
-
-    void setRows(EdgeRowList *rows) {
-        rows_.reset(rows);
     }
 
     std::vector<EdgeRowItem*> rows() const {
@@ -295,6 +299,7 @@ public:
 
 private:
     bool                                        overwritable_{true};
+    bool                                        ignoreExistedIndex_{false};
     std::unique_ptr<std::string>                edge_;
     std::unique_ptr<PropertyList>               properties_;
     std::unique_ptr<EdgeRowList>                rows_;

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -125,7 +125,7 @@ static constexpr size_t MAX_ABS_INTEGER = 9223372036854775808ULL;
 %token KW_USER KW_USERS KW_ACCOUNT
 %token KW_PASSWORD KW_CHANGE KW_ROLE KW_ROLES
 %token KW_GOD KW_ADMIN KW_DBA KW_GUEST KW_GRANT KW_REVOKE KW_ON
-%token KW_CONTAINS
+%token KW_CONTAINS KW_IGNORE_EXISTED_INDEX
 
 /* symbols */
 %token L_PAREN R_PAREN L_BRACKET R_BRACKET L_BRACE R_BRACE COMMA
@@ -1332,6 +1332,12 @@ insert_vertex_sentence
     | KW_INSERT KW_VERTEX KW_NO KW_OVERWRITE vertex_tag_list KW_VALUES vertex_row_list {
         $$ = new InsertVertexSentence($5, $7, false /* not overwritable */);
     }
+    | KW_INSERT KW_VERTEX KW_IGNORE_EXISTED_INDEX vertex_tag_list KW_VALUES vertex_row_list {
+        $$ = new InsertVertexSentence($4, $6, true, true);
+    }
+    | KW_INSERT KW_VERTEX KW_NO KW_OVERWRITE KW_IGNORE_EXISTED_INDEX vertex_tag_list KW_VALUES vertex_row_list {
+        $$ = new InsertVertexSentence($6, $8, false, true);
+    }
     ;
 
 vertex_tag_list
@@ -1404,34 +1410,28 @@ value_list
 
 insert_edge_sentence
     : KW_INSERT KW_EDGE name_label L_PAREN R_PAREN KW_VALUES edge_row_list {
-        auto sentence = new InsertEdgeSentence();
-        sentence->setEdge($3);
-        sentence->setProps(new PropertyList());
-        sentence->setRows($7);
-        $$ = sentence;
+        $$ = new InsertEdgeSentence($3, new PropertyList(), $7);
     }
     | KW_INSERT KW_EDGE name_label L_PAREN prop_list R_PAREN KW_VALUES edge_row_list {
-        auto sentence = new InsertEdgeSentence();
-        sentence->setEdge($3);
-        sentence->setProps($5);
-        sentence->setRows($8);
-        $$ = sentence;
+        $$ = new InsertEdgeSentence($3, $5, $8);
     }
     | KW_INSERT KW_EDGE KW_NO KW_OVERWRITE name_label L_PAREN R_PAREN KW_VALUES edge_row_list {
-        auto sentence = new InsertEdgeSentence();
-        sentence->setOverwrite(false);
-        sentence->setEdge($5);
-        sentence->setProps(new PropertyList());
-        sentence->setRows($9);
-        $$ = sentence;
+        $$ = new InsertEdgeSentence($5, new PropertyList(), $9, false);
     }
     | KW_INSERT KW_EDGE KW_NO KW_OVERWRITE name_label L_PAREN prop_list R_PAREN KW_VALUES edge_row_list {
-        auto sentence = new InsertEdgeSentence();
-        sentence->setOverwrite(false);
-        sentence->setEdge($5);
-        sentence->setProps($7);
-        sentence->setRows($10);
-        $$ = sentence;
+        $$ = new InsertEdgeSentence($5, $7, $10, false);
+    }
+    | KW_INSERT KW_EDGE KW_IGNORE_EXISTED_INDEX name_label L_PAREN R_PAREN KW_VALUES edge_row_list {
+        $$ = new InsertEdgeSentence($4, new PropertyList(), $8, true, true);
+    }
+    | KW_INSERT KW_EDGE KW_IGNORE_EXISTED_INDEX name_label L_PAREN prop_list R_PAREN KW_VALUES edge_row_list {
+        $$ = new InsertEdgeSentence($4, $6, $9, true, true);
+    }
+    | KW_INSERT KW_EDGE KW_NO KW_OVERWRITE KW_IGNORE_EXISTED_INDEX name_label L_PAREN R_PAREN KW_VALUES edge_row_list {
+        $$ = new InsertEdgeSentence($6, new PropertyList(), $10, false, true);
+    }
+    | KW_INSERT KW_EDGE KW_NO KW_OVERWRITE KW_IGNORE_EXISTED_INDEX name_label L_PAREN prop_list R_PAREN KW_VALUES edge_row_list {
+        $$ = new InsertEdgeSentence($6, $8, $11, false, true);
     }
     ;
 

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -72,6 +72,7 @@ INTERSECT                   ([Ii][Nn][Tt][Ee][Rr][Ss][Ee][Cc][Tt])
 MINUS                       ([Mm][Ii][Nn][Uu][Ss])
 NO                          ([Nn][Oo])
 OVERWRITE                   ([Oo][Vv][Ee][Rr][Ww][Rr][Ii][Tt][Ee])
+IGNORE_EXISTED_INDEX        ([Ii][Gg][Nn][Oo][Rr][Ee][_][Ee][Xx][Ii][Ss][Tt][Ee][Dd][_][Ii][Nn][Dd][Ee][Xx])
 TRUE                        ([Tt][Rr][Uu][Ee])
 FALSE                       ([Ff][Aa][Ll][Ss][Ee])
 SHOW                        ([Ss][Hh][Oo][Ww])
@@ -215,6 +216,7 @@ RECOVER                     ([Rr][Ee][Cc][Oo][Vv][Ee][Rr])
 {MINUS}                     { return TokenType::KW_MINUS; }
 {NO}                        { return TokenType::KW_NO; }
 {OVERWRITE}                 { return TokenType::KW_OVERWRITE; }
+{IGNORE_EXISTED_INDEX}      { return TokenType::KW_IGNORE_EXISTED_INDEX; }
 {SHOW}                      { return TokenType::KW_SHOW; }
 {ADD}                       { return TokenType::KW_ADD; }
 {TIMESTAMP}                 { return TokenType::KW_TIMESTAMP; }

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -716,6 +716,20 @@ TEST(Parser, InsertVertex) {
         auto result = parser.parse(query);
         ASSERT_TRUE(result.status().isSyntaxError());
     }
+    {
+        GQLParser parser;
+        std::string query = "INSERT VERTEX IGNORE_EXISTED_INDEX person(name, age) "
+                            "VALUES uuid(\"dutor\"):(\'dutor, 30)";
+        auto result = parser.parse(query);
+        ASSERT_TRUE(result.status().isSyntaxError());
+    }
+    {
+        GQLParser parser;
+        std::string query = "INSERT VERTEX NO OVERWRITE IGNORE_EXISTED_INDEX person(name, age) "
+                            "VALUES uuid(\"dutor\"):(\'dutor, 30)";
+        auto result = parser.parse(query);
+        ASSERT_TRUE(result.status().isSyntaxError());
+    }
 }
 
 TEST(Parser, UpdateVertex) {
@@ -834,6 +848,20 @@ TEST(Parser, InsertEdge) {
         GQLParser parser;
         std::string query = "INSERT EDGE NO OVERWRITE transfer() "
                             "VALUES 12345->54321@1537408527:()";
+        auto result = parser.parse(query);
+        ASSERT_TRUE(result.ok()) << result.status();
+    }
+    {
+        GQLParser parser;
+        std::string query = "INSERT EDGE IGNORE_EXISTED_INDEX transfer(amount, time) "
+                            "VALUES 12345->-54321@1537408527:(3.75, 1537408527)";
+        auto result = parser.parse(query);
+        ASSERT_TRUE(result.ok()) << result.status();
+    }
+    {
+        GQLParser parser;
+        std::string query = "INSERT EDGE NO OVERWRITE IGNORE_EXISTED_INDEX transfer(amount, time) "
+                            "VALUES 12345->-54321@1537408527:(3.75, 1537408527)";
         auto result = parser.parse(query);
         ASSERT_TRUE(result.ok()) << result.status();
     }

--- a/src/storage/client/StorageClient.cpp
+++ b/src/storage/client/StorageClient.cpp
@@ -35,6 +35,7 @@ folly::SemiFuture<StorageRpcResponse<cpp2::ExecResponse>> StorageClient::addVert
         GraphSpaceID space,
         std::vector<cpp2::Vertex> vertices,
         bool overwritable,
+        bool ignoreExistedIndex,
         folly::EventBase* evb) {
     auto status =
         clusterIdsToHosts(space, vertices, [](const cpp2::Vertex& v) { return v.get_id(); });
@@ -51,6 +52,7 @@ folly::SemiFuture<StorageRpcResponse<cpp2::ExecResponse>> StorageClient::addVert
         auto& req = requests[host];
         req.set_space_id(space);
         req.set_overwritable(overwritable);
+        req.set_ignore_existed_index(ignoreExistedIndex);
         req.set_parts(std::move(c.second));
     }
 
@@ -70,6 +72,7 @@ folly::SemiFuture<StorageRpcResponse<cpp2::ExecResponse>> StorageClient::addEdge
         GraphSpaceID space,
         std::vector<storage::cpp2::Edge> edges,
         bool overwritable,
+        bool ignoreExistedIndex,
         folly::EventBase* evb) {
     auto status =
         clusterIdsToHosts(space, edges, [](const cpp2::Edge& e) { return e.get_key().get_src(); });
@@ -86,6 +89,7 @@ folly::SemiFuture<StorageRpcResponse<cpp2::ExecResponse>> StorageClient::addEdge
         auto& req = requests[host];
         req.set_space_id(space);
         req.set_overwritable(overwritable);
+        req.set_ignore_existed_index(ignoreExistedIndex);
         req.set_parts(std::move(c.second));
     }
 

--- a/src/storage/client/StorageClient.h
+++ b/src/storage/client/StorageClient.h
@@ -113,12 +113,14 @@ public:
         GraphSpaceID space,
         std::vector<storage::cpp2::Vertex> vertices,
         bool overwritable,
+        bool ignoreExistedIndex = false,
         folly::EventBase* evb = nullptr);
 
     folly::SemiFuture<StorageRpcResponse<storage::cpp2::ExecResponse>> addEdges(
         GraphSpaceID space,
         std::vector<storage::cpp2::Edge> edges,
         bool overwritable,
+        bool ignoreExistedIndex = false,
         folly::EventBase* evb = nullptr);
 
     folly::SemiFuture<StorageRpcResponse<storage::cpp2::QueryResponse>> getNeighbors(

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -88,6 +88,7 @@ std::string AddEdgesProcessor::addEdges(int64_t version, PartitionID partId,
         newEdges[key] = std::move(prop);
     });
     for (auto& e : newEdges) {
+        std::string oldVal;
         RowReader reader = RowReader::getEmptyRowReader();
         RowReader nReader = RowReader::getEmptyRowReader();
         auto edgeType = NebulaKeyUtils::getEdgeType(e.first);
@@ -98,15 +99,15 @@ std::string AddEdgesProcessor::addEdges(int64_t version, PartitionID partId,
         });
         if (!ignoreExistedIndex_ && hasIndex) {
             // If there is any index on this edge type, get the reader of existed data
-            auto val = findObsoleteIndex(partId, e.first);
-            if (!val.empty()) {
+            oldVal = findObsoleteIndex(partId, e.first);
+            if (!oldVal.empty()) {
                 reader = RowReader::getEdgePropReader(this->schemaMan_,
-                                                      val,
+                                                      oldVal,
                                                       spaceId_,
                                                       edgeType);
                 if (reader == nullptr) {
                     LOG(WARNING) << "Bad format row, key: " << e.first
-                                 << ", value: " << folly::hexDump(val.data(), val.size());
+                                 << ", value: " << folly::hexDump(oldVal.data(), oldVal.size());
                     return "";
                 }
             }

--- a/src/storage/mutate/AddEdgesProcessor.h
+++ b/src/storage/mutate/AddEdgesProcessor.h
@@ -49,6 +49,7 @@ private:
     GraphSpaceID                                          spaceId_;
     meta::IndexManager*                                   indexMan_{nullptr};
     std::vector<std::shared_ptr<nebula::cpp2::IndexItem>> indexes_;
+    bool                                                  ignoreExistedIndex_{false};
 };
 
 }  // namespace storage

--- a/src/storage/mutate/AddEdgesProcessor.h
+++ b/src/storage/mutate/AddEdgesProcessor.h
@@ -45,6 +45,8 @@ private:
                          const folly::StringPiece& rawKey,
                          std::shared_ptr<nebula::cpp2::IndexItem> index);
 
+    bool hasRelatedIndex(EdgeType edgeType);
+
 private:
     GraphSpaceID                                          spaceId_;
     meta::IndexManager*                                   indexMan_{nullptr};

--- a/src/storage/mutate/AddVerticesProcessor.cpp
+++ b/src/storage/mutate/AddVerticesProcessor.cpp
@@ -102,6 +102,7 @@ std::string AddVerticesProcessor::addVerticesWithIndex(PartitionID partId,
                                                        std::vector<kvstore::KV>&& data) {
     std::unique_ptr<kvstore::BatchHolder> batchHolder = std::make_unique<kvstore::BatchHolder>();
     for (auto& v : data) {
+        std::string oldVal;
         RowReader reader = RowReader::getEmptyRowReader();
         RowReader nReader = RowReader::getEmptyRowReader();
         auto tagId = NebulaKeyUtils::getTagId(v.first);
@@ -113,15 +114,15 @@ std::string AddVerticesProcessor::addVerticesWithIndex(PartitionID partId,
         });
         if (!ignoreExistedIndex_ && hasIndex) {
             // If there is any index on this tag, get the reader of existed data
-            auto val = findObsoleteIndex(partId, vId, tagId);
-            if (!val.empty()) {
+            oldVal = findObsoleteIndex(partId, vId, tagId);
+            if (!oldVal.empty()) {
                 reader = RowReader::getTagPropReader(this->schemaMan_,
-                                                     val,
+                                                     oldVal,
                                                      spaceId_,
                                                      tagId);
                 if (reader == nullptr) {
                     LOG(WARNING) << "Bad format row, key: " << v.first
-                                 << ", value: " << folly::hexDump(val.data(), val.size());
+                                 << ", value: " << folly::hexDump(oldVal.data(), oldVal.size());
                     return "";
                 }
             }

--- a/src/storage/mutate/AddVerticesProcessor.h
+++ b/src/storage/mutate/AddVerticesProcessor.h
@@ -51,6 +51,8 @@ private:
                          RowReader* reader,
                          std::shared_ptr<nebula::cpp2::IndexItem> index);
 
+    bool hasRelatedIndex(TagID tagId);
+
 private:
     GraphSpaceID                                          spaceId_;
     meta::IndexManager*                                   indexMan_{nullptr};

--- a/src/storage/mutate/AddVerticesProcessor.h
+++ b/src/storage/mutate/AddVerticesProcessor.h
@@ -56,6 +56,7 @@ private:
     meta::IndexManager*                                   indexMan_{nullptr};
     VertexCache*                                          vertexCache_{nullptr};
     std::vector<std::shared_ptr<nebula::cpp2::IndexItem>> indexes_;
+    bool                                                  ignoreExistedIndex_{false};
 };
 
 }  // namespace storage


### PR DESCRIPTION
1. Add a keyword IGNORE_EXISTED_INDEX in `insert`, if it is specified, storage will not delete old index. As `update` will always try to read old data, so only `insert` is taken care of.
2. Slightly modify insert process in storage, we only need to initialize the old reader and new reader once.