### PR TITLE
support index range scan of timestamp

### DIFF
--- a/src/common/utils/NebulaKeyUtils.h
+++ b/src/common/utils/NebulaKeyUtils.h
@@ -255,7 +255,7 @@ public:
         return rawKey.subpiece(0, rawKey.size() - sizeof(int64_t));
     }
 
-    // Only int and double are supported
+    // Only int, double and timestamp are supported
     static std::string boundVariant(nebula::cpp2::SupportedType type,
                                     NebulaBoundValueType op,
                                     const VariantType& v = 0L) {
@@ -268,7 +268,8 @@ public:
             }
             case NebulaBoundValueType::kSubtraction : {
                 std::string str;
-                if (type == nebula::cpp2::SupportedType::INT) {
+                if (type == nebula::cpp2::SupportedType::INT ||
+                    type == nebula::cpp2::SupportedType::TIMESTAMP) {
                     str = encodeInt64(boost::get<int64_t>(v));
                 } else {
                     str = encodeDouble(boost::get<double>(v));
@@ -286,7 +287,8 @@ public:
             }
             case NebulaBoundValueType::kAddition : {
                 std::string str;
-                if (type == nebula::cpp2::SupportedType::INT) {
+                if (type == nebula::cpp2::SupportedType::INT ||
+                    type == nebula::cpp2::SupportedType::TIMESTAMP) {
                     str = encodeInt64(boost::get<int64_t>(v));
                 } else {
                     str = encodeDouble(boost::get<double>(v));


### PR DESCRIPTION
Please hold this PR.
A temporary solution for index range scan of timestamp data type. This requirement comes from community user.
This solution just converted the data type from timestamp to int64, without considering the time zone and time format.
