### PR TITLE
Fix ply.yacc read parsetab.py error and lookup tests optimization

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -25,7 +25,7 @@
 #include "webservice/Common.h"
 
 DEFINE_uint32(expired_time_factor, 5, "The factor of expired time based on heart beat interval");
-DEFINE_int32(heartbeat_interval_secs, 10, "Heartbeat interval");
+DEFINE_int32(heartbeat_interval_secs, 10, "Heartbeat interval in seconds");
 DEFINE_int32(meta_client_retry_times, 3, "meta client retry times, 0 means no retry");
 DEFINE_int32(meta_client_retry_interval_secs, 1, "meta client sleep interval between retry");
 DEFINE_int32(meta_client_timeout_ms, 60 * 1000, "meta client timeout");

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -556,8 +556,7 @@ void NebulaStore::removeSpaceDir(const std::string& dir) {
     LOG(INFO) << "Try to remove space directory: " << dir;
     boost::filesystem::remove_all(dir);
   } catch (const boost::filesystem::filesystem_error& e) {
-    LOG(ERROR) << "Exception caught while remove directory, please delelte it "
-                  "by manual: "
+    LOG(ERROR) << "Exception caught while remove directory, please delelte it by manual: "
                << e.what();
   }
 }

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -427,7 +427,7 @@ def load_csv_data(
             resp_ok(sess, line.strip(), True)
 
         # wait heartbeat_interval_secs seconds for schema synchronization
-        time.sleep(1)
+        time.sleep(2)
 
         for fd in config["files"]:
             _load_data_from_file(sess, data_dir, fd)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,5 +9,5 @@ pytest-drop-dup-tests==0.3.0
 pytest-bdd==4.0.2
 pytest-yapf3==0.5.1
 filelock==3.0.12
-ply==3.11
+ply==3.10
 pyyaml==5.4

--- a/tests/tck/features/lookup/ByIndex.feature
+++ b/tests/tck/features/lookup/ByIndex.feature
@@ -4,11 +4,8 @@
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
 Feature: Lookup by index itself
 
-  Background:
-    Given an empty graph
-    And load "nba" csv data to a new space
-
   Scenario: [1] tag index
+    Given a graph with space named "nba"
     When executing query:
       """
       LOOKUP ON team
@@ -81,9 +78,9 @@ Feature: Lookup by index itself
       | '76ers'         | '76ers'         |
       | 'Trail Blazers' | 'Trail Blazers' |
       | 'Bulls'         | 'Bulls'         |
-    And drop the used space
 
   Scenario: [1] Tag TODO
+    Given a graph with space named "nba"
     When executing query:
       """
       LOOKUP ON team WHERE 1 + 1 == 2
@@ -104,9 +101,9 @@ Feature: Lookup by index itself
       LOOKUP ON player WHERE player.age > -9223372036854775808-1
       """
     Then a ExecutionError should be raised at runtime: result of (-9223372036854775808-1) cannot be represented as an integer
-    And drop the used space
 
   Scenario: [2] edge index
+    Given a graph with space named "nba"
     When executing query:
       """
       LOOKUP ON serve
@@ -423,9 +420,9 @@ Feature: Lookup by index itself
       | 'Dwight Howard'         | 'Hawks'         | 0       | 2016      |
       | 'Dwight Howard'         | 'Hornets'       | 0       | 2017      |
       | 'Dwight Howard'         | 'Wizards'       | 0       | 2018      |
-    And drop the used space
 
   Scenario: [2] Edge TODO
+    Given a graph with space named "nba"
     When executing query:
       """
       LOOKUP ON serve WHERE 1 + 1 == 2
@@ -446,9 +443,9 @@ Feature: Lookup by index itself
       LOOKUP ON serve WHERE serve.start_year == serve.end_year YIELD serve.start_year AS startYear
       """
     Then a SemanticError should be raised at runtime:
-    And drop the used space
 
   Scenario: [1] Compare INT and FLOAT during IndexScan
+    Given a graph with space named "nba"
     When executing query:
       """
       LOOKUP ON player WHERE player.age == 40 YIELD player.age AS Age
@@ -549,10 +546,11 @@ Feature: Lookup by index itself
       | "Amar'e Stoudemire" | 36  | "Amar'e Stoudemire" |
       | "Boris Diaw"        | 36  | "Boris Diaw"        |
       | "Tony Parker"       | 36  | "Tony Parker"       |
-    And drop the used space
 
   Scenario: [2] Compare INT and FLOAT during IndexScan
-    Given having executed:
+    Given an empty graph
+    And load "nba" csv data to a new space
+    And having executed:
       """
       CREATE TAG weight (WEIGHT double);
       CREATE TAG INDEX weight_index ON weight(WEIGHT);

--- a/tests/tck/features/lookup/ByIndex.intVid.feature
+++ b/tests/tck/features/lookup/ByIndex.intVid.feature
@@ -4,11 +4,8 @@
 # attached with Common Clause Condition 1.0, found in the LICENSES directory.
 Feature: Lookup by index itself in integer vid
 
-  Background:
-    Given an empty graph
-    And load "nba_int_vid" csv data to a new space
-
   Scenario: [1] tag index
+    Given a graph with space named "nba_int_vid"
     When executing query:
       """
       LOOKUP ON team
@@ -81,9 +78,9 @@ Feature: Lookup by index itself in integer vid
       | '76ers'         | '76ers'         |
       | 'Trail Blazers' | 'Trail Blazers' |
       | 'Bulls'         | 'Bulls'         |
-    And drop the used space
 
   Scenario: [1] Tag TODO
+    Given a graph with space named "nba_int_vid"
     When executing query:
       """
       LOOKUP ON team WHERE 1 + 1 == 2
@@ -104,9 +101,9 @@ Feature: Lookup by index itself in integer vid
       LOOKUP ON player WHERE player.age > -9223372036854775808-1
       """
     Then a ExecutionError should be raised at runtime: result of (-9223372036854775808-1) cannot be represented as an integer
-    And drop the used space
 
   Scenario: [2] edge index
+    Given a graph with space named "nba_int_vid"
     When executing query:
       """
       LOOKUP ON serve
@@ -423,9 +420,9 @@ Feature: Lookup by index itself in integer vid
       | 'Dwight Howard'         | 'Hawks'         | 0       | 2016      |
       | 'Dwight Howard'         | 'Hornets'       | 0       | 2017      |
       | 'Dwight Howard'         | 'Wizards'       | 0       | 2018      |
-    And drop the used space
 
   Scenario: [2] Edge TODO
+    Given a graph with space named "nba_int_vid"
     When executing query:
       """
       LOOKUP ON serve WHERE 1 + 1 == 2
@@ -446,9 +443,9 @@ Feature: Lookup by index itself in integer vid
       LOOKUP ON serve WHERE serve.start_year == serve.end_year YIELD serve.start_year AS startYear
       """
     Then a SemanticError should be raised at runtime:
-    And drop the used space
 
   Scenario: [1] Compare INT and FLOAT during IndexScan
+    Given a graph with space named "nba_int_vid"
     When executing query:
       """
       LOOKUP ON player WHERE player.age == 40 YIELD player.age AS Age
@@ -549,10 +546,11 @@ Feature: Lookup by index itself in integer vid
       | "Amar'e Stoudemire" | 36  | "Amar'e Stoudemire" |
       | "Boris Diaw"        | 36  | "Boris Diaw"        |
       | "Tony Parker"       | 36  | "Tony Parker"       |
-    And drop the used space
 
   Scenario: [2] Compare INT and FLOAT during IndexScan
-    Given having executed:
+    Given an empty graph
+    And load "nba_int_vid" csv data to a new space
+    And having executed:
       """
       CREATE TAG weight (WEIGHT double);
       CREATE TAG INDEX weight_index ON weight(WEIGHT);

--- a/tests/tck/features/lookup/TagIndexFullScan.feature
+++ b/tests/tck/features/lookup/TagIndexFullScan.feature
@@ -1,8 +1,7 @@
 Feature: Lookup tag index full scan
 
   Background:
-    Given an empty graph
-    And load "nba" csv data to a new space
+    Given a graph with space named "nba"
 
   Scenario: Tag with relational RegExp filter[1]
     When executing query:

--- a/tests/tck/utils/nbv.py
+++ b/tests/tck/utils/nbv.py
@@ -563,11 +563,11 @@ def register_function(name, func):
 register_function('hash', murmurhash2)
 
 
-parser = yacc.yacc()
+parser = yacc.yacc(write_tables=False)
 
 
 def parse(s):
-    return parser.parse(s)
+    return parser.parse(s, lexer=lexer)
 
 
 def parse_row(row):


### PR DESCRIPTION
1. Need not to create new space for only read queries.
2. Wait more seconds to update schema cache in meta client

### Reference
* https://github.com/mailgun/flanker/issues/168
* https://github.com/mailgun/flanker/pull/188
* https://github.com/vesoft-inc/nebula/runs/3586920120?check_suite_focus=true