### PR TITLE
fixed fixed_string expression eval for go

### DIFF
--- a/src/storage/exec/QueryUtils.h
+++ b/src/storage/exec/QueryUtils.h
@@ -71,6 +71,10 @@ class QueryUtils final {
       }
       return Status::Error(folly::stringPrintf("Fail to read prop %s ", propName.c_str()));
     }
+    if (field->type() == meta::cpp2::PropertyType::FIXED_STRING) {
+      const auto& fixedStr = value.getStr();
+      return fixedStr.substr(0, fixedStr.find_first_of('\0'));
+    }
     return value;
   }
 

--- a/tests/tck/features/expression/FixedString.feature
+++ b/tests/tck/features/expression/FixedString.feature
@@ -1,0 +1,54 @@
+Feature: FixedString expression Eval
+
+  Scenario: FixedString GO Expression
+    Given an empty graph
+    And create a space with following options:
+      | partition_num  | 1        |
+      | replica_factor | 1        |
+      | vid_type       | int64    |
+      | charset        | utf8     |
+      | collate        | utf8_bin |
+    And having executed:
+      """
+      CREATE TAG IF NOT EXISTS fixed_string_tag_1(c1 fixed_string(30));
+      CREATE EDGE IF NOT EXISTS fixed_string_edge_1(c1 fixed_string(30));
+      """
+    # insert vertex succeeded
+    When try to execute query:
+      """
+      INSERT VERTEX fixed_string_tag_1(c1) VALUES 1:("row"), 2:("row"), 3:("row")
+      """
+    Then the execution should be successful
+    # insert edge succeeded
+    When executing query:
+      """
+      INSERT EDGE fixed_string_edge_1(c1) VALUES 1->2:("row"), 1->3:("row")
+      """
+    Then the execution should be successful
+    # check fixed string expression with go
+    When executing query:
+      """
+      GO from 1 over fixed_string_edge_1 where $$.fixed_string_tag_1.c1 == "row" yield $$.fixed_string_tag_1.c1 as c1
+      """
+    Then the result should be, in any order, with relax comparison:
+      | c1    |
+      | "row" |
+      | "row" |
+    # check fixed string expression with go
+    When executing query:
+      """
+      GO from 1 over fixed_string_edge_1 where $^.fixed_string_tag_1.c1 == "row" yield $$.fixed_string_tag_1.c1 as c1
+      """
+    Then the result should be, in any order, with relax comparison:
+      | c1    |
+      | "row" |
+      | "row" |
+    # check fixed string expression with go
+    When executing query:
+      """
+      GO from 1 over fixed_string_edge_1 where fixed_string_edge_1.c1 == "row" yield $$.fixed_string_tag_1.c1 as c1
+      """
+    Then the result should be, in any order, with relax comparison:
+      | c1    |
+      | "row" |
+      | "row" |


### PR DESCRIPTION
fixed bug for expression eval when prop data type is fixed_string
Repetition steps：
```
CREATE SPACE test_space (partition_num=1,replica_factor=1, vid_type=fixed_string(30));
USE test_space
create tag t1(c1 fixed_string(40))
create edge e1(c1 fixed_string(40))
insert vertex t1(c1) values "1":("row"), "2":("row"), "3":("row")
insert edge e1(c1) values "1" -> "2"@0:("row"), "1" -> "3"@0:("row")
go from "1" over e1 where e1.c1 == "row"
go from "1" over e1 where $$.t1.c1 == "row"
go from "1" over e1 where $^.t1.c1 == "row"
```