### PR TITLE
Fix the var-tracking-assignments warning.

### DIFF
--- a/src/common/function/test/FunctionManagerTest.cpp
+++ b/src/common/function/test/FunctionManagerTest.cpp
@@ -445,6 +445,9 @@ TEST_F(FunctionManagerTest, functionCall) {
     auto res = std::move(result).value()(genArgsRef({true}));
     EXPECT_EQ(res, Value::kNullBadType);
   }
+}
+
+TEST_F(FunctionManagerTest, time) {
   // current time
   static constexpr std::size_t kCurrentTimeParaNumber = 0;
   // time from literal


### PR DESCRIPTION
```
In file included from /home/william.chen/nebula/build/third-party/install/include/gtest/gtest.h:58,
                 from /home/william.chen/nebula/src/common/function/test/FunctionManagerTest.cpp:7:
/home/william.chen/nebula/src/common/function/test/FunctionManagerTest.cpp: In member function 'virtual void nebula::FunctionManagerTest_functionCall_Test::TestBody()':
/home/william.chen/nebula/src/common/function/test/FunctionManagerTest.cpp:212:8: note: variable tracking size limit exceeded with '-fvar-tracking-assignments', retrying without
  212 | TEST_F(FunctionManagerTest, functionCall) {
      |        ^~~~~~~~~~~~~~~~~~~
```