### PR TITLE
Improve raft stability

### DIFF
--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -21,6 +21,8 @@ DEFINE_int32(custom_filter_interval_secs, 24 * 3600,
 DEFINE_int32(num_workers, 4, "Number of worker threads");
 DEFINE_int32(clean_wal_interval_secs, 600, "inerval to trigger clean expired wal");
 DEFINE_bool(auto_remove_invalid_space, false, "whether remove data of invalid space when restart");
+DEFINE_int32(num_raft_client_threads, 16, "Number of raft client threads");
+DEFINE_int32(num_raft_workers, 16, "Number of raft worker threads");
 
 DECLARE_bool(rocksdb_disable_wal);
 
@@ -137,7 +139,7 @@ bool NebulaStore::init() {
                                                                        enginePtr->getDataRoot(),
                                                                        partId),
                                                                enginePtr,
-                                                               ioPool_,
+                                                               raftClientPool_,
                                                                bgWorkers_,
                                                                workers_,
                                                                snapshot_);
@@ -306,7 +308,7 @@ std::shared_ptr<Part> NebulaStore::newPart(GraphSpaceID spaceId,
                                                engine->getDataRoot(),
                                                partId),
                                        engine,
-                                       ioPool_,
+                                       raftClientPool_,
                                        bgWorkers_,
                                        workers_,
                                        snapshot_);

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -1525,7 +1525,6 @@ void RaftPart::processAppendLogRequest(
     }
 
     // Reset the timeout timer
-    lastMsgRecvDur_.reset();
     helper.setLastMsgRecvDur(&lastMsgRecvDur_);
 
     if (req.get_sending_snapshot() && status_ != Status::WAITING_SNAPSHOT) {

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -539,6 +539,15 @@ protected:
     std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool_;
     // Shared worker thread pool
     std::shared_ptr<thread::GenericThreadPool> bgWorkers_;
+    // In order to improve the stability of the heartbeat, each leader holds a separate thread
+    // to send its heartbeat.
+    // Note:
+    //  - leaderHeartbeatWorker_ only works when the role is leader, and other roles use the
+    //    shared bgWorker_.
+    // Problem solved:
+    //  - When the write load is high and the disk IO Util is high, shared bgworker_ may be too
+    //    busy, causing more frequent follower election.
+    thread::GenericThreadPool leaderHeartbeatWorker_;
     // Workers pool
     std::shared_ptr<folly::Executor> executor_;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve the stability of raft:
1. Delay the call to lastMsgRecvDur_.reset() as much as possible in processAppendLogRequest(), in order to reduce the probability of follower initiate election under high disk IO Util.
2. Add the raft client thread pool and separate it from the IO thread pool. The IO thread pool is not recommended to execute the client logic to avoid being blocked by the client logic.
3. Add the raft worker thread pool, which is isolated from the storage worker thread pool, which is conducive to the separation of read and write.
4. Each leader has an independent heartbeat sending thread to prevent the shared bgWorker_ thread from being blocked by individual partitions and affecting other leaders.

### Why are the changes needed?
In our needs, there is a large-scale data import requirement, which will continue to maintain disk IO Util at a high level for 4-5 hours, >=90% and often reach 100%. Under such high write pressure, raft Leader re-election frequently occurs, which greatly interferes with the stability of data import.

So I made the above changes and fixed a bug in raft(https://github.com/vesoft-inc/nebula/pull/2419),
In addition, increase raft_rpc_timeout_ms to >=5s at the same time, so that raft can reach a more stable situation.

### Will break the compatibility? How if so?
No

### Does this PR introduce any user-facing change?
No


### How was this patch tested?
1. Run the previous single test.
2. Start a large-scale data insert task, make the disk IO almost full, and observe whether the number of raft elections has improved, and it is expected to be greatly reduced

### Checklist
<!--Tick the checkbox(es) below to choose what you have done.-->

- [ Y ] I've run the tests to see all new and existing tests pass
- [ - ] If this Pull Request resolves an issue, I linked to the issue in the text above
- [ - ] I've informed the technical writer about the documentation change if necessary
