### PR TITLE
Support lookup indexScan using IN expression as filter

### DIFF
--- a/src/graph/optimizer/OptimizerUtils.cpp
+++ b/src/graph/optimizer/OptimizerUtils.cpp
@@ -642,7 +642,8 @@ StatusOr<ScoredColumnHint> selectRelExprIndex(const ColumnDef& field,
   }
 
   auto right = expr->right();
-  DCHECK(right->kind() == Expression::Kind::kConstant);
+  expr->kind() == Expression::Kind::kRelIn ? DCHECK(right->isContainerExpr())
+                                           : DCHECK(right->kind() == Expression::Kind::kConstant);
   const auto& value = static_cast<const ConstantExpression*>(right)->value();
 
   ScoredColumnHint hint;
@@ -662,6 +663,10 @@ StatusOr<ScoredColumnHint> selectRelExprIndex(const ColumnDef& field,
     }
     case Expression::Kind::kRelNE: {
       hint.score = IndexScore::kNotEqual;
+      break;
+    }
+    case Expression::Kind::kRelIn: {
+      // check the property has an index
       break;
     }
     default: {
@@ -910,6 +915,32 @@ bool OptimizerUtils::findOptimalIndex(const Expression* condition,
   ictx->set_index_id(index.index->get_index_id());
   ictx->set_column_hints(std::move(hints));
   return true;
+}
+
+// Check if the relational expression has a valid index
+// The left operand should either be a kEdgeProperty or kTagProperty expr
+bool OptimizerUtils::relExprHasIndex(
+    const Expression* expr,
+    const std::vector<std::shared_ptr<nebula::meta::cpp2::IndexItem>>& indexItems) {
+  DCHECK(expr->isRelExpr());
+
+  for (auto& index : indexItems) {
+    const auto& fields = index->get_fields();
+    if (fields.empty()) {
+      return false;
+    }
+
+    auto left = static_cast<const RelationalExpression*>(expr)->left();
+    DCHECK(left->kind() == Expression::Kind::kEdgeProperty ||
+           left->kind() == Expression::Kind::kTagProperty);
+
+    auto propExpr = static_cast<const PropertyExpression*>(left);
+    if (propExpr->prop() == fields[0].get_name()) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 void OptimizerUtils::copyIndexScanData(const nebula::graph::IndexScan* from,

--- a/src/graph/optimizer/OptimizerUtils.cpp
+++ b/src/graph/optimizer/OptimizerUtils.cpp
@@ -665,10 +665,6 @@ StatusOr<ScoredColumnHint> selectRelExprIndex(const ColumnDef& field,
       hint.score = IndexScore::kNotEqual;
       break;
     }
-    case Expression::Kind::kRelIn: {
-      // check the property has an index
-      break;
-    }
     default: {
       return Status::Error("Invalid expression kind");
     }

--- a/src/graph/optimizer/OptimizerUtils.cpp
+++ b/src/graph/optimizer/OptimizerUtils.cpp
@@ -642,8 +642,12 @@ StatusOr<ScoredColumnHint> selectRelExprIndex(const ColumnDef& field,
   }
 
   auto right = expr->right();
-  expr->kind() == Expression::Kind::kRelIn ? DCHECK(right->isContainerExpr())
-                                           : DCHECK(right->kind() == Expression::Kind::kConstant);
+  if (expr->kind() == Expression::Kind::kRelIn) {  // container expressions
+    DCHECK(right->isContainerExpr());
+  } else {  // other expressions
+    DCHECK(right->kind() == Expression::Kind::kConstant);
+  }
+
   const auto& value = static_cast<const ConstantExpression*>(right)->value();
 
   ScoredColumnHint hint;

--- a/src/graph/optimizer/OptimizerUtils.h
+++ b/src/graph/optimizer/OptimizerUtils.h
@@ -95,6 +95,10 @@ class OptimizerUtils {
       bool* isPrefixScan,
       nebula::storage::cpp2::IndexQueryContext* ictx);
 
+  static bool relExprHasIndex(
+      const Expression* expr,
+      const std::vector<std::shared_ptr<nebula::meta::cpp2::IndexItem>>& indexItems);
+
   static void copyIndexScanData(const nebula::graph::IndexScan* from, nebula::graph::IndexScan* to);
 };
 

--- a/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
+++ b/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
@@ -47,8 +47,14 @@ const Pattern& OptimizeTagIndexScanByFilterRule::pattern() const {
 }
 
 // Match 2 kinds of expressions:
-// 1. Relational expr
-// 2. Logical AND expr
+//
+// 1. Relational expr. If it is an IN expr, its list MUST have only 1 element, so it could always be
+// transformed to an relEQ expr. i.g.  A in [B]  =>  A == B
+// It the list has more than 1 element, the expr will be matched with UnionAllIndexScanBaseRule.
+//
+// 2. Logical AND expr. If the AND expr contains an operand that is an IN expr, the label attribute
+// in the IN expr SHUOLD NOT have a valid index, otherwise the expression should be matched with
+// UnionAllIndexScanBaseRule.
 bool OptimizeTagIndexScanByFilterRule::match(OptContext* ctx, const MatchedResult& matched) const {
   if (!OptRule::match(ctx, matched)) {
     return false;
@@ -61,6 +67,8 @@ bool OptimizeTagIndexScanByFilterRule::match(OptContext* ctx, const MatchedResul
     }
   }
   auto condition = filter->condition();
+
+  // Case1: relational expr
   if (condition->isRelExpr()) {
     auto relExpr = static_cast<const RelationalExpression*>(condition);
     // If the container in the IN expr has only 1 element, it will be converted to an relEQ
@@ -73,10 +81,16 @@ bool OptimizeTagIndexScanByFilterRule::match(OptContext* ctx, const MatchedResul
     return relExpr->left()->kind() == ExprKind::kTagProperty &&
            relExpr->right()->kind() == ExprKind::kConstant;
   }
-  if (condition->isLogicalExpr()) {
-    return condition->kind() == ExprKind::kLogicalAnd;
-  }
 
+  // Case2: logical AND expr
+  if (condition->kind() == ExprKind::kLogicalAnd) {
+    // for (auto operand : static_cast<const LogicalExpression*>(condition)->operands()) {
+    //   if (operand->kind() == ExprKind::kRelIn) {
+    //     return false;
+    //   }
+    // }
+    return true;
+  }
   return false;
 }
 
@@ -108,16 +122,31 @@ StatusOr<TransformResult> OptimizeTagIndexScanByFilterRule::transform(
   auto conditionType = condition->kind();
   Expression* transformedExpr = condition->clone();
 
-  // Stand alone IN expr
+  // Stand alone IN expr with only 1 element in the list, no need to check index
   if (conditionType == ExprKind::kRelIn) {
-    if (!OptimizerUtils::relExprHasIndex(condition, indexItems)) {
-      return TransformResult::noTransform();
-    }
     transformedExpr = graph::ExpressionUtils::rewriteInExpr(condition);
+    DCHECK(transformedExpr->kind() == ExprKind::kRelEQ);
   }
 
-  DCHECK(transformedExpr->kind() == ExprKind::kLogicalOr ||
-         transformedExpr->kind() == ExprKind::kRelEQ);
+  // case2: logical AND expr
+  if (condition->kind() == ExprKind::kLogicalAnd) {
+    for (auto& operand : static_cast<const LogicalExpression*>(condition)->operands()) {
+      if (operand->kind() == ExprKind::kRelIn) {
+        auto inExpr = static_cast<RelationalExpression*>(operand);
+        // Do not apply this rule if the IN expr has a valid index or it has only 1 element in the
+        // list
+        if (static_cast<ListExpression*>(inExpr->right())->size() > 1) {
+          return TransformResult::noTransform();
+        } else {
+          transformedExpr = graph::ExpressionUtils::rewriteInExpr(condition);
+        }
+        if (OptimizerUtils::relExprHasIndex(inExpr, indexItems)) {
+          return TransformResult::noTransform();
+        }
+      }
+    }
+  }
+
   IndexQueryContext ictx;
   bool isPrefixScan = false;
   if (!OptimizerUtils::findOptimalIndex(transformedExpr, indexItems, &isPrefixScan, &ictx)) {

--- a/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
+++ b/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
@@ -53,7 +53,7 @@ const Pattern& OptimizeTagIndexScanByFilterRule::pattern() const {
 // It the list has more than 1 element, the expr will be matched with UnionAllIndexScanBaseRule.
 //
 // 2. Logical AND expr. If the AND expr contains an operand that is an IN expr, the label attribute
-// in the IN expr SHUOLD NOT have a valid index, otherwise the expression should be matched with
+// in the IN expr SHOULD NOT have a valid index, otherwise the expression should be matched with
 // UnionAllIndexScanBaseRule.
 bool OptimizeTagIndexScanByFilterRule::match(OptContext* ctx, const MatchedResult& matched) const {
   if (!OptRule::match(ctx, matched)) {

--- a/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
+++ b/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
@@ -83,15 +83,7 @@ bool OptimizeTagIndexScanByFilterRule::match(OptContext* ctx, const MatchedResul
   }
 
   // Case2: logical AND expr
-  if (condition->kind() == ExprKind::kLogicalAnd) {
-    // for (auto operand : static_cast<const LogicalExpression*>(condition)->operands()) {
-    //   if (operand->kind() == ExprKind::kRelIn) {
-    //     return false;
-    //   }
-    // }
-    return true;
-  }
-  return false;
+  return condition->kind() == ExprKind::kLogicalAnd;
 }
 
 TagIndexScan* makeTagIndexScan(QueryContext* qctx, const TagIndexScan* scan, bool isPrefixScan) {

--- a/src/graph/optimizer/rule/UnionAllIndexScanBaseRule.cpp
+++ b/src/graph/optimizer/rule/UnionAllIndexScanBaseRule.cpp
@@ -15,6 +15,7 @@
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Query.h"
 #include "graph/planner/plan/Scan.h"
+#include "graph/util/ExpressionUtils.h"
 #include "interface/gen-cpp2/storage_types.h"
 
 using nebula::graph::Filter;
@@ -24,11 +25,18 @@ using nebula::graph::TagIndexFullScan;
 using nebula::storage::cpp2::IndexQueryContext;
 
 using Kind = nebula::graph::PlanNode::Kind;
+using ExprKind = nebula::Expression::Kind;
 using TransformResult = nebula::opt::OptRule::TransformResult;
 
 namespace nebula {
 namespace opt {
 
+// The matched expression should be either a OR expression or an expression that could be
+// rewrote to a OR expression. There are 3 senarios.
+// 1. OR expr. If OR expr has IN expr operand that has a valid index, expand it to OR expr.
+// 2. AND expr such as A in [a, b] AND B, because it can be transformed to (A==a AND B) OR (A==b
+// AND B)
+// 3. IN expr such as A in [a, b] since it can be transformed to (A==a) OR (A==b)
 bool UnionAllIndexScanBaseRule::match(OptContext* ctx, const MatchedResult& matched) const {
   if (!OptRule::match(ctx, matched)) {
     return false;
@@ -36,13 +44,32 @@ bool UnionAllIndexScanBaseRule::match(OptContext* ctx, const MatchedResult& matc
   auto filter = static_cast<const Filter*>(matched.planNode());
   auto scan = static_cast<const IndexScan*>(matched.planNode({0, 0}));
   auto condition = filter->condition();
-  if (!condition->isLogicalExpr() || condition->kind() != Expression::Kind::kLogicalOr) {
-    return false;
+  auto conditionType = condition->kind();
+
+  if (condition->isLogicalExpr()) {
+    if (conditionType == ExprKind::kLogicalOr) {
+      return true;
+    }
+    if (conditionType == ExprKind::kLogicalAnd &&
+        graph::ExpressionUtils::findAny(static_cast<LogicalExpression*>(condition),
+                                        {ExprKind::kRelIn})) {
+      return true;
+    }
+    // Check logical operands
+    for (auto operand : static_cast<const LogicalExpression*>(condition)->operands()) {
+      if (!operand->isRelExpr() || !operand->isLogicalExpr()) {
+        return false;
+      }
+    }
   }
 
-  for (auto operand : static_cast<const LogicalExpression*>(condition)->operands()) {
-    if (!operand->isRelExpr()) {
-      return false;
+  // If the number of elements is less or equal than 1, the IN expr will be transformed into a
+  // relEQ expr by the OptimizeTagIndexScanByFilterRule.
+  if (condition->isRelExpr()) {
+    auto relExpr = static_cast<const RelationalExpression*>(condition);
+    if (relExpr->kind() == ExprKind::kRelIn && relExpr->right()->isContainerExpr()) {
+      auto operandsVec = graph::ExpressionUtils::getContainerExprOperands(relExpr->right());
+      return operandsVec.size() > 1;
     }
   }
 
@@ -52,9 +79,10 @@ bool UnionAllIndexScanBaseRule::match(OptContext* ctx, const MatchedResult& matc
     }
   }
 
-  return true;
+  return false;
 }
 
+// If the IN expr has only 1 element in its container, it will be converted to an relEQ expr
 StatusOr<TransformResult> UnionAllIndexScanBaseRule::transform(OptContext* ctx,
                                                                const MatchedResult& matched) const {
   auto filter = static_cast<const Filter*>(matched.planNode());
@@ -62,20 +90,75 @@ StatusOr<TransformResult> UnionAllIndexScanBaseRule::transform(OptContext* ctx,
   auto scan = static_cast<const IndexScan*>(node);
 
   auto metaClient = ctx->qctx()->getMetaClient();
-  StatusOr<std::vector<std::shared_ptr<meta::cpp2::IndexItem>>> status;
-  if (node->kind() == graph::PlanNode::Kind::kTagIndexFullScan) {
-    status = metaClient->getTagIndexesFromCache(scan->space());
-  } else {
-    status = metaClient->getEdgeIndexesFromCache(scan->space());
-  }
+  auto status = node->kind() == graph::PlanNode::Kind::kTagIndexFullScan
+                    ? metaClient->getTagIndexesFromCache(scan->space())
+                    : metaClient->getEdgeIndexesFromCache(scan->space());
+
   NG_RETURN_IF_ERROR(status);
   auto indexItems = std::move(status).value();
 
   OptimizerUtils::eraseInvalidIndexItems(scan->schemaId(), &indexItems);
 
+  // Check whether the prop has index.
+  // Rewrite if the property in the IN expr has a valid index
+  if (indexItems.empty()) {
+    return TransformResult::noTransform();
+  }
+
+  auto condition = filter->condition();
+  auto conditionType = condition->kind();
+  Expression* transformedExpr = condition->clone();
+
+  // Stand alone IN expr
+  if (conditionType == ExprKind::kRelIn) {
+    if (!OptimizerUtils::relExprHasIndex(condition, indexItems)) {
+      return TransformResult::noTransform();
+    }
+    transformedExpr = graph::ExpressionUtils::rewriteInExpr(condition);
+  }
+
+  // AND expr containing IN expr operand
+  if (conditionType == ExprKind::kLogicalAnd) {
+    auto relInExprs = graph::ExpressionUtils::collectAll(transformedExpr, {ExprKind::kRelIn});
+    DCHECK(!relInExprs.empty());
+    bool indexFound = false;
+    // Iterate all operands and expand IN exprs if possible
+    for (auto& expr : static_cast<LogicalExpression*>(transformedExpr)->operands()) {
+      if (expr->kind() == ExprKind::kRelIn) {
+        if (OptimizerUtils::relExprHasIndex(transformedExpr, indexItems)) {
+          expr = graph::ExpressionUtils::rewriteInExpr(expr);
+        }
+      }
+    }
+    if (!indexFound) {
+      return TransformResult::noTransform();
+    }
+
+    // Reconstruct AND expr using distributive law
+  }
+
+  // OR expr
+  if (conditionType == ExprKind::kLogicalOr) {
+    auto relInExprs = graph::ExpressionUtils::collectAll(transformedExpr, {ExprKind::kRelIn});
+    if (!relInExprs.empty()) {
+      // Iterate all operands and expand IN exprs if possible
+      for (auto& expr : static_cast<LogicalExpression*>(transformedExpr)->operands()) {
+        if (expr->kind() == ExprKind::kRelIn) {
+          if (OptimizerUtils::relExprHasIndex(expr, indexItems)) {
+            expr = graph::ExpressionUtils::rewriteInExpr(expr);
+          }
+        }
+      }
+      // Flatten OR exprs
+      graph::ExpressionUtils::pullOrs(transformedExpr);
+    }
+  }
+
+  DCHECK(transformedExpr->kind() == ExprKind::kLogicalOr ||
+         transformedExpr->kind() == ExprKind::kRelEQ);
   std::vector<IndexQueryContext> idxCtxs;
-  auto condition = static_cast<const LogicalExpression*>(filter->condition());
-  for (auto operand : condition->operands()) {
+  auto logicalExpr = static_cast<const LogicalExpression*>(transformedExpr);
+  for (auto operand : logicalExpr->operands()) {
     IndexQueryContext ictx;
     bool isPrefixScan = false;
     if (!OptimizerUtils::findOptimalIndex(operand, indexItems, &isPrefixScan, &ictx)) {

--- a/src/graph/optimizer/rule/UnionAllIndexScanBaseRule.cpp
+++ b/src/graph/optimizer/rule/UnionAllIndexScanBaseRule.cpp
@@ -144,19 +144,17 @@ StatusOr<TransformResult> UnionAllIndexScanBaseRule::transform(OptContext* ctx,
 
     // OR expr
     case ExprKind::kLogicalOr: {
-      auto relInExprs = graph::ExpressionUtils::collectAll(transformedExpr, {ExprKind::kRelIn});
-      if (!relInExprs.empty()) {
-        // Iterate all operands and expand IN exprs if possible
-        for (auto& expr : static_cast<LogicalExpression*>(transformedExpr)->operands()) {
-          if (expr->kind() == ExprKind::kRelIn) {
-            if (OptimizerUtils::relExprHasIndex(expr, indexItems)) {
-              expr = graph::ExpressionUtils::rewriteInExpr(expr);
-            }
+      // Iterate all operands and expand IN exprs if possible
+      for (auto& expr : static_cast<LogicalExpression*>(transformedExpr)->operands()) {
+        if (expr->kind() == ExprKind::kRelIn) {
+          if (OptimizerUtils::relExprHasIndex(expr, indexItems)) {
+            expr = graph::ExpressionUtils::rewriteInExpr(expr);
           }
         }
-        // Flatten OR exprs
-        graph::ExpressionUtils::pullOrs(transformedExpr);
       }
+      // Flatten OR exprs
+      graph::ExpressionUtils::pullOrs(transformedExpr);
+
       break;
     }
     default:

--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -248,7 +248,7 @@ Expression *ExpressionUtils::rewriteLogicalAndToLogicalOr(const Expression *expr
   }
 
   // orExprOperands is a 2D vector where each sub-vector is the operands of AND expression.
-  // [[A, C], [A, D], [B, C], [B,D]]  =>  (A and C) or (A and D) or (B and C) or (B or D)
+  // [[A, C], [A, D], [B, C], [B,D]]  =>  (A and C) or (A and D) or (B and C) or (B and D)
   std::vector<Expression *> andExprList;
   andExprList.reserve(orExprOperands.size());
   for (auto &operand : orExprOperands) {

--- a/src/graph/util/ExpressionUtils.h
+++ b/src/graph/util/ExpressionUtils.h
@@ -66,6 +66,14 @@ class ExpressionUtils {
   static Expression* rewriteRelExpr(const Expression* expr);
   static Expression* rewriteRelExprHelper(const Expression* expr, Expression*& relRightOperandExpr);
 
+  // Rewrite IN expression into OR expression or relEQ expression
+  static Expression* rewriteInExpr(const Expression* expr);
+
+  // Return the operands of container expressions
+  // For list and set, return the operands
+  // For map, return the keys
+  static std::vector<Expression*> getContainerExprOperands(const Expression* expr);
+
   // Clone and fold constant expression
   static StatusOr<Expression*> foldConstantExpr(const Expression* expr);
 
@@ -73,6 +81,10 @@ class ExpressionUtils {
   static Expression* reduceUnaryNotExpr(const Expression* expr);
 
   // Transform filter using multiple expression rewrite strategies
+  // 1. rewrite relational expressions containing arithmetic operands so that
+  //    all constants are on the right side of relExpr.
+  // 2. fold constant
+  // 3. reduce unary expression e.g. !(A and B) => !A or !B
   static StatusOr<Expression*> filterTransform(const Expression* expr);
 
   // Negate the given logical expr: (A && B) -> (!A || !B)

--- a/src/graph/util/ExpressionUtils.h
+++ b/src/graph/util/ExpressionUtils.h
@@ -45,6 +45,9 @@ class ExpressionUtils {
   static std::vector<const Expression*> collectAll(
       const Expression* self, const std::unordered_set<Expression::Kind>& expected);
 
+  static std::vector<const Expression*> collectAllExcept(
+      const Expression* self, const std::unordered_set<Expression::Kind>& excludedKind);
+
   static std::vector<const Expression*> findAllStorage(const Expression* expr);
 
   static std::vector<const Expression*> findAllInputVariableProp(const Expression* expr);
@@ -68,6 +71,12 @@ class ExpressionUtils {
 
   // Rewrite IN expression into OR expression or relEQ expression
   static Expression* rewriteInExpr(const Expression* expr);
+
+  // Rewrite Logical AND expr to Logical OR expr using distributive law
+  // Examples:
+  // A and (B or C)  => (A and B) or (A and C)
+  // (A or B) and (C or D)  =>  (A and C) or (A and D) or (B and C) or (B or D)
+  static Expression* rewriteLogicalAndToLogicalOr(const Expression* expr);
 
   // Return the operands of container expressions
   // For list and set, return the operands

--- a/src/graph/util/ExpressionUtils.h
+++ b/src/graph/util/ExpressionUtils.h
@@ -45,9 +45,6 @@ class ExpressionUtils {
   static std::vector<const Expression*> collectAll(
       const Expression* self, const std::unordered_set<Expression::Kind>& expected);
 
-  static std::vector<const Expression*> collectAllExcept(
-      const Expression* self, const std::unordered_set<Expression::Kind>& excludedKind);
-
   static std::vector<const Expression*> findAllStorage(const Expression* expr);
 
   static std::vector<const Expression*> findAllInputVariableProp(const Expression* expr);

--- a/src/graph/validator/LookupValidator.cpp
+++ b/src/graph/validator/LookupValidator.cpp
@@ -234,10 +234,6 @@ StatusOr<Expression*> LookupValidator::handleLogicalExprOperands(LogicalExpressi
   auto& operands = lExpr->operands();
   for (auto i = 0u; i < operands.size(); i++) {
     auto operand = lExpr->operand(i);
-    // if (operand->isLogicalExpr()) {
-    //   // Not allow different logical expression to use: A AND B OR C
-    //   return Status::SemanticError("Not supported filter: %s", lExpr->toString().c_str());
-    // }
     auto ret = checkFilter(operand);
     NG_RETURN_IF_ERROR(ret);
 

--- a/src/graph/validator/LookupValidator.cpp
+++ b/src/graph/validator/LookupValidator.cpp
@@ -188,7 +188,7 @@ Status LookupValidator::validateYield() {
     return Status::OK();
   }
   lookupCtx_->dedup = yieldClause->isDistinct();
-  
+
   if (lookupCtx_->isEdge) {
     NG_RETURN_IF_ERROR(validateYieldEdge());
   } else {

--- a/src/graph/validator/LookupValidator.cpp
+++ b/src/graph/validator/LookupValidator.cpp
@@ -255,7 +255,7 @@ StatusOr<Expression*> LookupValidator::checkFilter(Expression* expr) {
     // Only starts with can be pushed down as a range scan, so forbid other string-related relExpr
     if (expr->kind() == ExprKind::kRelREG || expr->kind() == ExprKind::kContains ||
         expr->kind() == ExprKind::kNotContains || expr->kind() == ExprKind::kEndsWith ||
-        expr->kind() == ExprKind::kNotEndsWith) {
+        expr->kind() == ExprKind::kNotStartsWith || expr->kind() == ExprKind::kNotEndsWith) {
       return Status::SemanticError(
           "Expression %s is not supported, please use full-text index as an optimal solution",
           expr->toString().c_str());

--- a/src/graph/validator/LookupValidator.h
+++ b/src/graph/validator/LookupValidator.h
@@ -37,12 +37,11 @@ class LookupValidator final : public Validator {
   Status validateYieldEdge();
 
   StatusOr<Expression*> checkFilter(Expression* expr);
-  StatusOr<Expression*> checkRelExpr(RelationalExpression* expr);
+  Status checkRelExpr(RelationalExpression* expr);
   StatusOr<std::string> checkTSExpr(Expression* expr);
-  StatusOr<Value> checkConstExpr(Expression* expr,
-                                 const std::string& prop,
-                                 const Expression::Kind kind);
-
+  StatusOr<Expression*> checkConstExpr(Expression* expr,
+                                       const std::string& prop,
+                                       const Expression::Kind kind);
   StatusOr<Expression*> rewriteRelExpr(RelationalExpression* expr);
   Expression* reverseRelKind(RelationalExpression* expr);
 

--- a/src/graph/visitor/FindVisitor.cpp
+++ b/src/graph/visitor/FindVisitor.cpp
@@ -121,6 +121,15 @@ void FindVisitor::visit(ListComprehensionExpression* expr) {
   }
 }
 
+void FindVisitor::visit(LogicalExpression* expr) {
+  findInCurrentExpr(expr);
+  if (!needFindAll_ && !foundExprs_.empty()) return;
+  for (const auto& operand : expr->operands()) {
+    operand->accept(this);
+    if (!needFindAll_ && !foundExprs_.empty()) return;
+  }
+}
+
 void FindVisitor::visit(ConstantExpression* expr) { findInCurrentExpr(expr); }
 
 void FindVisitor::visit(EdgePropertyExpression* expr) { findInCurrentExpr(expr); }

--- a/src/graph/visitor/FindVisitor.h
+++ b/src/graph/visitor/FindVisitor.h
@@ -66,6 +66,7 @@ class FindVisitor final : public ExprVisitorImpl {
   void visit(ColumnExpression* expr) override;
   void visit(ListComprehensionExpression* expr) override;
   void visit(SubscriptRangeExpression* expr) override;
+  void visit(LogicalExpression* expr) override;
 
   void visitBinaryExpr(BinaryExpression* expr) override;
   void findInCurrentExpr(Expression* expr);

--- a/src/graph/visitor/FoldConstantExprVisitor.cpp
+++ b/src/graph/visitor/FoldConstantExprVisitor.cpp
@@ -338,6 +338,11 @@ void FoldConstantExprVisitor::visitBinaryExpr(BinaryExpression *expr) {
 }
 
 Expression *FoldConstantExprVisitor::fold(Expression *expr) {
+  // Container expresison shuold remain the same type after being folded
+  if (expr->isContainerExpr()) {
+    return expr;
+  }
+
   QueryExpressionContext ctx;
   auto value = expr->eval(ctx(nullptr));
   if (value.type() == Value::Type::NULLVALUE) {

--- a/src/graph/visitor/FoldConstantExprVisitor.cpp
+++ b/src/graph/visitor/FoldConstantExprVisitor.cpp
@@ -338,7 +338,7 @@ void FoldConstantExprVisitor::visitBinaryExpr(BinaryExpression *expr) {
 }
 
 Expression *FoldConstantExprVisitor::fold(Expression *expr) {
-  // Container expresison shuold remain the same type after being folded
+  // Container expresison should remain the same type after being folded
   if (expr->isContainerExpr()) {
     return expr;
   }

--- a/src/graph/visitor/VidExtractVisitor.cpp
+++ b/src/graph/visitor/VidExtractVisitor.cpp
@@ -135,7 +135,7 @@ void VidExtractVisitor::visit(ArithmeticExpression *expr) {
 
 void VidExtractVisitor::visit(RelationalExpression *expr) {
   if (expr->kind() == Expression::Kind::kRelIn) {
-    //    const auto *inExpr = static_cast<const RelationalExpression *>(expr);
+    // id(V) IN [List]
     if (expr->left()->kind() == Expression::Kind::kLabelAttribute) {
       const auto *labelExpr = static_cast<const LabelAttributeExpression *>(expr->left());
       const auto &label = labelExpr->left()->toString();
@@ -143,29 +143,29 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
                                {{label, {VidPattern::Vids::Kind::kOtherSource, {}}}}};
       return;
     }
+
     if (expr->left()->kind() != Expression::Kind::kFunctionCall ||
-        expr->right()->kind() != Expression::Kind::kConstant) {
+        expr->right()->kind() != Expression::Kind::kList) {
       vidPattern_ = VidPattern{};
       return;
     }
+
     const auto *fCallExpr = static_cast<const FunctionCallExpression *>(expr->left());
     if (fCallExpr->name() != "id" && fCallExpr->args()->numArgs() != 1 &&
         fCallExpr->args()->args().front()->kind() != Expression::Kind::kLabel) {
       vidPattern_ = VidPattern{};
       return;
     }
-    const auto *constExpr = static_cast<const ConstantExpression *>(expr->right());
-    if (constExpr->value().type() != Value::Type::LIST) {
-      vidPattern_ = VidPattern{};
-      return;
-    }
-    vidPattern_ = VidPattern{VidPattern::Special::kInUsed,
-                             {{fCallExpr->args()->args().front()->toString(),
-                               {VidPattern::Vids::Kind::kIn, constExpr->value().getList()}}}};
+
+    auto *listExpr = static_cast<ListExpression *>(expr->right());
+    QueryExpressionContext ctx;
+    vidPattern_ =
+        VidPattern{VidPattern::Special::kInUsed,
+                   {{fCallExpr->args()->args().front()->toString(),
+                     {VidPattern::Vids::Kind::kIn, listExpr->eval(ctx(nullptr)).getList()}}}};
     return;
   } else if (expr->kind() == Expression::Kind::kRelEQ) {
-    //        const auto *eqExpr = static_cast<const RelationalExpression
-    //        *>(expr);
+    // id(V) == vid
     if (expr->left()->kind() == Expression::Kind::kLabelAttribute) {
       const auto *labelExpr = static_cast<const LabelAttributeExpression *>(expr->left());
       const auto &label = labelExpr->left()->toString();

--- a/src/graph/visitor/VidExtractVisitor.cpp
+++ b/src/graph/visitor/VidExtractVisitor.cpp
@@ -145,7 +145,8 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
     }
 
     if (expr->left()->kind() != Expression::Kind::kFunctionCall ||
-        expr->right()->kind() != Expression::Kind::kList) {
+        expr->right()->kind() != Expression::Kind::kList ||
+        !ExpressionUtils::isEvaluableExpr(expr->right())) {
       vidPattern_ = VidPattern{};
       return;
     }

--- a/src/graph/visitor/test/FoldConstantExprVisitorTest.cpp
+++ b/src/graph/visitor/test/FoldConstantExprVisitorTest.cpp
@@ -104,6 +104,8 @@ TEST_F(FoldConstantExprVisitorTest, TestListExpr) {
   expr->accept(&visitor);
   ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
   ASSERT(visitor.canBeFolded());
+  // type should remain the same after folding
+  ASSERT_EQ(expr->kind(), Expression::Kind::kList);
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestSetExpr) {
@@ -116,6 +118,8 @@ TEST_F(FoldConstantExprVisitorTest, TestSetExpr) {
   expr->accept(&visitor);
   ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
   ASSERT(visitor.canBeFolded());
+  // type should remain the same after folding
+  ASSERT_EQ(expr->kind(), Expression::Kind::kList);
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestMapExpr) {
@@ -131,6 +135,8 @@ TEST_F(FoldConstantExprVisitorTest, TestMapExpr) {
   expr->accept(&visitor);
   ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
   ASSERT(visitor.canBeFolded());
+  // type should remain the same after folding
+  ASSERT_EQ(expr->kind(), Expression::Kind::kList);
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestCaseExpr) {

--- a/src/graph/visitor/test/FoldConstantExprVisitorTest.cpp
+++ b/src/graph/visitor/test/FoldConstantExprVisitorTest.cpp
@@ -119,7 +119,7 @@ TEST_F(FoldConstantExprVisitorTest, TestSetExpr) {
   ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
   ASSERT(visitor.canBeFolded());
   // type should remain the same after folding
-  ASSERT_EQ(expr->kind(), Expression::Kind::kList);
+  ASSERT_EQ(expr->kind(), Expression::Kind::kSet);
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestMapExpr) {
@@ -136,7 +136,7 @@ TEST_F(FoldConstantExprVisitorTest, TestMapExpr) {
   ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
   ASSERT(visitor.canBeFolded());
   // type should remain the same after folding
-  ASSERT_EQ(expr->kind(), Expression::Kind::kList);
+  ASSERT_EQ(expr->kind(), Expression::Kind::kMap);
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestCaseExpr) {

--- a/tests/tck/features/lookup/EdgeIndexFullScan.feature
+++ b/tests/tck/features/lookup/EdgeIndexFullScan.feature
@@ -202,11 +202,11 @@ Feature: Lookup edge index full scan
       | SrcVID | DstVID | Ranking | edge_1.col1_str | edge_1.col2_int |
       | "101"  | "102"  | 0       | "Red1"          | 11              |
     And the execution plan should be:
-      | id | name                | dependencies | operator info |
-      | 3  | Project             | 4            |               |
-      | 4  | EdgeIndexPrefixScan | 0            |               |
-      | 0  | Start               |              |               |
-    # a IN b AND c IN d (EdgeIndexFullScan)
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
+    # a IN b AND c IN d (4 prefixScan will be executed)
     When profiling query:
       """
       LOOKUP ON edge_1
@@ -217,11 +217,10 @@ Feature: Lookup edge index full scan
       | SrcVID | DstVID | Ranking | edge_1.col1_str | edge_1.col2_int |
       | "101"  | "102"  | 0       | "Red1"          | 11              |
     And the execution plan should be:
-      | id | name              | dependencies | operator info                                                                                                                       |
-      | 3  | Project           | 2            |                                                                                                                                     |
-      | 2  | Filter            | 4            | {"condition": "(((edge_1.col2_int==11) OR (edge_1.col2_int==33)) AND ((edge_1.col1_str==\"Red1\") OR (edge_1.col1_str==\"ABC\")))"} |
-      | 4  | EdgeIndexFullScan | 0            |                                                                                                                                     |
-      | 0  | Start             |              |                                                                                                                                     |
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
     When profiling query:
       """
       LOOKUP ON edge_1 WHERE edge_1.col1_str NOT IN ["Blue"] YIELD edge_1.col1_str

--- a/tests/tck/features/lookup/EdgeIndexFullScan.feature
+++ b/tests/tck/features/lookup/EdgeIndexFullScan.feature
@@ -33,51 +33,12 @@ Feature: Lookup edge index full scan
         '103'->'101':('Blue', 33);
       """
 
-  Scenario: Edge with relational RegExp filter[1]
+  Scenario: Edge with relational RegExp filter
     When executing query:
       """
       LOOKUP ON edge_1 WHERE edge_1.col1_str =~ "\\w+\\d+" YIELD edge_1.col1_str
       """
-    Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking | edge_1.col1_str |
-      | "101"  | "102"  | 0       | "Red1"          |
-    When executing query:
-      """
-      LOOKUP ON edge_1 WHERE edge_1.col1_str =~ "\\w+ll\\w+" YIELD edge_1.col1_str
-      """
-    Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking | edge_1.col1_str |
-      | "102"  | "103"  | 0       | "Yellow"        |
-
-  # skip because `make fmt` will delete '\' in the operator info and causes tests fail
-  @skip
-  Scenario: Edge with relational RegExp filter[2]
-    When profiling query:
-      """
-      LOOKUP ON edge_1 where edge_1.col1_str =~ "\\d+\\w+" YIELD edge_1.col1_str
-      """
-    Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking | edge_1.col1_str |
-      | "101"  | "102"  | 0       | "Red1"          |
-    And the execution plan should be:
-      | id | name              | dependencies | operator info                                  |
-      | 3  | Project           | 2            |                                                |
-      | 2  | Filter            | 4            | {"condition": "(edge_1.col1_str=~\"\w+\d+\")"} |
-      | 4  | EdgeIndexFullScan | 0            |                                                |
-      | 0  | Start             |              |                                                |
-    When profiling query:
-      """
-      LOOKUP ON edge_1 where edge_1.col1_str =~ "\\w+ea\\w+" YIELD edge_1.col1_str
-      """
-    Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking | edge_1.col1_str |
-      | "102"  | "103"  | 0       | "Yellow"        |
-    And the execution plan should be:
-      | id | name              | dependencies | operator info                                    |
-      | 3  | Project           | 2            |                                                  |
-      | 2  | Filter            | 4            | {"condition": "(edge_1.col1_str=~\"\w+ea\w+\")"} |
-      | 4  | EdgeIndexFullScan | 0            |                                                  |
-      | 0  | Start             |              |                                                  |
+    Then a SemanticError should be raised at runtime: Expression (edge_1.col1_str=~"\w+\d+") is not supported, please use full-text index as an optimal solution
 
   Scenario: Edge with relational NE filter
     When profiling query:
@@ -250,39 +211,16 @@ Feature: Lookup edge index full scan
       | 0  | Start             |              |                                                   |
 
   Scenario: Edge with relational CONTAINS/NOT CONTAINS filter
-    When profiling query:
-      """
-      LOOKUP ON edge_1 WHERE edge_1.col1_str CONTAINS toLower("L") YIELD edge_1.col1_str
-      """
-    Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking | edge_1.col1_str |
-      | "103"  | "101"  | 0       | "Blue"          |
-      | "102"  | "103"  | 0       | "Yellow"        |
-    And the execution plan should be:
-      | id | name              | dependencies | operator info                                     |
-      | 3  | Project           | 2            |                                                   |
-      | 2  | Filter            | 4            | {"condition": "(edge_1.col1_str CONTAINS \"l\")"} |
-      | 4  | EdgeIndexFullScan | 0            |                                                   |
-      | 0  | Start             |              |                                                   |
     When executing query:
       """
       LOOKUP ON edge_1 WHERE edge_1.col1_str CONTAINS "ABC" YIELD edge_1.col1_str
       """
-    Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking | edge_1.col1_str |
-    When profiling query:
+    Then a SemanticError should be raised at runtime: Expression (edge_1.col1_str CONTAINS "ABC") is not supported, please use full-text index as an optimal solution
+    When executing query:
       """
-      LOOKUP ON edge_1 WHERE edge_1.col1_str NOT CONTAINS toLower("L") YIELD edge_1.col1_str
+      LOOKUP ON edge_1 WHERE edge_1.col1_str NOT CONTAINS "ABC" YIELD edge_1.col1_str
       """
-    Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking | edge_1.col1_str |
-      | "101"  | "102"  | 0       | "Red1"          |
-    And the execution plan should be:
-      | id | name              | dependencies | operator info                                         |
-      | 3  | Project           | 2            |                                                       |
-      | 2  | Filter            | 4            | {"condition": "(edge_1.col1_str NOT CONTAINS \"l\")"} |
-      | 4  | EdgeIndexFullScan | 0            |                                                       |
-      | 0  | Start             |              |                                                       |
+    Then a SemanticError should be raised at runtime: Expression (edge_1.col1_str NOT CONTAINS "ABC") is not supported, please use full-text index as an optimal solution
 
   Scenario: Edge with relational STARTS/NOT STARTS WITH filter
     When profiling query:
@@ -325,41 +263,13 @@ Feature: Lookup edge index full scan
       | 0  | Start             |              |                                                          |
 
   Scenario: Edge with relational ENDS/NOT ENDS WITH filter
-    When profiling query:
-      """
-      LOOKUP ON edge_1 WHERE edge_1.col1_str ENDS WITH toLower("E") YIELD edge_1.col1_str
-      """
-    Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking | edge_1.col1_str |
-      | "103"  | "101"  | 0       | "Blue"          |
-    And the execution plan should be:
-      | id | name              | dependencies | operator info                                      |
-      | 3  | Project           | 2            |                                                    |
-      | 2  | Filter            | 4            | {"condition": "(edge_1.col1_str ENDS WITH \"e\")"} |
-      | 4  | EdgeIndexFullScan | 0            |                                                    |
-      | 0  | Start             |              |                                                    |
     When executing query:
       """
       LOOKUP ON edge_1 WHERE edge_1.col1_str ENDS WITH "ABC" YIELD edge_1.col1_str
       """
-    Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking | edge_1.col1_str |
+    Then a SemanticError should be raised at runtime: Expression (edge_1.col1_str ENDS WITH "ABC") is not supported, please use full-text index as an optimal solution
     When executing query:
-      """
-      LOOKUP ON edge_1 WHERE edge_1.col1_str ENDS WITH 123 YIELD edge_1.col1_str
-      """
-    Then a SemanticError should be raised at runtime: Column type error : col1_str
-    When profiling query:
       """
       LOOKUP ON edge_1 WHERE edge_1.col1_str NOT ENDS WITH toLower("E") YIELD edge_1.col1_str
       """
-    Then the result should be, in any order:
-      | SrcVID | DstVID | Ranking | edge_1.col1_str |
-      | "101"  | "102"  | 0       | "Red1"          |
-      | "102"  | "103"  | 0       | "Yellow"        |
-    And the execution plan should be:
-      | id | name              | dependencies | operator info                                          |
-      | 3  | Project           | 2            |                                                        |
-      | 2  | Filter            | 4            | {"condition": "(edge_1.col1_str NOT ENDS WITH \"e\")"} |
-      | 4  | EdgeIndexFullScan | 0            |                                                        |
-      | 0  | Start             |              |                                                        |
+    Then a SemanticError should be raised at runtime: Expression (edge_1.col1_str NOT ENDS WITH toLower("E")) is not supported, please use full-text index as an optimal solution

--- a/tests/tck/features/lookup/LookupEdge2.feature
+++ b/tests/tck/features/lookup/LookupEdge2.feature
@@ -29,6 +29,11 @@ Feature: Test lookup on edge index 2
   Scenario Outline: [edge] Simple test cases
     When executing query:
       """
+      LOOKUP ON lookup_edge_1 WHERE lookup_edge_1.col1 == 201 OR lookup_edge_1.col2 == 201 AND lookup_edge_1.col3 == 202
+      """
+    Then the execution should be successful
+    When executing query:
+      """
       LOOKUP ON lookup_edge_1 WHERE col1 == 201
       """
     Then a SemanticError should be raised at runtime: Expression (col1==201) not supported yet
@@ -37,11 +42,6 @@ Feature: Test lookup on edge index 2
       LOOKUP ON lookup_edge_1 WHERE lookup_edge_1.col1 == 201 OR lookup_edge_1.col5 == 201
       """
     Then a SemanticError should be raised at runtime: Invalid column: col5
-    When executing query:
-      """
-      LOOKUP ON lookup_edge_1 WHERE lookup_edge_1.col1 == 201 OR lookup_edge_1.col2 == 201 AND lookup_edge_1.col3 == 202
-      """
-    Then a SemanticError should be raised at runtime: Not supported filter
     When executing query:
       """
       LOOKUP ON lookup_edge_1 WHERE lookup_edge_1.col1 == 300

--- a/tests/tck/features/lookup/LookupTag2.feature
+++ b/tests/tck/features/lookup/LookupTag2.feature
@@ -30,6 +30,11 @@ Feature: Test lookup on tag index 2
   Scenario Outline: [tag] simple tag test cases
     When executing query:
       """
+      LOOKUP ON lookup_tag_1 WHERE lookup_tag_1.col1 == 201 OR lookup_tag_1.col2 == 201 AND lookup_tag_1.col3 == 202
+      """
+    Then the execution should be successful
+    When executing query:
+      """
       LOOKUP ON lookup_tag_1 WHERE col1 == 200;
       """
     Then a SemanticError should be raised at runtime: Expression (col1==200) not supported yet
@@ -38,11 +43,6 @@ Feature: Test lookup on tag index 2
       LOOKUP ON lookup_tag_1 WHERE lookup_tag_1.col1 == 200 OR lookup_tag_1.col5 == 20;
       """
     Then a SemanticError should be raised at runtime: Invalid column: col5
-    When executing query:
-      """
-      LOOKUP ON lookup_tag_1 WHERE lookup_tag_1.col1 == 201 OR lookup_tag_1.col2 == 201 AND lookup_tag_1.col3 == 202
-      """
-    Then a SemanticError should be raised at runtime: Not supported filter
     When executing query:
       """
       LOOKUP ON lookup_tag_1 WHERE lookup_tag_1.col1 == 300

--- a/tests/tck/features/lookup/TagIndexFullScan.feature
+++ b/tests/tck/features/lookup/TagIndexFullScan.feature
@@ -1,4 +1,3 @@
-@aiee
 Feature: Lookup tag index full scan
 
   Background:
@@ -94,6 +93,7 @@ Feature: Lookup tag index full scan
       | 0  | Start            |              |                                           |
 
   # TODO: Support compare operator info that has multiple column hints
+  @aiee
   Scenario: Tag with relational IN/NOT IN filter
     When profiling query:
       """
@@ -188,110 +188,110 @@ Feature: Lookup tag index full scan
       | 2  | Filter           | 4            | {"condition": "(((player.age==40) OR (player.age==25)) AND ((player.name==\"ABC\") OR (player.name==\"Kobe Bryant\")))"} |
       | 4  | TagIndexFullScan | 0            |                                                                                                                          |
       | 0  | Start            |              |                                                                                                                          |
-    When profiling query:
-      """
-      LOOKUP ON team WHERE team.name NOT IN ["Hornets", "Jazz"]
-      """
-    Then the result should be, in any order:
-      | VertexID        |
-      | "76ers"         |
-      | "Bucks"         |
-      | "Bulls"         |
-      | "Cavaliers"     |
-      | "Celtics"       |
-      | "Clippers"      |
-      | "Grizzlies"     |
-      | "Hawks"         |
-      | "Heat"          |
-      | "Wizards"       |
-      | "Warriors"      |
-      | "Kings"         |
-      | "Knicks"        |
-      | "Lakers"        |
-      | "Magic"         |
-      | "Mavericks"     |
-      | "Nets"          |
-      | "Nuggets"       |
-      | "Pacers"        |
-      | "Pelicans"      |
-      | "Pistons"       |
-      | "Raptors"       |
-      | "Rockets"       |
-      | "Spurs"         |
-      | "Suns"          |
-      | "Thunders"      |
-      | "Timberwolves"  |
-      | "Trail Blazers" |
-    And the execution plan should be:
-      | id | name             | dependencies | operator info                                              |
-      | 3  | Project          | 2            |                                                            |
-      | 2  | Filter           | 4            | {"condition": "(team.name NOT IN [\"Hornets\",\"Jazz\"])"} |
-      | 4  | TagIndexFullScan | 0            |                                                            |
-      | 0  | Start            |              |                                                            |
-    When profiling query:
-      """
-      LOOKUP ON player WHERE player.age NOT IN [40 - 1 , 72/2] YIELD player.age
-      """
-    Then the result should be, in any order:
-      | VertexID                | player.age |
-      | "Yao Ming"              | 38         |
-      | "Aron Baynes"           | 32         |
-      | "Ben Simmons"           | 22         |
-      | "Blake Griffin"         | 30         |
-      | "Vince Carter"          | 42         |
-      | "Carmelo Anthony"       | 34         |
-      | "Chris Paul"            | 33         |
-      | "Cory Joseph"           | 27         |
-      | "Damian Lillard"        | 28         |
-      | "Danny Green"           | 31         |
-      | "David West"            | 38         |
-      | "DeAndre Jordan"        | 30         |
-      | "Dejounte Murray"       | 29         |
-      | "Dirk Nowitzki"         | 40         |
-      | "Dwight Howard"         | 33         |
-      | "Dwyane Wade"           | 37         |
-      | "Giannis Antetokounmpo" | 24         |
-      | "Grant Hill"            | 46         |
-      | "JaVale McGee"          | 31         |
-      | "James Harden"          | 29         |
-      | "Jason Kidd"            | 45         |
-      | "Joel Embiid"           | 25         |
-      | "Jonathon Simmons"      | 29         |
-      | "Kevin Durant"          | 30         |
-      | "Klay Thompson"         | 29         |
-      | "Kobe Bryant"           | 40         |
-      | "Kristaps Porzingis"    | 23         |
-      | "Kyle Anderson"         | 25         |
-      | "Kyrie Irving"          | 26         |
-      | "LaMarcus Aldridge"     | 33         |
-      | "LeBron James"          | 34         |
-      | "Luka Doncic"           | 20         |
-      | "Manu Ginobili"         | 41         |
-      | "Marc Gasol"            | 34         |
-      | "Marco Belinelli"       | 32         |
-      | "Nobody"                | 0          |
-      | "Null1"                 | -1         |
-      | "Null2"                 | -2         |
-      | "Null3"                 | -3         |
-      | "Null4"                 | -4         |
-      | "Paul Gasol"            | 38         |
-      | "Paul George"           | 28         |
-      | "Rajon Rondo"           | 33         |
-      | "Ray Allen"             | 43         |
-      | "Ricky Rubio"           | 28         |
-      | "Rudy Gay"              | 32         |
-      | "Russell Westbrook"     | 30         |
-      | "Shaquile O'Neal"       | 47         |
-      | "Stephen Curry"         | 31         |
-      | "Steve Nash"            | 45         |
-      | "Tiago Splitter"        | 34         |
-      | "Tim Duncan"            | 42         |
-    And the execution plan should be:
-      | id | name             | dependencies | operator info                                |
-      | 3  | Project          | 2            |                                              |
-      | 2  | Filter           | 4            | {"condition": "(player.age NOT IN [39,36])"} |
-      | 4  | TagIndexFullScan | 0            |                                              |
-      | 0  | Start            |              |                                              |
+    # When profiling query:
+    #   """
+    #   LOOKUP ON team WHERE team.name NOT IN ["Hornets", "Jazz"]
+    #   """
+    # Then the result should be, in any order:
+    #   | VertexID        |
+    #   | "76ers"         |
+    #   | "Bucks"         |
+    #   | "Bulls"         |
+    #   | "Cavaliers"     |
+    #   | "Celtics"       |
+    #   | "Clippers"      |
+    #   | "Grizzlies"     |
+    #   | "Hawks"         |
+    #   | "Heat"          |
+    #   | "Wizards"       |
+    #   | "Warriors"      |
+    #   | "Kings"         |
+    #   | "Knicks"        |
+    #   | "Lakers"        |
+    #   | "Magic"         |
+    #   | "Mavericks"     |
+    #   | "Nets"          |
+    #   | "Nuggets"       |
+    #   | "Pacers"        |
+    #   | "Pelicans"      |
+    #   | "Pistons"       |
+    #   | "Raptors"       |
+    #   | "Rockets"       |
+    #   | "Spurs"         |
+    #   | "Suns"          |
+    #   | "Thunders"      |
+    #   | "Timberwolves"  |
+    #   | "Trail Blazers" |
+    # And the execution plan should be:
+    #   | id | name             | dependencies | operator info                                              |
+    #   | 3  | Project          | 2            |                                                            |
+    #   | 2  | Filter           | 4            | {"condition": "(team.name NOT IN [\"Hornets\",\"Jazz\"])"} |
+    #   | 4  | TagIndexFullScan | 0            |                                                            |
+    #   | 0  | Start            |              |                                                            |
+    # When profiling query:
+    #   """
+    #   LOOKUP ON player WHERE player.age NOT IN [40 - 1 , 72/2] YIELD player.age
+    #   """
+    # Then the result should be, in any order:
+    #   | VertexID                | player.age |
+    #   | "Yao Ming"              | 38         |
+    #   | "Aron Baynes"           | 32         |
+    #   | "Ben Simmons"           | 22         |
+    #   | "Blake Griffin"         | 30         |
+    #   | "Vince Carter"          | 42         |
+    #   | "Carmelo Anthony"       | 34         |
+    #   | "Chris Paul"            | 33         |
+    #   | "Cory Joseph"           | 27         |
+    #   | "Damian Lillard"        | 28         |
+    #   | "Danny Green"           | 31         |
+    #   | "David West"            | 38         |
+    #   | "DeAndre Jordan"        | 30         |
+    #   | "Dejounte Murray"       | 29         |
+    #   | "Dirk Nowitzki"         | 40         |
+    #   | "Dwight Howard"         | 33         |
+    #   | "Dwyane Wade"           | 37         |
+    #   | "Giannis Antetokounmpo" | 24         |
+    #   | "Grant Hill"            | 46         |
+    #   | "JaVale McGee"          | 31         |
+    #   | "James Harden"          | 29         |
+    #   | "Jason Kidd"            | 45         |
+    #   | "Joel Embiid"           | 25         |
+    #   | "Jonathon Simmons"      | 29         |
+    #   | "Kevin Durant"          | 30         |
+    #   | "Klay Thompson"         | 29         |
+    #   | "Kobe Bryant"           | 40         |
+    #   | "Kristaps Porzingis"    | 23         |
+    #   | "Kyle Anderson"         | 25         |
+    #   | "Kyrie Irving"          | 26         |
+    #   | "LaMarcus Aldridge"     | 33         |
+    #   | "LeBron James"          | 34         |
+    #   | "Luka Doncic"           | 20         |
+    #   | "Manu Ginobili"         | 41         |
+    #   | "Marc Gasol"            | 34         |
+    #   | "Marco Belinelli"       | 32         |
+    #   | "Nobody"                | 0          |
+    #   | "Null1"                 | -1         |
+    #   | "Null2"                 | -2         |
+    #   | "Null3"                 | -3         |
+    #   | "Null4"                 | -4         |
+    #   | "Paul Gasol"            | 38         |
+    #   | "Paul George"           | 28         |
+    #   | "Rajon Rondo"           | 33         |
+    #   | "Ray Allen"             | 43         |
+    #   | "Ricky Rubio"           | 28         |
+    #   | "Rudy Gay"              | 32         |
+    #   | "Russell Westbrook"     | 30         |
+    #   | "Shaquile O'Neal"       | 47         |
+    #   | "Stephen Curry"         | 31         |
+    #   | "Steve Nash"            | 45         |
+    #   | "Tiago Splitter"        | 34         |
+    #   | "Tim Duncan"            | 42         |
+    # And the execution plan should be:
+    #   | id | name             | dependencies | operator info                                |
+    #   | 3  | Project          | 2            |                                              |
+    #   | 2  | Filter           | 4            | {"condition": "(player.age NOT IN [39,36])"} |
+    #   | 4  | TagIndexFullScan | 0            |                                              |
+    #   | 0  | Start            |              |                                              |
 
   Scenario: Tag with relational CONTAINS/NOT CONTAINS filter
     When profiling query:

--- a/tests/tck/features/lookup/TagIndexFullScan.feature
+++ b/tests/tck/features/lookup/TagIndexFullScan.feature
@@ -1,3 +1,4 @@
+@aiee
 Feature: Lookup tag index full scan
 
   Background:
@@ -92,6 +93,7 @@ Feature: Lookup tag index full scan
       | 4  | TagIndexFullScan | 0            |                                           |
       | 0  | Start            |              |                                           |
 
+  # TODO: Support compare operator info that has multiple column hints
   Scenario: Tag with relational IN/NOT IN filter
     When profiling query:
       """
@@ -102,11 +104,10 @@ Feature: Lookup tag index full scan
       | "Jazz"    |
       | "Hornets" |
     And the execution plan should be:
-      | id | name             | dependencies | operator info                                          |
-      | 3  | Project          | 2            |                                                        |
-      | 2  | Filter           | 4            | {"condition": "(team.name IN [\"Hornets\",\"Jazz\"])"} |
-      | 4  | TagIndexFullScan | 0            |                                                        |
-      | 0  | Start            |              |                                                        |
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
     When executing query:
       """
       LOOKUP ON team WHERE team.name IN ["non-existed-name"]
@@ -124,11 +125,69 @@ Feature: Lookup tag index full scan
       | "Tony Parker"       | 36         |
       | "Boris Diaw"        | 36         |
     And the execution plan should be:
-      | id | name             | dependencies | operator info                            |
-      | 3  | Project          | 2            |                                          |
-      | 2  | Filter           | 4            | {"condition": "(player.age IN [39,36])"} |
-      | 4  | TagIndexFullScan | 0            |                                          |
-      | 0  | Start            |              |                                          |
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
+    # a IN b OR c
+    When profiling query:
+      """
+      LOOKUP ON player WHERE player.age IN [40, 25] OR player.name == "ABC" YIELD player.age
+      """
+    Then the result should be, in any order:
+      | VertexID        | player.age |
+      | "Dirk Nowitzki" | 40         |
+      | "Joel Embiid"   | 25         |
+      | "Kobe Bryant"   | 40         |
+      | "Kyle Anderson" | 25         |
+    And the execution plan should be:
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
+    # a IN b OR c IN d
+    When profiling query:
+      """
+      LOOKUP ON player WHERE player.age IN [40, 25] OR player.name IN ["Kobe Bryant"] YIELD player.age
+      """
+    Then the result should be, in any order:
+      | VertexID        | player.age |
+      | "Dirk Nowitzki" | 40         |
+      | "Joel Embiid"   | 25         |
+      | "Kobe Bryant"   | 40         |
+      | "Kyle Anderson" | 25         |
+    And the execution plan should be:
+      | id | name      | dependencies | operator info |
+      | 3  | Project   | 4            |               |
+      | 4  | IndexScan | 0            |               |
+      | 0  | Start     |              |               |
+    # a IN b AND c
+    When profiling query:
+      """
+      LOOKUP ON player WHERE player.age IN [40, 25] AND player.name == "Kobe Bryant" YIELD player.age
+      """
+    Then the result should be, in any order:
+      | VertexID      | player.age |
+      | "Kobe Bryant" | 40         |
+    And the execution plan should be:
+      | id | name               | dependencies | operator info                                                                                                           |
+      | 3  | Project            | 4            |                                                                                                                         |
+      | 4  | TagIndexPrefixScan | 0            | {"indexCtx": {"columnHints":{"endValue":"__EMPTY__","beginValue":"\"Kobe Bryant","scanType":"PREFIX","column":"name"}}} |
+      | 0  | Start              |              |                                                                                                                         |
+    # a IN b AND c IN d (TagIndexFullScan)
+    When profiling query:
+      """
+      LOOKUP ON player WHERE player.age IN [40, 25] AND player.name IN ["ABC", "Kobe Bryant"] YIELD player.age
+      """
+    Then the result should be, in any order:
+      | VertexID      | player.age |
+      | "Kobe Bryant" | 40         |
+    And the execution plan should be:
+      | id | name             | dependencies | operator info                                                                                                            |
+      | 3  | Project          | 2            |                                                                                                                          |
+      | 2  | Filter           | 4            | {"condition": "(((player.age==40) OR (player.age==25)) AND ((player.name==\"ABC\") OR (player.name==\"Kobe Bryant\")))"} |
+      | 4  | TagIndexFullScan | 0            |                                                                                                                          |
+      | 0  | Start            |              |                                                                                                                          |
     When profiling query:
       """
       LOOKUP ON team WHERE team.name NOT IN ["Hornets", "Jazz"]

--- a/tests/tck/features/match/SeekById.feature
+++ b/tests/tck/features/match/SeekById.feature
@@ -138,6 +138,15 @@ Feature: Match seek by id
     Then the result should be, in any order:
       | Name           |
       | 'James Harden' |
+    When executing query:
+      """
+      MATCH (v:player)
+      WHERE id(v) IN ['James Harden', v.age]
+      RETURN v.name AS Name
+      """
+    Then the result should be, in any order:
+      | Name           |
+      | 'James Harden' |
 
   Scenario: complicate logical
     When executing query:
@@ -248,6 +257,13 @@ Feature: Match seek by id
       """
       MATCH (v)
       WHERE (id(v) + '') == 'James Harden'
+      RETURN v.name AS Name
+      """
+    Then a SemanticError should be raised at runtime:
+    When executing query:
+      """
+      MATCH (v)
+      WHERE id(v) IN ['James Harden', v.name]
       RETURN v.name AS Name
       """
     Then a SemanticError should be raised at runtime:

--- a/tests/tck/features/match/SeekById.intVid.feature
+++ b/tests/tck/features/match/SeekById.intVid.feature
@@ -138,6 +138,15 @@ Feature: Match seek by id
     Then the result should be, in any order:
       | Name           |
       | 'James Harden' |
+    When executing query:
+      """
+      MATCH (v:player)
+      WHERE id(v) IN [hash('James Harden'), v.age]
+      RETURN v.name AS Name
+      """
+    Then the result should be, in any order:
+      | Name           |
+      | 'James Harden' |
 
   Scenario: complicate logical
     When executing query:
@@ -241,6 +250,13 @@ Feature: Match seek by id
       """
       MATCH (v)
       WHERE id(x) == hash('James Harden')
+      RETURN v.name AS Name
+      """
+    Then a SemanticError should be raised at runtime:
+    When executing query:
+      """
+      MATCH (v)
+      WHERE id(v) IN [hash('James Harden'), v.name]
       RETURN v.name AS Name
       """
     Then a SemanticError should be raised at runtime:


### PR DESCRIPTION
1. Fix constant fold for container expressions
2. Disable using other string-related relExpr as the filter of LOOKUP except `STARTS/NOT STARTS WITH`
3. Convert `IN` expression to `OR` expression in `LOOKUP` if the property in the`IN` expression has a valid index:
    - Stand alone `IN` expr: `A in [B, C, D]  =>  (A == B) or (A == C) or (A == D)`
    - With `AND` expr : `A in [a, b] AND B  =>  (A==a AND B) OR (A==b AND B)`
    - With `OR` expr: `A in [a, b] OR B  =>   A==a OR A==b OR B`
4. If the container has only one element, the `IN` expression will be transformed to a `relEQ` expression. e.g.  `A in [B]  =>  A==B`

Close https://github.com/vesoft-inc/nebula/issues/2881