### PR TITLE
Cleanup static variables in header files

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -109,8 +109,8 @@ jobs:
                 -DENABLE_ASAN=on \
                 -DENABLE_TESTING=on \
                 -B build
-              echo "::set-output name=j::6"
-              echo "::set-output name=t::10"
+            echo "::set-output name=j::6"
+            echo "::set-output name=t::10"
             ;;
           esac
       - name: Make

--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -24,6 +24,9 @@
 #include "version/Version.h"
 #include "webservice/Common.h"
 
+DECLARE_int32(ws_meta_http_port);
+DECLARE_int32(ws_meta_h2_port);
+
 DEFINE_uint32(expired_time_factor, 5, "The factor of expired time based on heart beat interval");
 DEFINE_int32(heartbeat_interval_secs, 10, "Heartbeat interval in seconds");
 DEFINE_int32(meta_client_retry_times, 3, "meta client retry times, 0 means no retry");
@@ -31,6 +34,7 @@ DEFINE_int32(meta_client_retry_interval_secs, 1, "meta client sleep interval bet
 DEFINE_int32(meta_client_timeout_ms, 60 * 1000, "meta client timeout");
 DEFINE_string(cluster_id_path, "cluster.id", "file path saved clusterId");
 DEFINE_int32(check_plan_killed_frequency, 8, "check plan killed every 1<<n times");
+
 namespace nebula {
 namespace meta {
 

--- a/src/meta/http/MetaHttpDownloadHandler.cpp
+++ b/src/meta/http/MetaHttpDownloadHandler.cpp
@@ -21,6 +21,8 @@
 #include "webservice/Common.h"
 #include "webservice/WebService.h"
 
+DECLARE_int32(ws_storage_http_port);
+
 namespace nebula {
 namespace meta {
 

--- a/src/meta/http/MetaHttpIngestHandler.cpp
+++ b/src/meta/http/MetaHttpIngestHandler.cpp
@@ -18,6 +18,9 @@
 #include "webservice/Common.h"
 #include "webservice/WebService.h"
 
+DECLARE_int32(ws_storage_http_port);
+DECLARE_int32(ws_storage_h2_port);
+
 DEFINE_int32(meta_ingest_thread_num, 3, "Meta daemon's ingest thread number");
 
 namespace nebula {

--- a/src/webservice/CMakeLists.txt
+++ b/src/webservice/CMakeLists.txt
@@ -10,9 +10,10 @@ nebula_add_library(
     GetFlagsHandler.cpp
     SetFlagsHandler.cpp
     GetStatsHandler.cpp
-	Router.cpp
-	StatusHandler.cpp
+    Router.cpp
+    StatusHandler.cpp
 )
+
 set_target_properties(ws_obj PROPERTIES COMPILE_FLAGS "-Wno-error=format-security")
 
 nebula_add_library(

--- a/src/webservice/Common.cpp
+++ b/src/webservice/Common.cpp
@@ -6,7 +6,21 @@
 
 #include "webservice/Common.h"
 
+#include <gflags/gflags.h>
+
 DEFINE_int32(ws_meta_http_port, 11000, "Port to listen on Meta with HTTP protocol");
 DEFINE_int32(ws_meta_h2_port, 11002, "Port to listen on Meta with HTTP/2 protocol");
 DEFINE_int32(ws_storage_http_port, 12000, "Port to listen on Storage with HTTP protocol");
 DEFINE_int32(ws_storage_h2_port, 12002, "Port to listen on Storage with HTTP/2 protocol");
+
+namespace nebula {
+
+std::unordered_map<HttpStatusCode, std::string> WebServiceUtils::kStatusStringMap_ = {
+    {HttpStatusCode::OK, "OK"},
+    {HttpStatusCode::BAD_REQUEST, "Bad Request"},
+    {HttpStatusCode::FORBIDDEN, "Forbidden"},
+    {HttpStatusCode::NOT_FOUND, "Not Found"},
+    {HttpStatusCode::METHOD_NOT_ALLOWED, "Method Not Allowed"},
+};
+
+}  // namespace nebula

--- a/src/webservice/Common.h
+++ b/src/webservice/Common.h
@@ -7,12 +7,9 @@
 #ifndef WEBSERVICE_COMMON_H_
 #define WEBSERVICE_COMMON_H_
 
-#include "common/base/Base.h"
-
-DECLARE_int32(ws_meta_http_port);
-DECLARE_int32(ws_meta_h2_port);
-DECLARE_int32(ws_storage_http_port);
-DECLARE_int32(ws_storage_h2_port);
+#include <cstdint>
+#include <string>
+#include <unordered_map>
 
 namespace nebula {
 
@@ -23,7 +20,7 @@ enum class HttpCode {
   E_ILLEGAL_ARGUMENT = -3,
 };
 
-enum class HttpStatusCode {
+enum class HttpStatusCode : int32_t {
   OK = 200,
   BAD_REQUEST = 400,
   FORBIDDEN = 403,
@@ -31,19 +28,15 @@ enum class HttpStatusCode {
   METHOD_NOT_ALLOWED = 405,
 };
 
-static std::map<HttpStatusCode, std::string> statusStringMap{
-    {HttpStatusCode::OK, "OK"},
-    {HttpStatusCode::BAD_REQUEST, "Bad Request"},
-    {HttpStatusCode::FORBIDDEN, "Forbidden"},
-    {HttpStatusCode::NOT_FOUND, "Not Found"},
-    {HttpStatusCode::METHOD_NOT_ALLOWED, "Method Not Allowed"}};
-
 class WebServiceUtils final {
  public:
   static int32_t to(HttpStatusCode code) { return static_cast<int32_t>(code); }
+  static std::string toString(HttpStatusCode code) { return kStatusStringMap_[code]; }
 
-  static std::string toString(HttpStatusCode code) { return statusStringMap[code]; }
+ private:
+  static std::unordered_map<HttpStatusCode, std::string> kStatusStringMap_;
 };
 
 }  // namespace nebula
+
 #endif  // WEBSERVICE_COMMON_H_

--- a/src/webservice/test/CMakeLists.txt
+++ b/src/webservice/test/CMakeLists.txt
@@ -11,6 +11,7 @@ nebula_add_test(
     OBJECTS
         $<TARGET_OBJECTS:http_client_obj>
         $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:ws_common_obj>
         $<TARGET_OBJECTS:base_obj>
         $<TARGET_OBJECTS:process_obj>
         $<TARGET_OBJECTS:fs_obj>
@@ -31,6 +32,7 @@ nebula_add_test(
     OBJECTS
         $<TARGET_OBJECTS:http_client_obj>
         $<TARGET_OBJECTS:ws_obj>
+        $<TARGET_OBJECTS:ws_common_obj>
         $<TARGET_OBJECTS:base_obj>
         $<TARGET_OBJECTS:process_obj>
         $<TARGET_OBJECTS:fs_obj>


### PR DESCRIPTION
We should not directly define static variables in the header file