### PR TITLE
tck testcases strengthening

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Make
         run: |
           ccache -z
-          cmake --build build/ -j $(nproc)
+          cmake --build build/ -j $(($(nproc)/2+1))
           ccache -s
       - name: CTest
         env:

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -426,6 +426,8 @@ def load_csv_data(
         for line in schemas.splitlines():
             resp_ok(sess, line.strip(), True)
 
+        time.sleep(1)
+
         for fd in config["files"]:
             _load_data_from_file(sess, data_dir, fd)
 


### PR DESCRIPTION
Remove unnecessary index rebuilding.
The index has been created before the data import, so instead of rebuilding.
Let's verify the stability of CI.