### PR TITLE
fix meta follower can't read clusterId

### DIFF
--- a/src/meta/ClusterIdMan.h
+++ b/src/meta/ClusterIdMan.h
@@ -81,7 +81,8 @@ public:
         // follower need to read from kv engine directly
         auto ret = kv->part(kDefaultSpaceId, kDefaultPartId);
         if (!ok(ret)) {
-            return error(ret);
+            LOG(ERROR) << "Part not found";
+            return 0;
         }
         auto part = nebula::value(ret);
         std::string value;

--- a/src/meta/test/ClusterIdManTest.cpp
+++ b/src/meta/test/ClusterIdManTest.cpp
@@ -29,7 +29,8 @@ TEST(ClusterIDManTest, KVTest) {
     auto clusterId = ClusterIdMan::create("127.0.0.1:44500");
     CHECK_NE(0, clusterId);
     CHECK(ClusterIdMan::persistInKV(kv.get(), "clusterId", clusterId));
-    auto ret = ClusterIdMan::getClusterIdFromKV(kv.get(), "clusterId");
+    auto ret = ClusterIdMan::getClusterIdFromKV(dynamic_cast<kvstore::NebulaStore*>(kv.get()),
+                                                "clusterId");
     CHECK_EQ(clusterId, ret);
 }
 


### PR DESCRIPTION
Introduced in https://github.com/vesoft-inc/nebula/pull/2403.