### PR TITLE
add a script to do metad folder scp

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -67,3 +67,16 @@ install(
     COMPONENT
         graph
 )
+
+install(
+    FILES
+        meta-transfer-tools.sh
+    PERMISSIONS
+        OWNER_EXECUTE OWNER_WRITE OWNER_READ
+        GROUP_EXECUTE GROUP_READ
+        WORLD_EXECUTE WORLD_READ
+    DESTINATION
+        scripts
+    COMPONENT
+        meta
+)

--- a/scripts/meta-transfer-tools.sh
+++ b/scripts/meta-transfer-tools.sh
@@ -22,10 +22,11 @@ Usage="this tool is a simple wrapper to scp to copy local folder of metad to ano
 echo -e $Usage
 }
 
-while getopts "hf:t:u:" opt; do
+while getopts ":hf:t:u:" opt; do
     case $opt in
         h)
             usage
+            exit 0
             ;;
         f)
             echo "trying to copy metad from: " $OPTARG
@@ -41,7 +42,8 @@ while getopts "hf:t:u:" opt; do
             configs=$OPTARG
             ;;
         \?)
-            echo "Invalid option: -$OPTARG" 
+            echo "Invalid option: -$OPTARG"
+            exit 1
             ;;
     esac
 done

--- a/scripts/meta-transfer-tools.sh
+++ b/scripts/meta-transfer-tools.sh
@@ -1,0 +1,83 @@
+#! /bin/bash
+
+src=
+dst=
+metaDirName=
+configs=
+
+function usage {
+Usage="this tool is a simple wrapper to scp to copy local folder of metad to another (remote)place \n \
+    it afford 4 options:    \n \
+        1. -f (from) local metad dir \n \
+        2. -t (to) remote destination \n \
+        3. -u (update) any configs need to be changed \n \
+            different configs should be seperated by ':' \n \
+            each config has to be the form of "local_ip=172.0.0.1" \n \
+        \n \
+    for example \n \
+        ./meta-transfer-tools.sh -f /path-to-src/metad1 -t bob@172.0.0.1:/path-to-dst -u local_ip=172.0.0.1:port=10086 \n \
+    "
+
+
+echo -e $Usage
+}
+
+while getopts "hf:t:u:" opt; do
+    case $opt in
+        h)
+            usage
+            ;;
+        f)
+            echo "trying to copy metad from: " $OPTARG
+            src=$OPTARG
+            metaDirName=${OPTARG##*/}
+            ;;
+        t)
+            echo "trying to copy metad to: " $OPTARG
+            dst=$OPTARG
+            ;;
+        u)
+            echo "-u: " $OPTARG
+            configs=$OPTARG
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" 
+            ;;
+    esac
+done
+
+if [[ ! -d ${src} ]]; then
+    echo "${src} does not exist or not a folder"
+    exit 1
+fi
+
+configSurfix=/etc/nebula-metad.conf
+if [[ ! -f ${src}${configSurfix} ]]; then
+    echo "${src}${configSurfix} does not exist"
+    exit 1
+fi
+
+tmpConfigFile=nebula-metad.conf.bak
+
+cp ${src}${configSurfix} ${tmpConfigFile}
+if [[ -z $configs ]]; then
+    echo no configs need to replace
+else
+    echo going to parse configs: $configs
+    array=(${configs//:/ })
+    for var in ${array[@]}
+    do
+        key=${var%=*}
+        val=${var#*=}
+        sed -iE "s/--${key}.*$/--${key}=${val}/" ${tmpConfigFile}
+    done
+fi
+
+echo "trying to copy metad from $src to $dst"
+
+set -x
+scp -r $src $dst
+scp $tmpConfigFile $dst/$metaDirName$configSurfix
+set +x
+
+rm $tmpConfigFile*

--- a/scripts/meta-transfer-tools.sh
+++ b/scripts/meta-transfer-tools.sh
@@ -43,6 +43,7 @@ while getopts ":hf:t:u:" opt; do
             ;;
         \?)
             echo "Invalid option: -$OPTARG"
+            usage
             exit 1
             ;;
     esac


### PR DESCRIPTION
In our forum, some user complain lack of mete transfer tools. 

this tool is a simple wrapper to scp to copy local folder of metad to another (remote)place
    it afford 4 options:   
        1. -f (from) local metad dir
        2. -t (to) remote destination
        3. -u (update) any configs need to be changed
            different configs should be seperated by ':'
            each config has to be the form of "local_ip=172.0.0.1"
       
for example
```
 ./meta-transfer-tools.sh -f /path-to-src/metad1 -t bob@172.0.0.1:/path-to-dst -u local_ip=172.0.0.1:port=10086
```
 this is not a well discussed solution for this, and I'm not very good at shell, any suggestion is welcome. 