### PR TITLE
skip the wait in rate limiter in CI

### DIFF
--- a/src/kvstore/CMakeLists.txt
+++ b/src/kvstore/CMakeLists.txt
@@ -8,6 +8,7 @@ nebula_add_library(
     RocksEngineConfig.cpp
     LogEncoder.cpp
     NebulaSnapshotManager.cpp
+    RateLimiter.cpp
     plugins/elasticsearch/ESListener.cpp
 )
 

--- a/src/kvstore/NebulaSnapshotManager.h
+++ b/src/kvstore/NebulaSnapshotManager.h
@@ -31,9 +31,9 @@ class NebulaSnapshotManager : public raftex::SnapshotManager {
                    raftex::SnapshotCallback& cb,
                    std::vector<std::string>& data,
                    int64_t& totalCount,
-                   int64_t& totalSize);
+                   int64_t& totalSize,
+                   kvstore::RateLimiter* rateLimiter);
 
-  std::unique_ptr<RateLimiter> rateLimiter_;
   NebulaStore* store_;
 };
 

--- a/src/kvstore/RateLimiter.cpp
+++ b/src/kvstore/RateLimiter.cpp
@@ -1,0 +1,11 @@
+/* Copyright (c) 2021 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#include "kvstore/RateLimiter.h"
+
+DEFINE_bool(skip_wait_in_rate_limiter,
+            false,
+            "skip the waiting of first second in rate limiter in CI");

--- a/src/kvstore/RateLimiter.h
+++ b/src/kvstore/RateLimiter.h
@@ -22,50 +22,29 @@ namespace kvstore {
 class RateLimiter {
  public:
   RateLimiter(int32_t rate, int32_t burstSize)
-      : rate_(static_cast<double>(rate)), burstSize_(static_cast<double>(burstSize)) {}
-
-  void add(GraphSpaceID spaceId, PartitionID partId) {
-    std::lock_guard<std::mutex> guard(lock_);
-    DCHECK(buckets_.find({spaceId, partId}) == buckets_.end());
+      : rate_(static_cast<double>(rate)), burstSize_(static_cast<double>(burstSize)) {
     // token will be available after 1 second, to prevent speed spike at the beginning
     auto now = time::WallClock::fastNowInSec();
     int64_t waitInSec = FLAGS_skip_wait_in_rate_limiter ? 0 : 1;
-    folly::TokenBucket bucket(rate_, burstSize_, static_cast<double>(now + waitInSec));
-    buckets_.emplace(std::make_pair(spaceId, partId), std::move(bucket));
-  }
-
-  void remove(GraphSpaceID spaceId, PartitionID partId) {
-    std::lock_guard<std::mutex> guard(lock_);
-    DCHECK(buckets_.find({spaceId, partId}) != buckets_.end());
-    buckets_.erase({spaceId, partId});
+    bucket_.reset(new folly::TokenBucket(rate_, burstSize_, static_cast<double>(now + waitInSec)));
   }
 
   // Caller must make sure the **the parition has been add, and won't be removed during consume.**
   // Snaphot and rebuild index follow this principle by design.
-  void consume(GraphSpaceID spaceId, PartitionID partId, size_t toConsume) {
-    // todo(doodle): enable this DCHECK later
-    // DCHECK(buckets_.find({spaceId, partId}) != buckets_.end());
-    auto iter = buckets_.find({spaceId, partId});
-    if (iter != buckets_.end()) {
-      if (toConsume > burstSize_) {
-        // consumeWithBorrowAndWait do nothing when toConsume > burstSize_, we sleep 1s instead
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-      } else {
-        // If there are enouth tokens, consume and return immediately.
-        // If not, cosume anyway, but sleep enough time before return.
-        auto now = time::WallClock::fastNowInSec();
-        iter->second.consumeWithBorrowAndWait(static_cast<double>(toConsume),
-                                              static_cast<double>(now));
-      }
+  void consume(size_t toConsume) {
+    if (toConsume > burstSize_) {
+      // consumeWithBorrowAndWait do nothing when toConsume > burstSize_, we sleep 1s instead
+      std::this_thread::sleep_for(std::chrono::seconds(1));
     } else {
-      LOG_EVERY_N(WARNING, 100) << folly::format(
-          "Rate limiter is not available for [{},{}]", spaceId, partId);
+      // If there are enouth tokens, consume and return immediately.
+      // If not, cosume anyway, but sleep enough time before return.
+      auto now = time::WallClock::fastNowInSec();
+      bucket_->consumeWithBorrowAndWait(static_cast<double>(toConsume), static_cast<double>(now));
     }
   }
 
  private:
-  std::unordered_map<std::pair<GraphSpaceID, PartitionID>, folly::TokenBucket> buckets_;
-  std::mutex lock_;
+  std::unique_ptr<folly::TokenBucket> bucket_;
   double rate_;
   double burstSize_;
 };

--- a/src/kvstore/RateLimiter.h
+++ b/src/kvstore/RateLimiter.h
@@ -45,8 +45,8 @@ class RateLimiter {
 
  private:
   std::unique_ptr<folly::TokenBucket> bucket_;
-  double rate_;
-  double burstSize_;
+  double rate_{1 << 20};
+  double burstSize_{1 << 20};
 };
 
 }  // namespace kvstore

--- a/src/kvstore/test/RateLimiterTest.cpp
+++ b/src/kvstore/test/RateLimiterTest.cpp
@@ -18,45 +18,33 @@ namespace kvstore {
 
 TEST(RateLimter, ConsumeLessEqualThanBurst) {
   RateLimiter limiter(FLAGS_snapshot_part_rate_limit, FLAGS_snapshot_part_rate_limit);
-  GraphSpaceID spaceId = 1;
-  PartitionID partId = 1;
-  limiter.add(spaceId, partId);
   auto now = time::WallClock::fastNowInSec();
   int64_t count = 0;
   while (count++ < 50) {
-    limiter.consume(spaceId, partId, FLAGS_snapshot_part_rate_limit / 10);
+    limiter.consume(FLAGS_snapshot_part_rate_limit / 10);
   }
   EXPECT_GE(time::WallClock::fastNowInSec() - now, 5);
-  limiter.remove(spaceId, partId);
 }
 
 TEST(RateLimter, ConsumeGreaterThanBurst) {
   RateLimiter limiter(FLAGS_snapshot_part_rate_limit, FLAGS_snapshot_part_rate_limit / 10);
-  GraphSpaceID spaceId = 1;
-  PartitionID partId = 1;
-  limiter.add(spaceId, partId);
   auto now = time::WallClock::fastNowInSec();
   int64_t count = 0;
   while (count++ < 5) {
     // greater than burst size, will sleep 1 second instead
-    limiter.consume(spaceId, partId, FLAGS_snapshot_part_rate_limit);
+    limiter.consume(FLAGS_snapshot_part_rate_limit);
   }
   EXPECT_GE(time::WallClock::fastNowInSec() - now, 5);
-  limiter.remove(spaceId, partId);
 }
 
 TEST(RateLimter, RateLessThanBurst) {
   RateLimiter limiter(FLAGS_snapshot_part_rate_limit, 2 * FLAGS_snapshot_part_rate_limit);
-  GraphSpaceID spaceId = 1;
-  PartitionID partId = 1;
-  limiter.add(spaceId, partId);
   auto now = time::WallClock::fastNowInSec();
   int64_t count = 0;
   while (count++ < 5) {
-    limiter.consume(spaceId, partId, FLAGS_snapshot_part_rate_limit);
+    limiter.consume(FLAGS_snapshot_part_rate_limit);
   }
   EXPECT_GE(time::WallClock::fastNowInSec() - now, 5);
-  limiter.remove(spaceId, partId);
 }
 
 }  // namespace kvstore

--- a/src/storage/admin/RebuildEdgeIndexTask.h
+++ b/src/storage/admin/RebuildEdgeIndexTask.h
@@ -25,7 +25,8 @@ class RebuildEdgeIndexTask : public RebuildIndexTask {
 
   nebula::cpp2::ErrorCode buildIndexGlobal(GraphSpaceID space,
                                            PartitionID part,
-                                           const IndexItems& items) override;
+                                           const IndexItems& items,
+                                           kvstore::RateLimiter* rateLimiter) override;
 };
 
 }  // namespace storage

--- a/src/storage/admin/RebuildIndexTask.h
+++ b/src/storage/admin/RebuildIndexTask.h
@@ -34,11 +34,14 @@ class RebuildIndexTask : public AdminTask {
 
   virtual nebula::cpp2::ErrorCode buildIndexGlobal(GraphSpaceID space,
                                                    PartitionID part,
-                                                   const IndexItems& items) = 0;
+                                                   const IndexItems& items,
+                                                   kvstore::RateLimiter* rateLimiter) = 0;
 
   void cancel() override { canceled_ = true; }
 
-  nebula::cpp2::ErrorCode buildIndexOnOperations(GraphSpaceID space, PartitionID part);
+  nebula::cpp2::ErrorCode buildIndexOnOperations(GraphSpaceID space,
+                                                 PartitionID part,
+                                                 kvstore::RateLimiter* rateLimiter);
 
   // Remove the legacy operation log to make sure the index is correct.
   nebula::cpp2::ErrorCode removeLegacyLogs(GraphSpaceID space, PartitionID part);
@@ -46,18 +49,19 @@ class RebuildIndexTask : public AdminTask {
   nebula::cpp2::ErrorCode writeData(GraphSpaceID space,
                                     PartitionID part,
                                     std::vector<kvstore::KV> data,
-                                    size_t batchSize);
+                                    size_t batchSize,
+                                    kvstore::RateLimiter* rateLimiter);
 
   nebula::cpp2::ErrorCode writeOperation(GraphSpaceID space,
                                          PartitionID part,
-                                         kvstore::BatchHolder* batchHolder);
+                                         kvstore::BatchHolder* batchHolder,
+                                         kvstore::RateLimiter* rateLimiter);
 
   nebula::cpp2::ErrorCode invoke(GraphSpaceID space, PartitionID part, const IndexItems& items);
 
  protected:
   std::atomic<bool> canceled_{false};
   GraphSpaceID space_;
-  std::unique_ptr<kvstore::RateLimiter> rateLimiter_;
 };
 
 }  // namespace storage

--- a/src/storage/admin/RebuildTagIndexTask.h
+++ b/src/storage/admin/RebuildTagIndexTask.h
@@ -26,7 +26,8 @@ class RebuildTagIndexTask : public RebuildIndexTask {
 
   nebula::cpp2::ErrorCode buildIndexGlobal(GraphSpaceID space,
                                            PartitionID part,
-                                           const IndexItems& items) override;
+                                           const IndexItems& items,
+                                           kvstore::RateLimiter* rateLimiter) override;
 };
 
 }  // namespace storage

--- a/tests/common/nebula_service.py
+++ b/tests/common/nebula_service.py
@@ -77,6 +77,7 @@ class NebulaService(object):
         if name == 'storaged':
             params.append('--local_config=false')
             params.append('--raft_heartbeat_interval_secs=30')
+            params.append('--skip_wait_in_rate_limiter=true')
         if debug_log:
             params.append('--v=4')
         param_format = " ".join(params)


### PR DESCRIPTION
Skip the first second wait in rate limiter, which will take 1 second in every case in TCK tests. And then, another core occur, see #2794, remove the DCHECK temporally. 

Duration of TCK should back to normal.

TCK with ASAN still time out, probably because of spin lock. Still working on it.

![image](https://user-images.githubusercontent.com/13706157/132304659-599a7447-556c-4eca-877a-0fe8abb29e9c.png)
