### PR TITLE
fix error:Space not found for xxx

### DIFF
--- a/src/meta/processors/BaseProcessor.inl
+++ b/src/meta/processors/BaseProcessor.inl
@@ -46,6 +46,8 @@ StatusOr<std::string> BaseProcessor<RESP>::doGet(const std::string& key) {
             return value;
         case kvstore::ResultCode::ERR_KEY_NOT_FOUND:
             return Status::Error("Key Not Found");
+        case kvstore::ResultCode::ERR_LEADER_CHANGED:
+            return Status::LeaderChanged("Leader Changed");
         default:
             return Status::Error("Get Failed");
     }

--- a/src/meta/processors/usersMan/AuthenticationProcessor.cpp
+++ b/src/meta/processors/usersMan/AuthenticationProcessor.cpp
@@ -186,8 +186,8 @@ void ListUsersProcessor::process(const cpp2::ListUsersReq& req) {
     std::string prefix = "__users__";
     auto ret = kvstore_->prefix(kDefaultSpaceId, kDefaultPartId, prefix, &iter);
     if (ret != kvstore::ResultCode::SUCCEEDED) {
-        LOG(ERROR) << "Can't find any users.";
-        handleErrorCode(cpp2::ErrorCode::E_NOT_FOUND);
+        LOG(ERROR) << "List users fail.";
+        handleErrorCode(MetaCommon::to(ret));
         onFinished();
         return;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
fix bug: `Space not found` on console.


### Why are the changes needed?
I execute 'use space' on console. It's `Space not found`.

step1: Space has created. And IP 106 is meta leader.
step2: Restart graphd(IP 105).  graphd(105) connects a metad follower(107)
![Jietu20210528-100605](https://user-images.githubusercontent.com/28890406/119924267-d8a2f780-bfa5-11eb-8db0-1f7ac03583d0.jpg)

step3: using console to connect graphd(105). type 'use finance'.
![image](https://user-images.githubusercontent.com/28890406/119924945-148a8c80-bfa7-11eb-867f-947aad8a5791.png)


step4: There are 'space not found'. Then I execute 'show spaces' and 'use finance'. It‘s success.

<img width="350" height="350" src="https://user-images.githubusercontent.com/28890406/119924288-e3f62300-bfa5-11eb-818d-ffbb3e8ad8a9.jpg"/>

Reason: MetaClient cannot get a LEADER_CHANGED response code.



### Will break the compatibility? How if so?
no

### Does this PR introduce any user-facing change?
no


### How was this patch tested?
1. start metad、storaged、graphd
2. create space.
3. restart graphd.
4. execute "use space_name" on console.


### Checklist
- [x] I've run the tests to see all new and existing tests pass
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above
- [x] I've informed the technical writer about the documentation change if necessary
