### PR TITLE
FIND PATH support REVERSELY / BIDIRECT

### DIFF
--- a/src/graph/FindPathExecutor.h
+++ b/src/graph/FindPathExecutor.h
@@ -50,6 +50,8 @@ public:
 
     static std::string buildPathString(const Path &path);
 
+    const std::string NEGATIVE_STR = "-";
+
     cpp2::RowValue buildPathRow(const Path &path);
 
 private:
@@ -78,7 +80,7 @@ private:
 
     inline void meetEvenPath(VertexID intersectId);
 
-    inline void updatePath(
+    inline bool updatePath(
             VertexID &src,
             std::multimap<VertexID, Path> &pathToSrc,
             Neighbor &neighbor,
@@ -108,6 +110,7 @@ private:
     Clause::Over                                    over_;
     Clause::Step                                    step_;
     Clause::Where                                   where_;
+    OverClause::Direction                           direction_{OverClause::Direction::kForward};
     bool                                            shortest_{false};
     using SchemaPropIndex = std::unordered_map<std::pair<std::string, std::string>, int64_t>;
     SchemaPropIndex                                 srcTagProps_;

--- a/src/graph/test/FindPathTest.cpp
+++ b/src/graph/test/FindPathTest.cpp
@@ -163,6 +163,120 @@ TEST_F(FindPathTest, SingleEdgeShortest) {
     }
 }
 
+TEST_F(FindPathTest, SingleEdgeShortestReversely) {
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "FIND SHORTEST PATH FROM %ld TO %ld OVER like REVERSELY UPTO 5 STEPS";
+        auto &tony = players_["Tony Parker"];
+        auto &tim = players_["Tim Duncan"];
+        auto query = folly::stringPrintf(fmt, tony.vid(), tim.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code) << *(resp.get_error_msg());
+        std::vector<std::string> expected = {
+            folly::stringPrintf("%ld<-like,0>%ld",
+                                tony.vid(), tim.vid())
+        };
+        ASSERT_TRUE(verifyPath(resp, expected));
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "FIND SHORTEST PATH FROM %ld TO %ld OVER like REVERSELY UPTO 5 STEPS";
+        auto &tony = players_["Tony Parker"];
+        auto &al = players_["LaMarcus Aldridge"];
+        auto &rudy = players_["Rudy Gay"];
+        auto query = folly::stringPrintf(fmt, tony.vid(), rudy.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code) << *(resp.get_error_msg());
+        std::vector<std::string> expected = {
+            folly::stringPrintf("%ld<-like,0>%ld<-like,0>%ld",
+                                tony.vid(), al.vid(), rudy.vid())
+        };
+        ASSERT_TRUE(verifyPath(resp, expected));
+    }
+    {
+        // we only find the shortest path to the dest
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "FIND SHORTEST PATH FROM %ld TO %ld,%ld OVER like REVERSELY UPTO 5 STEPS";
+        auto &tim = players_["Tim Duncan"];
+        auto &manu = players_["Manu Ginobili"];
+        auto &yao = players_["Yao Ming"];
+        auto &oneal = players_["Shaquile O'Neal"];
+        auto query = folly::stringPrintf(fmt, tim.vid(), manu.vid(), yao.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code) << *(resp.get_error_msg());
+        std::vector<std::string> expected = {
+            folly::stringPrintf("%ld<-like,0>%ld",
+                                tim.vid(), manu.vid()),
+            folly::stringPrintf("%ld<-like,0>%ld<-like,0>%ld",
+                                tim.vid(), oneal.vid(), yao.vid()),
+        };
+        ASSERT_TRUE(verifyPath(resp, expected));
+    }
+}
+
+TEST_F(FindPathTest, SingleEdgeShortestBidirect) {
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "FIND SHORTEST PATH FROM %ld TO %ld OVER like BIDIRECT UPTO 5 STEPS";
+        auto &tony = players_["Tony Parker"];
+        auto &tim = players_["Tim Duncan"];
+        auto query = folly::stringPrintf(fmt, tony.vid(), tim.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code) << *(resp.get_error_msg());
+        std::vector<std::string> expected = {
+            folly::stringPrintf("%ld<-like,0>%ld",
+                                tony.vid(), tim.vid()),
+            folly::stringPrintf("%ld<like,0>%ld",
+                                tony.vid(), tim.vid())
+        };
+        ASSERT_TRUE(verifyPath(resp, expected));
+    }
+    {
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "FIND SHORTEST PATH FROM %ld TO %ld OVER like BIDIRECT UPTO 5 STEPS";
+        auto &tony = players_["Tony Parker"];
+        auto &al = players_["LaMarcus Aldridge"];
+        auto &rudy = players_["Rudy Gay"];
+        auto query = folly::stringPrintf(fmt, tony.vid(), rudy.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code) << *(resp.get_error_msg());
+        std::vector<std::string> expected = {
+            folly::stringPrintf("%ld<-like,0>%ld<-like,0>%ld",
+                                tony.vid(), al.vid(), rudy.vid()),
+            folly::stringPrintf("%ld<like,0>%ld<-like,0>%ld",
+                                tony.vid(), al.vid(), rudy.vid())
+        };
+        ASSERT_TRUE(verifyPath(resp, expected));
+    }
+    {
+        // we only find the shortest path to the dest
+        cpp2::ExecutionResponse resp;
+        auto *fmt = "FIND SHORTEST PATH FROM %ld TO %ld,%ld,%ld OVER like BIDIRECT UPTO 5 STEPS";
+        auto &tiago = players_["Tiago Splitter"];
+        auto &tony = players_["Tony Parker"];
+        auto &manu = players_["Manu Ginobili"];
+        auto &al = players_["LaMarcus Aldridge"];
+        auto &tim = players_["Tim Duncan"];
+        auto query = folly::stringPrintf(fmt, tiago.vid(),
+                                         tony.vid(), manu.vid(), al.vid());
+        auto code = client_->execute(query, resp);
+        ASSERT_EQ(cpp2::ErrorCode::SUCCEEDED, code) << *(resp.get_error_msg());
+        std::vector<std::string> expected = {
+            folly::stringPrintf("%ld<like,0>%ld<-like,0>%ld",
+                                tiago.vid(), manu.vid(), tony.vid()),
+            folly::stringPrintf("%ld<like,0>%ld<-like,0>%ld",
+                                tiago.vid(), tim.vid(), tony.vid()),
+            folly::stringPrintf("%ld<like,0>%ld<like,0>%ld",
+                                tiago.vid(), tim.vid(), tony.vid()),
+            folly::stringPrintf("%ld<like,0>%ld<-like,0>%ld",
+                                tiago.vid(), tim.vid(), al.vid()),
+            folly::stringPrintf("%ld<like,0>%ld",
+                                tiago.vid(), manu.vid())
+        };
+        ASSERT_TRUE(verifyPath(resp, expected));
+    }
+}
+
 TEST_F(FindPathTest, SingleEdgeAll) {
     /*
      * TODO: There might exist loops when find all path,

--- a/src/graph/test/TraverseTestBase.h
+++ b/src/graph/test/TraverseTestBase.h
@@ -62,16 +62,19 @@ public:
 
         auto rows = buildPathString(*resp.get_rows());
 
-        if (expected.size() != rows.size()) {
-            return TestError() << "Rows' count not match: "
-                               << rows.size() << " vs. " << expected.size();
-        }
-
         std::sort(rows.begin(), rows.end());
         std::sort(expected.begin(), expected.end());
 
+        std::string joinedRowString;
         for (decltype(rows.size()) i = 0; i < rows.size(); ++i) {
             VLOG(2) << rows[i];
+            joinedRowString += rows[i] + "\n";
+        }
+
+        if (expected.size() != rows.size()) {
+            return TestError() << "Rows' count not match: "
+                               << rows.size() << " vs. " << expected.size() << "\n"
+                               << joinedRowString;
         }
 
         for (decltype(rows.size()) i = 0; i < rows.size(); ++i) {
@@ -816,6 +819,7 @@ AssertionResult TraverseTestBase::insertData() {
             query += "),\n\t";
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `players' failed: "
@@ -841,6 +845,7 @@ AssertionResult TraverseTestBase::insertData() {
             query += "),\n\t";
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `players' failed: "
@@ -865,6 +870,7 @@ AssertionResult TraverseTestBase::insertData() {
             query += "),\n\t";
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `players' failed: "
@@ -890,6 +896,7 @@ AssertionResult TraverseTestBase::insertData() {
             query += "),\n\t";
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `players' failed: "
@@ -912,6 +919,7 @@ AssertionResult TraverseTestBase::insertData() {
             query += "),\n\t";
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `teams' failed: "
@@ -935,6 +943,7 @@ AssertionResult TraverseTestBase::insertData() {
             query += "),\n\t";
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `teams' failed: "
@@ -958,6 +967,7 @@ AssertionResult TraverseTestBase::insertData() {
             query += "),\n\t";
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `teams' failed: "
@@ -990,6 +1000,7 @@ AssertionResult TraverseTestBase::insertData() {
             }
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `serve' failed: "
@@ -1022,6 +1033,7 @@ AssertionResult TraverseTestBase::insertData() {
             }
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `serve' failed: "
@@ -1054,6 +1066,7 @@ AssertionResult TraverseTestBase::insertData() {
             }
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `serve' failed: "
@@ -1080,6 +1093,7 @@ AssertionResult TraverseTestBase::insertData() {
             }
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `like' failed: "
@@ -1107,6 +1121,7 @@ AssertionResult TraverseTestBase::insertData() {
             }
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `like' failed: "
@@ -1134,6 +1149,7 @@ AssertionResult TraverseTestBase::insertData() {
             }
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `like' failed: "
@@ -1158,6 +1174,7 @@ AssertionResult TraverseTestBase::insertData() {
             }
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `teammate' failed: " << static_cast<int32_t>(code);
@@ -1185,6 +1202,7 @@ AssertionResult TraverseTestBase::insertData() {
             }
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `teammate' failed: " << static_cast<int32_t>(code);
@@ -1212,6 +1230,7 @@ AssertionResult TraverseTestBase::insertData() {
             }
         }
         query.resize(query.size() - 3);
+        LOG(INFO) << query;
         auto code = client_->execute(query, resp);
         if (code != cpp2::ErrorCode::SUCCEEDED) {
             return TestError() << "Insert `teammate' failed: " << static_cast<int32_t>(code);


### PR DESCRIPTION
<!--
Thank you for contributing to **Nebula Graph**! Please read the [CONTRIBUTING](https://github.com/vesoft-inc/nebula/blob/master/docs/manual-EN/4.contributions/how-to-contribute.md
) document **BEFORE** filing this PR.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some nGQL features, you can provide some references.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1、FIND PATH语句中的OVER子句现在支持REVERSELY和BIDIRECT。
FIND SHORTEST | ALL PATH FROM <vertex_id_list> TO <vertex_id_list>
OVER <edge_type_list> [REVERSELY] [BIDIRECT] [UPTO STEP]
使用BIDIRECT方式搜索时，路径中将出现A-B-A的无效循环，降低搜索效率。搜索中对这种情况进行了剪枝。

2、添加了对应的测试用例。

3、TraverseTestBase测试SetUp时，现在会输出所有INSERT语句。

4、FindPathTest中的测试用例由于行数不同而无法通过时，现在会输出调试信息。


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
#2381
业务需要FIND PATH支持无向图的路径查找算法。

### Will break the compatibility? How if so?
如上所述，nGQL语法存在变更，但可完全兼容旧版本。
<!--
Please label `alert/break' if so, such as
  1. nGQL grammar changes;
  2. RPC protocol can't be compatible with previous, refer to https://diwakergupta.github.io/thrift-missing-guide/#_versioning_compatibility;
  3. Storage format; etc.
-->

### Does this PR introduce any user-facing change?
当FIND PATH使用REVERSELY / BIDIRECT时，输出边时用“-”代表反向边。
示例：
find all path from 2001 to 2005 over follow bidirect
输出：
2001 <follow,0> 2002 <-follow,0> 2003 <-follow,0> 2004 <follow,0> 2005
<!--
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If no, write 'No'.
-->


### How was this patch tested?
单测用例通过。
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Checklist
<!--Tick the checkbox(es) below to choose what you have done.-->

- [ OK ] I've run the tests to see all new and existing tests pass
- [ OK ] If this Pull Request resolves an issue, I linked to the issue in the text above
- [ OK ] I've informed the technical writer about the documentation change if necessary
