### PR TITLE
Revert "Move union struct 'SchemaID' from meta.thrift to common.thrift"

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -3335,7 +3335,7 @@ StatusOr<std::pair<std::string, cpp2::FTIndex>> MetaClient::getFTIndexBySpaceSch
   }
   folly::RWSpinLock::ReadHolder holder(localCacheLock_);
   for (auto it = fulltextIndexMap_.begin(); it != fulltextIndexMap_.end(); ++it) {
-    auto id = it->second.get_depend_schema().getType() == nebula::cpp2::SchemaID::Type::edge_type
+    auto id = it->second.get_depend_schema().getType() == cpp2::SchemaID::Type::edge_type
                   ? it->second.get_depend_schema().get_edge_type()
                   : it->second.get_depend_schema().get_tag_id();
     if (it->second.get_space_id() == spaceId && id == schemaId) {

--- a/src/graph/executor/maintain/FTIndexExecutor.cpp
+++ b/src/graph/executor/maintain/FTIndexExecutor.cpp
@@ -75,7 +75,7 @@ folly::Future<Status> ShowFTIndexesExecutor::execute() {
             continue;
           }
           auto shmId = index.second.get_depend_schema();
-          auto isEdge = shmId.getType() == nebula::cpp2::SchemaID::Type::edge_type;
+          auto isEdge = shmId.getType() == meta::cpp2::SchemaID::Type::edge_type;
           auto shmNameRet =
               isEdge ? this->qctx_->schemaMng()->toEdgeName(spaceId, shmId.get_edge_type())
                      : this->qctx_->schemaMng()->toTagName(spaceId, shmId.get_tag_id());

--- a/src/graph/validator/MaintainValidator.cpp
+++ b/src/graph/validator/MaintainValidator.cpp
@@ -611,7 +611,7 @@ Status CreateFTIndexValidator::validateImpl() {
                     ? qctx_->schemaMng()->toEdgeType(space.id, *sentence->schemaName())
                     : qctx_->schemaMng()->toTagID(space.id, *sentence->schemaName());
   NG_RETURN_IF_ERROR(status);
-  nebula::cpp2::SchemaID id;
+  meta::cpp2::SchemaID id;
   if (sentence->isEdge()) {
     id.set_edge_type(status.value());
   } else {

--- a/src/graph/validator/test/MockIndexManager.cpp
+++ b/src/graph/validator/test/MockIndexManager.cpp
@@ -23,7 +23,7 @@ void MockIndexManager::init() {
   meta::cpp2::IndexItem person_no_props_index;
   person_no_props_index.set_index_id(233);
   person_no_props_index.set_index_name("person_no_props_index");
-  nebula::cpp2::SchemaID personSchemaId;
+  meta::cpp2::SchemaID personSchemaId;
   personSchemaId.set_tag_id(2);
   person_no_props_index.set_schema_id(std::move(personSchemaId));
   person_no_props_index.set_schema_name("person");
@@ -31,7 +31,7 @@ void MockIndexManager::init() {
   meta::cpp2::IndexItem book_name_index;
   book_name_index.set_index_id(234);
   book_name_index.set_index_name("book_name_index");
-  nebula::cpp2::SchemaID bookSchemaId;
+  meta::cpp2::SchemaID bookSchemaId;
   bookSchemaId.set_tag_id(5);
   book_name_index.set_schema_id(std::move(bookSchemaId));
   book_name_index.set_schema_name("book");
@@ -47,7 +47,7 @@ void MockIndexManager::init() {
   meta::cpp2::IndexItem like_index;
   like_index.set_index_id(235);
   like_index.set_index_name("like_index");
-  nebula::cpp2::SchemaID likeSchemaId;
+  meta::cpp2::SchemaID likeSchemaId;
   likeSchemaId.set_edge_type(3);
   like_index.set_schema_id(std::move(likeSchemaId));
   like_index.set_schema_name("like");

--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -51,11 +51,6 @@ typedef i64 (cpp.type = "nebula::SessionID") SessionID
 
 typedef i64 (cpp.type = "nebula::ExecutionPlanID") ExecutionPlanID
 
-union SchemaID {
-    1: TagID     tag_id,
-    2: EdgeType  edge_type,
-}
-
 // !! Struct Date has a shadow data type defined in the Date.h
 // So any change here needs to be reflected to the shadow type there
 struct Date {

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -156,10 +156,15 @@ struct EdgeItem {
     4: Schema           schema,
 }
 
+union SchemaID {
+    1: common.TagID     tag_id,
+    2: common.EdgeType  edge_type,
+}
+
 struct IndexItem {
     1: common.IndexID      index_id,
     2: binary              index_name,
-    3: common.SchemaID     schema_id
+    3: SchemaID            schema_id
     4: binary              schema_name,
     5: list<ColumnDef>     fields,
     6: optional binary     comment,
@@ -1038,7 +1043,7 @@ struct ListFTClientsResp {
 
 struct FTIndex {
     1: common.GraphSpaceID  space_id,
-    2: common.SchemaID      depend_schema,
+    2: SchemaID             depend_schema,
     3: list<binary>         fields,
 }
 

--- a/src/meta/processors/BaseProcessor-inl.h
+++ b/src/meta/processors/BaseProcessor-inl.h
@@ -464,10 +464,10 @@ ErrorOr<nebula::cpp2::ErrorCode, std::vector<cpp2::IndexItem>> BaseProcessor<RES
 
   while (indexIter->valid()) {
     auto item = MetaServiceUtils::parseIndex(indexIter->val());
-    if (item.get_schema_id().getType() == nebula::cpp2::SchemaID::Type::tag_id &&
+    if (item.get_schema_id().getType() == cpp2::SchemaID::Type::tag_id &&
         item.get_schema_id().get_tag_id() == tagOrEdge) {
       items.emplace_back(std::move(item));
-    } else if (item.get_schema_id().getType() == nebula::cpp2::SchemaID::Type::edge_type &&
+    } else if (item.get_schema_id().getType() == cpp2::SchemaID::Type::edge_type &&
                item.get_schema_id().get_edge_type() == tagOrEdge) {
       items.emplace_back(std::move(item));
     }
@@ -490,7 +490,7 @@ ErrorOr<nebula::cpp2::ErrorCode, cpp2::FTIndex> BaseProcessor<RESP>::getFTIndex(
 
   while (indexIter->valid()) {
     auto index = MetaServiceUtils::parsefulltextIndex(indexIter->val());
-    auto id = index.get_depend_schema().getType() == nebula::cpp2::SchemaID::Type::edge_type
+    auto id = index.get_depend_schema().getType() == cpp2::SchemaID::Type::edge_type
                   ? index.get_depend_schema().get_edge_type()
                   : index.get_depend_schema().get_tag_id();
     if (spaceId == index.get_space_id() && tagOrEdge == id) {

--- a/src/meta/processors/index/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/index/CreateEdgeIndexProcessor.cpp
@@ -87,7 +87,7 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
   while (checkIter->valid()) {
     auto val = checkIter->val();
     auto item = MetaServiceUtils::parseIndex(val);
-    if (item.get_schema_id().getType() != nebula::cpp2::SchemaID::Type::edge_type ||
+    if (item.get_schema_id().getType() != cpp2::SchemaID::Type::edge_type ||
         fields.size() > item.get_fields().size() ||
         edgeType != item.get_schema_id().get_edge_type()) {
       checkIter->next();
@@ -173,7 +173,7 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
   cpp2::IndexItem item;
   item.set_index_id(edgeIndex);
   item.set_index_name(indexName);
-  nebula::cpp2::SchemaID schemaID;
+  cpp2::SchemaID schemaID;
   schemaID.set_edge_type(edgeType);
   item.set_schema_id(schemaID);
   item.set_schema_name(edgeName);

--- a/src/meta/processors/index/CreateTagIndexProcessor.cpp
+++ b/src/meta/processors/index/CreateTagIndexProcessor.cpp
@@ -87,7 +87,7 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
   while (checkIter->valid()) {
     auto val = checkIter->val();
     auto item = MetaServiceUtils::parseIndex(val);
-    if (item.get_schema_id().getType() != nebula::cpp2::SchemaID::Type::tag_id ||
+    if (item.get_schema_id().getType() != cpp2::SchemaID::Type::tag_id ||
         fields.size() > item.get_fields().size() || tagID != item.get_schema_id().get_tag_id()) {
       checkIter->next();
       continue;
@@ -171,7 +171,7 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
   cpp2::IndexItem item;
   item.set_index_id(tagIndex);
   item.set_index_name(indexName);
-  nebula::cpp2::SchemaID schemaID;
+  cpp2::SchemaID schemaID;
   schemaID.set_tag_id(tagID);
   item.set_schema_id(schemaID);
   item.set_schema_name(tagName);

--- a/src/meta/processors/index/FTIndexProcessor.cpp
+++ b/src/meta/processors/index/FTIndexProcessor.cpp
@@ -16,7 +16,7 @@ void CreateFTIndexProcessor::process(const cpp2::CreateFTIndexReq& req) {
   const auto& index = req.get_index();
   const std::string& name = req.get_fulltext_index_name();
   CHECK_SPACE_ID_AND_RETURN(index.get_space_id());
-  auto isEdge = index.get_depend_schema().getType() == nebula::cpp2::SchemaID::Type::edge_type;
+  auto isEdge = index.get_depend_schema().getType() == cpp2::SchemaID::Type::edge_type;
   folly::SharedMutex::ReadHolder rHolder(isEdge ? LockUtils::edgeLock() : LockUtils::tagLock());
   auto schemaPrefix = isEdge ? MetaServiceUtils::schemaEdgePrefix(
                                    index.get_space_id(), index.get_depend_schema().get_edge_type())

--- a/src/meta/processors/index/GetEdgeIndexProcessor.cpp
+++ b/src/meta/processors/index/GetEdgeIndexProcessor.cpp
@@ -41,7 +41,7 @@ void GetEdgeIndexProcessor::process(const cpp2::GetEdgeIndexReq& req) {
   }
 
   auto item = MetaServiceUtils::parseIndex(nebula::value(indexItemRet));
-  if (item.get_schema_id().getType() != nebula::cpp2::SchemaID::Type::edge_type) {
+  if (item.get_schema_id().getType() != cpp2::SchemaID::Type::edge_type) {
     LOG(ERROR) << "Get Edge Index Failed: Index Name " << indexName << " is not EdgeIndex";
     resp_.set_code(nebula::cpp2::ErrorCode::E_INDEX_NOT_FOUND);
     onFinished();

--- a/src/meta/processors/index/GetTagIndexProcessor.cpp
+++ b/src/meta/processors/index/GetTagIndexProcessor.cpp
@@ -42,7 +42,7 @@ void GetTagIndexProcessor::process(const cpp2::GetTagIndexReq& req) {
   }
 
   auto item = MetaServiceUtils::parseIndex(nebula::value(indexItemRet));
-  if (item.get_schema_id().getType() != nebula::cpp2::SchemaID::Type::tag_id) {
+  if (item.get_schema_id().getType() != cpp2::SchemaID::Type::tag_id) {
     LOG(ERROR) << "Get Tag Index Failed: Index Name " << indexName << " is not TagIndex";
     resp_.set_code(nebula::cpp2::ErrorCode::E_INDEX_NOT_FOUND);
     onFinished();

--- a/src/meta/processors/index/ListEdgeIndexesProcessor.cpp
+++ b/src/meta/processors/index/ListEdgeIndexesProcessor.cpp
@@ -30,7 +30,7 @@ void ListEdgeIndexesProcessor::process(const cpp2::ListEdgeIndexesReq& req) {
   while (iter->valid()) {
     auto val = iter->val();
     auto item = MetaServiceUtils::parseIndex(val);
-    if (item.get_schema_id().getType() == nebula::cpp2::SchemaID::Type::edge_type) {
+    if (item.get_schema_id().getType() == cpp2::SchemaID::Type::edge_type) {
       items.emplace_back(std::move(item));
     }
     iter->next();

--- a/src/meta/processors/index/ListTagIndexesProcessor.cpp
+++ b/src/meta/processors/index/ListTagIndexesProcessor.cpp
@@ -30,7 +30,7 @@ void ListTagIndexesProcessor::process(const cpp2::ListTagIndexesReq& req) {
   while (iter->valid()) {
     auto val = iter->val();
     auto item = MetaServiceUtils::parseIndex(val);
-    if (item.get_schema_id().getType() == nebula::cpp2::SchemaID::Type::tag_id) {
+    if (item.get_schema_id().getType() == cpp2::SchemaID::Type::tag_id) {
       items.emplace_back(std::move(item));
     }
     iter->next();

--- a/src/meta/test/CreateBackupProcessorTest.cpp
+++ b/src/meta/test/CreateBackupProcessorTest.cpp
@@ -128,7 +128,7 @@ TEST(ProcessorTest, CreateBackupTest) {
   cpp2::IndexItem item;
   item.set_index_id(tagIndex);
   item.set_index_name(indexName);
-  nebula::cpp2::SchemaID schemaID;
+  cpp2::SchemaID schemaID;
   TagID tagID = 3;
   std::string tagName = "test_space_tag1";
   schemaID.set_tag_id(tagID);

--- a/src/meta/test/IndexProcessorTest.cpp
+++ b/src/meta/test/IndexProcessorTest.cpp
@@ -1605,7 +1605,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
     {
       cpp2::CreateFTIndexReq req;
       cpp2::FTIndex index;
-      nebula::cpp2::SchemaID schemaId;
+      cpp2::SchemaID schemaId;
       if (id == 5) {
         schemaId.set_tag_id(5);
       } else {
@@ -1627,7 +1627,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
     {
       cpp2::CreateFTIndexReq req;
       cpp2::FTIndex index;
-      nebula::cpp2::SchemaID schemaId;
+      cpp2::SchemaID schemaId;
       if (id == 5) {
         schemaId.set_tag_id(5);
       } else {
@@ -1649,7 +1649,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
     {
       cpp2::CreateFTIndexReq req;
       cpp2::FTIndex index;
-      nebula::cpp2::SchemaID schemaId;
+      cpp2::SchemaID schemaId;
       if (id == 5) {
         schemaId.set_tag_id(5);
       } else {
@@ -1671,7 +1671,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
     {
       cpp2::CreateFTIndexReq req;
       cpp2::FTIndex index;
-      nebula::cpp2::SchemaID schemaId;
+      cpp2::SchemaID schemaId;
       if (id == 5) {
         schemaId.set_tag_id(55);
       } else {
@@ -1695,7 +1695,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
     {
       cpp2::CreateFTIndexReq req;
       cpp2::FTIndex index;
-      nebula::cpp2::SchemaID schemaId;
+      cpp2::SchemaID schemaId;
       if (id == 5) {
         schemaId.set_tag_id(5);
       } else {
@@ -1720,7 +1720,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
   {
     cpp2::CreateFTIndexReq req;
     cpp2::FTIndex index;
-    nebula::cpp2::SchemaID schemaId;
+    cpp2::SchemaID schemaId;
     schemaId.set_tag_id(5);
     index.set_space_id(1);
     index.set_depend_schema(std::move(schemaId));
@@ -1738,7 +1738,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
   {
     cpp2::CreateFTIndexReq req;
     cpp2::FTIndex index;
-    nebula::cpp2::SchemaID schemaId;
+    cpp2::SchemaID schemaId;
     schemaId.set_tag_id(5);
     index.set_space_id(1);
     index.set_depend_schema(std::move(schemaId));
@@ -1756,7 +1756,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
   {
     cpp2::CreateFTIndexReq req;
     cpp2::FTIndex index;
-    nebula::cpp2::SchemaID schemaId;
+    cpp2::SchemaID schemaId;
     schemaId.set_tag_id(5);
     index.set_space_id(1);
     index.set_depend_schema(std::move(schemaId));
@@ -1774,7 +1774,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
   {
     cpp2::CreateFTIndexReq req;
     cpp2::FTIndex index;
-    nebula::cpp2::SchemaID schemaId;
+    cpp2::SchemaID schemaId;
     schemaId.set_tag_id(5);
     index.set_space_id(1);
     index.set_depend_schema(std::move(schemaId));
@@ -1792,7 +1792,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
   {
     cpp2::CreateFTIndexReq req;
     cpp2::FTIndex index;
-    nebula::cpp2::SchemaID schemaId;
+    cpp2::SchemaID schemaId;
     schemaId.set_edge_type(6);
     index.set_space_id(1);
     index.set_depend_schema(std::move(schemaId));
@@ -1819,7 +1819,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
     std::vector<std::string> fields = {"col_string", "col_fixed_string_1"};
     ASSERT_EQ(fields, index->second.get_fields());
     ASSERT_EQ(1, index->second.get_space_id());
-    nebula::cpp2::SchemaID schemaId;
+    cpp2::SchemaID schemaId;
     schemaId.set_tag_id(5);
     ASSERT_EQ(schemaId, index->second.get_depend_schema());
   }
@@ -1865,7 +1865,7 @@ TEST(IndexProcessorTest, DropWithFTIndexTest) {
     {
       cpp2::CreateFTIndexReq req;
       cpp2::FTIndex index;
-      nebula::cpp2::SchemaID schemaId;
+      cpp2::SchemaID schemaId;
       if (id == 5) {
         schemaId.set_tag_id(5);
       } else {
@@ -1916,7 +1916,7 @@ TEST(IndexProcessorTest, AlterWithFTIndexTest) {
     {
       cpp2::CreateFTIndexReq req;
       cpp2::FTIndex index;
-      nebula::cpp2::SchemaID schemaId;
+      cpp2::SchemaID schemaId;
       if (id == 5) {
         schemaId.set_tag_id(5);
       } else {

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -300,7 +300,7 @@ class TestUtils {
     cpp2::IndexItem item;
     item.set_index_id(indexID);
     item.set_index_name(indexName);
-    nebula::cpp2::SchemaID schemaID;
+    cpp2::SchemaID schemaID;
     schemaID.set_tag_id(tagID);
     item.set_schema_id(std::move(schemaID));
     item.set_schema_name(std::move(tagName));
@@ -328,7 +328,7 @@ class TestUtils {
     cpp2::IndexItem item;
     item.set_index_id(indexID);
     item.set_index_name(indexName);
-    nebula::cpp2::SchemaID schemaID;
+    cpp2::SchemaID schemaID;
     schemaID.set_edge_type(edgeType);
     item.set_schema_id(std::move(schemaID));
     item.set_schema_name(std::move(edgeName));

--- a/src/meta/upgrade/MetaDataUpgrade.cpp
+++ b/src/meta/upgrade/MetaDataUpgrade.cpp
@@ -104,7 +104,7 @@ Status MetaDataUpgrade::rewriteIndexes(const folly::StringPiece &key,
   cpp2::IndexItem newItem;
   newItem.set_index_id(oldItem.get_index_id());
   newItem.set_index_name(oldItem.get_index_name());
-  nebula::cpp2::SchemaID schemaId;
+  cpp2::SchemaID schemaId;
   if (oldItem.get_schema_id().getType() == meta::v1::cpp2::SchemaID::Type::tag_id) {
     schemaId.set_tag_id(oldItem.get_schema_id().get_tag_id());
   } else {

--- a/src/mock/AdHocIndexManager.cpp
+++ b/src/mock/AdHocIndexManager.cpp
@@ -17,7 +17,7 @@ void AdHocIndexManager::addTagIndex(GraphSpaceID space,
   IndexItem item;
   item.set_index_id(indexID);
   item.set_index_name(folly::stringPrintf("index_%d", indexID));
-  nebula::cpp2::SchemaID schemaID;
+  nebula::meta::cpp2::SchemaID schemaID;
   schemaID.set_tag_id(tagID);
   item.set_schema_id(schemaID);
   item.set_schema_name(folly::stringPrintf("tag_%d", tagID));
@@ -55,7 +55,7 @@ void AdHocIndexManager::addEdgeIndex(GraphSpaceID space,
   IndexItem item;
   item.set_index_id(indexID);
   item.set_index_name(folly::stringPrintf("index_%d", indexID));
-  nebula::cpp2::SchemaID schemaID;
+  nebula::meta::cpp2::SchemaID schemaID;
   schemaID.set_edge_type(edgeType);
   item.set_schema_id(schemaID);
   item.set_schema_name(folly::stringPrintf("edge_%d", edgeType));


### PR DESCRIPTION
Reverts vesoft-inc/nebula#2560
for nebula-ent release.