### PR TITLE
If an edge prepareLocal(), it should not go into resume process. 

### DIFF
--- a/src/storage/transaction/ChainAddEdgesProcessorLocal.h
+++ b/src/storage/transaction/ChainAddEdgesProcessorLocal.h
@@ -134,6 +134,9 @@ class ChainAddEdgesProcessorLocal : public BaseProcessor<cpp2::ExecResponse>,
   std::unique_ptr<TransactionManager::LockGuard> lk_{nullptr};
   int retryLimit_{10};
   TermID localTerm_{-1};
+  // set to true when prime insert succeed
+  // in processLocal(), we check this to determine if need to do abort()
+  bool primeInserted_{false};
 
   std::vector<std::string> kvErased_;
   std::vector<kvstore::KV> kvAppend_;

--- a/src/storage/transaction/ChainResumeProcessor.cpp
+++ b/src/storage/transaction/ChainResumeProcessor.cpp
@@ -30,7 +30,13 @@ void ChainResumeProcessor::process() {
     auto key = prefix + edgeKey;
     std::string val;
     auto rc = env_->kvstore_->get(spaceId, partId, key, &val);
-    if (rc != nebula::cpp2::ErrorCode::SUCCEEDED) {
+    if (rc == nebula::cpp2::ErrorCode::SUCCEEDED) {
+      // do nothing
+    } else if (rc == nebula::cpp2::ErrorCode::E_LEADER_CHANGED) {
+      // not leader any more, stop trying resume
+      env_->txnMan_->delPrime(spaceId, edgeKey);
+      continue;
+    } else {
       LOG(WARNING) << "kvstore->get() failed, " << apache::thrift::util::enumNameSafe(rc);
       continue;
     }


### PR DESCRIPTION
prepareLocal() failed will also lock edge in transaction manager, which is not necessary. 

(because there isn't any prime)