### PR TITLE
Improve the log of slow and failed queries

### DIFF
--- a/share/resources/gflags.json
+++ b/share/resources/gflags.json
@@ -10,7 +10,8 @@
         "wal_ttl",
         "enable_reservoir_sampling",
         "custom_filter_interval_secs",
-        "enable_multi_versions"
+        "enable_multi_versions",
+        "slow_query_threshold_us"
     ],
     "NESTED": [
         "rocksdb_db_options",

--- a/src/graph/ExecutionPlan.cpp
+++ b/src/graph/ExecutionPlan.cpp
@@ -75,7 +75,7 @@ void ExecutionPlan::onFinish() {
         stats::Stats::addStatsValue(slowQueryStats_.get(), true, latency);
         LOG(WARNING) << "Slow query: exec succ, cost: " << latency
             << "us, space: " << spaceName
-            << ", query: " << rctx->query().c_str();
+            << ", query: " << rctx->query();
     }
     rctx->finish();
 
@@ -110,7 +110,7 @@ void ExecutionPlan::onError(Status status) {
                 : std::to_string(int32_t(rctx->resp().get_error_code())))
         << ", cost: " << latency
         << "us, space: " << (rctx->session()->spaceName())
-        << ", query: " << (rctx->query().c_str())
+        << ", query: " << (rctx->query())
         << ", errmsg: " << status.toString();
 
     // slow query
@@ -122,7 +122,7 @@ void ExecutionPlan::onError(Status status) {
                     ? errorCodeIt->second
                     : std::to_string(int32_t(rctx->resp().get_error_code())))
             << ", space: " << (rctx->session()->spaceName())
-            << ", query: " << (rctx->query().c_str());
+            << ", query: " << (rctx->query());
     }
 
     rctx->finish();

--- a/src/graph/ExecutionPlan.cpp
+++ b/src/graph/ExecutionPlan.cpp
@@ -73,9 +73,9 @@ void ExecutionPlan::onFinish() {
     // slow query
     if (latency >= static_cast<uint32_t>(FLAGS_slow_query_threshold_us)) {
         stats::Stats::addStatsValue(slowQueryStats_.get(), true, latency);
-        LOG(WARNING) << "Slow query: exec succ, cost=" << latency
-            << "us, space=" << spaceName
-            << ", query="<< rctx->query().c_str();
+        LOG(WARNING) << "Slow query: exec succ, cost: " << latency
+            << "us, space: " << spaceName
+            << ", query: " << rctx->query().c_str();
     }
     rctx->finish();
 
@@ -103,19 +103,26 @@ void ExecutionPlan::onError(Status status) {
     stats::Stats::addStatsValue(allStats_.get(), false, latency);
     rctx->resp().set_latency_in_us(latency);
 
-    LOG(ERROR) << "Execute failed! code=" << int32_t(rctx->resp().get_error_code())
-        << ", cost=" << latency
-        << "us, space=" << (rctx->session()->spaceName())
-        << ", query=" << (rctx->query().c_str())
-        << ", errmsg="<< status.toString();
+    auto errorCodeIt = cpp2::_ErrorCode_VALUES_TO_NAMES.find(rctx->resp().get_error_code());
+    LOG(ERROR) << "Execute failed! errcode: "
+        << (errorCodeIt != cpp2::_ErrorCode_VALUES_TO_NAMES.end()
+                ? errorCodeIt->second
+                : std::to_string(int32_t(rctx->resp().get_error_code())))
+        << ", cost: " << latency
+        << "us, space: " << (rctx->session()->spaceName())
+        << ", query: " << (rctx->query().c_str())
+        << ", errmsg: " << status.toString();
 
     // slow query
     if (latency >= static_cast<uint32_t>(FLAGS_slow_query_threshold_us)) {
         stats::Stats::addStatsValue(slowQueryStats_.get(), false, latency);
-        LOG(WARNING) << "Slow query: exec failed! cost=" << latency
-            << "us, errcode="<< int32_t(rctx->resp().get_error_code())
-            << ", space=" << (rctx->session()->spaceName())
-            << ", query="<< (rctx->query().c_str());
+        LOG(WARNING) << "Slow query: exec failed! cost: " << latency
+            << "us, errcode: "
+            << (errorCodeIt != cpp2::_ErrorCode_VALUES_TO_NAMES.end()
+                    ? errorCodeIt->second
+                    : std::to_string(int32_t(rctx->resp().get_error_code())))
+            << ", space: " << (rctx->session()->spaceName())
+            << ", query: " << (rctx->query().c_str());
     }
 
     rctx->finish();

--- a/src/graph/ExecutionPlan.h
+++ b/src/graph/ExecutionPlan.h
@@ -29,6 +29,7 @@ public:
         ectx_ = std::move(ectx);
         allStats_ = std::make_unique<stats::Stats>("graph", "all");
         parseStats_ = std::make_unique<stats::Stats>("graph", "parse");
+        slowQueryStats_ = std::make_unique<stats::Stats>("graph", "slow_query");
     }
 
     ~ExecutionPlan() = default;
@@ -58,6 +59,7 @@ private:
     std::unique_ptr<SequentialExecutor>         executor_;
     std::unique_ptr<stats::Stats>               allStats_;
     std::unique_ptr<stats::Stats>               parseStats_;
+    std::unique_ptr<stats::Stats>               slowQueryStats_;
 };
 
 }   // namespace graph


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve the log of slow and failed queries:
- Print slow query log for GNQL whose latency >= slow_query_threshold_us.
- Improve log for GNQL who executed failed.


### Why are the changes needed?
Our online service is sensitive to RT(RT999 should <= 100ms), but the actual latency is seldom high, and graph's log is not conducive to quickly locate the GNQL causing the problem.
In addition, adding slowQueryStats_ is also conducive to observing service stability. We can collect slow query information through http and report it.


### Will break the compatibility? How if so?
No, just add log.

### Does this PR introduce any user-facing change?
No.


### How was this patch tested?
1. Slow query log: Use nebula command line to set slow_query_threshold_us, then execute GNQL and observe logs.
Like:
![image](https://user-images.githubusercontent.com/5928054/103088386-a02d7500-4625-11eb-9e09-f4ad26e22dd8.png)

2. Failed query log: Exec some error GQNL.
Like:
![image](https://user-images.githubusercontent.com/5928054/103088434-c94e0580-4625-11eb-9adc-9e990c141384.png)



### Checklist
<!--Tick the checkbox(es) below to choose what you have done.-->

- [ Y ] I've run the tests to see all new and existing tests pass
- [ - ] If this Pull Request resolves an issue, I linked to the issue in the text above
- [ - ] I've informed the technical writer about the documentation change if necessary
