### PR TITLE
Fix slow query test.

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           make RM_DIR=false DEBUG=false J=${{ steps.cmake.outputs.j }} tck
         working-directory: tests/
-        timeout-minutes: 60
+        timeout-minutes: 120
       - name: Down cluster
         run: |
           make down

--- a/tests/tck/slowquery/KillSlowQueryViaDiffrentService.feature
+++ b/tests/tck/slowquery/KillSlowQueryViaDiffrentService.feature
@@ -26,7 +26,7 @@ Feature: Slow Query Test
       """
     Then the execution should be successful
     # In case that rebuild indexes cost too much time.
-    And wait 10 seconds
+    And wait 20 seconds
     When executing query via graph 1:
       """
       SHOW ALL QUERIES

--- a/tests/tck/slowquery/KillSlowQueryViaSameService.feature
+++ b/tests/tck/slowquery/KillSlowQueryViaSameService.feature
@@ -26,7 +26,7 @@ Feature: Slow Query Test
       """
     Then the execution should be successful
     # In case that rebuild indexes cost too much time.
-    And wait 10 seconds
+    And wait 20 seconds
     When executing query:
       """
       SHOW ALL QUERIES


### PR DESCRIPTION
The rebuild_index job is rate limited now. This makes the test has to wait for much time.