### PR TITLE
support clean last invalid balance plan

### DIFF
--- a/src/graph/BalanceExecutor.cpp
+++ b/src/graph/BalanceExecutor.cpp
@@ -26,10 +26,13 @@ void BalanceExecutor::execute() {
             balanceLeader();
             break;
         case BalanceSentence::SubType::kData:
-            balanceData();
+            balanceData(false, false);
             break;
         case BalanceSentence::SubType::kDataStop:
-            balanceData(true);
+            balanceData(true, false);
+            break;
+        case BalanceSentence::SubType::kDataReset:
+            balanceData(false, true);
             break;
         case BalanceSentence::SubType::kShowBalancePlan:
             showBalancePlan();
@@ -66,14 +69,15 @@ void BalanceExecutor::balanceLeader() {
     std::move(future).via(runner).thenValue(cb).thenError(error);
 }
 
-void BalanceExecutor::balanceData(bool isStop) {
+void BalanceExecutor::balanceData(bool isStop, bool isReset) {
     std::vector<HostAddr> hostDelList;
     auto hostDel = sentence_->hostDel();
     if (hostDel != nullptr) {
         hostDelList = hostDel->hosts();
     }
     auto future = ectx()->getMetaClient()->balance(std::move(hostDelList),
-                                                   isStop);
+                                                   isStop,
+                                                   isReset);
     auto *runner = ectx()->rctx()->runner();
 
     auto cb = [this] (auto &&resp) {

--- a/src/graph/BalanceExecutor.h
+++ b/src/graph/BalanceExecutor.h
@@ -27,7 +27,7 @@ public:
 
     void balanceLeader();
 
-    void balanceData(bool isStop = false);
+    void balanceData(bool isStop, bool isReset);
 
     void stopBalanceData();
 

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -40,6 +40,7 @@ enum ErrorCode {
     E_NO_RUNNING_BALANCE_PLAN   = -36,
     E_NO_VALID_HOST             = -37,
     E_CORRUPTTED_BALANCE_PLAN   = -38,
+    E_NO_INVALID_BALANCE_PLAN   = -39,
 
     // Authentication Failure
     E_INVALID_PASSWORD          = -41,
@@ -562,6 +563,7 @@ struct BalanceReq {
     2: optional i64 id,
     3: optional list<common.HostAddr> host_del,
     4: optional bool stop,
+    5: optional bool reset,
 }
 
 enum TaskResult {

--- a/src/meta/client/MetaClient.cpp
+++ b/src/meta/client/MetaClient.cpp
@@ -1991,7 +1991,8 @@ MetaClient::getUserRoles(std::string account) {
 }
 
 folly::Future<StatusOr<int64_t>> MetaClient::balance(std::vector<HostAddr> hostDel,
-                                                     bool isStop) {
+                                                     bool isStop,
+                                                     bool isReset) {
     cpp2::BalanceReq req;
     if (!hostDel.empty()) {
         std::vector<nebula::cpp2::HostAddr> tHostDel;
@@ -2007,6 +2008,9 @@ folly::Future<StatusOr<int64_t>> MetaClient::balance(std::vector<HostAddr> hostD
     }
     if (isStop) {
         req.set_stop(isStop);
+    }
+    if (isReset) {
+        req.set_reset(isReset);
     }
 
     folly::Promise<StatusOr<int64_t>> promise;

--- a/src/meta/client/MetaClient.h
+++ b/src/meta/client/MetaClient.h
@@ -375,7 +375,7 @@ public:
 
     // Operations for admin
     folly::Future<StatusOr<int64_t>>
-    balance(std::vector<HostAddr> hostDel, bool isStop = false);
+    balance(std::vector<HostAddr> hostDel, bool isStop, bool isReset);
 
     folly::Future<StatusOr<std::vector<cpp2::BalanceTask>>>
     showBalance(int64_t balanceId);

--- a/src/meta/processors/admin/BalancePlan.cpp
+++ b/src/meta/processors/admin/BalancePlan.cpp
@@ -179,10 +179,8 @@ cpp2::ErrorCode BalancePlan::recovery(bool resume) {
                 task.startTimeMs_ = std::get<2>(tup);
                 task.endTimeMs_ = std::get<3>(tup);
                 if (resume && task.ret_ != BalanceTask::Result::SUCCEEDED) {
-                    // Resume the failed task, skip the in-progress and invalid tasks
-                    if (task.ret_ == BalanceTask::Result::FAILED) {
-                        task.ret_ = BalanceTask::Result::IN_PROGRESS;
-                    }
+                    // Resume any task not finished
+                    task.ret_ = BalanceTask::Result::IN_PROGRESS;
                     task.status_ = BalanceTask::Status::START;
                     if (!ActiveHostsMan::isLived(kv_, task.dst_)) {
                         task.ret_ = BalanceTask::Result::INVALID;

--- a/src/meta/processors/admin/BalancePlan.h
+++ b/src/meta/processors/admin/BalancePlan.h
@@ -24,7 +24,7 @@ class BalancePlan {
     FRIEND_TEST(BalanceTest, SingleReplicaTest);
     FRIEND_TEST(BalanceTest, RecoveryTest);
     FRIEND_TEST(BalanceTest, DispatchTasksTest);
-    FRIEND_TEST(BalanceTest, StopBalanceDataTest);
+    FRIEND_TEST(BalanceTest, StopAndRecoverTest);
     FRIEND_TEST(BalanceTest, CleanLastInvalidBalancePlanTest);
 
 public:

--- a/src/meta/processors/admin/BalancePlan.h
+++ b/src/meta/processors/admin/BalancePlan.h
@@ -25,6 +25,7 @@ class BalancePlan {
     FRIEND_TEST(BalanceTest, RecoveryTest);
     FRIEND_TEST(BalanceTest, DispatchTasksTest);
     FRIEND_TEST(BalanceTest, StopBalanceDataTest);
+    FRIEND_TEST(BalanceTest, CleanLastInvalidBalancePlanTest);
 
 public:
     enum class Status : uint8_t {

--- a/src/meta/processors/admin/BalanceProcessor.cpp
+++ b/src/meta/processors/admin/BalanceProcessor.cpp
@@ -35,6 +35,23 @@ void BalanceProcessor::process(const cpp2::BalanceReq& req) {
         onFinished();
         return;
     }
+    if (req.get_reset() != nullptr) {
+        if (!(*req.get_reset())) {
+            handleErrorCode(cpp2::ErrorCode::E_UNKNOWN);
+            onFinished();
+            return;
+        }
+        auto plan = Balancer::instance(kvstore_)->cleanLastInValidPlan();
+        if (!ok(plan)) {
+            handleErrorCode(error(plan));
+            onFinished();
+            return;
+        }
+        resp_.set_id(value(plan));
+        handleErrorCode(cpp2::ErrorCode::SUCCEEDED);
+        onFinished();
+        return;
+    }
     if (req.get_id() != nullptr) {
         auto ret = Balancer::instance(kvstore_)->show(*req.get_id());
         if (!ret.ok()) {

--- a/src/meta/processors/admin/BalanceTask.cpp
+++ b/src/meta/processors/admin/BalanceTask.cpp
@@ -26,7 +26,7 @@ void BalanceTask::invoke() {
         endTimeMs_ = time::WallClock::fastNowInMilliSec();
         saveInStore();
         LOG(ERROR) << taskIdStr_ << "Task invalid, status " << static_cast<int32_t>(status_);
-        onFinished_();
+        onError_();
         return;
     }
     if (ret_ == Result::FAILED) {

--- a/src/meta/processors/admin/BalanceTask.h
+++ b/src/meta/processors/admin/BalanceTask.h
@@ -28,7 +28,7 @@ class BalanceTask {
     FRIEND_TEST(BalanceTest, SingleReplicaTest);
     FRIEND_TEST(BalanceTest, NormalTest);
     FRIEND_TEST(BalanceTest, RecoveryTest);
-    FRIEND_TEST(BalanceTest, StopBalanceDataTest);
+    FRIEND_TEST(BalanceTest, StopAndRecoverTest);
 
 public:
     enum class Status : uint8_t {

--- a/src/meta/processors/admin/Balancer.cpp
+++ b/src/meta/processors/admin/Balancer.cpp
@@ -96,7 +96,7 @@ ErrorOr<cpp2::ErrorCode, BalanceID> Balancer::cleanLastInValidPlan() {
     // There should be at most one invalid plan, and it must be the latest one
     while (iter->valid()) {
         auto status = BalancePlan::status(iter->val());
-        if (status == BalancePlan::Status::IN_PROGRESS || status == BalancePlan::Status::FAILED) {
+        if (status == BalancePlan::Status::FAILED) {
             auto balanceId = BalancePlan::id(iter->key());
             folly::Baton<true, std::atomic> baton;
             cpp2::ErrorCode result = cpp2::ErrorCode::SUCCEEDED;

--- a/src/meta/processors/admin/Balancer.h
+++ b/src/meta/processors/admin/Balancer.h
@@ -48,7 +48,7 @@ class Balancer {
     FRIEND_TEST(BalanceTest, MockReplaceMachineTest);
     FRIEND_TEST(BalanceTest, SingleReplicaTest);
     FRIEND_TEST(BalanceTest, RecoveryTest);
-    FRIEND_TEST(BalanceTest, StopBalanceDataTest);
+    FRIEND_TEST(BalanceTest, StopAndRecoverTest);
     FRIEND_TEST(BalanceTest, CleanLastInvalidBalancePlanTest);
     FRIEND_TEST(BalanceTest, LeaderBalancePlanTest);
     FRIEND_TEST(BalanceTest, SimpleLeaderBalancePlanTest);

--- a/src/meta/processors/admin/Balancer.h
+++ b/src/meta/processors/admin/Balancer.h
@@ -49,6 +49,7 @@ class Balancer {
     FRIEND_TEST(BalanceTest, SingleReplicaTest);
     FRIEND_TEST(BalanceTest, RecoveryTest);
     FRIEND_TEST(BalanceTest, StopBalanceDataTest);
+    FRIEND_TEST(BalanceTest, CleanLastInvalidBalancePlanTest);
     FRIEND_TEST(BalanceTest, LeaderBalancePlanTest);
     FRIEND_TEST(BalanceTest, SimpleLeaderBalancePlanTest);
     FRIEND_TEST(BalanceTest, IntersectHostsLeaderBalancePlanTest);
@@ -80,6 +81,11 @@ public:
      * Stop balance plan by canceling all waiting balance task.
      * */
     StatusOr<BalanceID> stop();
+
+    /**
+     * Clean invalid plan, return the invalid plan key if any
+     * */
+    ErrorOr<cpp2::ErrorCode, BalanceID> cleanLastInValidPlan();
 
     /**
      * TODO(heng): rollback some balance plan.

--- a/src/parser/AdminSentences.h
+++ b/src/parser/AdminSentences.h
@@ -378,6 +378,7 @@ public:
         kLeader,
         kData,
         kDataStop,
+        kDataReset,
         kShowBalancePlan,
     };
 

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -116,7 +116,7 @@ static constexpr size_t MAX_ABS_INTEGER = 9223372036854775808ULL;
 %token KW_FETCH KW_PROP KW_UPDATE KW_UPSERT KW_WHEN
 %token KW_ORDER KW_ASC KW_LIMIT KW_OFFSET KW_GROUP
 %token KW_DISTINCT KW_ALL KW_OF
-%token KW_BALANCE KW_LEADER
+%token KW_BALANCE KW_LEADER KW_RESET
 %token KW_SHORTEST KW_PATH KW_NOLOOP
 %token KW_IS KW_NULL KW_DEFAULT
 %token KW_SNAPSHOT KW_SNAPSHOTS KW_LOOKUP
@@ -313,6 +313,7 @@ unreserved_keyword
      | KW_NOLOOP             { $$ = new std::string("noloop"); }
      | KW_COUNT_DISTINCT     { $$ = new std::string("count_distinct"); }
      | KW_CONTAINS           { $$ = new std::string("contains"); }
+     | KW_RESET              { $$ = new std::string("reset"); }
      ;
 
 agg_function
@@ -1965,6 +1966,9 @@ balance_sentence
     }
     | KW_BALANCE KW_DATA KW_STOP {
         $$ = new BalanceSentence(BalanceSentence::SubType::kDataStop);
+    }
+    | KW_BALANCE KW_DATA KW_RESET {
+        $$ = new BalanceSentence(BalanceSentence::SubType::kDataReset);
     }
     | KW_BALANCE KW_DATA KW_REMOVE host_list {
         $$ = new BalanceSentence(BalanceSentence::SubType::kData, $4);

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -116,7 +116,7 @@ static constexpr size_t MAX_ABS_INTEGER = 9223372036854775808ULL;
 %token KW_FETCH KW_PROP KW_UPDATE KW_UPSERT KW_WHEN
 %token KW_ORDER KW_ASC KW_LIMIT KW_OFFSET KW_GROUP
 %token KW_DISTINCT KW_ALL KW_OF
-%token KW_BALANCE KW_LEADER KW_RESET
+%token KW_BALANCE KW_LEADER KW_RESET KW_PLAN
 %token KW_SHORTEST KW_PATH KW_NOLOOP
 %token KW_IS KW_NULL KW_DEFAULT
 %token KW_SNAPSHOT KW_SNAPSHOTS KW_LOOKUP
@@ -314,6 +314,7 @@ unreserved_keyword
      | KW_COUNT_DISTINCT     { $$ = new std::string("count_distinct"); }
      | KW_CONTAINS           { $$ = new std::string("contains"); }
      | KW_RESET              { $$ = new std::string("reset"); }
+     | KW_PLAN               { $$ = new std::string("plan"); }
      ;
 
 agg_function
@@ -1967,7 +1968,7 @@ balance_sentence
     | KW_BALANCE KW_DATA KW_STOP {
         $$ = new BalanceSentence(BalanceSentence::SubType::kDataStop);
     }
-    | KW_BALANCE KW_DATA KW_RESET {
+    | KW_BALANCE KW_DATA KW_RESET KW_PLAN {
         $$ = new BalanceSentence(BalanceSentence::SubType::kDataReset);
     }
     | KW_BALANCE KW_DATA KW_REMOVE host_list {

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -158,6 +158,7 @@ ACCOUNT                     ([Aa][Cc][Cc][Oo][Uu][Nn][Tt])
 DBA                         ([Dd][Bb][Aa])
 CONTAINS                    ([Cc][Oo][Nn][Tt][Aa][Ii][Nn][Ss])
 RESET                       ([Rr][Ee][Ss][Ee][Tt])
+PLAN                        ([Pp][Ll][Aa][Nn])
 
 LABEL                       ([a-zA-Z][_a-zA-Z0-9]*)
 DEC                         ([0-9])
@@ -312,6 +313,7 @@ RECOVER                     ([Rr][Ee][Cc][Oo][Vv][Ee][Rr])
 {SHORTEST}                  { return TokenType::KW_SHORTEST; }
 {CONTAINS}                  { return TokenType::KW_CONTAINS; }
 {RESET}                     { return TokenType::KW_RESET; }
+{PLAN}                      { return TokenType::KW_PLAN; }
 
 
 {TRUE}                      { yylval->boolval = true; return TokenType::BOOL; }

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -157,6 +157,7 @@ BIDIRECT                    ([Bb][Ii][Dd][Ii][Rr][Ee][Cc][Tt])
 ACCOUNT                     ([Aa][Cc][Cc][Oo][Uu][Nn][Tt])
 DBA                         ([Dd][Bb][Aa])
 CONTAINS                    ([Cc][Oo][Nn][Tt][Aa][Ii][Nn][Ss])
+RESET                       ([Rr][Ee][Ss][Ee][Tt])
 
 LABEL                       ([a-zA-Z][_a-zA-Z0-9]*)
 DEC                         ([0-9])
@@ -310,6 +311,7 @@ RECOVER                     ([Rr][Ee][Cc][Oo][Vv][Ee][Rr])
 {NOLOOP}                    { return TokenType::KW_NOLOOP; }
 {SHORTEST}                  { return TokenType::KW_SHORTEST; }
 {CONTAINS}                  { return TokenType::KW_CONTAINS; }
+{RESET}                     { return TokenType::KW_RESET; }
 
 
 {TRUE}                      { yylval->boolval = true; return TokenType::BOOL; }

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -1773,7 +1773,7 @@ TEST(Parser, BalanceOperation) {
     }
     {
         GQLParser parser;
-        std::string query = "BALANCE DATA RESET";
+        std::string query = "BALANCE DATA RESET PLAN";
         auto result = parser.parse(query);
         ASSERT_TRUE(result.ok()) << result.status();
     }

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -1773,6 +1773,12 @@ TEST(Parser, BalanceOperation) {
     }
     {
         GQLParser parser;
+        std::string query = "BALANCE DATA RESET";
+        auto result = parser.parse(query);
+        ASSERT_TRUE(result.ok()) << result.status();
+    }
+    {
+        GQLParser parser;
         std::string query = "BALANCE DATA REMOVE 192.168.0.1:50000,192.168.0.1:50001";
         auto result = parser.parse(query);
         ASSERT_TRUE(result.ok()) << result.status();


### PR DESCRIPTION
1. For now, balancer will try to recover the failed plan, but sometimes the plan can't be executed (e.g. src or dst is offline). So support a cmd to clean last invalid plan. `balance data reset plan`
2. Modify recover mechanism
* Previously: When a plan is stopped, all remaining task will be marked as INVALID, but the plan itself will be marked as `SUCCEEDED`. And we only `recover` FAILED task, not the INVALID ones. The behavior is a bit weird.
* Now: Since we support clean a plan which we don't want it, all FAILED and INVALID task will `recover`. A stopped plan will be marked as `FAILED` as well (if it has remaining tasks).

Will support in 2.0 later.