### PR TITLE
format find path

### DIFF
--- a/.linters/cpp/checkKeyword.py
+++ b/.linters/cpp/checkKeyword.py
@@ -37,6 +37,7 @@ reserved_key_words = [
     'KW_WHEN',
     'KW_DELETE',
     'KW_FIND',
+    'KW_PATH',
     'KW_LOOKUP',
     'KW_ALTER',
     'KW_STEPS',

--- a/src/graph/context/ast/QueryAstContext.h
+++ b/src/graph/context/ast/QueryAstContext.h
@@ -43,6 +43,7 @@ struct PathContext final : AstContext {
   StepClause steps;
   Over over;
   Expression* filter{nullptr};
+  YieldColumns* yieldExpr{nullptr};
 
   /*
    * find path from A to B OR find path from $-.src to $-.dst

--- a/src/graph/context/ast/QueryAstContext.h
+++ b/src/graph/context/ast/QueryAstContext.h
@@ -43,7 +43,7 @@ struct PathContext final : AstContext {
   StepClause steps;
   Over over;
   Expression* filter{nullptr};
-  YieldColumns* yieldExpr{nullptr};
+  std::vector<std::string> colNames;
 
   /*
    * find path from A to B OR find path from $-.src to $-.dst

--- a/src/graph/optimizer/OptGroup.h
+++ b/src/graph/optimizer/OptGroup.h
@@ -6,10 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_OPTGROUP_H_
 #define GRAPH_OPTIMIZER_OPTGROUP_H_
 
-#include <algorithm>
-#include <list>
-#include <vector>
-
 #include "common/base/Status.h"
 
 namespace nebula {

--- a/src/graph/optimizer/Optimizer.h
+++ b/src/graph/optimizer/Optimizer.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_OPTIMIZER_H_
 #define GRAPH_OPTIMIZER_OPTIMIZER_H_
 
-#include <memory>
-
 #include "common/base/Base.h"
 #include "common/base/StatusOr.h"
 

--- a/src/graph/optimizer/OptimizerUtils.cpp
+++ b/src/graph/optimizer/OptimizerUtils.cpp
@@ -5,21 +5,9 @@
 
 #include "graph/optimizer/OptimizerUtils.h"
 
-#include <algorithm>
-#include <iterator>
-#include <memory>
-#include <unordered_set>
-
 #include "common/base/Status.h"
 #include "common/datatypes/Value.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/PropertyExpression.h"
-#include "common/expression/RelationalExpression.h"
 #include "graph/planner/plan/Query.h"
-#include "interface/gen-cpp2/meta_types.h"
-#include "interface/gen-cpp2/storage_types.h"
 
 using nebula::meta::cpp2::ColumnDef;
 using nebula::meta::cpp2::IndexItem;

--- a/src/graph/optimizer/rule/CollapseProjectRule.h
+++ b/src/graph/optimizer/rule/CollapseProjectRule.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_RULE_COLLAPSEPROJECTRULE_H_
 #define GRAPH_OPTIMIZER_RULE_COLLAPSEPROJECTRULE_H_
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/CombineFilterRule.h
+++ b/src/graph/optimizer/rule/CombineFilterRule.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_RULE_COMBINEFILTERRULE_H_
 #define GRAPH_OPTIMIZER_RULE_COMBINEFILTERRULE_H_
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/GeoPredicateIndexScanBaseRule.cpp
+++ b/src/graph/optimizer/rule/GeoPredicateIndexScanBaseRule.cpp
@@ -5,8 +5,6 @@
 
 #include "graph/optimizer/rule/GeoPredicateIndexScanBaseRule.h"
 
-#include "common/expression/Expression.h"
-#include "common/expression/LogicalExpression.h"
 #include "common/geo/GeoIndex.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
@@ -16,7 +14,6 @@
 #include "graph/planner/plan/Query.h"
 #include "graph/planner/plan/Scan.h"
 #include "graph/util/ExpressionUtils.h"
-#include "interface/gen-cpp2/storage_types.h"
 
 using nebula::graph::Filter;
 using nebula::graph::IndexScan;

--- a/src/graph/optimizer/rule/IndexScanRule.cpp
+++ b/src/graph/optimizer/rule/IndexScanRule.cpp
@@ -5,8 +5,6 @@
 
 #include "graph/optimizer/rule/IndexScanRule.h"
 
-#include <vector>
-
 #include "common/expression/LabelAttributeExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"

--- a/src/graph/optimizer/rule/OptimizeEdgeIndexScanByFilterRule.cpp
+++ b/src/graph/optimizer/rule/OptimizeEdgeIndexScanByFilterRule.cpp
@@ -5,24 +5,12 @@
 
 #include "graph/optimizer/rule/OptimizeEdgeIndexScanByFilterRule.h"
 
-#include <algorithm>
-#include <memory>
-#include <vector>
-
-#include "common/base/Base.h"
-#include "common/base/Status.h"
-#include "common/expression/Expression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/PropertyExpression.h"
-#include "common/expression/RelationalExpression.h"
 #include "graph/context/QueryContext.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/optimizer/OptimizerUtils.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Scan.h"
-#include "interface/gen-cpp2/meta_types.h"
-#include "interface/gen-cpp2/storage_types.h"
 
 using nebula::Expression;
 using nebula::graph::EdgeIndexFullScan;

--- a/src/graph/optimizer/rule/OptimizeEdgeIndexScanByFilterRule.h
+++ b/src/graph/optimizer/rule/OptimizeEdgeIndexScanByFilterRule.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_RULE_OPTIMIZEEDGEINDEXSCANBYFILTERRULE_H_
 #define GRAPH_OPTIMIZER_RULE_OPTIMIZEEDGEINDEXSCANBYFILTERRULE_H_
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
+++ b/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
@@ -5,7 +5,6 @@
 
 #include "graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.h"
 
-#include "common/expression/Expression.h"
 #include "graph/context/QueryContext.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
@@ -13,7 +12,6 @@
 #include "graph/optimizer/rule/IndexScanRule.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Scan.h"
-#include "interface/gen-cpp2/storage_types.h"
 
 using nebula::graph::Filter;
 using nebula::graph::OptimizerUtils;

--- a/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.h
+++ b/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_RULE_OPTIMIZETAGINDEXSCANBYFILTERRULE_H_
 #define GRAPH_OPTIMIZER_RULE_OPTIMIZETAGINDEXSCANBYFILTERRULE_H_
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushFilterDownAggregateRule.h
+++ b/src/graph/optimizer/rule/PushFilterDownAggregateRule.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_RULE_PUSHFILTERDOWNAGGREGATERULE_H_
 #define GRAPH_OPTIMIZER_RULE_PUSHFILTERDOWNAGGREGATERULE_H_
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -5,12 +5,7 @@
 
 #include "graph/optimizer/rule/PushFilterDownGetNbrsRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
 #include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"

--- a/src/graph/optimizer/rule/PushFilterDownGetNbrsRule.h
+++ b/src/graph/optimizer/rule/PushFilterDownGetNbrsRule.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_RULE_PUSHFILTERDOWNGETNBRSRULE_H_
 #define GRAPH_OPTIMIZER_RULE_PUSHFILTERDOWNGETNBRSRULE_H_
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushFilterDownLeftJoinRule.h
+++ b/src/graph/optimizer/rule/PushFilterDownLeftJoinRule.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_RULE_PUSHFILTERDOWNLEFTJOINRULE_H_
 #define GRAPH_OPTIMIZER_RULE_PUSHFILTERDOWNLEFTJOINRULE_H_
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushFilterDownProjectRule.h
+++ b/src/graph/optimizer/rule/PushFilterDownProjectRule.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_RULE_PUSHFILTERDOWNPROJECTRULE_H_
 #define GRAPH_OPTIMIZER_RULE_PUSHFILTERDOWNPROJECTRULE_H_
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushLimitDownEdgeIndexFullScanRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownEdgeIndexFullScanRule.cpp
@@ -5,12 +5,6 @@
 
 #include "graph/optimizer/rule/PushLimitDownEdgeIndexFullScanRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"

--- a/src/graph/optimizer/rule/PushLimitDownEdgeIndexFullScanRule.h
+++ b/src/graph/optimizer/rule/PushLimitDownEdgeIndexFullScanRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushLimitDownEdgeIndexPrefixScanRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownEdgeIndexPrefixScanRule.cpp
@@ -5,12 +5,6 @@
 
 #include "graph/optimizer/rule/PushLimitDownEdgeIndexPrefixScanRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"

--- a/src/graph/optimizer/rule/PushLimitDownEdgeIndexPrefixScanRule.h
+++ b/src/graph/optimizer/rule/PushLimitDownEdgeIndexPrefixScanRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushLimitDownEdgeIndexRangeScanRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownEdgeIndexRangeScanRule.cpp
@@ -5,12 +5,6 @@
 
 #include "graph/optimizer/rule/PushLimitDownEdgeIndexRangeScanRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"

--- a/src/graph/optimizer/rule/PushLimitDownEdgeIndexRangeScanRule.h
+++ b/src/graph/optimizer/rule/PushLimitDownEdgeIndexRangeScanRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushLimitDownGetNeighborsRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownGetNeighborsRule.cpp
@@ -5,17 +5,10 @@
 
 #include "graph/optimizer/rule/PushLimitDownGetNeighborsRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Query.h"
-#include "graph/visitor/ExtractFilterExprVisitor.h"
 
 using nebula::graph::GetNeighbors;
 using nebula::graph::Limit;

--- a/src/graph/optimizer/rule/PushLimitDownGetNeighborsRule.h
+++ b/src/graph/optimizer/rule/PushLimitDownGetNeighborsRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushLimitDownIndexScanRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownIndexScanRule.cpp
@@ -5,17 +5,10 @@
 
 #include "graph/optimizer/rule/PushLimitDownIndexScanRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Query.h"
-#include "graph/visitor/ExtractFilterExprVisitor.h"
 
 using nebula::graph::IndexScan;
 using nebula::graph::Limit;

--- a/src/graph/optimizer/rule/PushLimitDownIndexScanRule.h
+++ b/src/graph/optimizer/rule/PushLimitDownIndexScanRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushLimitDownProjectRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownProjectRule.cpp
@@ -5,17 +5,10 @@
 
 #include "graph/optimizer/rule/PushLimitDownProjectRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Query.h"
-#include "graph/visitor/ExtractFilterExprVisitor.h"
 
 using nebula::graph::Limit;
 using nebula::graph::PlanNode;

--- a/src/graph/optimizer/rule/PushLimitDownProjectRule.h
+++ b/src/graph/optimizer/rule/PushLimitDownProjectRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushLimitDownTagIndexFullScanRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownTagIndexFullScanRule.cpp
@@ -5,17 +5,10 @@
 
 #include "graph/optimizer/rule/PushLimitDownTagIndexFullScanRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Scan.h"
-#include "graph/visitor/ExtractFilterExprVisitor.h"
 
 using nebula::graph::Limit;
 using nebula::graph::PlanNode;

--- a/src/graph/optimizer/rule/PushLimitDownTagIndexFullScanRule.h
+++ b/src/graph/optimizer/rule/PushLimitDownTagIndexFullScanRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushLimitDownTagIndexPrefixScanRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownTagIndexPrefixScanRule.cpp
@@ -5,17 +5,10 @@
 
 #include "graph/optimizer/rule/PushLimitDownTagIndexPrefixScanRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Scan.h"
-#include "graph/visitor/ExtractFilterExprVisitor.h"
 
 using nebula::graph::Limit;
 using nebula::graph::PlanNode;

--- a/src/graph/optimizer/rule/PushLimitDownTagIndexPrefixScanRule.h
+++ b/src/graph/optimizer/rule/PushLimitDownTagIndexPrefixScanRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushLimitDownTagIndexRangeScanRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownTagIndexRangeScanRule.cpp
@@ -5,17 +5,10 @@
 
 #include "graph/optimizer/rule/PushLimitDownTagIndexRangeScanRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Scan.h"
-#include "graph/visitor/ExtractFilterExprVisitor.h"
 
 using nebula::graph::Limit;
 using nebula::graph::PlanNode;

--- a/src/graph/optimizer/rule/PushLimitDownTagIndexRangeScanRule.h
+++ b/src/graph/optimizer/rule/PushLimitDownTagIndexRangeScanRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushStepLimitDownGetNeighborsRule.cpp
+++ b/src/graph/optimizer/rule/PushStepLimitDownGetNeighborsRule.cpp
@@ -5,17 +5,10 @@
 
 #include "graph/optimizer/rule/PushStepLimitDownGetNeighborsRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Query.h"
-#include "graph/visitor/ExtractFilterExprVisitor.h"
 
 using nebula::graph::GetNeighbors;
 using nebula::graph::Limit;

--- a/src/graph/optimizer/rule/PushStepLimitDownGetNeighborsRule.h
+++ b/src/graph/optimizer/rule/PushStepLimitDownGetNeighborsRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/PushStepSampleDownGetNeighborsRule.cpp
+++ b/src/graph/optimizer/rule/PushStepSampleDownGetNeighborsRule.cpp
@@ -5,17 +5,10 @@
 
 #include "graph/optimizer/rule/PushStepSampleDownGetNeighborsRule.h"
 
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Query.h"
-#include "graph/visitor/ExtractFilterExprVisitor.h"
 
 using nebula::graph::GetNeighbors;
 using nebula::graph::PlanNode;

--- a/src/graph/optimizer/rule/PushStepSampleDownGetNeighborsRule.h
+++ b/src/graph/optimizer/rule/PushStepSampleDownGetNeighborsRule.h
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/RemoveNoopProjectRule.h
+++ b/src/graph/optimizer/rule/RemoveNoopProjectRule.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_RULE_REMOVENOOPPROJECTRULE_H_
 #define GRAPH_OPTIMIZER_RULE_REMOVENOOPPROJECTRULE_H_
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/TopNRule.cpp
+++ b/src/graph/optimizer/rule/TopNRule.cpp
@@ -4,18 +4,10 @@
  */
 
 #include "graph/optimizer/rule/TopNRule.h"
-
-#include "common/expression/BinaryExpression.h"
-#include "common/expression/ConstantExpression.h"
-#include "common/expression/Expression.h"
-#include "common/expression/FunctionCallExpression.h"
-#include "common/expression/LogicalExpression.h"
-#include "common/expression/UnaryExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/planner/plan/PlanNode.h"
 #include "graph/planner/plan/Query.h"
-#include "graph/visitor/ExtractFilterExprVisitor.h"
 
 using nebula::graph::Limit;
 using nebula::graph::PlanNode;

--- a/src/graph/optimizer/rule/TopNRule.h
+++ b/src/graph/optimizer/rule/TopNRule.h
@@ -6,8 +6,6 @@
 #ifndef GRAPH_OPTIMIZER_RULE_TOPNRULE_H_
 #define GRAPH_OPTIMIZER_RULE_TOPNRULE_H_
 
-#include <memory>
-
 #include "graph/optimizer/OptRule.h"
 
 namespace nebula {

--- a/src/graph/optimizer/rule/UnionAllIndexScanBaseRule.cpp
+++ b/src/graph/optimizer/rule/UnionAllIndexScanBaseRule.cpp
@@ -5,8 +5,6 @@
 
 #include "graph/optimizer/rule/UnionAllIndexScanBaseRule.h"
 
-#include "common/expression/Expression.h"
-#include "common/expression/LogicalExpression.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
 #include "graph/optimizer/OptRule.h"
@@ -15,7 +13,6 @@
 #include "graph/planner/plan/Query.h"
 #include "graph/planner/plan/Scan.h"
 #include "graph/util/ExpressionUtils.h"
-#include "interface/gen-cpp2/storage_types.h"
 
 using nebula::graph::Filter;
 using nebula::graph::IndexScan;

--- a/src/graph/planner/ngql/PathPlanner.cpp
+++ b/src/graph/planner/ngql/PathPlanner.cpp
@@ -271,7 +271,7 @@ SubPlan PathPlanner::singlePairPlan(PlanNode* dep) {
   auto* dc = DataCollect::make(qctx, DataCollect::DCKind::kBFSShortest);
   dc->setInputVars({conjunct->outputVar()});
   dc->addDep(loop);
-  dc->setColNames({"path"});
+  dc->setColNames({"PATH"});
 
   SubPlan subPlan;
   subPlan.root = dc;
@@ -321,7 +321,7 @@ SubPlan PathPlanner::allPairPlan(PlanNode* dep) {
   auto* dc = DataCollect::make(qctx, DataCollect::DCKind::kAllPaths);
   dc->addDep(loop);
   dc->setInputVars({conjunct->outputVar()});
-  dc->setColNames({"path"});
+  dc->setColNames({"PATH"});
 
   SubPlan subPlan;
   subPlan.root = dc;
@@ -374,7 +374,7 @@ SubPlan PathPlanner::multiPairPlan(PlanNode* dep) {
   auto* dc = DataCollect::make(qctx, DataCollect::DCKind::kMultiplePairShortest);
   dc->addDep(loop);
   dc->setInputVars({conjunct->outputVar()});
-  dc->setColNames({"path"});
+  dc->setColNames({"PATH"});
 
   SubPlan subPlan;
   subPlan.root = dc;
@@ -503,18 +503,20 @@ PlanNode* PathPlanner::buildPathProp(PlanNode* dep) {
   dc->addDep(vertexPlan);
   dc->addDep(edgePlan);
   dc->setInputVars({vertexPlan->outputVar(), edgePlan->outputVar(), dep->outputVar()});
-  dc->setColNames({"path"});
+  dc->setColNames({"PATH"});
   return dc;
 }
 
 StatusOr<SubPlan> PathPlanner::transform(AstContext* astCtx) {
   pathCtx_ = static_cast<PathContext*>(astCtx);
+  auto qctx = pathCtx_->qctx;
+  auto& from = pathCtx_->from;
+  auto& to = pathCtx_->to;
+  buildStart(from, pathCtx_->fromVidsVar, false);
+  buildStart(to, pathCtx_->toVidsVar, true);
 
-  buildStart(pathCtx_->from, pathCtx_->fromVidsVar, false);
-  buildStart(pathCtx_->to, pathCtx_->toVidsVar, true);
-
-  auto* startNode = StartNode::make(pathCtx_->qctx);
-  auto* pt = PassThroughNode::make(pathCtx_->qctx, startNode);
+  auto* startNode = StartNode::make(qctx);
+  auto* pt = PassThroughNode::make(qctx, startNode);
 
   SubPlan subPlan;
   do {
@@ -522,7 +524,7 @@ StatusOr<SubPlan> PathPlanner::transform(AstContext* astCtx) {
       subPlan = allPairPlan(pt);
       break;
     }
-    if (pathCtx_->from.vids.size() == 1 && pathCtx_->to.vids.size() == 1) {
+    if (from.vids.size() == 1 && to.vids.size() == 1) {
       subPlan = singlePairPlan(pt);
       break;
     }
@@ -532,6 +534,8 @@ StatusOr<SubPlan> PathPlanner::transform(AstContext* astCtx) {
   if (pathCtx_->withProp) {
     subPlan.root = buildPathProp(subPlan.root);
   }
+
+  subPlan.root = Project::make(qctx, subPlan.root, pathCtx_->yieldExpr);
 
   return subPlan;
 }

--- a/src/graph/planner/ngql/PathPlanner.cpp
+++ b/src/graph/planner/ngql/PathPlanner.cpp
@@ -271,7 +271,7 @@ SubPlan PathPlanner::singlePairPlan(PlanNode* dep) {
   auto* dc = DataCollect::make(qctx, DataCollect::DCKind::kBFSShortest);
   dc->setInputVars({conjunct->outputVar()});
   dc->addDep(loop);
-  dc->setColNames({"PATH"});
+  dc->setColNames(pathCtx_->colNames);
 
   SubPlan subPlan;
   subPlan.root = dc;
@@ -321,7 +321,7 @@ SubPlan PathPlanner::allPairPlan(PlanNode* dep) {
   auto* dc = DataCollect::make(qctx, DataCollect::DCKind::kAllPaths);
   dc->addDep(loop);
   dc->setInputVars({conjunct->outputVar()});
-  dc->setColNames({"PATH"});
+  dc->setColNames(pathCtx_->colNames);
 
   SubPlan subPlan;
   subPlan.root = dc;
@@ -374,7 +374,7 @@ SubPlan PathPlanner::multiPairPlan(PlanNode* dep) {
   auto* dc = DataCollect::make(qctx, DataCollect::DCKind::kMultiplePairShortest);
   dc->addDep(loop);
   dc->setInputVars({conjunct->outputVar()});
-  dc->setColNames({"PATH"});
+  dc->setColNames(pathCtx_->colNames);
 
   SubPlan subPlan;
   subPlan.root = dc;
@@ -503,7 +503,7 @@ PlanNode* PathPlanner::buildPathProp(PlanNode* dep) {
   dc->addDep(vertexPlan);
   dc->addDep(edgePlan);
   dc->setInputVars({vertexPlan->outputVar(), edgePlan->outputVar(), dep->outputVar()});
-  dc->setColNames({"PATH"});
+  dc->setColNames(std::move(pathCtx_->colNames));
   return dc;
 }
 
@@ -534,8 +534,6 @@ StatusOr<SubPlan> PathPlanner::transform(AstContext* astCtx) {
   if (pathCtx_->withProp) {
     subPlan.root = buildPathProp(subPlan.root);
   }
-
-  subPlan.root = Project::make(qctx, subPlan.root, pathCtx_->yieldExpr);
 
   return subPlan;
 }

--- a/src/graph/validator/FindPathValidator.cpp
+++ b/src/graph/validator/FindPathValidator.cpp
@@ -67,13 +67,13 @@ Status FindPathValidator::validateYield(YieldClause* yield) {
   if (yield == nullptr) {
     // TODO: compatible with previous version, this will be deprecated in version 3.0
     auto* yieldColumns = new YieldColumns();
-    auto* pathExpr = new YieldColumn(PathBuildExpression::make(pool), "path");
+    auto* pathExpr = new YieldColumn(LabelExpression::make(pool, "PATH"), "path");
     yieldColumns->addColumn(pathExpr);
     yield = pool->add(new YieldClause(yieldColumns));
   }
 
   for (auto& col : yield->columns()) {
-    if (col->expr()->kind() != Expression::Kind::kPathBuild) {
+    if (col->expr()->kind() != Expression::Kind::kLabel || col->expr()->toString() != "PATH") {
       return Status::SemanticError("illegal yield clauses `%s'. only support yield path",
                                    col->toString().c_str());
     }

--- a/src/graph/validator/FindPathValidator.cpp
+++ b/src/graph/validator/FindPathValidator.cpp
@@ -64,14 +64,14 @@ Status FindPathValidator::validateWhere(WhereClause* where) {
 
 Status FindPathValidator::validateYield(YieldClause* yield) {
   if (yield == nullptr) {
-    return Status::SemanticError("missing yield clause.");
+    return Status::SemanticError("Missing yield clause.");
   }
   if (yield->columns().size() != 1) {
-    return Status::SemanticError("only support yield path");
+    return Status::SemanticError("Only support yield path");
   }
-  const auto& col = yield->columns().front();
+  auto col = yield->columns().front();
   if (col->expr()->kind() != Expression::Kind::kLabel || col->expr()->toString() != "PATH") {
-    return Status::SemanticError("illegal yield clauses `%s'. only support yield path",
+    return Status::SemanticError("Illegal yield clauses `%s'. only support yield path",
                                  col->toString().c_str());
   }
   outputs_.emplace_back(col->name(), Value::Type::PATH);

--- a/src/graph/validator/FindPathValidator.cpp
+++ b/src/graph/validator/FindPathValidator.cpp
@@ -5,7 +5,6 @@
 
 #include "graph/validator/FindPathValidator.h"
 
-#include "common/expression/VariableExpression.h"
 #include "graph/planner/plan/Algo.h"
 #include "graph/planner/plan/Logic.h"
 #include "graph/util/ValidateUtil.h"

--- a/src/graph/validator/FindPathValidator.h
+++ b/src/graph/validator/FindPathValidator.h
@@ -23,6 +23,8 @@ class FindPathValidator final : public Validator {
 
   Status validateWhere(WhereClause* where);
 
+  Status validateYield(YieldClause* yield);
+
  private:
   std::unique_ptr<PathContext> pathCtx_;
 };

--- a/src/graph/validator/GetSubgraphValidator.cpp
+++ b/src/graph/validator/GetSubgraphValidator.cpp
@@ -5,9 +5,6 @@
 
 #include "graph/validator/GetSubgraphValidator.h"
 
-#include <memory>
-
-#include "graph/context/QueryExpressionContext.h"
 #include "graph/planner/plan/Logic.h"
 #include "graph/planner/plan/Query.h"
 #include "graph/util/ValidateUtil.h"

--- a/src/graph/validator/test/FindPathValidatorTest.cpp
+++ b/src/graph/validator/test/FindPathValidatorTest.cpp
@@ -37,7 +37,7 @@ TEST_F(FindPathValidatorTest, invalidYield) {
         "FIND NOLOOP PATH WITH PROP FROM \"Tim Duncan\" TO \"Yao Ming\" OVER teammate YIELD path";
     auto result = checkResult(query);
     EXPECT_EQ(std::string(result.message()),
-              "SyntaxError: please add alias when using path. near `path'");
+              "SyntaxError: please add alias when using `path'. near `path'");
   }
   {
     std::string query =

--- a/src/graph/validator/test/FindPathValidatorTest.cpp
+++ b/src/graph/validator/test/FindPathValidatorTest.cpp
@@ -19,29 +19,33 @@ using PK = nebula::graph::PlanNode::Kind;
 
 TEST_F(FindPathValidatorTest, invalidYield) {
   {
-    std::string query =
-        "FIND SHORTEST PATH  FROM \"Tim Duncan\" TO \"Tony Paker\" OVER * YIELD vertex";
+    std::string query = "FIND SHORTEST PATH  FROM \"Tim\" TO \"Tony\" OVER *";
+    auto result = checkResult(query);
+    EXPECT_EQ(std::string(result.message()), "SemanticError: missing yield clause.");
+  }
+  {
+    std::string query = "FIND SHORTEST PATH  FROM \"Tim\" TO \"Tony\" OVER * YIELD vertex";
     auto result = checkResult(query);
     EXPECT_EQ(std::string(result.message()),
               "SyntaxError: please add alias when using `vertex'. near `vertex'");
   }
   {
     std::string query =
-        "FIND ALL PATH WITH PROP FROM \"Tim Duncan\" TO \"Tony Paker\" OVER like YIELD edge as e";
+        "FIND ALL PATH WITH PROP FROM \"Tim\" TO \"Tony\" OVER like YIELD edge as e";
     auto result = checkResult(query);
     EXPECT_EQ(std::string(result.message()),
               "SemanticError: illegal yield clauses `EDGE AS e'. only support yield path");
   }
   {
     std::string query =
-        "FIND NOLOOP PATH WITH PROP FROM \"Tim Duncan\" TO \"Yao Ming\" OVER teammate YIELD path";
+        "FIND NOLOOP PATH WITH PROP FROM \"Tim\" TO \"Yao\" OVER teammate YIELD path";
     auto result = checkResult(query);
     EXPECT_EQ(std::string(result.message()),
               "SyntaxError: please add alias when using `path'. near `path'");
   }
   {
     std::string query =
-        "FIND NOLOOP PATH WITH PROP FROM \"Tim Duncan\" TO \"Yao Ming\" OVER * YIELD "
+        "FIND NOLOOP PATH WITH PROP FROM \"Tim\" TO \"Yao\" OVER * YIELD "
         "$$.player.name";
     auto result = checkResult(query);
     EXPECT_EQ(std::string(result.message()),
@@ -51,7 +55,8 @@ TEST_F(FindPathValidatorTest, invalidYield) {
 
 TEST_F(FindPathValidatorTest, SinglePairPath) {
   {
-    std::string query = "FIND SHORTEST PATH FROM \"1\" TO \"2\" OVER like UPTO 5 STEPS";
+    std::string query =
+        "FIND SHORTEST PATH FROM \"1\" TO \"2\" OVER like UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -67,7 +72,8 @@ TEST_F(FindPathValidatorTest, SinglePairPath) {
     EXPECT_TRUE(checkResult(query, expected));
   }
   {
-    std::string query = "FIND SHORTEST PATH FROM \"1\" TO \"2\" OVER like, serve UPTO 5 STEPS";
+    std::string query =
+        "FIND SHORTEST PATH FROM \"1\" TO \"2\" OVER like, serve UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -86,7 +92,8 @@ TEST_F(FindPathValidatorTest, SinglePairPath) {
 
 TEST_F(FindPathValidatorTest, MultiPairPath) {
   {
-    std::string query = "FIND SHORTEST PATH FROM \"1\" TO \"2\",\"3\" OVER like UPTO 5 STEPS";
+    std::string query =
+        "FIND SHORTEST PATH FROM \"1\" TO \"2\",\"3\" OVER like UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -107,7 +114,7 @@ TEST_F(FindPathValidatorTest, MultiPairPath) {
   {
     std::string query =
         "FIND SHORTEST PATH FROM \"1\",\"2\" TO \"3\",\"4\" OVER like UPTO 5 "
-        "STEPS";
+        "STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -129,7 +136,7 @@ TEST_F(FindPathValidatorTest, MultiPairPath) {
 
 TEST_F(FindPathValidatorTest, ALLPath) {
   {
-    std::string query = "FIND ALL PATH FROM \"1\" TO \"2\" OVER like UPTO 5 STEPS";
+    std::string query = "FIND ALL PATH FROM \"1\" TO \"2\" OVER like UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -147,7 +154,8 @@ TEST_F(FindPathValidatorTest, ALLPath) {
     EXPECT_TRUE(checkResult(query, expected));
   }
   {
-    std::string query = "FIND ALL PATH FROM \"1\" TO \"2\",\"3\" OVER like UPTO 5 STEPS";
+    std::string query =
+        "FIND ALL PATH FROM \"1\" TO \"2\",\"3\" OVER like UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -171,7 +179,7 @@ TEST_F(FindPathValidatorTest, RunTimePath) {
     std::string query =
         "GO FROM \"1\" OVER like YIELD like._src AS src, like._dst AS dst "
         " | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like, serve UPTO 5 "
-        "STEPS";
+        "STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -198,7 +206,7 @@ TEST_F(FindPathValidatorTest, RunTimePath) {
   {
     std::string query =
         "GO FROM \"1\" OVER like YIELD like._src AS src, like._dst AS dst "
-        " | FIND ALL PATH FROM $-.src TO $-.dst OVER like, serve UPTO 5 STEPS";
+        " | FIND ALL PATH FROM $-.src TO $-.dst OVER like, serve UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -225,7 +233,7 @@ TEST_F(FindPathValidatorTest, RunTimePath) {
     std::string query =
         "GO FROM \"1\" OVER like YIELD like._src AS src, like._dst AS dst "
         " | FIND SHORTEST PATH FROM \"2\" TO $-.dst OVER like, serve UPTO 5 "
-        "STEPS";
+        "STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -251,7 +259,7 @@ TEST_F(FindPathValidatorTest, RunTimePath) {
     std::string query =
         "GO FROM \"1\" OVER like YIELD like._src AS src, like._dst AS dst "
         " | FIND SHORTEST PATH FROM $-.src TO \"2\" OVER like, serve UPTO 5 "
-        "STEPS";
+        "STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -277,7 +285,7 @@ TEST_F(FindPathValidatorTest, RunTimePath) {
     std::string query =
         "$a = GO FROM \"1\" OVER like yield like._src AS src; "
         "GO FROM \"2\" OVER like yield like._src AS src, like._dst AS dst "
-        " | FIND SHORTEST PATH FROM $a.src TO $-.dst OVER like UPTO 5 STEPS";
+        " | FIND SHORTEST PATH FROM $a.src TO $-.dst OVER like UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -307,7 +315,7 @@ TEST_F(FindPathValidatorTest, RunTimePath) {
     std::string query =
         "YIELD \"1\" AS src, \"2\" AS dst"
         " | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like, serve UPTO 5 "
-        "STEPS";
+        "STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -333,7 +341,7 @@ TEST_F(FindPathValidatorTest, RunTimePath) {
   {
     std::string query =
         "YIELD \"1\" AS src, \"2\" AS dst"
-        " | FIND ALL PATH FROM $-.src TO $-.dst OVER like, serve UPTO 5 STEPS";
+        " | FIND ALL PATH FROM $-.src TO $-.dst OVER like, serve UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -361,7 +369,7 @@ TEST_F(FindPathValidatorTest, PathWithFilter) {
   {
     std::string query =
         "FIND ALL PATH FROM \"1\" TO \"2\" OVER like WHERE like.likeness > 30 "
-        "UPTO 5 STEPS";
+        "UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -383,7 +391,7 @@ TEST_F(FindPathValidatorTest, PathWithFilter) {
   {
     std::string query =
         "FIND SHORTEST PATH FROM \"1\" TO \"2\" OVER like WHERE like.likeness "
-        "> 30 UPTO 5 STEPS";
+        "> 30 UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,
@@ -403,7 +411,7 @@ TEST_F(FindPathValidatorTest, PathWithFilter) {
   {
     std::string query =
         "FIND SHORTEST PATH FROM \"1\" TO \"2\", \"3\" OVER like WHERE "
-        "like.likeness > 30 UPTO 5 STEPS";
+        "like.likeness > 30 UPTO 5 STEPS YIELD path as p";
     std::vector<PlanNode::Kind> expected = {
         PK::kDataCollect,
         PK::kLoop,

--- a/src/graph/validator/test/FindPathValidatorTest.cpp
+++ b/src/graph/validator/test/FindPathValidatorTest.cpp
@@ -23,7 +23,7 @@ TEST_F(FindPathValidatorTest, invalidYield) {
         "FIND SHORTEST PATH  FROM \"Tim Duncan\" TO \"Tony Paker\" OVER * YIELD vertex";
     auto result = checkResult(query);
     EXPECT_EQ(std::string(result.message()),
-              "SyntaxError: please add alias when using vertex. near `vertex'");
+              "SyntaxError: please add alias when using `vertex'. near `vertex'");
   }
   {
     std::string query =

--- a/src/graph/validator/test/FindPathValidatorTest.cpp
+++ b/src/graph/validator/test/FindPathValidatorTest.cpp
@@ -21,7 +21,7 @@ TEST_F(FindPathValidatorTest, invalidYield) {
   {
     std::string query = "FIND SHORTEST PATH  FROM \"Tim\" TO \"Tony\" OVER *";
     auto result = checkResult(query);
-    EXPECT_EQ(std::string(result.message()), "SemanticError: missing yield clause.");
+    EXPECT_EQ(std::string(result.message()), "SemanticError: Missing yield clause.");
   }
   {
     std::string query = "FIND SHORTEST PATH  FROM \"Tim\" TO \"Tony\" OVER * YIELD vertex";
@@ -34,7 +34,7 @@ TEST_F(FindPathValidatorTest, invalidYield) {
         "FIND ALL PATH WITH PROP FROM \"Tim\" TO \"Tony\" OVER like YIELD edge as e";
     auto result = checkResult(query);
     EXPECT_EQ(std::string(result.message()),
-              "SemanticError: illegal yield clauses `EDGE AS e'. only support yield path");
+              "SemanticError: Illegal yield clauses `EDGE AS e'. only support yield path");
   }
   {
     std::string query =
@@ -49,7 +49,7 @@ TEST_F(FindPathValidatorTest, invalidYield) {
         "$$.player.name";
     auto result = checkResult(query);
     EXPECT_EQ(std::string(result.message()),
-              "SemanticError: illegal yield clauses `$$.player.name'. only support yield path");
+              "SemanticError: Illegal yield clauses `$$.player.name'. only support yield path");
   }
 }
 

--- a/src/graph/validator/test/GetSubgraphValidatorTest.cpp
+++ b/src/graph/validator/test/GetSubgraphValidatorTest.cpp
@@ -190,7 +190,7 @@ TEST_F(GetSubgraphValidatorTest, invalidYield) {
     std::string query = "GET SUBGRAPH WITH PROP FROM \"Tim Duncan\" YIELD path";
     auto result = checkResult(query);
     EXPECT_EQ(std::string(result.message()),
-              "SemanticError: Get Subgraph only support YIELD vertices OR edges");
+              "SyntaxError: please add alias when using path. near `path'");
   }
   {
     std::string query = "GET SUBGRAPH WITH PROP FROM \"Tim Duncan\" YIELD 123";

--- a/src/graph/validator/test/GetSubgraphValidatorTest.cpp
+++ b/src/graph/validator/test/GetSubgraphValidatorTest.cpp
@@ -190,7 +190,7 @@ TEST_F(GetSubgraphValidatorTest, invalidYield) {
     std::string query = "GET SUBGRAPH WITH PROP FROM \"Tim Duncan\" YIELD path";
     auto result = checkResult(query);
     EXPECT_EQ(std::string(result.message()),
-              "SyntaxError: please add alias when using path. near `path'");
+              "SyntaxError: please add alias when using `path'. near `path'");
   }
   {
     std::string query = "GET SUBGRAPH WITH PROP FROM \"Tim Duncan\" YIELD 123";

--- a/src/graph/validator/test/QueryValidatorTest.cpp
+++ b/src/graph/validator/test/QueryValidatorTest.cpp
@@ -953,9 +953,10 @@ TEST_F(QueryValidatorTest, GoInvalid) {
               "SemanticError: `VERTEX AS v' is not support in go sentence.");
   }
   {
-    std::string query = "GO FROM \"Tim\" OVER * YIELD path as p";
+    std::string query = "GO FROM \"Tim\" OVER * YIELD path";
     auto result = checkResult(query);
-    EXPECT_EQ(std::string(result.message()), "SemanticError: Invalid label identifiers: path");
+    EXPECT_EQ(std::string(result.message()),
+              "SyntaxError: please add alias when using `path'. near `path'");
   }
   {
     std::string query = "GO FROM \"Tim\" OVER * YIELD $$";

--- a/src/graph/validator/test/YieldValidatorTest.cpp
+++ b/src/graph/validator/test/YieldValidatorTest.cpp
@@ -223,7 +223,7 @@ TEST_F(YieldValidatorTest, TypeCastTest) {
   {
     std::string query = "YIELD (PATH)true";
     auto result = checkResult(query);
-    EXPECT_EQ(std::string(result.message()), "SyntaxError: syntax error near `true'");
+    EXPECT_EQ(std::string(result.message()), "SyntaxError: syntax error near `PATH'");
   }
   {
     std::string query = "YIELD (NOEXIST)true";

--- a/src/graph/visitor/FindVisitor.cpp
+++ b/src/graph/visitor/FindVisitor.cpp
@@ -171,9 +171,16 @@ void FindVisitor::visit(VertexExpression* expr) { findInCurrentExpr(expr); }
 
 void FindVisitor::visit(EdgeExpression* expr) { findInCurrentExpr(expr); }
 
-void FindVisitor::visit(PathBuildExpression* expr) { findInCurrentExpr(expr); }
-
 void FindVisitor::visit(ColumnExpression* expr) { findInCurrentExpr(expr); }
+
+void FindVisitor::visit(PathBuildExpression* expr) {
+  findInCurrentExpr(expr);
+  if (!needFindAll_ && !foundExprs_.empty()) return;
+  for (const auto& item : expr->items()) {
+    item->accept(this);
+    if (!needFindAll_ && !foundExprs_.empty()) return;
+  }
+}
 
 void FindVisitor::visit(SubscriptRangeExpression* expr) {
   findInCurrentExpr(expr);

--- a/src/graph/visitor/FindVisitor.cpp
+++ b/src/graph/visitor/FindVisitor.cpp
@@ -171,6 +171,8 @@ void FindVisitor::visit(VertexExpression* expr) { findInCurrentExpr(expr); }
 
 void FindVisitor::visit(EdgeExpression* expr) { findInCurrentExpr(expr); }
 
+void FindVisitor::visit(PathBuildExpression* expr) { findInCurrentExpr(expr); }
+
 void FindVisitor::visit(ColumnExpression* expr) { findInCurrentExpr(expr); }
 
 void FindVisitor::visit(SubscriptRangeExpression* expr) {

--- a/src/graph/visitor/FindVisitor.h
+++ b/src/graph/visitor/FindVisitor.h
@@ -62,6 +62,7 @@ class FindVisitor final : public ExprVisitorImpl {
   void visit(LabelAttributeExpression* expr) override;
   void visit(VertexExpression* expr) override;
   void visit(EdgeExpression* expr) override;
+  void visit(PathBuildExpression* expr) override;
   void visit(ColumnExpression* expr) override;
   void visit(ListComprehensionExpression* expr) override;
   void visit(SubscriptRangeExpression* expr) override;

--- a/src/parser/TraverseSentences.cpp
+++ b/src/parser/TraverseSentences.cpp
@@ -181,35 +181,38 @@ std::string GroupBySentence::toString() const {
 std::string FindPathSentence::toString() const {
   std::string buf;
   buf.reserve(256);
-  buf += "FIND ";
+  buf += "FIND";
   if (noLoop_) {
-    buf += "NOLOOP PATH ";
+    buf += " NOLOOP PATH";
   } else if (isShortest_) {
-    buf += "SHORTEST PATH ";
+    buf += " SHORTEST PATH";
   } else {
-    buf += "ALL PATH ";
+    buf += " ALL PATH";
   }
 
   if (from_ != nullptr) {
-    buf += from_->toString();
     buf += " ";
+    buf += from_->toString();
   }
   if (to_ != nullptr) {
-    buf += to_->toString();
     buf += " ";
+    buf += to_->toString();
   }
   if (over_ != nullptr) {
-    buf += over_->toString();
     buf += " ";
+    buf += over_->toString();
   }
   if (where_ != nullptr) {
-    buf += where_->toString();
     buf += " ";
+    buf += where_->toString();
   }
   if (step_ != nullptr) {
-    buf += "UPTO ";
+    buf += " UPTO ";
     buf += step_->toString();
+  }
+  if (yield_ != nullptr) {
     buf += " ";
+    buf += yield_->toString();
   }
   return buf;
 }

--- a/src/parser/TraverseSentences.h
+++ b/src/parser/TraverseSentences.h
@@ -320,6 +320,8 @@ class FindPathSentence final : public Sentence {
 
   void setWhere(WhereClause* clause) { where_.reset(clause); }
 
+  void setYield(YieldClause* yield) { yield_.reset(yield); }
+
   FromClause* from() const { return from_.get(); }
 
   ToClause* to() const { return to_.get(); }
@@ -329,6 +331,8 @@ class FindPathSentence final : public Sentence {
   StepClause* step() const { return step_.get(); }
 
   WhereClause* where() const { return where_.get(); }
+
+  YieldClause* yield() const { return yield_.get(); }
 
   bool isShortest() const { return isShortest_; }
 
@@ -347,6 +351,7 @@ class FindPathSentence final : public Sentence {
   std::unique_ptr<OverClause> over_;
   std::unique_ptr<StepClause> step_;
   std::unique_ptr<WhereClause> where_;
+  std::unique_ptr<YieldClause> yield_;
 };
 
 class LimitSentence final : public Sentence {

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -1077,11 +1077,6 @@ argument_list
         Expression *arg = EdgeExpression::make(qctx->objPool());
         $$->addArgument(arg);
     }
-    | KW_PATH {
-        $$ = ArgumentList::make(qctx->objPool());
-        Expression *arg = PathBuildExpression::make(qctx->objPool());
-        $$->addArgument(arg);
-    }
     | expression {
         $$ = ArgumentList::make(qctx->objPool());
         Expression* arg = nullptr;
@@ -1444,7 +1439,7 @@ yield_column
     }
     | KW_PATH {
         $$ = nullptr;
-        throw nebula::GraphParser::syntax_error(@1, "please add alias when using path.");
+        throw nebula::GraphParser::syntax_error(@1, "please add alias when using `path'.");
     }
     | KW_PATH KW_AS name_label {
         $$ = new YieldColumn(PathBuildExpression::make(qctx->objPool()), *$3);

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -1442,7 +1442,7 @@ yield_column
         throw nebula::GraphParser::syntax_error(@1, "please add alias when using `path'.");
     }
     | KW_PATH KW_AS name_label {
-        $$ = new YieldColumn(PathBuildExpression::make(qctx->objPool()), *$3);
+        $$ = new YieldColumn(LabelExpression::make(qctx->objPool(), "PATH"), *$3);
         delete $3;
     }
     | expression {

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -1444,7 +1444,7 @@ yield_column
     }
     | KW_PATH {
         $$ = nullptr;
-        throw nebula::GraphParser::syntax_error(@1, "please add alias when using path");
+        throw nebula::GraphParser::syntax_error(@1, "please add alias when using path.");
     }
     | KW_PATH KW_AS name_label {
         $$ = new YieldColumn(PathBuildExpression::make(qctx->objPool()), *$3);

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -2084,7 +2084,7 @@ fetch_sentence
     ;
 
 find_path_sentence
-    : KW_FIND KW_ALL KW_PATH opt_with_properites from_clause to_clause over_clause where_clause find_path_upto_clause yield_clause {
+    : KW_FIND KW_ALL KW_PATH opt_with_properties from_clause to_clause over_clause where_clause find_path_upto_clause yield_clause {
         auto *s = new FindPathSentence(false, $4, false);
         s->setFrom($5);
         s->setTo($6);
@@ -2094,7 +2094,7 @@ find_path_sentence
         s->setYield($10);
         $$ = s;
     }
-    | KW_FIND KW_SHORTEST KW_PATH opt_with_properites from_clause to_clause over_clause where_clause find_path_upto_clause yield_clause {
+    | KW_FIND KW_SHORTEST KW_PATH opt_with_properties from_clause to_clause over_clause where_clause find_path_upto_clause yield_clause {
         auto *s = new FindPathSentence(true, $4, false);
         s->setFrom($5);
         s->setTo($6);
@@ -2104,7 +2104,7 @@ find_path_sentence
         s->setYield($10);
         $$ = s;
     }
-    | KW_FIND KW_NOLOOP KW_PATH opt_with_properites from_clause to_clause over_clause where_clause find_path_upto_clause yield_clause {
+    | KW_FIND KW_NOLOOP KW_PATH opt_with_properties from_clause to_clause over_clause where_clause find_path_upto_clause yield_clause {
         auto *s = new FindPathSentence(false, $4, true);
         s->setFrom($5);
         s->setTo($6);

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -73,6 +73,7 @@ IP_OCTET                    ([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])
 "WHEN"                      { return TokenType::KW_WHEN; }
 "DELETE"                    { return TokenType::KW_DELETE; }
 "FIND"                      { return TokenType::KW_FIND; }
+"PATH"                      { return TokenType::KW_PATH; }
 "LOOKUP"                    { return TokenType::KW_LOOKUP; }
 "ALTER"                     { return TokenType::KW_ALTER; }
 "STEPS"                     { return TokenType::KW_STEPS; }
@@ -205,7 +206,6 @@ IP_OCTET                    ([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])
 "STORAGE"                   { return TokenType::KW_STORAGE; }
 "SHORTEST"                  { return TokenType::KW_SHORTEST; }
 "NOLOOP"                    { return TokenType::KW_NOLOOP; }
-"PATH"                      { return TokenType::KW_PATH; }
 "OUT"                       { return TokenType::KW_OUT; }
 "BOTH"                      { return TokenType::KW_BOTH; }
 "SUBGRAPH"                  { return TokenType::KW_SUBGRAPH; }

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -1659,7 +1659,7 @@ TEST_F(ParserTest, UnreservedKeywords) {
     std::string query =
         "CREATE TAG tag1(space string, spaces string, "
         "email string, password string, roles string, uuid int, "
-        "path string, variables string, leader string, data string)";
+        "paths string, variables string, leader string, data string)";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
@@ -2506,7 +2506,7 @@ TEST_F(ParserTest, Match) {
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "MATCH p = (a) -[m:like*..2]- (b) RETURN p as Path";
+    std::string query = "MATCH p = (a) -[m:like*..2]- (b) RETURN p as PathA";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }

--- a/tests/query/stateless/test_keyword.py
+++ b/tests/query/stateless/test_keyword.py
@@ -124,7 +124,7 @@ class TestReservedKeyword(NebulaTestSuite):
         resp = self.execute(cmd)
         self.check_resp_succeeded(resp)
 
-        cmd = 'create tag x23 (path string)'
+        cmd = 'create tag x23 (paths string)'
         resp = self.execute(cmd)
         self.check_resp_succeeded(resp)
 
@@ -280,7 +280,7 @@ class TestReservedKeyword(NebulaTestSuite):
         resp = self.execute(cmd)
         self.check_resp_succeeded(resp)
 
-        cmd = 'create tag x233 (PATH string)'
+        cmd = 'create tag x233 (PATHS string)'
         resp = self.execute(cmd)
         self.check_resp_succeeded(resp)
 

--- a/tests/tck/features/match/Unwind.feature
+++ b/tests/tck/features/match/Unwind.feature
@@ -119,14 +119,14 @@ Feature: Unwind clause
   Scenario: unwind match with
     When executing query:
       """
-      MATCH path=(x:player{name: "Tim Duncan"})-[:like*..2]->(y)
-      UNWIND nodes(path) as n
-      WITH path, size(collect(distinct n)) AS testLength
-      WHERE testLength == length(path) + 1
-      RETURN path
+      MATCH p = (x:player{name: "Tim Duncan"})-[:like*..2]->(y)
+      UNWIND nodes(p) as n
+      WITH p, size(collect(distinct n)) AS testLength
+      WHERE testLength == length(p) + 1
+      RETURN p
       """
     Then the result should be, in any order:
-      | path                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                         |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                                                             |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})>                                                                                         |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 95}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})>         |

--- a/tests/tck/features/path/AllPath.IntVid.feature
+++ b/tests/tck/features/path/AllPath.IntVid.feature
@@ -218,8 +218,8 @@ Feature: Integer Vid All Path
       WHERE (like.likeness >= 80 and like.likeness <= 90) OR (teammate.start_year is not EMPTY and teammate.start_year > 2001) UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | p                                                                                                                                                                                                                                                                                |
-      | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquile O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |
+      | p                                                                                                                                                                                                                                                                                 |
+      | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |
     When executing query:
       """
       FIND ALL PATH WITH PROP FROM hash("Tony Parker") TO hash("Yao Ming") OVER * BIDIRECT

--- a/tests/tck/features/path/AllPath.IntVid.feature
+++ b/tests/tck/features/path/AllPath.IntVid.feature
@@ -254,18 +254,18 @@ Feature: Integer Vid All Path
     Then the execution should be successful
     When executing query:
       """
-      FIND ALL PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 2 steps
+      FIND ALL PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 2 steps YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                   |
+      | p                                                                                                                                                                                                                                      |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                          |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 99}]->("Tim Parker")-[:like@0 {likeness: 90}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
     When executing query:
       """
-      FIND ALL PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like BIDIRECT UPTO 2 steps
+      FIND ALL PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like BIDIRECT UPTO 2 steps YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                         |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 95}]-("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                                                             |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                                                             |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 99}]->("Tim Parker")-[:like@0 {likeness: 90}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                    |

--- a/tests/tck/features/path/AllPath.IntVid.feature
+++ b/tests/tck/features/path/AllPath.IntVid.feature
@@ -7,10 +7,10 @@ Feature: Integer Vid All Path
     Given a graph with space named "nba_int_vid"
     When executing query:
       """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tim Duncan") OVER * UPTO 2 STEPS
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tim Duncan") OVER * UPTO 2 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                        |
+      | p                                                                           |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("Tim Duncan")>           |
       | <("Tim Duncan")-[:teammate]->("Tony Parker")-[:like]->("Tim Duncan")>       |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:teammate]->("Tim Duncan")>       |
@@ -23,19 +23,19 @@ Feature: Integer Vid All Path
       | <("Tim Duncan")-[:teammate]->("LaMarcus Aldridge")-[:like]->("Tim Duncan")> |
     When executing query:
       """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                         |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>      |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")> |
     When executing query:
       """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Manu Ginobili") OVER like UPTO 3 STEPS
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Manu Ginobili") OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                         |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")>                                                       |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("Manu Ginobili")>                              |
@@ -44,20 +44,20 @@ Feature: Integer Vid All Path
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>      |
     When executing query:
       """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like UPTO 3 STEPS
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                         |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")>                          |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>      |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")> |
     When executing query:
       """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 3 STEPS
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                         |
       | <("Tim Duncan")-[:serve]->("Spurs")>                                                              |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:serve]->("Spurs")>                                   |
@@ -73,11 +73,11 @@ Feature: Integer Vid All Path
     Given a graph with space named "nba_int_vid"
     When executing query:
       """
-      GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst
-      | FIND ALL PATH FROM $-.src TO $-.dst OVER like UPTO 3 STEPS
+      GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst |
+      FIND ALL PATH FROM $-.src TO $-.dst OVER like UPTO 3 STEPS YIELD PATH as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                                                       |
       | <("Tony Parker")-[:like]->("Tim Duncan")>                                                         |
       | <("Tony Parker")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>                              |
@@ -88,10 +88,10 @@ Feature: Integer Vid All Path
     When executing query:
       """
       $a = GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst;
-      FIND ALL PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS
+      FIND ALL PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                                                       |
       | <("Tony Parker")-[:like]->("Tim Duncan")>                                                         |
       | <("Tony Parker")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>                              |
@@ -130,16 +130,16 @@ Feature: Integer Vid All Path
     Given a graph with space named "nba_int_vid"
     When executing query:
       """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Nobody"), hash("Spur") OVER like REVERSELY UPTO 3 STEPS
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Nobody"), hash("Spur") OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
     When executing query:
       """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like REVERSELY UPTO 3 STEPS
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                         |
       | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>                          |
       | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tony Parker")>                              |
@@ -147,10 +147,10 @@ Feature: Integer Vid All Path
       | <("Tim Duncan")<-[:like]-("Tony Parker")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")> |
     When executing query:
       """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like REVERSELY UPTO 3 STEPS
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                    |
+      | p                                                                                                       |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                               |
       | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")>                                                         |
       | <("Tim Duncan")<-[:like]-("Tony Parker")<-[:like]-("LaMarcus Aldridge")>                                |
@@ -167,10 +167,10 @@ Feature: Integer Vid All Path
     Given a graph with space named "nba_int_vid"
     When executing query:
       """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like BIDIRECT UPTO 3 STEPS
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like BIDIRECT UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                |
+      | p                                                                                                   |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                           |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                           |
       | <("Tim Duncan")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>                              |
@@ -202,10 +202,10 @@ Feature: Integer Vid All Path
     Given a graph with space named "nba_int_vid"
     When executing query:
       """
-      FIND ALL PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS
+      FIND ALL PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | p                                                                                                                                                                                                                                                                                                                                                                                                                       |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                                                                                                                                                                                           |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})-[:like@0 {likeness: 90}]->("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 90}]->("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})-[:like@0 {likeness: 75}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                               |
@@ -215,18 +215,18 @@ Feature: Integer Vid All Path
     When executing query:
       """
       FIND ALL PATH WITH PROP FROM hash("Tim Duncan") TO hash("Yao Ming") OVER * BIDIRECT
-      WHERE (like.likeness >= 80 and like.likeness <= 90) OR (teammate.start_year is not EMPTY and teammate.start_year > 2001) UPTO 3 STEPS
+      WHERE (like.likeness >= 80 and like.likeness <= 90) OR (teammate.start_year is not EMPTY and teammate.start_year > 2001) UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                              |
-      | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |
+      | p                                                                                                                                                                                                                                                                                |
+      | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquile O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |
     When executing query:
       """
       FIND ALL PATH WITH PROP FROM hash("Tony Parker") TO hash("Yao Ming") OVER * BIDIRECT
-      WHERE  teammate.start_year > 2000 OR (like.likeness is not EMPTY AND like.likeness >= 80) UPTO 3 STEPS
+      WHERE  teammate.start_year > 2000 OR (like.likeness is not EMPTY AND like.likeness >= 80) UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                                                                                                                         |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:like@0 {likeness: 95}]-("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})>                         |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:teammate@0 {end_year: 2016, start_year: 2001}]-("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 95}]->("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})>                         |
@@ -234,10 +234,10 @@ Feature: Integer Vid All Path
     When executing query:
       """
       FIND ALL PATH WITH PROP FROM hash("Yao Ming") TO hash("Danny Green") OVER * BIDIRECT
-      WHERE like.likeness is  EMPTY OR like.likeness >= 80 UPTO 3 STEPS
+      WHERE like.likeness is  EMPTY OR like.likeness >= 80 UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                                                                                                                         |
       | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})-[:serve@0 {end_year: 2010, start_year: 2009}]->("Cavaliers" :team{name: "Cavaliers"})<-[:serve@0 {end_year: 2010, start_year: 2009}]-("Danny Green" :player{age: 31, name: "Danny Green"})>                                                    |
       | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})-[:like@0 {likeness: 80}]->("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:teammate@0 {end_year: 2016, start_year: 2010}]->("Danny Green" :player{age: 31, name: "Danny Green"})> |
       | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Tracy McGrady" :player{age: 39, name: "Tracy McGrady"})-[:serve@0 {end_year: 2000, start_year: 1997}]->("Raptors" :team{name: "Raptors"})<-[:serve@0 {end_year: 2019, start_year: 2018}]-("Danny Green" :player{age: 31, name: "Danny Green"})>                                                              |
@@ -280,38 +280,6 @@ Feature: Integer Vid All Path
 
   Scenario: Integer Vid ALL PATH YIELD PATH
     Given a graph with space named "nba_int_vid"
-    When executing query:
-      """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like BIDIRECT UPTO 3 STEPS YIELD path as p
-      """
-    Then the result should be, in any order, with relax comparison:
-      | p                                                                                                   |
-      | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                           |
-      | <("Tim Duncan")-[:like]->("Tony Parker")>                                                           |
-      | <("Tim Duncan")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>                              |
-      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>                              |
-      | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>                            |
-      | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")-[:like]->("Tony Parker")>                            |
-      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tony Parker")>                                |
-      | <("Tim Duncan")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>                                |
-      | <("Tim Duncan")<-[:like]-("Boris Diaw")-[:like]->("Tony Parker")>                                   |
-      | <("Tim Duncan")<-[:like]-("Danny Green")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>     |
-      | <("Tim Duncan")<-[:like]-("Danny Green")-[:like]->("Marco Belinelli")-[:like]->("Tony Parker")>     |
-      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Marco Belinelli")-[:like]->("Tony Parker")> |
-      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>   |
-      | <("Tim Duncan")-[:like]->("Manu Ginobili")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>   |
-      | <("Tim Duncan")<-[:like]-("Danny Green")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>     |
-      | <("Tim Duncan")<-[:like]-("Marco Belinelli")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")> |
-      | <("Tim Duncan")<-[:like]-("Tony Parker")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>   |
-      | <("Tim Duncan")-[:like]->("Tony Parker")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>   |
-      | <("Tim Duncan")<-[:like]-("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")>   |
-      | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")>   |
-      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tim Duncan")<-[:like]-("Tony Parker")>        |
-      | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")<-[:like]-("Tony Parker")>        |
-      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tim Duncan")-[:like]->("Tony Parker")>        |
-      | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>        |
-      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>   |
-      | <("Tim Duncan")<-[:like]-("Tiago Splitter")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>    |
     When executing query:
       """
       FIND ALL PATH WITH PROP FROM hash("Yao Ming") TO hash("Danny Green") OVER * BIDIRECT

--- a/tests/tck/features/path/AllPath.IntVid.feature
+++ b/tests/tck/features/path/AllPath.IntVid.feature
@@ -101,11 +101,11 @@ Feature: Integer Vid All Path
       | <("Tony Parker")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>      |
     When executing query:
       """
-      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 3 STEPS
-      | ORDER BY $-.path | LIMIT 3
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 3 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 3
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                         |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")> |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:serve]->("Spurs")>      |
@@ -115,11 +115,11 @@ Feature: Integer Vid All Path
     When executing query:
       """
       $a = GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst;
-      FIND ALL PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS
-      | ORDER BY $-.path | LIMIT 5
+      FIND ALL PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 5
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                    |
+      | p                                                                                                       |
       | <("Tony Parker")-[:like@0]->("LaMarcus Aldridge")-[:like@0]->("Tim Duncan")>                            |
       | <("Tony Parker")-[:like@0]->("LaMarcus Aldridge")-[:like@0]->("Tony Parker")-[:like@0]->("Tim Duncan")> |
       | <("Tony Parker")-[:like@0]->("Manu Ginobili")-[:like@0]->("Tim Duncan")>                                |
@@ -277,3 +277,92 @@ Feature: Integer Vid All Path
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})<-[:like@0 {likeness: 95}]-("Tony Parker" :player{age: 36, name: "Tony Parker"})>         |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Boris Diaw" :player{age: 36, name: "Boris Diaw"})-[:like@0 {likeness: 80}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>               |
     Then drop the used space
+
+  Scenario: Integer Vid ALL PATH YIELD PATH
+    Given a graph with space named "nba_int_vid"
+    When executing query:
+      """
+      FIND ALL PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like BIDIRECT UPTO 3 STEPS YIELD path as p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p                                                                                                   |
+      | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                           |
+      | <("Tim Duncan")-[:like]->("Tony Parker")>                                                           |
+      | <("Tim Duncan")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>                              |
+      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>                              |
+      | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>                            |
+      | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")-[:like]->("Tony Parker")>                            |
+      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tony Parker")>                                |
+      | <("Tim Duncan")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>                                |
+      | <("Tim Duncan")<-[:like]-("Boris Diaw")-[:like]->("Tony Parker")>                                   |
+      | <("Tim Duncan")<-[:like]-("Danny Green")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>     |
+      | <("Tim Duncan")<-[:like]-("Danny Green")-[:like]->("Marco Belinelli")-[:like]->("Tony Parker")>     |
+      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Marco Belinelli")-[:like]->("Tony Parker")> |
+      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>   |
+      | <("Tim Duncan")-[:like]->("Manu Ginobili")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>   |
+      | <("Tim Duncan")<-[:like]-("Danny Green")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>     |
+      | <("Tim Duncan")<-[:like]-("Marco Belinelli")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")> |
+      | <("Tim Duncan")<-[:like]-("Tony Parker")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>   |
+      | <("Tim Duncan")-[:like]->("Tony Parker")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>   |
+      | <("Tim Duncan")<-[:like]-("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")>   |
+      | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")>   |
+      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tim Duncan")<-[:like]-("Tony Parker")>        |
+      | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")<-[:like]-("Tony Parker")>        |
+      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tim Duncan")-[:like]->("Tony Parker")>        |
+      | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>        |
+      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>   |
+      | <("Tim Duncan")<-[:like]-("Tiago Splitter")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>    |
+    When executing query:
+      """
+      FIND ALL PATH WITH PROP FROM hash("Yao Ming") TO hash("Danny Green") OVER * BIDIRECT
+      WHERE like.likeness is  EMPTY OR like.likeness >= 80 UPTO 3 STEPS YIELD path as p |
+      YIELD startnode($-.p) as startnode
+      """
+    Then the result should be, in any order, with relax comparison:
+      | startnode                                       |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+    When executing query:
+      """
+      FIND ALL PATH WITH PROP FROM hash("Yao Ming") TO hash("Danny Green") OVER * BIDIRECT
+      WHERE like.likeness is  EMPTY OR like.likeness >= 80 UPTO 3 STEPS YIELD path as p |
+      YIELD endnode($-.p) as endnode
+      """
+    Then the result should be, in any order, with relax comparison:
+      | endnode                                               |
+      | ("Danny Green" :player{age: 31, name: "Danny Green"}) |
+      | ("Danny Green" :player{age: 31, name: "Danny Green"}) |
+      | ("Danny Green" :player{age: 31, name: "Danny Green"}) |
+      | ("Danny Green" :player{age: 31, name: "Danny Green"}) |
+    When executing query:
+      """
+      FIND ALL PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS YIELD path as p |
+      YIELD length($-.p) as length
+      """
+    Then the result should be, in any order, with relax comparison:
+      | length |
+      | 1      |
+      | 3      |
+      | 3      |
+    When executing query:
+      """
+      FIND ALL PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS YIELD path as p |
+      YIELD relationships($-.p) as relationships
+      """
+    Then the result should be, in any order, with relax comparison:
+      | relationships                                                                                                                                                                       |
+      | [[:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}]]                                                                                                                             |
+      | [[:like "Tim Duncan"->"Manu Ginobili" @0 {likeness: 95}], [:like "Manu Ginobili"->"Tim Duncan" @0 {likeness: 90}], [:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}]]           |
+      | [[:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}], [:like "Tony Parker"->"LaMarcus Aldridge" @0 {likeness: 90}], [:like "LaMarcus Aldridge"->"Tony Parker" @0 {likeness: 75}]] |
+    When executing query:
+      """
+      FIND ALL PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS YIELD path as p |
+      YIELD nodes($-.p) as nodes
+      """
+    Then the result should be, in any order, with relax comparison:
+      | nodes                                                                                                                                                                                                                                                              |
+      | [("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"}), ("Tony Parker" :player{age: 36, name: "Tony Parker"})]                                                                                                                                    |
+      | [("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"}), ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"}), ("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"}), ("Tony Parker" :player{age: 36, name: "Tony Parker"})] |
+      | [("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"}), ("Tony Parker" :player{age: 36, name: "Tony Parker"}), ("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"}), ("Tony Parker" :player{age: 36, name: "Tony Parker"})]          |

--- a/tests/tck/features/path/AllPath.feature
+++ b/tests/tck/features/path/AllPath.feature
@@ -254,18 +254,18 @@ Feature: All Path
     Then the execution should be successful
     When executing query:
       """
-      FIND ALL PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 2 steps
+      FIND ALL PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 2 steps YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                   |
+      | p                                                                                                                                                                                                                                      |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                          |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 99}]->("Tim Parker")-[:like@0 {likeness: 90}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
     When executing query:
       """
-      FIND ALL PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like BIDIRECT UPTO 2 steps
+      FIND ALL PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like BIDIRECT UPTO 2 steps YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                         |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 95}]-("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                                                             |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                                                             |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 99}]->("Tim Parker")-[:like@0 {likeness: 90}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                    |

--- a/tests/tck/features/path/AllPath.feature
+++ b/tests/tck/features/path/AllPath.feature
@@ -73,8 +73,8 @@ Feature: All Path
     Given a graph with space named "nba"
     When executing query:
       """
-      GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst
-      | FIND ALL PATH FROM $-.src TO $-.dst OVER like UPTO 3 STEPS
+      GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst |
+      FIND ALL PATH FROM $-.src TO $-.dst OVER like UPTO 3 STEPS
       """
     Then the result should be, in any order, with relax comparison:
       | path                                                                                              |
@@ -104,22 +104,22 @@ Feature: All Path
     Given a graph with space named "nba"
     When executing query:
       """
-      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve UPTO 3 STEPS
-      | ORDER BY $-.path | LIMIT 3
+      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve UPTO 3 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 3
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                         |
+      | p                                                                                            |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:serve]->("Spurs")>                              |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")-[:serve]->("Spurs")>      |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")> |
     When executing query:
       """
       $a = GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst;
-      FIND ALL PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS
-      | ORDER BY $-.path | LIMIT 5
+      FIND ALL PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 5
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                                                       |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("Tim Duncan")>      |
       | <("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tim Duncan")>                          |
@@ -277,3 +277,92 @@ Feature: All Path
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})<-[:like@0 {likeness: 95}]-("Tony Parker" :player{age: 36, name: "Tony Parker"})>         |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Boris Diaw" :player{age: 36, name: "Boris Diaw"})-[:like@0 {likeness: 80}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>               |
     Then drop the used space
+
+  Scenario: ALL PATH YIELD PATH
+    Given a graph with space named "nba_int_vid"
+    When executing query:
+      """
+      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker" OVER like BIDIRECT UPTO 3 STEPS YIELD path as p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p                                                                                                   |
+      | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                           |
+      | <("Tim Duncan")-[:like]->("Tony Parker")>                                                           |
+      | <("Tim Duncan")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>                              |
+      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>                              |
+      | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>                            |
+      | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")-[:like]->("Tony Parker")>                            |
+      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tony Parker")>                                |
+      | <("Tim Duncan")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>                                |
+      | <("Tim Duncan")<-[:like]-("Boris Diaw")-[:like]->("Tony Parker")>                                   |
+      | <("Tim Duncan")<-[:like]-("Danny Green")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>     |
+      | <("Tim Duncan")<-[:like]-("Danny Green")-[:like]->("Marco Belinelli")-[:like]->("Tony Parker")>     |
+      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Marco Belinelli")-[:like]->("Tony Parker")> |
+      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>   |
+      | <("Tim Duncan")-[:like]->("Manu Ginobili")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>   |
+      | <("Tim Duncan")<-[:like]-("Danny Green")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>     |
+      | <("Tim Duncan")<-[:like]-("Marco Belinelli")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")> |
+      | <("Tim Duncan")<-[:like]-("Tony Parker")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>   |
+      | <("Tim Duncan")-[:like]->("Tony Parker")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>   |
+      | <("Tim Duncan")<-[:like]-("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")>   |
+      | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")>   |
+      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tim Duncan")<-[:like]-("Tony Parker")>        |
+      | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")<-[:like]-("Tony Parker")>        |
+      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tim Duncan")-[:like]->("Tony Parker")>        |
+      | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>        |
+      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>   |
+      | <("Tim Duncan")<-[:like]-("Tiago Splitter")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>    |
+    When executing query:
+      """
+      FIND ALL PATH WITH PROP FROM "Yao Ming" TO "Danny Green" OVER * BIDIRECT
+      WHERE like.likeness is  EMPTY OR like.likeness >= 80 UPTO 3 STEPS YIELD path as p |
+      YIELD startnode($-.p) as startnode
+      """
+    Then the result should be, in any order, with relax comparison:
+      | startnode                                       |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+    When executing query:
+      """
+      FIND ALL PATH WITH PROP FROM "Yao Ming" TO "Danny Green" OVER * BIDIRECT
+      WHERE like.likeness is  EMPTY OR like.likeness >= 80 UPTO 3 STEPS YIELD path as p |
+      YIELD endnode($-.p) as endnode
+      """
+    Then the result should be, in any order, with relax comparison:
+      | endnode                                               |
+      | ("Danny Green" :player{age: 31, name: "Danny Green"}) |
+      | ("Danny Green" :player{age: 31, name: "Danny Green"}) |
+      | ("Danny Green" :player{age: 31, name: "Danny Green"}) |
+      | ("Danny Green" :player{age: 31, name: "Danny Green"}) |
+    When executing query:
+      """
+      FIND ALL PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS YIELD path as p |
+      YIELD length($-.p) as length
+      """
+    Then the result should be, in any order, with relax comparison:
+      | length |
+      | 1      |
+      | 3      |
+      | 3      |
+    When executing query:
+      """
+      FIND ALL PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS YIELD path as p |
+      YIELD relationships($-.p) as relationships
+      """
+    Then the result should be, in any order, with relax comparison:
+      | relationships                                                                                                                                                                       |
+      | [[:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}]]                                                                                                                             |
+      | [[:like "Tim Duncan"->"Manu Ginobili" @0 {likeness: 95}], [:like "Manu Ginobili"->"Tim Duncan" @0 {likeness: 90}], [:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}]]           |
+      | [[:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}], [:like "Tony Parker"->"LaMarcus Aldridge" @0 {likeness: 90}], [:like "LaMarcus Aldridge"->"Tony Parker" @0 {likeness: 75}]] |
+    When executing query:
+      """
+      FIND ALL PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS YIELD path as p |
+      YIELD nodes($-.p) as nodes
+      """
+    Then the result should be, in any order, with relax comparison:
+      | nodes                                                                                                                                                                                                                                                              |
+      | [("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"}), ("Tony Parker" :player{age: 36, name: "Tony Parker"})]                                                                                                                                    |
+      | [("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"}), ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"}), ("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"}), ("Tony Parker" :player{age: 36, name: "Tony Parker"})] |
+      | [("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"}), ("Tony Parker" :player{age: 36, name: "Tony Parker"}), ("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"}), ("Tony Parker" :player{age: 36, name: "Tony Parker"})]          |

--- a/tests/tck/features/path/AllPath.feature
+++ b/tests/tck/features/path/AllPath.feature
@@ -7,10 +7,10 @@ Feature: All Path
     Given a graph with space named "nba"
     When executing query:
       """
-      FIND ALL PATH FROM "Tim Duncan" TO "Tim Duncan" OVER * UPTO 2 STEPS
+      FIND ALL PATH FROM "Tim Duncan" TO "Tim Duncan" OVER * UPTO 2 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                        |
+      | p                                                                           |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("Tim Duncan")>           |
       | <("Tim Duncan")-[:teammate]->("Tony Parker")-[:like]->("Tim Duncan")>       |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:teammate]->("Tim Duncan")>       |
@@ -23,19 +23,19 @@ Feature: All Path
       | <("Tim Duncan")-[:teammate]->("LaMarcus Aldridge")-[:like]->("Tim Duncan")> |
     When executing query:
       """
-      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS
+      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                         |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>      |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")> |
     When executing query:
       """
-      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker", "Manu Ginobili" OVER like UPTO 3 STEPS
+      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker", "Manu Ginobili" OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                         |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")>                                                       |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("Manu Ginobili")>                              |
@@ -44,20 +44,20 @@ Feature: All Path
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>      |
     When executing query:
       """
-      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like UPTO 3 STEPS
+      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                         |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")>                          |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>      |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")> |
     When executing query:
       """
-      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve UPTO 3 STEPS
+      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                         |
       | <("Tim Duncan")-[:serve]->("Spurs")>                                                              |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:serve]->("Spurs")>                                   |
@@ -74,10 +74,10 @@ Feature: All Path
     When executing query:
       """
       GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst |
-      FIND ALL PATH FROM $-.src TO $-.dst OVER like UPTO 3 STEPS
+      FIND ALL PATH FROM $-.src TO $-.dst OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                                                       |
       | <("Tony Parker")-[:like]->("Tim Duncan")>                                                         |
       | <("Tony Parker")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>                              |
@@ -88,10 +88,10 @@ Feature: All Path
     When executing query:
       """
       $a = GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst;
-      FIND ALL PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS
+      FIND ALL PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                                                       |
       | <("Tony Parker")-[:like]->("Tim Duncan")>                                                         |
       | <("Tony Parker")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>                              |
@@ -130,16 +130,16 @@ Feature: All Path
     Given a graph with space named "nba"
     When executing query:
       """
-      FIND ALL PATH FROM "Tim Duncan" TO "Nobody","Spur" OVER like REVERSELY UPTO 3 STEPS
+      FIND ALL PATH FROM "Tim Duncan" TO "Nobody","Spur" OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
     When executing query:
       """
-      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker" OVER like REVERSELY UPTO 3 STEPS
+      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker" OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                         |
       | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>                          |
       | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tony Parker")>                              |
@@ -147,10 +147,10 @@ Feature: All Path
       | <("Tim Duncan")<-[:like]-("Tony Parker")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")> |
     When executing query:
       """
-      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like REVERSELY UPTO 3 STEPS
+      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                    |
+      | p                                                                                                       |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                               |
       | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")>                                                         |
       | <("Tim Duncan")<-[:like]-("Tony Parker")<-[:like]-("LaMarcus Aldridge")>                                |
@@ -167,10 +167,10 @@ Feature: All Path
     Given a graph with space named "nba"
     When executing query:
       """
-      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker" OVER like BIDIRECT UPTO 3 STEPS
+      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker" OVER like BIDIRECT UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                |
+      | p                                                                                                   |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                           |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                           |
       | <("Tim Duncan")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>                              |
@@ -202,10 +202,10 @@ Feature: All Path
     Given a graph with space named "nba"
     When executing query:
       """
-      FIND ALL PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS
+      FIND ALL PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | p                                                                                                                                                                                                                                                                                                                                                                                                                       |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                                                                                                                                                                                           |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})-[:like@0 {likeness: 90}]->("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 90}]->("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})-[:like@0 {likeness: 75}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                               |
@@ -215,18 +215,18 @@ Feature: All Path
     When executing query:
       """
       FIND ALL PATH WITH PROP FROM "Tim Duncan" TO "Yao Ming" OVER * BIDIRECT
-      WHERE (like.likeness >= 80 and like.likeness <= 90) OR (teammate.start_year is not EMPTY and teammate.start_year > 2001) UPTO 3 STEPS
+      WHERE (like.likeness >= 80 and like.likeness <= 90) OR (teammate.start_year is not EMPTY and teammate.start_year > 2001) UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                              |
+      | p                                                                                                                                                                                                                                                                                 |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |
     When executing query:
       """
       FIND ALL PATH WITH PROP FROM "Tony Parker" TO "Yao Ming" OVER * BIDIRECT
-      WHERE  teammate.start_year > 2000 OR (like.likeness is not EMPTY AND like.likeness >= 80) UPTO 3 STEPS
+      WHERE  teammate.start_year > 2000 OR (like.likeness is not EMPTY AND like.likeness >= 80) UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                                                                                                                         |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:like@0 {likeness: 95}]-("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})>                         |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:teammate@0 {end_year: 2016, start_year: 2001}]-("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 95}]->("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 80}]-("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})>                         |
@@ -234,10 +234,10 @@ Feature: All Path
     When executing query:
       """
       FIND ALL PATH WITH PROP FROM "Yao Ming" TO "Danny Green" OVER * BIDIRECT
-      WHERE like.likeness is  EMPTY OR like.likeness >= 80 UPTO 3 STEPS
+      WHERE like.likeness is  EMPTY OR like.likeness >= 80 UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                                                                                                                         |
       | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})-[:serve@0 {end_year: 2010, start_year: 2009}]->("Cavaliers" :team{name: "Cavaliers"})<-[:serve@0 {end_year: 2010, start_year: 2009}]-("Danny Green" :player{age: 31, name: "Danny Green"})>                                                    |
       | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})-[:like@0 {likeness: 80}]->("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:teammate@0 {end_year: 2016, start_year: 2010}]->("Danny Green" :player{age: 31, name: "Danny Green"})> |
       | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Tracy McGrady" :player{age: 39, name: "Tracy McGrady"})-[:serve@0 {end_year: 2000, start_year: 1997}]->("Raptors" :team{name: "Raptors"})<-[:serve@0 {end_year: 2019, start_year: 2018}]-("Danny Green" :player{age: 31, name: "Danny Green"})>                                                              |
@@ -279,39 +279,7 @@ Feature: All Path
     Then drop the used space
 
   Scenario: ALL PATH YIELD PATH
-    Given a graph with space named "nba_int_vid"
-    When executing query:
-      """
-      FIND ALL PATH FROM "Tim Duncan" TO "Tony Parker" OVER like BIDIRECT UPTO 3 STEPS YIELD path as p
-      """
-    Then the result should be, in any order, with relax comparison:
-      | p                                                                                                   |
-      | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                           |
-      | <("Tim Duncan")-[:like]->("Tony Parker")>                                                           |
-      | <("Tim Duncan")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>                              |
-      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>                              |
-      | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>                            |
-      | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")-[:like]->("Tony Parker")>                            |
-      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tony Parker")>                                |
-      | <("Tim Duncan")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>                                |
-      | <("Tim Duncan")<-[:like]-("Boris Diaw")-[:like]->("Tony Parker")>                                   |
-      | <("Tim Duncan")<-[:like]-("Danny Green")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>     |
-      | <("Tim Duncan")<-[:like]-("Danny Green")-[:like]->("Marco Belinelli")-[:like]->("Tony Parker")>     |
-      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Marco Belinelli")-[:like]->("Tony Parker")> |
-      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>   |
-      | <("Tim Duncan")-[:like]->("Manu Ginobili")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>   |
-      | <("Tim Duncan")<-[:like]-("Danny Green")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")>     |
-      | <("Tim Duncan")<-[:like]-("Marco Belinelli")<-[:like]-("Dejounte Murray")-[:like]->("Tony Parker")> |
-      | <("Tim Duncan")<-[:like]-("Tony Parker")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>   |
-      | <("Tim Duncan")-[:like]->("Tony Parker")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")>   |
-      | <("Tim Duncan")<-[:like]-("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")>   |
-      | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")>   |
-      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tim Duncan")<-[:like]-("Tony Parker")>        |
-      | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")<-[:like]-("Tony Parker")>        |
-      | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tim Duncan")-[:like]->("Tony Parker")>        |
-      | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>        |
-      | <("Tim Duncan")<-[:like]-("Dejounte Murray")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>   |
-      | <("Tim Duncan")<-[:like]-("Tiago Splitter")-[:like]->("Manu Ginobili")<-[:like]-("Tony Parker")>    |
+    Given a graph with space named "nba"
     When executing query:
       """
       FIND ALL PATH WITH PROP FROM "Yao Ming" TO "Danny Green" OVER * BIDIRECT

--- a/tests/tck/features/path/NoLoop.IntVid.feature
+++ b/tests/tck/features/path/NoLoop.IntVid.feature
@@ -9,19 +9,19 @@ Feature: Integer Vid NoLoop Path
   Scenario: Integer Vid [1] NOLOOP Path
     When executing query:
       """
-      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                      |
+      | p                                         |
       | <("Tim Duncan")-[:like]->("Tony Parker")> |
 
   Scenario: Integer Vid [2] NOLOOP Path
     When executing query:
       """
-      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Manu Ginobili") OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Manu Ginobili") OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                 |
+      | p                                                                    |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                            |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")>                          |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("Manu Ginobili")> |
@@ -29,20 +29,20 @@ Feature: Integer Vid NoLoop Path
   Scenario: Integer Vid [3] NOLOOP Path
     When executing query:
       """
-      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")> |
 
   Scenario: Integer Vid [4] NOLOOP Path
     When executing query:
       """
-      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 3 STEPS
+      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                         |
+      | p                                                                                            |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                    |
       | <("Tim Duncan")-[:serve]->("Spurs")>                                                         |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:serve]->("Spurs")>                              |
@@ -54,10 +54,10 @@ Feature: Integer Vid NoLoop Path
     When executing query:
       """
       GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst
-      | FIND NOLOOP PATH FROM $-.src TO $-.dst OVER like UPTO 3 STEPS
+      | FIND NOLOOP PATH FROM $-.src TO $-.dst OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                              |
       | <("Tony Parker")-[:like]->("Tim Duncan")>                                |
       | <("Tony Parker")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>     |
@@ -67,10 +67,10 @@ Feature: Integer Vid NoLoop Path
     When executing query:
       """
       $a = GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst;
-      FIND NOLOOP PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                              |
       | <("Tony Parker")-[:like]->("Tim Duncan")>                                |
       | <("Tony Parker")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>     |
@@ -105,18 +105,18 @@ Feature: Integer Vid NoLoop Path
   Scenario: Integer Vid [1] NOLOOP Path REVERSELY
     When executing query:
       """
-      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Nobody"), hash("Spur") OVER like REVERSELY UPTO 3 STEPS
+      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Nobody"), hash("Spur") OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
 
   Scenario: Integer Vid [2] NOLOOP Path REVERSELY
     When executing query:
       """
-      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like REVERSELY UPTO 3 STEPS
+      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                |
       | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")> |
       | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tony Parker")>     |
@@ -124,10 +124,10 @@ Feature: Integer Vid NoLoop Path
   Scenario: Integer Vid [3] NOLOOP Path REVERSELY
     When executing query:
       """
-      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like REVERSELY UPTO 3 STEPS
+      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                |
+      | p                                                                                                   |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                           |
       | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")>                                                     |
       | <("Tim Duncan")<-[:like]-("Tony Parker")<-[:like]-("LaMarcus Aldridge")>                            |
@@ -138,10 +138,10 @@ Feature: Integer Vid NoLoop Path
   Scenario: Integer Vid [2] NOLOOP Path BIDIRECT
     When executing query:
       """
-      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like BIDIRECT UPTO 3 STEPS
+      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like BIDIRECT UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                |
+      | p                                                                                                   |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                           |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                           |
       | <("Tim Duncan")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>                              |
@@ -164,34 +164,34 @@ Feature: Integer Vid NoLoop Path
   Scenario: Integer Vid NOLOOP Path WITH PROP
     When executing query:
       """
-      FIND NOLOOP PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                          |
+      | p                                                                                                                                                                                             |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
     When executing query:
       """
-      FIND NOLOOP PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                         |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                                                             |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 90}]->("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})> |
 
   Scenario: Integer Vid NOLOOP Path WITH FILTER
     When executing query:
       """
-      FIND NOLOOP PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like BIDIRECT WHERE like.likeness > 95 UPTO 3 STEPS
+      FIND NOLOOP PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like BIDIRECT WHERE like.likeness > 95 UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                  |
+      | p                                                                                                                                                                                                                                                                                     |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 99}]-("Dejounte Murray" :player{age: 29, name: "Dejounte Murray"})-[:like@0 {likeness: 99}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
     When executing query:
       """
-      FIND NOLOOP PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like, serve WHERE serve.start_year > 1990 OR like.likeness is EMPTY UPTO 3 STEPS
+      FIND NOLOOP PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like, serve WHERE serve.start_year > 1990 OR like.likeness is EMPTY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                        |
+      | p                                                                                                                                                                                           |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:serve@0 {end_year: 2016, start_year: 1997}]->("Spurs" :team{name: "Spurs"})> |
     When executing query:
       """

--- a/tests/tck/features/path/NoLoop.IntVid.feature
+++ b/tests/tck/features/path/NoLoop.IntVid.feature
@@ -79,11 +79,11 @@ Feature: Integer Vid NoLoop Path
   Scenario: Integer Vid [1] NOLOOP Path With Limit
     When executing query:
       """
-      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 3 STEPS
-      | ORDER BY $-.path | LIMIT 3
+      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 3 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 3
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                         |
+      | p                                                                                            |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                    |
       | < ("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("Manu Ginobili")-[:serve]->("Spurs")>    |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:serve]->("Spurs")> |
@@ -92,11 +92,11 @@ Feature: Integer Vid NoLoop Path
     When executing query:
       """
       $a = GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst;
-      FIND NOLOOP PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS
-      | ORDER BY $-.path | LIMIT 5
+      FIND NOLOOP PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 5
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                              |
       | <("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tim Duncan")> |
       | <("Tony Parker")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>     |
@@ -196,9 +196,49 @@ Feature: Integer Vid NoLoop Path
     When executing query:
       """
       $a = GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst;
-      FIND NOLOOP PATH WITH PROP FROM $a.src TO $a.dst OVER like WHERE like.likeness > 90 UPTO 3 STEPS
-      | ORDER BY $-.path | LIMIT 5
+      FIND NOLOOP PATH WITH PROP FROM $a.src TO $a.dst OVER like WHERE like.likeness > 90 UPTO 3 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 5
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                          |
+      | p                                                                                                                                                                                             |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 95}]->("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})> |
+
+  Scenario: Integer Vid NOLOOP Path YIELD PATH
+    When executing query:
+      """
+      FIND NOLOOP PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like UPTO 3 STEPS YIELD path as p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p                                                                                                                                                                                             |
+      | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
+    When executing query:
+      """
+      FIND NOLOOP PATH WITH PROP FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like UPTO 3 STEPS YIELD path as p |
+      YIELD startnode($-.p) as startnode
+      """
+    Then the result should be, in any order, with relax comparison:
+      | startnode                                                                                                   |
+      | ("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"}) |
+      | ("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"}) |
+    When executing query:
+      """
+      $a = GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst;
+      FIND NOLOOP PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS YIELD path as p |
+      YIELD nodes($-.p) as nodes
+      """
+    Then the result should be, in any order, with relax comparison:
+      | nodes                                                    |
+      | [("Manu Ginobili"), ("Tim Duncan")]                      |
+      | [("Tony Parker"), ("Tim Duncan")]                        |
+      | [("Tony Parker"), ("Manu Ginobili"), ("Tim Duncan")]     |
+      | [("Tony Parker"), ("LaMarcus Aldridge"), ("Tim Duncan")] |
+    When executing query:
+      """
+      FIND NOLOOP PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like REVERSELY UPTO 3 STEPS YIELD path as p |
+      YIELD relationships($-.p) as relationships
+      """
+    Then the result should be, in any order, with relax comparison:
+      | relationships                                                                                       |
+      | [[:like "Tony Parker"->"Tim Duncan" @0 {}]]                                                         |
+      | [[:like "LaMarcus Aldridge"->"Tim Duncan" @0 {}], [:like "Tony Parker"->"LaMarcus Aldridge" @0 {}]] |
+      | [[:like "Manu Ginobili"->"Tim Duncan" @0 {}], [:like "Tony Parker"->"Manu Ginobili" @0 {}]]         |

--- a/tests/tck/features/path/NoLoop.feature
+++ b/tests/tck/features/path/NoLoop.feature
@@ -79,11 +79,11 @@ Feature: NoLoop Path
   Scenario: [1] NOLOOP Path With Limit
     When executing query:
       """
-      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve UPTO 3 STEPS
-      | ORDER BY $-.path | LIMIT 3
+      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve UPTO 3 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 3
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                            |
+      | p                                                               |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:serve]->("Spurs")> |
       | <("Tim Duncan")-[:serve]->("Spurs")>                            |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                       |
@@ -92,11 +92,11 @@ Feature: NoLoop Path
     When executing query:
       """
       $a = GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst;
-      FIND NOLOOP PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS
-      | ORDER BY $-.path | LIMIT 5
+      FIND NOLOOP PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 5
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                              |
       | <("Tony Parker")-[:like]->("LaMarcus Aldridge")-[:like]->("Tim Duncan")> |
       | <("Tony Parker")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>     |
@@ -196,9 +196,49 @@ Feature: NoLoop Path
     When executing query:
       """
       $a = GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst;
-      FIND NOLOOP PATH WITH PROP FROM $a.src TO $a.dst OVER like WHERE like.likeness > 90 UPTO 3 STEPS
-      | ORDER BY $-.path | LIMIT 5
+      FIND NOLOOP PATH WITH PROP FROM $a.src TO $a.dst OVER like WHERE like.likeness > 90 UPTO 3 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 5
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                          |
+      | p                                                                                                                                                                                             |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 95}]->("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})> |
+
+  Scenario: NOLOOP Path YIELD PATH
+    When executing query:
+      """
+      FIND NOLOOP PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS YIELD path as p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p                                                                                                                                                                                             |
+      | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
+    When executing query:
+      """
+      FIND NOLOOP PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like UPTO 3 STEPS YIELD path as p |
+      YIELD startnode($-.p) as startnode
+      """
+    Then the result should be, in any order, with relax comparison:
+      | startnode                                                                                                   |
+      | ("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"}) |
+      | ("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"}) |
+    When executing query:
+      """
+      $a = GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst;
+      FIND NOLOOP PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS YIELD path as p |
+      YIELD nodes($-.p) as nodes
+      """
+    Then the result should be, in any order, with relax comparison:
+      | nodes                                                    |
+      | [("Manu Ginobili"), ("Tim Duncan")]                      |
+      | [("Tony Parker"), ("Tim Duncan")]                        |
+      | [("Tony Parker"), ("Manu Ginobili"), ("Tim Duncan")]     |
+      | [("Tony Parker"), ("LaMarcus Aldridge"), ("Tim Duncan")] |
+    When executing query:
+      """
+      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker" OVER like REVERSELY UPTO 3 STEPS YIELD path as p |
+      YIELD relationships($-.p) as relationships
+      """
+    Then the result should be, in any order, with relax comparison:
+      | relationships                                                                                       |
+      | [[:like "Tony Parker"->"Tim Duncan" @0 {}]]                                                         |
+      | [[:like "LaMarcus Aldridge"->"Tim Duncan" @0 {}], [:like "Tony Parker"->"LaMarcus Aldridge" @0 {}]] |
+      | [[:like "Manu Ginobili"->"Tim Duncan" @0 {}], [:like "Tony Parker"->"Manu Ginobili" @0 {}]]         |

--- a/tests/tck/features/path/NoLoop.feature
+++ b/tests/tck/features/path/NoLoop.feature
@@ -9,19 +9,19 @@ Feature: NoLoop Path
   Scenario: [1] NOLOOP Path
     When executing query:
       """
-      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                      |
+      | p                                         |
       | <("Tim Duncan")-[:like]->("Tony Parker")> |
 
   Scenario: [2] NOLOOP Path
     When executing query:
       """
-      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker", "Manu Ginobili" OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker", "Manu Ginobili" OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                 |
+      | p                                                                    |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                            |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")>                          |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("Manu Ginobili")> |
@@ -29,20 +29,20 @@ Feature: NoLoop Path
   Scenario: [3] NOLOOP Path
     When executing query:
       """
-      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")> |
 
   Scenario: [4] NOLOOP Path
     When executing query:
       """
-      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve UPTO 3 STEPS
+      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                         |
+      | p                                                                                            |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                    |
       | <("Tim Duncan")-[:serve]->("Spurs")>                                                         |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")-[:serve]->("Spurs")>                              |
@@ -54,10 +54,10 @@ Feature: NoLoop Path
     When executing query:
       """
       GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst
-      | FIND NOLOOP PATH FROM $-.src TO $-.dst OVER like UPTO 3 STEPS
+      | FIND NOLOOP PATH FROM $-.src TO $-.dst OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                              |
       | <("Tony Parker")-[:like]->("Tim Duncan")>                                |
       | <("Tony Parker")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>     |
@@ -67,10 +67,10 @@ Feature: NoLoop Path
     When executing query:
       """
       $a = GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst;
-      FIND NOLOOP PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH FROM $a.src TO $a.dst OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")>                              |
       | <("Tony Parker")-[:like]->("Tim Duncan")>                                |
       | <("Tony Parker")-[:like]->("Manu Ginobili")-[:like]->("Tim Duncan")>     |
@@ -105,18 +105,18 @@ Feature: NoLoop Path
   Scenario: [1] NOLOOP Path REVERSELY
     When executing query:
       """
-      FIND NOLOOP PATH FROM "Tim Duncan" TO "Nobody","Spur" OVER like REVERSELY UPTO 3 STEPS
+      FIND NOLOOP PATH FROM "Tim Duncan" TO "Nobody","Spur" OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
 
   Scenario: [2] NOLOOP Path REVERSELY
     When executing query:
       """
-      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker" OVER like REVERSELY UPTO 3 STEPS
+      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker" OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                |
       | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")<-[:like]-("Tony Parker")> |
       | <("Tim Duncan")<-[:like]-("Manu Ginobili")<-[:like]-("Tony Parker")>     |
@@ -124,10 +124,10 @@ Feature: NoLoop Path
   Scenario: [3] NOLOOP Path REVERSELY
     When executing query:
       """
-      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like REVERSELY UPTO 3 STEPS
+      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                |
+      | p                                                                                                   |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                           |
       | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")>                                                     |
       | <("Tim Duncan")<-[:like]-("Tony Parker")<-[:like]-("LaMarcus Aldridge")>                            |
@@ -138,10 +138,10 @@ Feature: NoLoop Path
   Scenario: [2] NOLOOP Path BIDIRECT
     When executing query:
       """
-      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker" OVER like BIDIRECT UPTO 3 STEPS
+      FIND NOLOOP PATH FROM "Tim Duncan" TO "Tony Parker" OVER like BIDIRECT UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                |
+      | p                                                                                                   |
       | <("Tim Duncan")<-[:like]-("Tony Parker")>                                                           |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                                           |
       | <("Tim Duncan")<-[:like]-("Marco Belinelli")-[:like]->("Tony Parker")>                              |
@@ -164,34 +164,34 @@ Feature: NoLoop Path
   Scenario: NOLOOP Path WITH PROP
     When executing query:
       """
-      FIND NOLOOP PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                          |
+      | p                                                                                                                                                                                             |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
     When executing query:
       """
-      FIND NOLOOP PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like UPTO 3 STEPS
+      FIND NOLOOP PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                         |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                                                                                             |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 90}]->("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})> |
 
   Scenario: NOLOOP Path WITH FILTER
     When executing query:
       """
-      FIND NOLOOP PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like BIDIRECT WHERE like.likeness > 95 UPTO 3 STEPS
+      FIND NOLOOP PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker" OVER like BIDIRECT WHERE like.likeness > 95 UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                  |
+      | p                                                                                                                                                                                                                                                                                     |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 99}]-("Dejounte Murray" :player{age: 29, name: "Dejounte Murray"})-[:like@0 {likeness: 99}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
     When executing query:
       """
-      FIND NOLOOP PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker", "Spurs" OVER like, serve WHERE serve.start_year > 1990 OR like.likeness is EMPTY UPTO 3 STEPS
+      FIND NOLOOP PATH WITH PROP FROM "Tim Duncan" TO "Tony Parker", "Spurs" OVER like, serve WHERE serve.start_year > 1990 OR like.likeness is EMPTY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                        |
+      | p                                                                                                                                                                                           |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:serve@0 {end_year: 2016, start_year: 1997}]->("Spurs" :team{name: "Spurs"})> |
     When executing query:
       """

--- a/tests/tck/features/path/ShortestPath.IntVid.feature
+++ b/tests/tck/features/path/ShortestPath.IntVid.feature
@@ -9,80 +9,80 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [1] SinglePair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                      |
+      | p                                         |
       | <("Tim Duncan")-[:like]->("Tony Parker")> |
 
   Scenario: Integer Vid [2] SinglePair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("LaMarcus Aldridge") OVER like
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("LaMarcus Aldridge") OVER like YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")> |
 
   Scenario: Integer Vid [3] SinglePair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("LaMarcus Aldridge") OVER like
+      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("LaMarcus Aldridge") OVER like YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                 |
+      | p                                                                                                    |
       | <("Tiago Splitter")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")> |
 
   Scenario: Integer Vid [4] SinglePair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("LaMarcus Aldridge") OVER like, teammate
+      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("LaMarcus Aldridge") OVER like, teammate YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                            |
+      | p                                                                               |
       | <("Tiago Splitter")-[:like]->("Tim Duncan")-[:teammate]->("LaMarcus Aldridge")> |
 
   Scenario: Integer Vid [5] SinglePair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("LaMarcus Aldridge") OVER *
+      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("LaMarcus Aldridge") OVER * YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                            |
+      | p                                                                               |
       | <("Tiago Splitter")-[:like]->("Tim Duncan")-[:teammate]->("LaMarcus Aldridge")> |
 
   Scenario: Integer Vid [6] SinglePair Shortest Path limit steps
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("Tony Parker") OVER * UPTO 1 STEPS
+      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("Tony Parker") OVER * UPTO 1 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("Tim Duncan") OVER * UPTO 1 STEPS
+      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("Tim Duncan") OVER * UPTO 1 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                         |
+      | p                                            |
       | <("Tiago Splitter")-[:like]->("Tim Duncan")> |
 
   Scenario: Integer Vid [1] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 3 STEPS
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                      |
+      | p                                         |
       | <("Tim Duncan")-[:like]->("Tony Parker")> |
       | <("Tim Duncan")-[:serve]->("Spurs")>      |
 
   Scenario: Integer Vid [2] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER * UPTO 5 STEPS
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                          |
+      | p                                             |
       | <("Tim Duncan")-[:like]->("Tony Parker")>     |
       | <("Tim Duncan")-[:teammate]->("Tony Parker")> |
       | <("Tim Duncan")-[:serve]->("Spurs")>          |
@@ -90,10 +90,10 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [3] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS
+      FIND SHORTEST PATH FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                      |
+      | p                                                                                                                         |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>                           |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")>                       |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")>                                                             |
@@ -107,10 +107,10 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [4] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 3 STEPS
+      FIND SHORTEST PATH FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                |
+      | p                                                                                                   |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")>                                       |
@@ -120,10 +120,10 @@ Feature: Integer Vid Shortest Path
       | <("Tony Parker")-[:serve]->("Spurs")>                                                               |
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Yao Ming") TO hash("Tim Duncan"), hash("Spurs"), hash("Lakers") OVER * UPTO 2 STEPS
+      FIND SHORTEST PATH FROM hash("Yao Ming") TO hash("Tim Duncan"), hash("Spurs"), hash("Lakers") OVER * UPTO 2 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                 |
+      | p                                                                    |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")> |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")>        |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:serve]->("Lakers")>    |
@@ -131,10 +131,10 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [5] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Marco Belinelli"), hash("Yao Ming") TO hash("Spurs"), hash("Lakers") OVER * UPTO 3 STEPS
+      FIND SHORTEST PATH FROM hash("Marco Belinelli"), hash("Yao Ming") TO hash("Spurs"), hash("Lakers") OVER * UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                          |
+      | p                                                                                             |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")>                                 |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:serve]->("Lakers")>                             |
       | <("Marco Belinelli")-[:like]->("Danny Green")-[:like]->("LeBron James")-[:serve]->("Lakers")> |
@@ -144,20 +144,20 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [6] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like UPTO 3 STEPS
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("LaMarcus Aldridge") OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")> |
 
   Scenario: Integer Vid [7] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan"), hash("Tiago Splitter") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 5 STEPS
+      FIND SHORTEST PATH FROM hash("Tim Duncan"), hash("Tiago Splitter") TO hash("Tony Parker"), hash("Spurs") OVER like,serve UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                  |
+      | p                                                                     |
       | <("Tiago Splitter")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")> |
       | <("Tiago Splitter")-[:serve]->("Spurs")>                              |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                             |
@@ -166,20 +166,20 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [8] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Yao Ming")  TO hash("Tony Parker"), hash("Tracy McGrady") OVER like,serve UPTO 5 STEPS
+      FIND SHORTEST PATH FROM hash("Yao Ming")  TO hash("Tony Parker"), hash("Tracy McGrady") OVER like,serve UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                          |
+      | p                                                                                             |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")> |
       | <("Yao Ming")-[:like]->("Tracy McGrady")>                                                     |
 
   Scenario: Integer Vid [9] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Shaquille O\'Neal") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS
+      FIND SHORTEST PATH FROM hash("Shaquille O\'Neal") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                          |
+      | p                                                                             |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:serve]->("Spurs")>            |
       | <("Shaquille O'Neal")-[:serve]->("Lakers")>                                   |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
@@ -188,10 +188,10 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [10] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Shaquille O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS
+      FIND SHORTEST PATH FROM hash("Shaquille O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                          |
+      | p                                                                             |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:serve]->("Spurs")>            |
       | <("Shaquille O'Neal")-[:serve]->("Lakers")>                                   |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
@@ -200,19 +200,19 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [11] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Shaquille O\'Neal") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER like UPTO 5 STEPS
+      FIND SHORTEST PATH FROM hash("Shaquille O\'Neal") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER like UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                      |
+      | p                                                                         |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")> |
 
   Scenario: Integer Vid [12] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Marco Belinelli") TO hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS
+      FIND SHORTEST PATH FROM hash("Marco Belinelli") TO hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                          |
+      | p                                                                                             |
       | <("Marco Belinelli")-[:serve]->("Spurs")>                                                     |
       | <("Marco Belinelli")-[:serve@1]->("Spurs")>                                                   |
       | <("Marco Belinelli")-[:like]->("Danny Green")-[:like]->("LeBron James")-[:serve]->("Lakers")> |
@@ -220,29 +220,29 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [1] MultiPair Shortest Path Empty Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Nobody"), hash("Spur") OVER like,serve UPTO 3 STEPS
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Nobody"), hash("Spur") OVER like,serve UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
 
   Scenario: Integer Vid [1] MultiPair Shortest Path Run Time input
     When executing query:
       """
       YIELD hash("Yao Ming") AS src, hash("Tony Parker") AS dst
-      | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like, serve UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like, serve UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                          |
+      | p                                                                                             |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")> |
 
   Scenario: Integer Vid [2] MultiPair Shortest Path Run Time input
     When executing query:
       """
       YIELD hash("Shaquille O\'Neal") AS src
-      | FIND SHORTEST PATH FROM $-.src TO hash("Manu Ginobili") OVER * UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM $-.src TO hash("Manu Ginobili") OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                          |
+      | p                                                                             |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
 
@@ -250,10 +250,10 @@ Feature: Integer Vid Shortest Path
     When executing query:
       """
       YIELD hash("Manu Ginobili") AS dst
-      | FIND SHORTEST PATH FROM hash("Shaquille O\'Neal") TO $-.dst OVER * UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM hash("Shaquille O\'Neal") TO $-.dst OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                          |
+      | p                                                                             |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
 
@@ -261,10 +261,10 @@ Feature: Integer Vid Shortest Path
     When executing query:
       """
       GO FROM hash("Yao Ming") over like YIELD like._dst AS src
-      | FIND SHORTEST PATH FROM $-.src TO hash("Tony Parker") OVER like, serve UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM $-.src TO hash("Tony Parker") OVER like, serve UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tracy McGrady")-[:like]->("Rudy Gay")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")> |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>                           |
 
@@ -272,10 +272,10 @@ Feature: Integer Vid Shortest Path
     When executing query:
       """
       $a = GO FROM hash("Yao Ming") over like YIELD like._dst AS src;
-      FIND SHORTEST PATH FROM $a.src TO hash("Tony Parker") OVER like, serve UPTO 5 STEPS
+      FIND SHORTEST PATH FROM $a.src TO hash("Tony Parker") OVER like, serve UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tracy McGrady")-[:like]->("Rudy Gay")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")> |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>                           |
 
@@ -283,10 +283,10 @@ Feature: Integer Vid Shortest Path
     When executing query:
       """
       GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst
-      | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                        |
+      | p                                           |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")> |
       | <("Tony Parker")-[:like]->("Tim Duncan")>   |
 
@@ -294,10 +294,10 @@ Feature: Integer Vid Shortest Path
     When executing query:
       """
       $a = GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst;
-      FIND SHORTEST PATH FROM $a.src TO $a.dst OVER like UPTO 5 STEPS
+      FIND SHORTEST PATH FROM $a.src TO $a.dst OVER like UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                        |
+      | p                                           |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")> |
       | <("Tony Parker")-[:like]->("Tim Duncan")>   |
 
@@ -306,10 +306,10 @@ Feature: Integer Vid Shortest Path
       """
       $a = GO FROM hash("Tim Duncan") over like YIELD like._src AS src;
       GO FROM hash("Tony Parker") OVER like YIELD like._src AS src, like._dst AS dst
-      | FIND SHORTEST PATH FROM $a.src TO $-.dst OVER like UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM $a.src TO $-.dst OVER like UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")>                              |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")> |
 
@@ -358,62 +358,62 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [1] Shortest Path REVERSELY
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Nobody"), hash("Spur") OVER like REVERSELY UPTO 3 STEPS
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Nobody"), hash("Spur") OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
 
   Scenario: Integer Vid [2] Shortest Path REVERSELY
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like REVERSELY
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker") OVER like REVERSELY YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                      |
+      | p                                         |
       | <("Tim Duncan")<-[:like]-("Tony Parker")> |
 
   Scenario: Integer Vid [3] Shortest Path REVERSELY
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("LaMarcus Aldridge") OVER like REVERSELY
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("LaMarcus Aldridge") OVER like REVERSELY YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                            |
+      | p                                               |
       | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")> |
 
   Scenario: Integer Vid [4] Shortest Path REVERSELY
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve REVERSELY UPTO 3 STEPS
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Tony Parker"), hash("Spurs") OVER like,serve REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                      |
+      | p                                         |
       | <("Tim Duncan")<-[:like]-("Tony Parker")> |
 
   Scenario: Integer Vid [5] Shortest Path REVERSELY
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * REVERSELY
+      FIND SHORTEST PATH FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * REVERSELY YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                             |
+      | p                                                |
       | <("Tony Parker")<-[:teammate]-("Manu Ginobili")> |
 
   Scenario: Integer Vid [1] Shortest Path BIDIRECT
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Nobody"),hash("Spur") OVER like BIDIRECT UPTO 3 STEPS
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Nobody"),hash("Spur") OVER like BIDIRECT UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order:
-      | path |
+      | p |
 
   Scenario: Integer Vid [2] Shortest Path BIDIRECT
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT UPTO 2 STEPS
+      FIND SHORTEST PATH FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT UPTO 2 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                              |
+      | p                                                                 |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")>     |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:serve]->("Lakers")> |
       | <("Tony Parker")-[:serve]->("Spurs")>                             |
@@ -424,10 +424,10 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [3] Shortest Path BIDIRECT
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT UPTO 3 STEPS
+      FIND SHORTEST PATH FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                |
+      | p                                                                                                   |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")<-[:serve]-("Manu Ginobili")>           |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")<-[:like]-("Manu Ginobili")>     |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
@@ -450,24 +450,24 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid Shortest Path With PROP
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM hash("Tim Duncan") TO hash("LaMarcus Aldridge") OVER like
+      FIND SHORTEST PATH WITH PROP FROM hash("Tim Duncan") TO hash("LaMarcus Aldridge") OVER like YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                         |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 90}]->("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})> |
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * REVERSELY
+      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * REVERSELY YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                |
+      | p                                                                                                                                                                   |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:teammate@0 {end_year: 2016, start_year: 2002}]-("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})> |
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT UPTO 2 STEPS
+      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT UPTO 2 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                        |
+      | p                                                                                                                                                                                                                           |
       | <("Yao Ming" : player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal": player{age: 47, name: "Shaquille O'Neal"})-[:serve@0 {end_year: 2004,start_year: 1996}]->("Lakers": team{name: "Lakers"})> |
       | <("Yao Ming" : player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Tracy McGrady": player{age: 39, name: "Tracy McGrady"})-[:serve@0 {end_year: 2013, start_year: 2013}]->("Spurs": team{name: "Spurs"})>        |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:serve@0 {end_year: 2018, start_year: 1999}]->("Spurs" :team{name: "Spurs"})>                                                                                       |
@@ -478,10 +478,10 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid Shortest Path With Filter
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT WHERE like.likeness == 90 OR like.likeness is empty UPTO 2 STEPS
+      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT WHERE like.likeness == 90 OR like.likeness is empty UPTO 2 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                         |
+      | p                                                                                                                                                                                                                            |
       | <("Yao Ming" : player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player {age: 47,name: "Shaquille O'Neal"})-[:serve@0 {end_year: 2004, start_year: 1996}]->("Lakers": team{name: "Lakers"})> |
       | <("Yao Ming" : player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Tracy McGrady": player{age: 39,name: "Tracy McGrady"})-[:serve@0 {end_year: 2013, start_year: 2013}]->("Spurs": team{name: "Spurs"})>          |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:serve@0 {end_year: 2018, start_year: 1999}]->("Spurs" :team{name: "Spurs"})>                                                                                        |
@@ -489,26 +489,26 @@ Feature: Integer Vid Shortest Path
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:teammate@0 {end_year: 2018, start_year: 2002}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})>                                                          |
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * REVERSELY WHERE like.likeness > 70
+      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * REVERSELY WHERE like.likeness > 70 YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                              |
+      | p                                                                                                                                                                                                                                                                                 |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:like@0 {likeness: 95}]-("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 90}]-("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})> |
     When executing query:
       """
       $a = GO FROM hash("Yao Ming") over like YIELD like._dst AS src;
-      FIND SHORTEST PATH WITH PROP FROM $a.src TO hash("Tony Parker") OVER like, serve WHERE serve.start_year is EMPTY UPTO 5 STEPS
+      FIND SHORTEST PATH WITH PROP FROM $a.src TO hash("Tony Parker") OVER like, serve WHERE serve.start_year is EMPTY UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                                              |
+      | p                                                                                                                                                                                                                                                                                                                 |
       | <("Tracy McGrady" :player{age: 39, name: "Tracy McGrady"})-[:like@0 {likeness: 90}]->("Rudy Gay" :player{age: 32, name: "Rudy Gay"})-[:like@0 {likeness: 70}]->("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})-[:like@0 {likeness: 75}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
       | <("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})-[:like@0 {likeness: 80}]->("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                           |
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT WHERE teammate.start_year is not EMPTY OR like.likeness > 90 UPTO 3 STEPS
+      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT WHERE teammate.start_year is not EMPTY OR like.likeness > 90 UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                |
+      | p                                                                                                                                                                   |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:teammate@0 {end_year: 2016, start_year: 2002}]-("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})> |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 95}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})>                         |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:teammate@0 {end_year: 2018, start_year: 2002}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})> |

--- a/tests/tck/features/path/ShortestPath.IntVid.feature
+++ b/tests/tck/features/path/ShortestPath.IntVid.feature
@@ -324,13 +324,13 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [2] Shortest Path With Limit
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Shaquile O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p |
+      FIND SHORTEST PATH FROM hash("Shaquille O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p |
       ORDER BY $-.p | LIMIT 2
       """
     Then the result should be, in any order, with relax comparison:
-      | p                                                                        |
-      | <("Shaquile O'Neal")-[:serve]->("Lakers")>                               |
-      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")> |
+      | p                                                                         |
+      | <("Shaquille O'Neal")-[:serve]->("Lakers")>                               |
+      | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")> |
 
   Scenario: Integer Vid [3] Shortest Path With Limit
     When executing query:
@@ -516,17 +516,17 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid Shortest Path YIELD path
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Shaquile O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p
+      FIND SHORTEST PATH FROM hash("Shaquille O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | p                                                                            |
-      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:serve]->("Spurs")>            |
-      | <("Shaquile O'Neal")-[:serve]->("Lakers")>                                   |
-      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
-      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
+      | p                                                                             |
+      | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:serve]->("Spurs")>            |
+      | <("Shaquille O'Neal")-[:serve]->("Lakers")>                                   |
+      | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
+      | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Shaquile O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p |
+      FIND SHORTEST PATH FROM hash("Shaquille O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p |
       YIELD length($-.p) as length
       """
     Then the result should be, in any order, with relax comparison:

--- a/tests/tck/features/path/ShortestPath.IntVid.feature
+++ b/tests/tck/features/path/ShortestPath.IntVid.feature
@@ -316,42 +316,42 @@ Feature: Integer Vid Shortest Path
   Scenario: Integer Vid [1] Shortest Path With Limit
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Nobody"), hash("Spur") OVER like,serve UPTO 3 STEPS | ORDER BY $-.path | LIMIT 3
+      FIND SHORTEST PATH FROM hash("Tim Duncan") TO hash("Nobody"), hash("Spur") OVER like,serve UPTO 3 STEPS YIELD path as p | ORDER BY $-.p | LIMIT 3
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
 
   Scenario: Integer Vid [2] Shortest Path With Limit
     When executing query:
       """
-      FIND SHORTEST PATH FROM hash("Shaquille O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS
-      | ORDER BY $-.path | LIMIT 2
+      FIND SHORTEST PATH FROM hash("Shaquile O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 2
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                      |
-      | <("Shaquille O'Neal")-[:serve]->("Lakers")>                               |
-      | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")> |
+      | p                                                                        |
+      | <("Shaquile O'Neal")-[:serve]->("Lakers")>                               |
+      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")> |
 
   Scenario: Integer Vid [3] Shortest Path With Limit
     When executing query:
       """
-      GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst
-      | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like UPTO 5 STEPS
-      | ORDER BY $-.path | LIMIT 1
+      GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst |
+      FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like UPTO 5 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 1
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                        |
+      | p                                           |
       | <("Tony Parker")-[:like@0]->("Tim Duncan")> |
 
   Scenario: Integer Vid [4] Shortest Path With Limit
     When executing query:
       """
-      GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst
-      | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like UPTO 5 STEPS
-      | ORDER BY $-.path | LIMIT 10
+      GO FROM hash("Tim Duncan") over * YIELD like._dst AS src, serve._src AS dst |
+      FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like UPTO 5 STEPS YIELD path as p |
+      ORDER BY $-.p | LIMIT 10
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                        |
+      | p                                           |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")> |
       | <("Tony Parker")-[:like]->("Tim Duncan")>   |
 
@@ -512,3 +512,52 @@ Feature: Integer Vid Shortest Path
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:teammate@0 {end_year: 2016, start_year: 2002}]-("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})> |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 95}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})>                         |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:teammate@0 {end_year: 2018, start_year: 2002}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})> |
+
+  Scenario: Integer Vid Shortest Path YIELD path
+    When executing query:
+      """
+      FIND SHORTEST PATH FROM hash("Shaquile O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p                                                                            |
+      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:serve]->("Spurs")>            |
+      | <("Shaquile O'Neal")-[:serve]->("Lakers")>                                   |
+      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
+      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
+    When executing query:
+      """
+      FIND SHORTEST PATH FROM hash("Shaquile O\'Neal"), hash("Nobody") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * UPTO 5 STEPS YIELD path as p |
+      YIELD length($-.p) as length
+      """
+    Then the result should be, in any order, with relax comparison:
+      | length |
+      | 2      |
+      | 1      |
+      | 2      |
+      | 2      |
+    When executing query:
+      """
+      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT WHERE teammate.start_year is not EMPTY OR like.likeness > 90 UPTO 3 STEPS YIELD path as p |
+      YIELD nodes($-.p) as nodes
+      """
+    Then the result should be, in any order, with relax comparison:
+      | nodes                                                                                                              |
+      | [("Tony Parker" :player{age: 36, name: "Tony Parker"}), ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})] |
+      | [("Tony Parker" :player{age: 36, name: "Tony Parker"}), ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})] |
+      | [("Tony Parker" :player{age: 36, name: "Tony Parker"}), ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})] |
+    When executing query:
+      """
+      FIND SHORTEST PATH WITH PROP FROM hash("Tony Parker"), hash("Yao Ming") TO hash("Manu Ginobili"), hash("Spurs"), hash("Lakers") OVER * BIDIRECT WHERE teammate.start_year is not EMPTY OR like.likeness > 90 UPTO 3 STEPS YIELD path as p |
+      YIELD distinct nodes($-.p) as nodes
+      """
+    Then the result should be, in any order, with relax comparison:
+      | nodes                                                                                                              |
+      | [("Tony Parker" :player{age: 36, name: "Tony Parker"}), ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})] |
+    When executing query:
+      """
+      FIND SHORTEST PATH FROM hash("Tiago Splitter") TO hash("Tim Duncan") OVER * UPTO 1 STEPS YIELD path as p |
+      YIELD relationships($-.p) as relationships
+      """
+    Then the result should be, in any order, with relax comparison:
+      | relationships                                  |
+      | [[:like "Tiago Splitter"->"Tim Duncan" @0 {}]] |

--- a/tests/tck/features/path/ShortestPath.feature
+++ b/tests/tck/features/path/ShortestPath.feature
@@ -9,80 +9,80 @@ Feature: Shortest Path
   Scenario: [1] SinglePair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker" OVER like
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker" OVER like YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                      |
+      | p                                         |
       | <("Tim Duncan")-[:like]->("Tony Parker")> |
 
   Scenario: [2] SinglePair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "LaMarcus Aldridge" OVER like
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "LaMarcus Aldridge" OVER like YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")> |
 
   Scenario: [3] SinglePair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tiago Splitter" TO "LaMarcus Aldridge" OVER like
+      FIND SHORTEST PATH FROM "Tiago Splitter" TO "LaMarcus Aldridge" OVER like YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                 |
+      | p                                                                                                    |
       | <("Tiago Splitter")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")> |
 
   Scenario: [4] SinglePair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tiago Splitter" TO "LaMarcus Aldridge" OVER like, teammate
+      FIND SHORTEST PATH FROM "Tiago Splitter" TO "LaMarcus Aldridge" OVER like, teammate YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                            |
+      | p                                                                               |
       | <("Tiago Splitter")-[:like]->("Tim Duncan")-[:teammate]->("LaMarcus Aldridge")> |
 
   Scenario: [5] SinglePair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tiago Splitter" TO "LaMarcus Aldridge" OVER *
+      FIND SHORTEST PATH FROM "Tiago Splitter" TO "LaMarcus Aldridge" OVER * YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                            |
+      | p                                                                               |
       | <("Tiago Splitter")-[:like]->("Tim Duncan")-[:teammate]->("LaMarcus Aldridge")> |
 
   Scenario: [6] SinglePair Shortest Path limit steps
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tiago Splitter" TO "Tony Parker" OVER * UPTO 1 STEPS
+      FIND SHORTEST PATH FROM "Tiago Splitter" TO "Tony Parker" OVER * UPTO 1 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tiago Splitter" TO "Tim Duncan" OVER * UPTO 1 STEPS
+      FIND SHORTEST PATH FROM "Tiago Splitter" TO "Tim Duncan" OVER * UPTO 1 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                         |
+      | p                                            |
       | <("Tiago Splitter")-[:like]->("Tim Duncan")> |
 
   Scenario: [1] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve UPTO 3 STEPS
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                      |
+      | p                                         |
       | <("Tim Duncan")-[:like]->("Tony Parker")> |
       | <("Tim Duncan")-[:serve]->("Spurs")>      |
 
   Scenario: [2] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER * UPTO 5 STEPS
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                          |
+      | p                                             |
       | <("Tim Duncan")-[:like]->("Tony Parker")>     |
       | <("Tim Duncan")-[:teammate]->("Tony Parker")> |
       | <("Tim Duncan")-[:serve]->("Spurs")>          |
@@ -90,10 +90,10 @@ Feature: Shortest Path
   Scenario: [3] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS
+      FIND SHORTEST PATH FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                      |
+      | p                                                                                                                         |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>                           |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")>                       |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")>                                                             |
@@ -107,10 +107,10 @@ Feature: Shortest Path
   Scenario: [4] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 3 STEPS
+      FIND SHORTEST PATH FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                |
+      | p                                                                                                   |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")>                                       |
@@ -120,10 +120,10 @@ Feature: Shortest Path
       | <("Tony Parker")-[:serve]->("Spurs")>                                                               |
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Yao Ming" TO "Tim Duncan", "Spurs", "Lakers" OVER * UPTO 2 STEPS
+      FIND SHORTEST PATH FROM "Yao Ming" TO "Tim Duncan", "Spurs", "Lakers" OVER * UPTO 2 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                 |
+      | p                                                                    |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")> |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")>        |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:serve]->("Lakers")>    |
@@ -131,10 +131,10 @@ Feature: Shortest Path
   Scenario: [5] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Marco Belinelli", "Yao Ming" TO "Spurs", "Lakers" OVER * UPTO 3 STEPS
+      FIND SHORTEST PATH FROM "Marco Belinelli", "Yao Ming" TO "Spurs", "Lakers" OVER * UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                          |
+      | p                                                                                             |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")>                                 |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:serve]->("Lakers")>                             |
       | <("Marco Belinelli")-[:like]->("Danny Green")-[:like]->("LeBron James")-[:serve]->("Lakers")> |
@@ -144,20 +144,20 @@ Feature: Shortest Path
   Scenario: [6] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like UPTO 3 STEPS
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker","LaMarcus Aldridge" OVER like UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                                |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")> |
 
   Scenario: [7] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan", "Tiago Splitter" TO "Tony Parker","Spurs" OVER like,serve UPTO 5 STEPS
+      FIND SHORTEST PATH FROM "Tim Duncan", "Tiago Splitter" TO "Tony Parker","Spurs" OVER like,serve UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                  |
+      | p                                                                     |
       | <("Tiago Splitter")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")> |
       | <("Tiago Splitter")-[:serve]->("Spurs")>                              |
       | <("Tim Duncan")-[:like]->("Tony Parker")>                             |
@@ -166,20 +166,20 @@ Feature: Shortest Path
   Scenario: [8] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Yao Ming"  TO "Tony Parker","Tracy McGrady" OVER like,serve UPTO 5 STEPS
+      FIND SHORTEST PATH FROM "Yao Ming"  TO "Tony Parker","Tracy McGrady" OVER like,serve UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                          |
+      | p                                                                                             |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")> |
       | <("Yao Ming")-[:like]->("Tracy McGrady")>                                                     |
 
   Scenario: [9] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Shaquille O\'Neal" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS
+      FIND SHORTEST PATH FROM "Shaquille O\'Neal" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                          |
+      | p                                                                             |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:serve]->("Spurs")>            |
       | <("Shaquille O'Neal")-[:serve]->("Lakers")>                                   |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
@@ -188,10 +188,10 @@ Feature: Shortest Path
   Scenario: [10] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Shaquille O\'Neal", "Nobody" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS
+      FIND SHORTEST PATH FROM "Shaquille O\'Neal", "Nobody" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                          |
+      | p                                                                             |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:serve]->("Spurs")>            |
       | <("Shaquille O'Neal")-[:serve]->("Lakers")>                                   |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
@@ -200,19 +200,19 @@ Feature: Shortest Path
   Scenario: [11] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Shaquille O\'Neal" TO "Manu Ginobili", "Spurs", "Lakers" OVER like UPTO 5 STEPS
+      FIND SHORTEST PATH FROM "Shaquille O\'Neal" TO "Manu Ginobili", "Spurs", "Lakers" OVER like UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                      |
+      | p                                                                         |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")> |
 
   Scenario: [12] MultiPair Shortest Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Marco Belinelli" TO "Spurs", "Lakers" OVER * UPTO 5 STEPS
+      FIND SHORTEST PATH FROM "Marco Belinelli" TO "Spurs", "Lakers" OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                          |
+      | p                                                                                             |
       | <("Marco Belinelli")-[:serve]->("Spurs")>                                                     |
       | <("Marco Belinelli")-[:serve@1]->("Spurs")>                                                   |
       | <("Marco Belinelli")-[:like]->("Danny Green")-[:like]->("LeBron James")-[:serve]->("Lakers")> |
@@ -220,29 +220,29 @@ Feature: Shortest Path
   Scenario: [1] MultiPair Shortest Path Empty Path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "Nobody","Spur" OVER like,serve UPTO 3 STEPS
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "Nobody","Spur" OVER like,serve UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
 
   Scenario: [1] MultiPair Shortest Path Run Time input
     When executing query:
       """
       YIELD "Yao Ming" AS src, "Tony Parker" AS dst
-      | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like, serve UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like, serve UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                          |
+      | p                                                                                             |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")> |
 
   Scenario: [2] MultiPair Shortest Path Run Time input
     When executing query:
       """
       YIELD "Shaquille O\'Neal" AS src
-      | FIND SHORTEST PATH FROM $-.src TO "Manu Ginobili" OVER * UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM $-.src TO "Manu Ginobili" OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                          |
+      | p                                                                             |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
 
@@ -250,10 +250,10 @@ Feature: Shortest Path
     When executing query:
       """
       YIELD "Manu Ginobili" AS dst
-      | FIND SHORTEST PATH FROM "Shaquille O\'Neal" TO $-.dst OVER * UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM "Shaquille O\'Neal" TO $-.dst OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                          |
+      | p                                                                             |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
 
@@ -261,10 +261,10 @@ Feature: Shortest Path
     When executing query:
       """
       GO FROM "Yao Ming" over like YIELD like._dst AS src
-      | FIND SHORTEST PATH FROM $-.src TO "Tony Parker" OVER like, serve UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM $-.src TO "Tony Parker" OVER like, serve UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tracy McGrady")-[:like]->("Rudy Gay")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")> |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>                           |
 
@@ -272,10 +272,10 @@ Feature: Shortest Path
     When executing query:
       """
       $a = GO FROM "Yao Ming" over like YIELD like._dst AS src;
-      FIND SHORTEST PATH FROM $a.src TO "Tony Parker" OVER like, serve UPTO 5 STEPS
+      FIND SHORTEST PATH FROM $a.src TO "Tony Parker" OVER like, serve UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                              |
+      | p                                                                                                 |
       | <("Tracy McGrady")-[:like]->("Rudy Gay")-[:like]->("LaMarcus Aldridge")-[:like]->("Tony Parker")> |
       | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Tony Parker")>                           |
 
@@ -283,10 +283,10 @@ Feature: Shortest Path
     When executing query:
       """
       GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst
-      | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM $-.src TO $-.dst OVER like UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                        |
+      | p                                           |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")> |
       | <("Tony Parker")-[:like]->("Tim Duncan")>   |
 
@@ -294,10 +294,10 @@ Feature: Shortest Path
     When executing query:
       """
       $a = GO FROM "Tim Duncan" over * YIELD like._dst AS src, serve._src AS dst;
-      FIND SHORTEST PATH FROM $a.src TO $a.dst OVER like UPTO 5 STEPS
+      FIND SHORTEST PATH FROM $a.src TO $a.dst OVER like UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                        |
+      | p                                           |
       | <("Manu Ginobili")-[:like]->("Tim Duncan")> |
       | <("Tony Parker")-[:like]->("Tim Duncan")>   |
 
@@ -306,10 +306,10 @@ Feature: Shortest Path
       """
       $a = GO FROM "Tim Duncan" over like YIELD like._src AS src;
       GO FROM "Tony Parker" OVER like YIELD like._src AS src, like._dst AS dst
-      | FIND SHORTEST PATH FROM $a.src TO $-.dst OVER like UPTO 5 STEPS
+      | FIND SHORTEST PATH FROM $a.src TO $-.dst OVER like UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                     |
+      | p                                                                        |
       | <("Tim Duncan")-[:like]->("Manu Ginobili")>                              |
       | <("Tim Duncan")-[:like]->("Tony Parker")-[:like]->("LaMarcus Aldridge")> |
 
@@ -358,62 +358,62 @@ Feature: Shortest Path
   Scenario: [1] Shortest Path REVERSELY
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "Nobody","Spur" OVER like REVERSELY UPTO 3 STEPS
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "Nobody","Spur" OVER like REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path |
+      | p |
 
   Scenario: [2] Shortest Path REVERSELY
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker" OVER like REVERSELY
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker" OVER like REVERSELY YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                      |
+      | p                                         |
       | <("Tim Duncan")<-[:like]-("Tony Parker")> |
 
   Scenario: [3] Shortest Path REVERSELY
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "LaMarcus Aldridge" OVER like REVERSELY
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "LaMarcus Aldridge" OVER like REVERSELY YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                            |
+      | p                                               |
       | <("Tim Duncan")<-[:like]-("LaMarcus Aldridge")> |
 
   Scenario: [4] Shortest Path REVERSELY
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve REVERSELY UPTO 3 STEPS
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "Tony Parker","Spurs" OVER like,serve REVERSELY UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                      |
+      | p                                         |
       | <("Tim Duncan")<-[:like]-("Tony Parker")> |
 
   Scenario: [5] Shortest Path REVERSELY
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * REVERSELY
+      FIND SHORTEST PATH FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * REVERSELY YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                             |
+      | p                                                |
       | <("Tony Parker")<-[:teammate]-("Manu Ginobili")> |
 
   Scenario: [1] Shortest Path BIDIRECT
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tim Duncan" TO "Nobody","Spur" OVER like BIDIRECT UPTO 3 STEPS
+      FIND SHORTEST PATH FROM "Tim Duncan" TO "Nobody","Spur" OVER like BIDIRECT UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order:
-      | path |
+      | p |
 
   Scenario: [2] Shortest Path BIDIRECT
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * BIDIRECT UPTO 2 STEPS
+      FIND SHORTEST PATH FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * BIDIRECT UPTO 2 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                              |
+      | p                                                                 |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")>     |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:serve]->("Lakers")> |
       | <("Tony Parker")-[:serve]->("Spurs")>                             |
@@ -424,10 +424,10 @@ Feature: Shortest Path
   Scenario: [3] Shortest Path BIDIRECT
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * BIDIRECT UPTO 3 STEPS
+      FIND SHORTEST PATH FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * BIDIRECT UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                |
+      | p                                                                                                   |
       | <("Yao Ming")-[:like]->("Tracy McGrady")-[:serve]->("Spurs")<-[:serve]-("Manu Ginobili")>           |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")<-[:like]-("Manu Ginobili")>     |
       | <("Yao Ming")-[:like]->("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
@@ -450,24 +450,24 @@ Feature: Shortest Path
   Scenario: Shortest Path With PROP
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM "Tim Duncan" TO "LaMarcus Aldridge" OVER like
+      FIND SHORTEST PATH WITH PROP FROM "Tim Duncan" TO "LaMarcus Aldridge" OVER like YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                      |
+      | p                                                                                                                                                                                                                                                                                         |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 90}]->("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})> |
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * REVERSELY
+      FIND SHORTEST PATH WITH PROP FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * REVERSELY  YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                |
+      | p                                                                                                                                                                   |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:teammate@0 {end_year: 2016, start_year: 2002}]-("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})> |
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * BIDIRECT UPTO 2 STEPS
+      FIND SHORTEST PATH WITH PROP FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * BIDIRECT UPTO 2 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                         |
+      | p                                                                                                                                                                                                                            |
       | <("Yao Ming" : player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player {age: 47,name: "Shaquille O'Neal"})-[:serve@0 {end_year: 2004, start_year: 1996}]->("Lakers": team{name: "Lakers"})> |
       | <("Yao Ming" : player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Tracy McGrady": player{age: 39,name: "Tracy McGrady"})-[:serve@0 {end_year: 2013, start_year: 2013}]->("Spurs": team{name: "Spurs"})>          |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:serve@0 {end_year: 2018, start_year: 1999}]->("Spurs" :team{name: "Spurs"})>                                                                                        |
@@ -478,10 +478,10 @@ Feature: Shortest Path
   Scenario: Shortest Path With Filter
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * BIDIRECT WHERE like.likeness == 90 OR like.likeness is empty UPTO 2 STEPS
+      FIND SHORTEST PATH WITH PROP FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * BIDIRECT WHERE like.likeness == 90 OR like.likeness is empty UPTO 2 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                         |
+      | p                                                                                                                                                                                                                            |
       | <("Yao Ming" : player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player {age: 47,name: "Shaquille O'Neal"})-[:serve@0 {end_year: 2004, start_year: 1996}]->("Lakers": team{name: "Lakers"})> |
       | <("Yao Ming" : player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Tracy McGrady": player{age: 39,name: "Tracy McGrady"})-[:serve@0 {end_year: 2013, start_year: 2013}]->("Spurs": team{name: "Spurs"})>          |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:serve@0 {end_year: 2018, start_year: 1999}]->("Spurs" :team{name: "Spurs"})>                                                                                        |
@@ -489,26 +489,26 @@ Feature: Shortest Path
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:teammate@0 {end_year: 2018, start_year: 2002}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})>                                                          |
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * REVERSELY WHERE like.likeness > 70
+      FIND SHORTEST PATH WITH PROP FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * REVERSELY WHERE like.likeness > 70 YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                              |
+      | p                                                                                                                                                                                                                                                                                 |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:like@0 {likeness: 95}]-("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})<-[:like@0 {likeness: 90}]-("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})> |
     When executing query:
       """
       $a = GO FROM "Yao Ming" over like YIELD like._dst AS src;
-      FIND SHORTEST PATH WITH PROP FROM $a.src TO "Tony Parker" OVER like, serve WHERE serve.start_year is EMPTY UPTO 5 STEPS
+      FIND SHORTEST PATH WITH PROP FROM $a.src TO "Tony Parker" OVER like, serve WHERE serve.start_year is EMPTY UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                                                                                                                                                              |
+      | p                                                                                                                                                                                                                                                                                                                 |
       | <("Tracy McGrady" :player{age: 39, name: "Tracy McGrady"})-[:like@0 {likeness: 90}]->("Rudy Gay" :player{age: 32, name: "Rudy Gay"})-[:like@0 {likeness: 70}]->("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})-[:like@0 {likeness: 75}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})> |
       | <("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})-[:like@0 {likeness: 80}]->("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:like@0 {likeness: 95}]->("Tony Parker" :player{age: 36, name: "Tony Parker"})>                           |
     When executing query:
       """
-      FIND SHORTEST PATH WITH PROP FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * BIDIRECT WHERE teammate.start_year is not EMPTY OR like.likeness > 90 UPTO 3 STEPS
+      FIND SHORTEST PATH WITH PROP FROM "Tony Parker", "Yao Ming" TO "Manu Ginobili", "Spurs", "Lakers" OVER * BIDIRECT WHERE teammate.start_year is not EMPTY OR like.likeness > 90 UPTO 3 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | path                                                                                                                                                                |
+      | p                                                                                                                                                                   |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})<-[:teammate@0 {end_year: 2016, start_year: 2002}]-("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})> |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:like@0 {likeness: 95}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})>                         |
       | <("Tony Parker" :player{age: 36, name: "Tony Parker"})-[:teammate@0 {end_year: 2018, start_year: 2002}]->("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})> |

--- a/tests/tck/features/path/ShortestPath.feature
+++ b/tests/tck/features/path/ShortestPath.feature
@@ -324,13 +324,13 @@ Feature: Shortest Path
   Scenario: [2] Shortest Path With Limit
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Shaquile O\'Neal", "Nobody" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS YIELD path as p |
+      FIND SHORTEST PATH FROM "Shaquille O\'Neal", "Nobody" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS YIELD path as p |
       ORDER BY $-.p | LIMIT 2
       """
     Then the result should be, in any order, with relax comparison:
-      | p                                                                        |
-      | <("Shaquile O'Neal")-[:serve]->("Lakers")>                               |
-      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")> |
+      | p                                                                         |
+      | <("Shaquille O'Neal")-[:serve]->("Lakers")>                               |
+      | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")> |
 
   Scenario: [3] Shortest Path With Limit
     When executing query:
@@ -516,17 +516,17 @@ Feature: Shortest Path
   Scenario: Shortest Path YIELD path
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Shaquile O\'Neal", "Nobody" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS YIELD path as p
+      FIND SHORTEST PATH FROM "Shaquille O\'Neal", "Nobody" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS YIELD path as p
       """
     Then the result should be, in any order, with relax comparison:
-      | p                                                                            |
-      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:serve]->("Spurs")>            |
-      | <("Shaquile O'Neal")-[:serve]->("Lakers")>                                   |
-      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
-      | <("Shaquile O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
+      | p                                                                             |
+      | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:serve]->("Spurs")>            |
+      | <("Shaquille O'Neal")-[:serve]->("Lakers")>                                   |
+      | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:like]->("Manu Ginobili")>     |
+      | <("Shaquille O'Neal")-[:like]->("Tim Duncan")-[:teammate]->("Manu Ginobili")> |
     When executing query:
       """
-      FIND SHORTEST PATH FROM "Shaquile O\'Neal", "Nobody" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS YIELD path as p |
+      FIND SHORTEST PATH FROM "Shaquille O\'Neal", "Nobody" TO "Manu Ginobili", "Spurs", "Lakers" OVER * UPTO 5 STEPS YIELD path as p |
       YIELD length($-.p) as length
       """
     Then the result should be, in any order, with relax comparison:


### PR DESCRIPTION
must add YIELD path in findpath sentence

incompatible
KW_PATH changed from non-keyword to keyword, so disallow users  to define path as a variable .
some test case :
find path from a to b over like |order by $-.path  or. match path = (a)-[]->(b) return path.   are not allowed