### PR TITLE
Revert "Ignore some path don't impact workflow."

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,11 +6,6 @@ on:
     branches:
       - master
       - 'v[0-9]+.*'
-    paths-ignore:
-      - 'docs/**'
-      - 'LICENSES/**'
-      - 'LICENSE'
-      - '**.md'
 
 defaults:
   run:


### PR DESCRIPTION
Reverts vesoft-inc/nebula#2513

Some markdown modifications can no longer trigger our CI, which in turn prevents PR from being merged