### PR TITLE
fixed bug limit push down of index scan.

### DIFF
--- a/src/storage/exec/IndexEdgeNode.h
+++ b/src/storage/exec/IndexEdgeNode.h
@@ -22,7 +22,7 @@ class IndexEdgeNode final : public RelNode<T> {
                 IndexScanNode<T>* indexScanNode,
                 const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& schemas,
                 const std::string& schemaName,
-                int64_t limit)
+                int64_t limit = -1)
       : context_(context),
         indexScanNode_(indexScanNode),
         schemas_(schemas),
@@ -42,11 +42,7 @@ class IndexEdgeNode final : public RelNode<T> {
     data_.clear();
     std::vector<storage::cpp2::EdgeKey> edges;
     auto* iter = static_cast<EdgeIndexIterator*>(indexScanNode_->iterator());
-    int64_t count = 0;
     while (iter && iter->valid()) {
-      if (limit_ > -1 && count++ == limit_) {
-        break;
-      }
       if (context_->isPlanKilled()) {
         return nebula::cpp2::ErrorCode::E_PLAN_IS_KILLED;
       }
@@ -66,6 +62,7 @@ class IndexEdgeNode final : public RelNode<T> {
       edges.emplace_back(std::move(edge));
       iter->next();
     }
+    int64_t count = 1;
     for (const auto& edge : edges) {
       auto key = NebulaKeyUtils::edgeKey(context_->vIdLen(),
                                          partId,
@@ -81,6 +78,9 @@ class IndexEdgeNode final : public RelNode<T> {
         continue;
       } else {
         return ret;
+      }
+      if (limit_ > 0 && ++count > limit_) {
+        break;
       }
     }
     return nebula::cpp2::ErrorCode::SUCCEEDED;

--- a/src/storage/exec/IndexEdgeNode.h
+++ b/src/storage/exec/IndexEdgeNode.h
@@ -62,7 +62,7 @@ class IndexEdgeNode final : public RelNode<T> {
       edges.emplace_back(std::move(edge));
       iter->next();
     }
-    int64_t count = 1;
+    int64_t count = 0;
     for (const auto& edge : edges) {
       auto key = NebulaKeyUtils::edgeKey(context_->vIdLen(),
                                          partId,
@@ -79,7 +79,7 @@ class IndexEdgeNode final : public RelNode<T> {
       } else {
         return ret;
       }
-      if (limit_ > 0 && ++count > limit_) {
+      if (limit_ > 0 && ++count >= limit_) {
         break;
       }
     }

--- a/src/storage/exec/IndexFilterNode.h
+++ b/src/storage/exec/IndexFilterNode.h
@@ -86,7 +86,7 @@ class IndexFilterNode final : public RelNode<T> {
     } else {
       data = indexVertexNode_->moveData();
     }
-    int64_t count = 1;
+    int64_t count = 0;
     for (const auto& k : data) {
       if (context_->isPlanKilled()) {
         return nebula::cpp2::ErrorCode::E_PLAN_IS_KILLED;
@@ -108,7 +108,7 @@ class IndexFilterNode final : public RelNode<T> {
           count++;
         }
       }
-      if (limit_ > 0 && count > limit_) {
+      if (limit_ > 0 && count >= limit_) {
         break;
       }
     }

--- a/src/storage/exec/IndexScanNode.h
+++ b/src/storage/exec/IndexScanNode.h
@@ -72,7 +72,7 @@ class IndexScanNode : public RelNode<T> {
     auto* sh = context_->isEdge() ? context_->edgeSchema_ : context_->tagSchema_;
     auto ttlProp = CommonUtils::ttlProps(sh);
     data_.clear();
-    int64_t count = 1;
+    int64_t count = 0;
     while (!!iter_ && iter_->valid()) {
       if (context_->isPlanKilled()) {
         return {};
@@ -86,7 +86,7 @@ class IndexScanNode : public RelNode<T> {
         }
       }
       data_.emplace_back(iter_->key(), "");
-      if (limit_ > 0 && ++count > limit_) {
+      if (limit_ > 0 && ++count >= limit_) {
         break;
       }
       iter_->next();

--- a/src/storage/exec/IndexVertexNode.h
+++ b/src/storage/exec/IndexVertexNode.h
@@ -58,7 +58,7 @@ class IndexVertexNode final : public RelNode<T> {
       vids.emplace_back(iter->vId());
       iter->next();
     }
-    int64_t count = 1;
+    int64_t count = 0;
     for (const auto& vId : vids) {
       VLOG(1) << "partId " << partId << ", vId " << vId << ", tagId " << context_->tagId_;
       auto key = NebulaKeyUtils::vertexKey(context_->vIdLen(), partId, vId, context_->tagId_);
@@ -71,7 +71,7 @@ class IndexVertexNode final : public RelNode<T> {
       } else {
         return ret;
       }
-      if (limit_ > 0 && ++count > limit_) {
+      if (limit_ > 0 && ++count >= limit_) {
         break;
       }
     }

--- a/src/storage/exec/IndexVertexNode.h
+++ b/src/storage/exec/IndexVertexNode.h
@@ -22,7 +22,7 @@ class IndexVertexNode final : public RelNode<T> {
                   IndexScanNode<T>* indexScanNode,
                   const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& schemas,
                   const std::string& schemaName,
-                  int64_t limit)
+                  int64_t limit = -1)
       : context_(context),
         indexScanNode_(indexScanNode),
         schemas_(schemas),
@@ -42,11 +42,8 @@ class IndexVertexNode final : public RelNode<T> {
     data_.clear();
     std::vector<VertexID> vids;
     auto* iter = static_cast<VertexIndexIterator*>(indexScanNode_->iterator());
-    int64_t count = 0;
+
     while (iter && iter->valid()) {
-      if (limit_ > -1 && count++ == limit_) {
-        break;
-      }
       if (context_->isPlanKilled()) {
         return nebula::cpp2::ErrorCode::E_PLAN_IS_KILLED;
       }
@@ -61,6 +58,7 @@ class IndexVertexNode final : public RelNode<T> {
       vids.emplace_back(iter->vId());
       iter->next();
     }
+    int64_t count = 1;
     for (const auto& vId : vids) {
       VLOG(1) << "partId " << partId << ", vId " << vId << ", tagId " << context_->tagId_;
       auto key = NebulaKeyUtils::vertexKey(context_->vIdLen(), partId, vId, context_->tagId_);
@@ -72,6 +70,9 @@ class IndexVertexNode final : public RelNode<T> {
         continue;
       } else {
         return ret;
+      }
+      if (limit_ > 0 && ++count > limit_) {
+        break;
       }
     }
     return nebula::cpp2::ErrorCode::SUCCEEDED;

--- a/src/storage/index/LookupBaseProcessor-inl.h
+++ b/src/storage/index/LookupBaseProcessor-inl.h
@@ -167,6 +167,8 @@ template <typename REQ, typename RESP>
 StatusOr<StoragePlan<IndexID>> LookupBaseProcessor<REQ, RESP>::buildPlan(
     IndexFilterItem* filterItem, nebula::DataSet* result) {
   StoragePlan<IndexID> plan;
+  // TODO(sky) : Limit is not supported yet for de-dup node.
+  //             Related to paging scan, the de-dup execution plan needs to be refactored
   auto deDup = std::make_unique<DeDupNode<IndexID>>(result, deDupColPos_);
   int32_t filterId = 0;
   std::unique_ptr<IndexOutputNode<IndexID>> out;
@@ -319,8 +321,8 @@ std::unique_ptr<IndexOutputNode<IndexID>> LookupBaseProcessor<REQ, RESP>::buildP
   auto indexId = ctx.get_index_id();
   auto colHints = ctx.get_column_hints();
 
-  auto indexScan = std::make_unique<IndexScanNode<IndexID>>(
-      context_.get(), indexId, std::move(colHints), limit_);
+  auto indexScan =
+      std::make_unique<IndexScanNode<IndexID>>(context_.get(), indexId, std::move(colHints));
   if (context_->isEdge()) {
     auto edge = std::make_unique<IndexEdgeNode<IndexID>>(
         context_.get(), indexScan.get(), schemas_, context_->edgeName_, limit_);
@@ -370,11 +372,11 @@ std::unique_ptr<IndexOutputNode<IndexID>> LookupBaseProcessor<REQ, RESP>::buildP
   auto indexId = ctx.get_index_id();
   auto colHints = ctx.get_column_hints();
 
-  auto indexScan = std::make_unique<IndexScanNode<IndexID>>(
-      context_.get(), indexId, std::move(colHints), limit_);
+  auto indexScan =
+      std::make_unique<IndexScanNode<IndexID>>(context_.get(), indexId, std::move(colHints));
 
   auto filter = std::make_unique<IndexFilterNode<IndexID>>(
-      context_.get(), indexScan.get(), exprCtx, exp, context_->isEdge());
+      context_.get(), indexScan.get(), exprCtx, exp, context_->isEdge(), limit_);
   filter->addDependency(indexScan.get());
   auto output =
       std::make_unique<IndexOutputNode<IndexID>>(result, context_.get(), filter.get(), true);
@@ -421,14 +423,14 @@ LookupBaseProcessor<REQ, RESP>::buildPlanWithDataAndFilter(nebula::DataSet* resu
   auto indexId = ctx.get_index_id();
   auto colHints = ctx.get_column_hints();
 
-  auto indexScan = std::make_unique<IndexScanNode<IndexID>>(
-      context_.get(), indexId, std::move(colHints), limit_);
+  auto indexScan =
+      std::make_unique<IndexScanNode<IndexID>>(context_.get(), indexId, std::move(colHints));
   if (context_->isEdge()) {
     auto edge = std::make_unique<IndexEdgeNode<IndexID>>(
-        context_.get(), indexScan.get(), schemas_, context_->edgeName_, limit_);
+        context_.get(), indexScan.get(), schemas_, context_->edgeName_);
     edge->addDependency(indexScan.get());
-    auto filter =
-        std::make_unique<IndexFilterNode<IndexID>>(context_.get(), edge.get(), exprCtx, exp);
+    auto filter = std::make_unique<IndexFilterNode<IndexID>>(
+        context_.get(), edge.get(), exprCtx, exp, limit_);
     filter->addDependency(edge.get());
 
     auto output = std::make_unique<IndexOutputNode<IndexID>>(result, context_.get(), filter.get());
@@ -439,10 +441,10 @@ LookupBaseProcessor<REQ, RESP>::buildPlanWithDataAndFilter(nebula::DataSet* resu
     return output;
   } else {
     auto vertex = std::make_unique<IndexVertexNode<IndexID>>(
-        context_.get(), indexScan.get(), schemas_, context_->tagName_, limit_);
+        context_.get(), indexScan.get(), schemas_, context_->tagName_);
     vertex->addDependency(indexScan.get());
-    auto filter =
-        std::make_unique<IndexFilterNode<IndexID>>(context_.get(), vertex.get(), exprCtx, exp);
+    auto filter = std::make_unique<IndexFilterNode<IndexID>>(
+        context_.get(), vertex.get(), exprCtx, exp, limit_);
     filter->addDependency(vertex.get());
 
     auto output = std::make_unique<IndexOutputNode<IndexID>>(result, context_.get(), filter.get());

--- a/src/storage/index/LookupProcessor.cpp
+++ b/src/storage/index/LookupProcessor.cpp
@@ -23,6 +23,11 @@ void LookupProcessor::process(const cpp2::LookupIndexRequest& req) {
 
 void LookupProcessor::doProcess(const cpp2::LookupIndexRequest& req) {
   auto retCode = requestCheck(req);
+  if (limit_ == 0) {
+    onProcessFinished();
+    onFinished();
+    return;
+  }
   if (retCode != nebula::cpp2::ErrorCode::SUCCEEDED) {
     for (auto& p : req.get_parts()) {
       pushResultCode(retCode, p);

--- a/src/storage/test/IndexScanLimitTest.cpp
+++ b/src/storage/test/IndexScanLimitTest.cpp
@@ -20,6 +20,9 @@
 
 namespace nebula {
 namespace storage {
+ObjectPool objPool;
+auto pool = &objPool;
+
 class IndexScanLimitTest : public ::testing::Test {
  protected:
   GraphSpaceID spaceId = 1;
@@ -98,36 +101,35 @@ class IndexScanLimitTest : public ::testing::Test {
     }
 
     // Edge and vertex have the same schema of structure, so it's good to only generate it once.
-    RowWriterV2 writer(tag.get());
-    auto r1 = writer.setValue(0, 888);
-    if (r1 != WriteResult::SUCCEEDED) {
-      LOG(ERROR) << "Invalid prop col1";
-      return false;
-    }
-    auto r2 = writer.setValue(1, "row");
-    if (r2 != WriteResult::SUCCEEDED) {
-      LOG(ERROR) << "Invalid prop col2";
-      return false;
-    }
-    auto ret = writer.finish();
-    if (ret != WriteResult::SUCCEEDED) {
-      LOG(ERROR) << "Failed to write data";
-      return false;
-    }
-    auto val = std::move(writer).moveEncodedStr();
+    RowWriterV2 writer1(tag.get());
+    EXPECT_EQ(WriteResult::SUCCEEDED, writer1.setValue(0, 111));
+    EXPECT_EQ(WriteResult::SUCCEEDED, writer1.setValue(1, "row_111"));
+    EXPECT_EQ(WriteResult::SUCCEEDED, writer1.finish());
+    auto val1 = std::move(writer1).moveEncodedStr();
+    RowWriterV2 writer2(tag.get());
+    EXPECT_EQ(WriteResult::SUCCEEDED, writer2.setValue(0, 222));
+    EXPECT_EQ(WriteResult::SUCCEEDED, writer2.setValue(1, "row_222"));
+    EXPECT_EQ(WriteResult::SUCCEEDED, writer2.finish());
+    auto val2 = std::move(writer2).moveEncodedStr();
 
     for (auto pId : parts) {
       std::vector<kvstore::KV> data;
       for (int64_t vid = pId * 1000; vid < (pId + 1) * 1000; vid++) {
+        int64_t col1Val = vid % 2 == 0 ? 111 : 222;
+        std::string val = vid % 2 == 0 ? val1 : val2;
         auto vertex = folly::to<std::string>(vid);
-        auto edgeKey = NebulaKeyUtils::edgeKey(8, pId, vertex, edgeType, 0, vertex);
-        auto vertexKey = NebulaKeyUtils::vertexKey(8, pId, vertex, tagId);
+        auto edgeKey = NebulaKeyUtils::edgeKey(vertexLen, pId, vertex, edgeType, 0, vertex);
+        auto vertexKey = NebulaKeyUtils::vertexKey(vertexLen, pId, vertex, tagId);
         data.emplace_back(std::move(edgeKey), val);
-        data.emplace_back(std::move(vertexKey), val);
+        data.emplace_back(std::move(vertexKey), std::move(val));
         if (indexMan_ != nullptr) {
           if (indexMan_->getTagIndex(spaceId, tagIndex).ok()) {
-            auto vertexIndexKey = IndexKeyUtils::vertexIndexKey(
-                vertexLen, pId, tagIndex, vertex, IndexKeyUtils::encodeValues({888}, genCols()));
+            auto vertexIndexKey =
+                IndexKeyUtils::vertexIndexKey(vertexLen,
+                                              pId,
+                                              tagIndex,
+                                              vertex,
+                                              IndexKeyUtils::encodeValues({col1Val}, genCols()));
             data.emplace_back(std::move(vertexIndexKey), "");
           }
           if (indexMan_->getEdgeIndex(spaceId, edgeIndex).ok()) {
@@ -138,7 +140,7 @@ class IndexScanLimitTest : public ::testing::Test {
                                             vertex,
                                             0,
                                             vertex,
-                                            IndexKeyUtils::encodeValues({888}, genCols()));
+                                            IndexKeyUtils::encodeValues({col1Val}, genCols()));
             data.emplace_back(std::move(edgeIndexKey), "");
           }
         }
@@ -239,18 +241,41 @@ TEST_F(IndexScanLimitTest, LookupTagIndexLimit) {
     EXPECT_EQ(5 * parts.size(), resp.get_data()->rows.size());
   }
 
-  // limit 5 by each part through IndexScanNode->DataNode->FilterNode
+  // limit 5 by each part through IndexScanNode->DataNode
   {
     req.set_limit(5);
     cpp2::IndexColumnHint columnHint;
-    columnHint.set_begin_value(Value(888));
+    columnHint.set_begin_value(Value(111));
     columnHint.set_column_name("col1");
     columnHint.set_scan_type(cpp2::ScanType::PREFIX);
     std::vector<cpp2::IndexColumnHint> columnHints;
     columnHints.emplace_back(std::move(columnHint));
+    req.return_columns_ref().value().emplace_back("col2");
     req.indices_ref().value().contexts_ref().value().begin()->set_column_hints(
         std::move(columnHints));
+    auto* processor = LookupProcessor::instance(storageEnv_.get(), nullptr, nullptr);
+    auto fut = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(fut).get();
+    EXPECT_EQ(0, resp.result.failed_parts.size());
+    EXPECT_EQ(5 * parts.size(), resp.get_data()->rows.size());
+  }
 
+  // limit 5 by each part through IndexScanNode->DataNode->FilterNode
+  {
+    req.set_limit(5);
+    cpp2::IndexColumnHint columnHint;
+    columnHint.set_begin_value(Value(111));
+    columnHint.set_column_name("col1");
+    columnHint.set_scan_type(cpp2::ScanType::PREFIX);
+    std::vector<cpp2::IndexColumnHint> columnHints;
+    columnHints.emplace_back(std::move(columnHint));
+    auto expr = RelationalExpression::makeNE(pool,
+                                             TagPropertyExpression::make(pool, "100", "col1"),
+                                             ConstantExpression::make(pool, Value(300L)));
+    req.indices_ref().value().contexts_ref().value().begin()->set_filter(expr->encode());
+    req.indices_ref().value().contexts_ref().value().begin()->set_column_hints(
+        std::move(columnHints));
     auto* processor = LookupProcessor::instance(storageEnv_.get(), nullptr, nullptr);
     auto fut = processor->getFuture();
     processor->process(req);
@@ -310,18 +335,42 @@ TEST_F(IndexScanLimitTest, LookupEdgeIndexLimit) {
     EXPECT_EQ(5 * parts.size(), resp.get_data()->rows.size());
   }
 
-  // limit 5 by each part through IndexScanNode->DataNode->FilterNode
+  // limit 5 by each part through IndexScanNode->DataNode
   {
     req.set_limit(5);
     cpp2::IndexColumnHint columnHint;
-    columnHint.set_begin_value(Value(888));
+    columnHint.set_begin_value(Value(111));
     columnHint.set_column_name("col1");
     columnHint.set_scan_type(cpp2::ScanType::PREFIX);
     std::vector<cpp2::IndexColumnHint> columnHints;
     columnHints.emplace_back(std::move(columnHint));
+    req.return_columns_ref().value().emplace_back("col2");
     req.indices_ref().value().contexts_ref().value().begin()->set_column_hints(
         std::move(columnHints));
 
+    auto* processor = LookupProcessor::instance(storageEnv_.get(), nullptr, nullptr);
+    auto fut = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(fut).get();
+    EXPECT_EQ(0, resp.result.failed_parts.size());
+    EXPECT_EQ(5 * parts.size(), resp.get_data()->rows.size());
+  }
+
+  // limit 5 by each part through IndexScanNode->DataNode->FilterNode
+  {
+    req.set_limit(5);
+    cpp2::IndexColumnHint columnHint;
+    columnHint.set_begin_value(Value(111));
+    columnHint.set_column_name("col1");
+    columnHint.set_scan_type(cpp2::ScanType::PREFIX);
+    std::vector<cpp2::IndexColumnHint> columnHints;
+    columnHints.emplace_back(std::move(columnHint));
+    auto expr = RelationalExpression::makeNE(pool,
+                                             EdgePropertyExpression::make(pool, "200", "col1"),
+                                             ConstantExpression::make(pool, Value(300L)));
+    req.indices_ref().value().contexts_ref().value().begin()->set_filter(expr->encode());
+    req.indices_ref().value().contexts_ref().value().begin()->set_column_hints(
+        std::move(columnHints));
     auto* processor = LookupProcessor::instance(storageEnv_.get(), nullptr, nullptr);
     auto fut = processor->getFuture();
     processor->process(req);

--- a/src/storage/test/IndexScanLimitTest.cpp
+++ b/src/storage/test/IndexScanLimitTest.cpp
@@ -230,6 +230,17 @@ TEST_F(IndexScanLimitTest, LookupTagIndexLimit) {
     EXPECT_EQ(0, resp.get_data()->rows.size());
   }
 
+  // limit == 1
+  {
+    req.set_limit(1);
+    auto* processor = LookupProcessor::instance(storageEnv_.get(), nullptr, nullptr);
+    auto fut = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(fut).get();
+    EXPECT_EQ(0, resp.result.failed_parts.size());
+    EXPECT_EQ(1 * parts.size(), resp.get_data()->rows.size());
+  }
+
   // limit 5 by each part
   {
     req.set_limit(5);
@@ -322,6 +333,17 @@ TEST_F(IndexScanLimitTest, LookupEdgeIndexLimit) {
     auto resp = std::move(fut).get();
     EXPECT_EQ(0, resp.result.failed_parts.size());
     EXPECT_EQ(0, resp.get_data()->rows.size());
+  }
+
+  // limit == 1
+  {
+    req.set_limit(1);
+    auto* processor = LookupProcessor::instance(storageEnv_.get(), nullptr, nullptr);
+    auto fut = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(fut).get();
+    EXPECT_EQ(0, resp.result.failed_parts.size());
+    EXPECT_EQ(1 * parts.size(), resp.get_data()->rows.size());
   }
 
   // limit 5 by each part


### PR DESCRIPTION
related PR #2796 
The logic of the previous PR is simple, handles limits during the index scan phase. Scanning filter, data validity, etc., are not considered.

for this PR , The items below will be covered by：

- index filter
- index ttl
- Invalid data for index
- Invalid data for prop value
- skip the execution plan when limit = 0

Temporarily unsupported

- de-dup execute node. currently, de-Dup does not work on index scans. We can ignore it for now. Handler it when `Limit + Paging Scan` is integrated



