### PR TITLE
Refactor storage::RelNode constructors

### DIFF
--- a/src/storage/exec/AggregateNode.h
+++ b/src/storage/exec/AggregateNode.h
@@ -85,21 +85,13 @@ class AggregateNode : public IterateNode<T> {
   }
 
  private:
-  VertexIDSlice srcId() const {
-    return NebulaKeyUtils::getSrcId(this->context_->vIdLen(), this->key());
-  }
+  VertexIDSlice srcId() const { return NebulaKeyUtils::getSrcId(this->vidLen(), this->key()); }
 
-  EdgeType edgeType() const {
-    return NebulaKeyUtils::getEdgeType(this->context_->vIdLen(), this->key());
-  }
+  EdgeType edgeType() const { return NebulaKeyUtils::getEdgeType(this->vidLen(), this->key()); }
 
-  EdgeRanking edgeRank() const {
-    return NebulaKeyUtils::getRank(this->context_->vIdLen(), this->key());
-  }
+  EdgeRanking edgeRank() const { return NebulaKeyUtils::getRank(this->vidLen(), this->key()); }
 
-  VertexIDSlice dstId() const {
-    return NebulaKeyUtils::getDstId(this->context_->vIdLen(), this->key());
-  }
+  VertexIDSlice dstId() const { return NebulaKeyUtils::getDstId(this->vidLen(), this->key()); }
 
   void initStatValue(EdgeContext* edgeContext) {
     stats_.clear();
@@ -126,8 +118,8 @@ class AggregateNode : public IterateNode<T> {
       if (prop.hasStat_) {
         for (const auto statIndex : prop.statIndex_) {
           VLOG(2) << "Collect stat prop " << prop.name_;
-          auto ctx = this->context_;
-          auto value = QueryUtils::readEdgeProp(key, ctx->vIdLen(), ctx->isIntId(), reader, prop);
+          auto value = QueryUtils::readEdgeProp(
+              key, this->vidLen(), this->context_->isIntId(), reader, prop);
           if (!value.ok()) {
             return nebula::cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND;
           }

--- a/src/storage/exec/AggregateNode.h
+++ b/src/storage/exec/AggregateNode.h
@@ -61,7 +61,7 @@ class AggregateNode : public IterateNode<T> {
 
   void next() override {
     // we need to collect the stat during `next`
-    collectEdgeStats(this->key(), this->reader(), this->context()->props_);
+    collectEdgeStats(this->key(), this->reader(), this->context_->props_);
     IterateNode<T>::next();
   }
 

--- a/src/storage/exec/AggregateNode.h
+++ b/src/storage/exec/AggregateNode.h
@@ -38,7 +38,7 @@ class AggregateNode : public IterateNode<T> {
   using RelNode<T>::doExecute;
 
   AggregateNode(RuntimeContext* context, IterateNode<T>* upstream, EdgeContext* edgeContext)
-      : IterateNode<T>(context, upstream, "AggregateNode"), edgeContext_(edgeContext) {}
+      : IterateNode<T>(context, "AggregateNode", upstream), edgeContext_(edgeContext) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const T& input) override {
     auto ret = RelNode<T>::doExecute(partId, input);

--- a/src/storage/exec/AggregateNode.h
+++ b/src/storage/exec/AggregateNode.h
@@ -61,7 +61,7 @@ class AggregateNode : public IterateNode<T> {
 
   void next() override {
     // we need to collect the stat during `next`
-    collectEdgeStats(this->key(), this->reader(), this->context_->props_);
+    collectEdgeStats(this->key(), this->reader(), this->context()->props_);
     IterateNode<T>::next();
   }
 
@@ -118,8 +118,7 @@ class AggregateNode : public IterateNode<T> {
       if (prop.hasStat_) {
         for (const auto statIndex : prop.statIndex_) {
           VLOG(2) << "Collect stat prop " << prop.name_;
-          auto value = QueryUtils::readEdgeProp(
-              key, this->vidLen(), this->context_->isIntId(), reader, prop);
+          auto value = QueryUtils::readEdgeProp(key, this->vIdLen(), this->isIntId(), reader, prop);
           if (!value.ok()) {
             return nebula::cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND;
           }

--- a/src/storage/exec/DeDupNode.h
+++ b/src/storage/exec/DeDupNode.h
@@ -14,7 +14,7 @@
 namespace nebula {
 namespace storage {
 
-// DedupNode will used dedup the result set based on the given fields
+// DedupNode will be used to dedup the resultset based on the given fields
 template <typename T>
 class DeDupNode : public IterateNode<T> {
  public:

--- a/src/storage/exec/DeDupNode.h
+++ b/src/storage/exec/DeDupNode.h
@@ -20,8 +20,8 @@ class DeDupNode : public IterateNode<T> {
  public:
   using RelNode<T>::doExecute;
 
-  DeDupNode(nebula::DataSet* resultSet, const std::vector<size_t>& pos)
-      : IterateNode<T>(nullptr, "DedupNode"), resultSet_(resultSet), pos_(pos) {}
+  DeDupNode(RuntimeContext* context, nebula::DataSet* resultSet, const std::vector<size_t>& pos)
+      : IterateNode<T>(context, "DedupNode"), resultSet_(resultSet), pos_(pos) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId) override {
     auto ret = RelNode<T>::doExecute(partId);

--- a/src/storage/exec/EdgeNode.h
+++ b/src/storage/exec/EdgeNode.h
@@ -169,8 +169,8 @@ class SingleEdgeNode final : public EdgeNode<VertexID> {
     prefix_ = NebulaKeyUtils::edgePrefix(this->vIdLen(), partId, vId, edgeType_);
     ret = this->prefix(partId, prefix_, &iter);
     if (ret == nebula::cpp2::ErrorCode::SUCCEEDED && iter && iter->valid()) {
-      iter_.reset(new SingleEdgeIterator(
-          RelNode<VertexID>::context(), std::move(iter), edgeType_, schemas_, &ttl_));
+      iter_.reset(
+          new SingleEdgeIterator(this->context_, std::move(iter), edgeType_, schemas_, &ttl_));
     } else {
       iter_.reset();
     }

--- a/src/storage/exec/EdgeNode.h
+++ b/src/storage/exec/EdgeNode.h
@@ -35,29 +35,25 @@ class EdgeNode : public IterateNode<T> {
            EdgeType edgeType,
            const std::vector<PropContext>* props,
            StorageExpressionContext* expCtx,
-           Expression* exp)
-      : context_(context),
+           Expression* exp,
+           const std::string& name = "EdgeNode")
+      : IterateNode<T>(context, name),
         edgeContext_(edgeContext),
         edgeType_(edgeType),
         props_(props),
         expCtx_(expCtx),
         exp_(exp) {
-    UNUSED(expCtx_);
-    UNUSED(exp_);
     auto schemaIter = edgeContext_->schemas_.find(std::abs(edgeType_));
     CHECK(schemaIter != edgeContext_->schemas_.end());
     CHECK(!schemaIter->second.empty());
     schemas_ = &(schemaIter->second);
     ttl_ = QueryUtils::getEdgeTTLInfo(edgeContext_, std::abs(edgeType_));
     edgeName_ = edgeContext_->edgeNames_[edgeType_];
-    IterateNode<T>::name_ = "EdgeNode";
   }
 
-  EdgeNode(RuntimeContext* context, EdgeContext* ctx) : context_(context), edgeContext_(ctx) {
-    IterateNode<T>::name_ = "EdgeNode";
-  }
+  EdgeNode(RuntimeContext* context, EdgeContext* ctx)
+      : IterateNode<T>(context, "EdgeNode"), edgeContext_(ctx) {}
 
-  RuntimeContext* context_;
   EdgeContext* edgeContext_;
   EdgeType edgeType_;
   const std::vector<PropContext>* props_;

--- a/src/storage/exec/EdgeNode.h
+++ b/src/storage/exec/EdgeNode.h
@@ -51,9 +51,6 @@ class EdgeNode : public IterateNode<T> {
     edgeName_ = edgeContext_->edgeNames_[edgeType_];
   }
 
-  EdgeNode(RuntimeContext* context, EdgeContext* ctx)
-      : IterateNode<T>(context, "EdgeNode"), edgeContext_(ctx) {}
-
   EdgeContext* edgeContext_;
   EdgeType edgeType_;
   const std::vector<PropContext>* props_;
@@ -76,9 +73,7 @@ class FetchEdgeNode final : public EdgeNode<cpp2::EdgeKey> {
                 const std::vector<PropContext>* props,
                 StorageExpressionContext* expCtx = nullptr,
                 Expression* exp = nullptr)
-      : EdgeNode(context, edgeContext, edgeType, props, expCtx, exp) {
-    name_ = "FetchEdgeNode";
-  }
+      : EdgeNode(context, edgeContext, edgeType, props, expCtx, exp, "FetchEdgeNode") {}
 
   bool valid() const override { return valid_; }
 
@@ -149,9 +144,7 @@ class SingleEdgeNode final : public EdgeNode<VertexID> {
                  const std::vector<PropContext>* props,
                  StorageExpressionContext* expCtx = nullptr,
                  Expression* exp = nullptr)
-      : EdgeNode(context, edgeContext, edgeType, props, expCtx, exp) {
-    name_ = "SingleEdgeNode";
-  }
+      : EdgeNode(context, edgeContext, edgeType, props, expCtx, exp, "SingleEdgeNode") {}
 
   SingleEdgeIterator* iter() { return iter_.get(); }
 

--- a/src/storage/exec/FilterNode.h
+++ b/src/storage/exec/FilterNode.h
@@ -36,9 +36,7 @@ class FilterNode : public IterateNode<T> {
              IterateNode<T>* upstream,
              StorageExpressionContext* expCtx = nullptr,
              Expression* exp = nullptr)
-      : IterateNode<T>(upstream), context_(context), expCtx_(expCtx), filterExp_(exp) {
-    IterateNode<T>::name_ = "FilterNode";
-  }
+      : IterateNode<T>(context, upstream, "FilterNode"), expCtx_(expCtx), filterExp_(exp) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const T& vId) override {
     auto ret = RelNode<T>::doExecute(partId, vId);
@@ -47,11 +45,11 @@ class FilterNode : public IterateNode<T> {
     }
 
     do {
-      if (context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+      if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
         break;
       }
       if (this->valid() && !check()) {
-        context_->resultStat_ = ResultStatus::FILTER_OUT;
+        this->context_->resultStat_ = ResultStatus::FILTER_OUT;
         this->next();
         continue;
       }
@@ -78,7 +76,6 @@ class FilterNode : public IterateNode<T> {
   }
 
  private:
-  RuntimeContext* context_;
   StorageExpressionContext* expCtx_;
   Expression* filterExp_;
 };

--- a/src/storage/exec/FilterNode.h
+++ b/src/storage/exec/FilterNode.h
@@ -45,11 +45,11 @@ class FilterNode : public IterateNode<T> {
     }
 
     do {
-      if (this->context()->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+      if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
         break;
       }
       if (this->valid() && !check()) {
-        this->context()->resultStat_ = ResultStatus::FILTER_OUT;
+        this->context_->resultStat_ = ResultStatus::FILTER_OUT;
         this->next();
         continue;
       }

--- a/src/storage/exec/FilterNode.h
+++ b/src/storage/exec/FilterNode.h
@@ -45,11 +45,11 @@ class FilterNode : public IterateNode<T> {
     }
 
     do {
-      if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+      if (this->context()->resultStat_ == ResultStatus::ILLEGAL_DATA) {
         break;
       }
       if (this->valid() && !check()) {
-        this->context_->resultStat_ = ResultStatus::FILTER_OUT;
+        this->context()->resultStat_ = ResultStatus::FILTER_OUT;
         this->next();
         continue;
       }

--- a/src/storage/exec/FilterNode.h
+++ b/src/storage/exec/FilterNode.h
@@ -36,7 +36,7 @@ class FilterNode : public IterateNode<T> {
              IterateNode<T>* upstream,
              StorageExpressionContext* expCtx = nullptr,
              Expression* exp = nullptr)
-      : IterateNode<T>(context, upstream, "FilterNode"), expCtx_(expCtx), filterExp_(exp) {}
+      : IterateNode<T>(context, "FilterNode", upstream), expCtx_(expCtx), filterExp_(exp) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const T& vId) override {
     auto ret = RelNode<T>::doExecute(partId, vId);

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -30,14 +30,12 @@ class GetNeighborsNode : public QueryNode<VertexID> {
                    EdgeContext* edgeContext,
                    nebula::DataSet* resultDataSet,
                    int64_t limit = 0)
-      : context_(context),
+      : QueryNode<VertexID>(context, "GetNeighborsNode"),
         hashJoinNode_(hashJoinNode),
         upstream_(upstream),
         edgeContext_(edgeContext),
         resultDataSet_(resultDataSet),
-        limit_(limit) {
-    name_ = "GetNeighborsNode";
-  }
+        limit_(limit) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const VertexID& vId) override {
     auto ret = RelNode::doExecute(partId, vId);
@@ -88,8 +86,6 @@ class GetNeighborsNode : public QueryNode<VertexID> {
   }
 
  protected:
-  GetNeighborsNode() = default;
-
   virtual nebula::cpp2::ErrorCode iterateEdges(std::vector<Value>& row) {
     int64_t edgeRowCount = 0;
     nebula::List list;
@@ -123,7 +119,6 @@ class GetNeighborsNode : public QueryNode<VertexID> {
     return nebula::cpp2::ErrorCode::SUCCEEDED;
   }
 
-  RuntimeContext* context_;
   IterateNode<VertexID>* hashJoinNode_;
   IterateNode<VertexID>* upstream_;
   EdgeContext* edgeContext_;

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -103,7 +103,8 @@ class GetNeighborsNode : public QueryNode<VertexID> {
 
       list.reserve(props->size());
       // collect props need to return
-      auto status = QueryUtils::collectEdgeProps(key, vIdLen(), isIntId(), reader, props, list);
+      auto status =
+          QueryUtils::collectEdgeProps(key, this->vIdLen(), this->isIntId(), reader, props, list);
       if (!status.ok()) {
         return nebula::cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND;
       }
@@ -164,14 +165,17 @@ class GetNeighborsSampleNode : public GetNeighborsNode {
 
       auto edgeType = std::get<0>(sample);
       const auto& val = std::get<1>(sample);
-      reader = RowReaderWrapper::getEdgePropReader(schemaMgr(), space(), std::abs(edgeType), val);
+      reader = RowReaderWrapper::getEdgePropReader(
+          this->schemaMgr(), this->space(), std::abs(edgeType), val);
       if (!reader) {
         continue;
       }
 
       const auto& key = std::get<2>(sample);
       const auto& props = std::get<3>(sample);
-      if (!QueryUtils::collectEdgeProps(key, vIdLen(), isIntId(), reader.get(), props, list).ok()) {
+      auto status = QueryUtils::collectEdgeProps(
+          key, this->vIdLen(), this->isIntId(), reader.get(), props, list);
+      if (!status.ok()) {
         return nebula::cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND;
       }
       auto& cell = row[columnIdx].mutableList();

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -45,7 +45,7 @@ class GetNeighborsNode : public QueryNode<VertexID> {
     if (this->isPlanKilled()) {
       return nebula::cpp2::ErrorCode::E_PLAN_IS_KILLED;
     }
-    if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+    if (context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
       return nebula::cpp2::ErrorCode::E_INVALID_DATA;
     }
 
@@ -98,8 +98,8 @@ class GetNeighborsNode : public QueryNode<VertexID> {
       }
       auto key = upstream_->key();
       auto reader = upstream_->reader();
-      auto props = this->context_->props_;
-      auto columnIdx = this->context_->columnIdx_;
+      auto props = context_->props_;
+      auto columnIdx = context_->columnIdx_;
 
       list.reserve(props->size());
       // collect props need to return
@@ -148,9 +148,9 @@ class GetNeighborsSampleNode : public GetNeighborsNode {
     for (; upstream_->valid(); upstream_->next(), ++edgeRowCount) {
       auto val = upstream_->val();
       auto key = upstream_->key();
-      auto edgeType = this->context_->edgeType_;
-      auto props = this->context_->props_;
-      auto columnIdx = this->context_->columnIdx_;
+      auto edgeType = context_->edgeType_;
+      auto props = context_->props_;
+      auto columnIdx = context_->columnIdx_;
       sampler_->sampling(std::make_tuple(edgeType, val.str(), key.str(), props, columnIdx));
     }
 

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -166,7 +166,7 @@ class GetNeighborsSampleNode : public GetNeighborsNode {
       auto edgeType = std::get<0>(sample);
       const auto& val = std::get<1>(sample);
       reader = RowReaderWrapper::getEdgePropReader(
-          this->schemaMgr(), this->space(), std::abs(edgeType), val);
+          this->schemaMgr(), this->spaceId(), std::abs(edgeType), val);
       if (!reader) {
         continue;
       }

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -51,7 +51,7 @@ class GetNeighborsNode : public QueryNode<VertexID> {
 
     std::vector<Value> row;
     // vertexId is the first column
-    if (isIntId()) {
+    if (this->isIntId()) {
       row.emplace_back(*reinterpret_cast<const int64_t*>(vId.data()));
     } else {
       row.emplace_back(vId);

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -45,7 +45,7 @@ class GetNeighborsNode : public QueryNode<VertexID> {
     if (this->isPlanKilled()) {
       return nebula::cpp2::ErrorCode::E_PLAN_IS_KILLED;
     }
-    if (this->context()->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+    if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
       return nebula::cpp2::ErrorCode::E_INVALID_DATA;
     }
 
@@ -98,8 +98,8 @@ class GetNeighborsNode : public QueryNode<VertexID> {
       }
       auto key = upstream_->key();
       auto reader = upstream_->reader();
-      auto props = this->context()->props_;
-      auto columnIdx = this->context()->columnIdx_;
+      auto props = this->context_->props_;
+      auto columnIdx = this->context_->columnIdx_;
 
       list.reserve(props->size());
       // collect props need to return
@@ -147,9 +147,9 @@ class GetNeighborsSampleNode : public GetNeighborsNode {
     for (; upstream_->valid(); upstream_->next(), ++edgeRowCount) {
       auto val = upstream_->val();
       auto key = upstream_->key();
-      auto edgeType = this->context()->edgeType_;
-      auto props = this->context()->props_;
-      auto columnIdx = this->context()->columnIdx_;
+      auto edgeType = this->context_->edgeType_;
+      auto props = this->context_->props_;
+      auto columnIdx = this->context_->columnIdx_;
       sampler_->sampling(std::make_tuple(edgeType, val.str(), key.str(), props, columnIdx));
     }
 

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -21,9 +21,9 @@ class GetTagPropNode : public QueryNode<VertexID> {
   explicit GetTagPropNode(RuntimeContext* context,
                           std::vector<TagNode*> tagNodes,
                           nebula::DataSet* resultDataSet)
-      : context_(context), tagNodes_(std::move(tagNodes)), resultDataSet_(resultDataSet) {
-    name_ = "GetTagPropNode";
-  }
+      : QueryNode<VertexID>(context, "GetTagPropNode"),
+        tagNodes_(std::move(tagNodes)),
+        resultDataSet_(resultDataSet) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const VertexID& vId) override {
     auto ret = RelNode::doExecute(partId, vId);
@@ -75,7 +75,6 @@ class GetTagPropNode : public QueryNode<VertexID> {
   }
 
  private:
-  RuntimeContext* context_;
   std::vector<TagNode*> tagNodes_;
   nebula::DataSet* resultDataSet_;
 };
@@ -87,9 +86,9 @@ class GetEdgePropNode : public QueryNode<cpp2::EdgeKey> {
   GetEdgePropNode(RuntimeContext* context,
                   std::vector<EdgeNode<cpp2::EdgeKey>*> edgeNodes,
                   nebula::DataSet* resultDataSet)
-      : context_(context), edgeNodes_(std::move(edgeNodes)), resultDataSet_(resultDataSet) {
-    QueryNode::name_ = "GetEdgePropNode";
-  }
+      : QueryNode<cpp2::EdgeKey>(context, "GetEdgePropNode"),
+        edgeNodes_(std::move(edgeNodes)),
+        resultDataSet_(resultDataSet) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const cpp2::EdgeKey& edgeKey) override {
     auto ret = RelNode::doExecute(partId, edgeKey);
@@ -128,7 +127,6 @@ class GetEdgePropNode : public QueryNode<cpp2::EdgeKey> {
   }
 
  private:
-  RuntimeContext* context_;
   std::vector<EdgeNode<cpp2::EdgeKey>*> edgeNodes_;
   nebula::DataSet* resultDataSet_;
 };

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -97,8 +97,8 @@ class GetEdgePropNode : public QueryNode<cpp2::EdgeKey> {
     }
 
     List row;
-    auto vIdLen = this->context_->vIdLen();
-    auto isIntId = this->context_->isIntId();
+    auto vIdLen = context_->vIdLen();
+    auto isIntId = context_->isIntId();
     for (auto* edgeNode : edgeNodes_) {
       ret = edgeNode->collectEdgePropsIfValid(
           [&row](const std::vector<PropContext>* props) -> nebula::cpp2::ErrorCode {

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -97,8 +97,8 @@ class GetEdgePropNode : public QueryNode<cpp2::EdgeKey> {
     }
 
     List row;
-    auto vIdLen = this->context()->vIdLen();
-    auto isIntId = this->context()->isIntId();
+    auto vIdLen = this->context_->vIdLen();
+    auto isIntId = this->context_->isIntId();
     for (auto* edgeNode : edgeNodes_) {
       ret = edgeNode->collectEdgePropsIfValid(
           [&row](const std::vector<PropContext>* props) -> nebula::cpp2::ErrorCode {

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -40,7 +40,7 @@ class GetTagPropNode : public QueryNode<VertexID> {
 
     List row;
     // vertexId is the first column
-    if (isIntId()) {
+    if (this->isIntId()) {
       row.emplace_back(*reinterpret_cast<const int64_t*>(vId.data()));
     } else {
       row.emplace_back(vId);

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -40,13 +40,13 @@ class GetTagPropNode : public QueryNode<VertexID> {
 
     List row;
     // vertexId is the first column
-    if (context_->isIntId()) {
+    if (isIntId()) {
       row.emplace_back(*reinterpret_cast<const int64_t*>(vId.data()));
     } else {
       row.emplace_back(vId);
     }
-    auto vIdLen = context_->vIdLen();
-    auto isIntId = context_->isIntId();
+    auto vIdLen = this->vIdLen();
+    auto isIntId = this->isIntId();
     for (auto* tagNode : tagNodes_) {
       ret = tagNode->collectTagPropsIfValid(
           [&row](const std::vector<PropContext>* props) -> nebula::cpp2::ErrorCode {
@@ -97,8 +97,8 @@ class GetEdgePropNode : public QueryNode<cpp2::EdgeKey> {
     }
 
     List row;
-    auto vIdLen = context_->vIdLen();
-    auto isIntId = context_->isIntId();
+    auto vIdLen = this->context()->vIdLen();
+    auto isIntId = this->context()->isIntId();
     for (auto* edgeNode : edgeNodes_) {
       ret = edgeNode->collectEdgePropsIfValid(
           [&row](const std::vector<PropContext>* props) -> nebula::cpp2::ErrorCode {

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -47,7 +47,7 @@ class HashJoinNode : public IterateNode<VertexID> {
     }
     result_.setList(nebula::List());
     auto& result = result_.mutableList();
-    if (context()->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+    if (context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
       return nebula::cpp2::ErrorCode::E_INVALID_DATA;
     }
 

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -126,24 +126,24 @@ class HashJoinNode : public IterateNode<VertexID> {
     EdgeType type = iter_->edgeType();
     // update info when edgeType changes while iterating over different
     // edgeTypes
-    if (type != this->context()->edgeType_) {
+    if (type != this->context_->edgeType_) {
       auto idxIter = edgeContext_->indexMap_.find(type);
       CHECK(idxIter != edgeContext_->indexMap_.end());
       auto schemaIter = edgeContext_->schemas_.find(std::abs(type));
       CHECK(schemaIter != edgeContext_->schemas_.end());
       CHECK(!schemaIter->second.empty());
 
-      this->context()->edgeSchema_ = schemaIter->second.back().get();
+      this->context_->edgeSchema_ = schemaIter->second.back().get();
       // idx is the index in all edges need to return
       auto idx = idxIter->second;
-      this->context()->edgeType_ = type;
-      this->context()->edgeName_ = edgeNodes_[iter_->getIdx()]->getEdgeName();
+      this->context_->edgeType_ = type;
+      this->context_->edgeName_ = edgeNodes_[iter_->getIdx()]->getEdgeName();
       // the columnIdx_ would be the column index in a response row, so need to
       // add the offset of tags and other fields
-      this->context()->columnIdx_ = edgeContext_->offset_ + idx;
-      this->context()->props_ = &(edgeContext_->propContexts_[idx].second);
+      this->context_->columnIdx_ = edgeContext_->offset_ + idx;
+      this->context_->props_ = &(edgeContext_->propContexts_[idx].second);
 
-      expCtx_->resetSchema(this->context()->edgeName_, this->context()->edgeSchema_, true);
+      expCtx_->resetSchema(this->context_->edgeName_, this->context_->edgeSchema_, true);
     }
   }
 

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -31,14 +31,13 @@ class HashJoinNode : public IterateNode<VertexID> {
                TagContext* tagContext,
                EdgeContext* edgeContext,
                StorageExpressionContext* expCtx)
-      : context_(context),
+      : IterateNode<VertexID>(context, "HashJoinNode"),
         tagNodes_(tagNodes),
         edgeNodes_(edgeNodes),
         tagContext_(tagContext),
         edgeContext_(edgeContext),
         expCtx_(expCtx) {
     UNUSED(tagContext_);
-    IterateNode::name_ = "HashJoinNode";
   }
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const VertexID& vId) override {
@@ -154,7 +153,6 @@ class HashJoinNode : public IterateNode<VertexID> {
   }
 
  private:
-  RuntimeContext* context_;
   std::vector<TagNode*> tagNodes_;
   std::vector<SingleEdgeNode*> edgeNodes_;
   TagContext* tagContext_;

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -70,7 +70,8 @@ class HashJoinNode : public IterateNode<VertexID> {
             const auto& tagName = tagNode->getTagName();
             for (const auto& prop : *props) {
               VLOG(2) << "Collect prop " << prop.name_;
-              auto value = QueryUtils::readVertexProp(key, vIdLen(), isIntId(), reader, prop);
+              auto value =
+                  QueryUtils::readVertexProp(key, this->vIdLen(), this->isIntId(), reader, prop);
               if (!value.ok()) {
                 return nebula::cpp2::ErrorCode::E_TAG_PROP_NOT_FOUND;
               }
@@ -126,24 +127,24 @@ class HashJoinNode : public IterateNode<VertexID> {
     EdgeType type = iter_->edgeType();
     // update info when edgeType changes while iterating over different
     // edgeTypes
-    if (type != this->context_->edgeType_) {
+    if (type != context_->edgeType_) {
       auto idxIter = edgeContext_->indexMap_.find(type);
       CHECK(idxIter != edgeContext_->indexMap_.end());
       auto schemaIter = edgeContext_->schemas_.find(std::abs(type));
       CHECK(schemaIter != edgeContext_->schemas_.end());
       CHECK(!schemaIter->second.empty());
 
-      this->context_->edgeSchema_ = schemaIter->second.back().get();
+      context_->edgeSchema_ = schemaIter->second.back().get();
       // idx is the index in all edges need to return
       auto idx = idxIter->second;
-      this->context_->edgeType_ = type;
-      this->context_->edgeName_ = edgeNodes_[iter_->getIdx()]->getEdgeName();
+      context_->edgeType_ = type;
+      context_->edgeName_ = edgeNodes_[iter_->getIdx()]->getEdgeName();
       // the columnIdx_ would be the column index in a response row, so need to
       // add the offset of tags and other fields
-      this->context_->columnIdx_ = edgeContext_->offset_ + idx;
-      this->context_->props_ = &(edgeContext_->propContexts_[idx].second);
+      context_->columnIdx_ = edgeContext_->offset_ + idx;
+      context_->props_ = &(edgeContext_->propContexts_[idx].second);
 
-      expCtx_->resetSchema(this->context_->edgeName_, this->context_->edgeSchema_, true);
+      expCtx_->resetSchema(context_->edgeName_, context_->edgeSchema_, true);
     }
   }
 

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -28,17 +28,13 @@ class HashJoinNode : public IterateNode<VertexID> {
   HashJoinNode(RuntimeContext* context,
                const std::vector<TagNode*>& tagNodes,
                const std::vector<SingleEdgeNode*>& edgeNodes,
-               TagContext* tagContext,
                EdgeContext* edgeContext,
                StorageExpressionContext* expCtx)
       : IterateNode<VertexID>(context, "HashJoinNode"),
         tagNodes_(tagNodes),
         edgeNodes_(edgeNodes),
-        tagContext_(tagContext),
         edgeContext_(edgeContext),
-        expCtx_(expCtx) {
-    UNUSED(tagContext_);
-  }
+        expCtx_(expCtx) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const VertexID& vId) override {
     auto ret = RelNode::doExecute(partId, vId);
@@ -155,7 +151,6 @@ class HashJoinNode : public IterateNode<VertexID> {
  private:
   std::vector<TagNode*> tagNodes_;
   std::vector<SingleEdgeNode*> edgeNodes_;
-  TagContext* tagContext_;
   EdgeContext* edgeContext_;
   StorageExpressionContext* expCtx_;
 

--- a/src/storage/exec/IndexEdgeNode.h
+++ b/src/storage/exec/IndexEdgeNode.h
@@ -40,7 +40,6 @@ class IndexEdgeNode final : public IndexNode<T> {
 
     data_.clear();
     std::vector<storage::cpp2::EdgeKey> edges;
-    auto part = this->part(partId);
     for (auto* iter = indexScanNode_->iterator(); iter && iter->valid(); iter->next()) {
       if (this->isPlanKilled()) {
         return nebula::cpp2::ErrorCode::E_PLAN_IS_KILLED;
@@ -49,7 +48,7 @@ class IndexEdgeNode final : public IndexNode<T> {
         auto eiter = static_cast<const EdgeIndexIterator*>(iter);
         storage::cpp2::EdgeKey edge;
         edge.set_src(eiter->srcId());
-        edge.set_edge_type(this->context_->edgeType_);
+        edge.set_edge_type(this->context()->edgeType_);
         edge.set_ranking(eiter->ranking());
         edge.set_dst(eiter->dstId());
         edges.emplace_back(std::move(edge));
@@ -57,10 +56,10 @@ class IndexEdgeNode final : public IndexNode<T> {
     }
     int64_t count = 0;
     for (const auto& edge : edges) {
-      auto key =
-          part.edgeKey(edge.src_ref()->getStr(), edge.dst_ref()->getStr(), edge.get_ranking());
+      auto key = this->edgeKey(
+          partId, edge.src_ref()->getStr(), edge.dst_ref()->getStr(), edge.get_ranking());
       std::string val;
-      ret = part.get(key, &val);
+      ret = this->get(partId, key, &val);
       if (ret == nebula::cpp2::ErrorCode::SUCCEEDED) {
         data_.emplace_back(std::move(key), std::move(val));
       } else if (ret == nebula::cpp2::ErrorCode::E_KEY_NOT_FOUND) {

--- a/src/storage/exec/IndexEdgeNode.h
+++ b/src/storage/exec/IndexEdgeNode.h
@@ -48,7 +48,7 @@ class IndexEdgeNode final : public IndexNode<T> {
         auto eiter = static_cast<const EdgeIndexIterator*>(iter);
         storage::cpp2::EdgeKey edge;
         edge.set_src(eiter->srcId());
-        edge.set_edge_type(this->context()->edgeType_);
+        edge.set_edge_type(this->context_->edgeType_);
         edge.set_ranking(eiter->ranking());
         edge.set_dst(eiter->dstId());
         edges.emplace_back(std::move(edge));

--- a/src/storage/exec/IndexFilterNode.h
+++ b/src/storage/exec/IndexFilterNode.h
@@ -30,15 +30,14 @@ class IndexFilterNode final : public RelNode<T> {
                   Expression* exp,
                   bool isEdge,
                   int64_t limit = -1)
-      : context_(context),
+      : RelNode<T>("IndexFilterNode"),
+        context_(context),
         indexScanNode_(indexScanNode),
         exprCtx_(exprCtx),
         filterExp_(exp),
         isEdge_(isEdge),
-        limit_(limit) {
-    evalExprByIndex_ = true;
-    RelNode<T>::name_ = "IndexFilterNode";
-  }
+        evalExprByIndex_(true),
+        limit_(limit) {}
 
   // evalExprByIndex_ is false, some fileds in filter is out of index, which
   // need to read data.
@@ -47,14 +46,14 @@ class IndexFilterNode final : public RelNode<T> {
                   StorageExpressionContext* exprCtx,
                   Expression* exp,
                   int64_t limit = -1)
-      : context_(context),
+      : RelNode<T>("IndexFilterNode"),
+        context_(context),
         indexEdgeNode_(indexEdgeNode),
         exprCtx_(exprCtx),
         filterExp_(exp),
-        limit_(limit) {
-    evalExprByIndex_ = false;
-    isEdge_ = true;
-  }
+        isEdge_(true),
+        evalExprByIndex_(false),
+        limit_(limit) {}
 
   // evalExprByIndex_ is false, some fileds in filter is out of index, which
   // need to read data.
@@ -63,14 +62,14 @@ class IndexFilterNode final : public RelNode<T> {
                   StorageExpressionContext* exprCtx,
                   Expression* exp,
                   int64_t limit = -1)
-      : context_(context),
+      : RelNode<T>("IndexFilterNode"),
+        context_(context),
         indexVertexNode_(indexVertexNode),
         exprCtx_(exprCtx),
         filterExp_(exp),
-        limit_(limit) {
-    evalExprByIndex_ = false;
-    isEdge_ = false;
-  }
+        isEdge_(false),
+        evalExprByIndex_(false),
+        limit_(limit) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId) override {
     data_.clear();

--- a/src/storage/exec/IndexFilterNode.h
+++ b/src/storage/exec/IndexFilterNode.h
@@ -10,15 +10,15 @@
 #include "common/context/ExpressionContext.h"
 #include "common/expression/Expression.h"
 #include "storage/exec/IndexEdgeNode.h"
+#include "storage/exec/IndexNode.h"
 #include "storage/exec/IndexScanNode.h"
 #include "storage/exec/IndexVertexNode.h"
-#include "storage/exec/RelNode.h"
 
 namespace nebula {
 namespace storage {
 
 template <typename T>
-class IndexFilterNode final : public RelNode<T> {
+class IndexFilterNode final : public IndexNode<T> {
  public:
   using RelNode<T>::doExecute;
 
@@ -30,8 +30,7 @@ class IndexFilterNode final : public RelNode<T> {
                   Expression* exp,
                   bool isEdge,
                   int64_t limit = -1)
-      : RelNode<T>("IndexFilterNode"),
-        context_(context),
+      : IndexNode<T>(context, "IndexFilterNode"),
         indexScanNode_(indexScanNode),
         exprCtx_(exprCtx),
         filterExp_(exp),
@@ -46,8 +45,7 @@ class IndexFilterNode final : public RelNode<T> {
                   StorageExpressionContext* exprCtx,
                   Expression* exp,
                   int64_t limit = -1)
-      : RelNode<T>("IndexFilterNode"),
-        context_(context),
+      : IndexNode<T>(context, "IndexFilterNode"),
         indexEdgeNode_(indexEdgeNode),
         exprCtx_(exprCtx),
         filterExp_(exp),
@@ -62,8 +60,7 @@ class IndexFilterNode final : public RelNode<T> {
                   StorageExpressionContext* exprCtx,
                   Expression* exp,
                   int64_t limit = -1)
-      : RelNode<T>("IndexFilterNode"),
-        context_(context),
+      : IndexNode<T>(context, "IndexFilterNode"),
         indexVertexNode_(indexVertexNode),
         exprCtx_(exprCtx),
         filterExp_(exp),
@@ -87,7 +84,7 @@ class IndexFilterNode final : public RelNode<T> {
     }
     int64_t count = 0;
     for (const auto& k : data) {
-      if (context_->isPlanKilled()) {
+      if (this->isPlanKilled()) {
         return nebula::cpp2::ErrorCode::E_PLAN_IS_KILLED;
       }
       if (evalExprByIndex_) {
@@ -152,7 +149,6 @@ class IndexFilterNode final : public RelNode<T> {
   }
 
  private:
-  RuntimeContext* context_;
   IndexScanNode<T>* indexScanNode_{nullptr};
   IndexEdgeNode<T>* indexEdgeNode_{nullptr};
   IndexVertexNode<T>* indexVertexNode_{nullptr};

--- a/src/storage/exec/IndexNode.h
+++ b/src/storage/exec/IndexNode.h
@@ -1,0 +1,107 @@
+/* Copyright (c) 2021 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License,
+ * attached with Common Clause Condition 1.0, found in the LICENSES directory.
+ */
+
+#pragma once
+
+#include "storage/exec/RelNode.h"
+
+namespace nebula {
+
+namespace meta::cpp2 {
+class IndexItem;
+}
+
+namespace storage {
+
+/**
+ * This class as the base class of index related rel-nodes is aimed to reuse some common codes.
+ */
+template <typename T>
+class IndexNode : public RelNode<T> {
+ public:
+  kvstore::KVStore* kvstore() const { return context_->env()->kvstore_; }
+  meta::IndexManager* idxMgr() const { return context_->env()->indexMan_; }
+
+  bool isPlanKilled() const { return context_->isPlanKilled(); }
+
+  const meta::NebulaSchemaProvider* schema() const {
+    return context_->isEdge() ? context_->edgeSchema_ : context_->tagSchema_;
+  }
+
+  bool isEdge() const { return context_->isEdge(); }
+
+  StatusOr<std::shared_ptr<meta::cpp2::IndexItem>> index(IndexID id) const {
+    if (isEdge()) {
+      return idxMgr()->getEdgeIndex(context_->spaceId(), id);
+    } else {
+      return idxMgr()->getTagIndex(context_->spaceId(), id);
+    }
+  }
+
+  std::unique_ptr<IndexIterator> iterator(std::unique_ptr<kvstore::KVIterator> iter) const {
+    if (isEdge()) {
+      return std::make_unique<EdgeIndexIterator>(std::move(iter), context_->vIdLen());
+    } else {
+      return std::make_unique<VertexIndexIterator>(std::move(iter), context_->vIdLen());
+    }
+  }
+
+  bool isTTLExpired(const folly::StringPiece& val,
+                    const std::pair<bool, std::pair<int64_t, std::string>>& ttl,
+                    const meta::NebulaSchemaProvider* schema) const {
+    if (val.empty() || !ttl.first) {
+      return false;
+    }
+    auto v = IndexKeyUtils::parseIndexTTL(val);
+    auto duration = ttl.second.first;
+    const auto& col = ttl.second.second;
+    return CommonUtils::checkDataExpiredForTTL(schema, std::move(v), col, duration);
+  }
+
+ protected:
+  IndexNode(RuntimeContext* context, const std::string& name)
+      : RelNode<T>(name), context_(DCHECK_NOTNULL(context)) {}
+
+  class Part {
+   public:
+    Part(RuntimeContext* ctx, PartitionID partId) : ctx_(ctx), partId_(partId) {}
+
+    std::string vertexKey(VertexID vId) const {
+      return NebulaKeyUtils::vertexKey(ctx_->vIdLen(), partId_, vId, ctx_->tagId_);
+    }
+
+    std::string edgeKey(const std::string& src, const std::string& dst, EdgeRanking rank) const {
+      return NebulaKeyUtils::edgeKey(ctx_->vIdLen(), partId_, src, ctx_->edgeType_, rank, dst);
+    }
+
+    auto get(const std::string& key, std::string* val) const {
+      return kvstore()->get(ctx_->spaceId(), partId_, key, val);
+    }
+
+    auto range(const std::string& begin,
+               const std::string& end,
+               std::unique_ptr<kvstore::KVIterator>* iter) const {
+      return kvstore()->range(ctx_->spaceId(), partId_, begin, end, iter);
+    }
+
+    auto prefix(const std::string& prefix, std::unique_ptr<kvstore::KVIterator>* iter) const {
+      return kvstore()->prefix(ctx_->spaceId(), partId_, prefix, iter);
+    }
+
+    kvstore::KVStore* kvstore() const { return ctx_->env()->kvstore_; }
+
+   private:
+    RuntimeContext* ctx_;
+    PartitionID partId_;
+  };
+
+  Part part(PartitionID partId) const { return Part(context_, partId); }
+
+  RuntimeContext* context_;
+};
+
+}  // namespace storage
+}  // namespace nebula

--- a/src/storage/exec/IndexNode.h
+++ b/src/storage/exec/IndexNode.h
@@ -51,7 +51,7 @@ class IndexNode : public RelNode<T> {
   }
 
  protected:
-  IndexNode(RuntimeContext* context, const std::string& name) : RelNode<T>(context, name) {}
+  IndexNode(RuntimeContext* context, const std::string& name) : RelNode<T>(name, context) {}
 };
 
 }  // namespace storage

--- a/src/storage/exec/IndexNode.h
+++ b/src/storage/exec/IndexNode.h
@@ -24,9 +24,9 @@ class IndexNode : public RelNode<T> {
  public:
   StatusOr<std::shared_ptr<meta::cpp2::IndexItem>> index(IndexID id) const {
     if (this->isEdge()) {
-      return this->idxMgr()->getEdgeIndex(this->space(), id);
+      return this->idxMgr()->getEdgeIndex(this->spaceId(), id);
     } else {
-      return this->idxMgr()->getTagIndex(this->space(), id);
+      return this->idxMgr()->getTagIndex(this->spaceId(), id);
     }
   }
 

--- a/src/storage/exec/IndexOutputNode.h
+++ b/src/storage/exec/IndexOutputNode.h
@@ -69,11 +69,11 @@ class IndexOutputNode final : public IndexNode<T> {
         hasNullableCol_(indexFilterNode->hasNullableCol()),
         fields_(indexFilterNode_->indexCols()) {
     if (indexFilter) {
-      type_ = this->context_->isEdge() ? IndexResultType::kEdgeFromIndexFilter
-                                       : IndexResultType::kVertexFromIndexFilter;
+      type_ = this->isEdge() ? IndexResultType::kEdgeFromIndexFilter
+                             : IndexResultType::kVertexFromIndexFilter;
     } else {
-      type_ = this->context_->isEdge() ? IndexResultType::kEdgeFromDataFilter
-                                       : IndexResultType::kVertexFromDataFilter;
+      type_ = this->isEdge() ? IndexResultType::kEdgeFromDataFilter
+                             : IndexResultType::kVertexFromDataFilter;
     }
   }
 
@@ -235,11 +235,11 @@ class IndexOutputNode final : public IndexNode<T> {
                        const kvstore::KV& data,
                        const std::string& col,
                        const meta::NebulaSchemaProvider* schema) {
-    auto vIdLen = this->context_->vIdLen();
+    auto vIdLen = this->vIdLen();
     switch (QueryUtils::toReturnColType(col)) {
       case QueryUtils::ReturnColType::kVid: {
         auto vId = NebulaKeyUtils::getVertexId(vIdLen, data.first);
-        if (this->context_->isIntId()) {
+        if (this->isIntId()) {
           row.emplace_back(*reinterpret_cast<const int64_t*>(vId.data()));
         } else {
           row.emplace_back(vId.subpiece(0, vId.find_first_of('\0')).toString());
@@ -252,7 +252,7 @@ class IndexOutputNode final : public IndexNode<T> {
       }
       case QueryUtils::ReturnColType::kSrc: {
         auto src = NebulaKeyUtils::getSrcId(vIdLen, data.first);
-        if (this->context_->isIntId()) {
+        if (this->isIntId()) {
           row.emplace_back(*reinterpret_cast<const int64_t*>(src.data()));
         } else {
           row.emplace_back(src.subpiece(0, src.find_first_of('\0')).toString());
@@ -269,7 +269,7 @@ class IndexOutputNode final : public IndexNode<T> {
       }
       case QueryUtils::ReturnColType::kDst: {
         auto dst = NebulaKeyUtils::getDstId(vIdLen, data.first);
-        if (this->context_->isIntId()) {
+        if (this->isIntId()) {
           row.emplace_back(*reinterpret_cast<const int64_t*>(dst.data()));
         } else {
           row.emplace_back(dst.subpiece(0, dst.find_first_of('\0')).toString());
@@ -290,11 +290,11 @@ class IndexOutputNode final : public IndexNode<T> {
 
   // Add the value by index key
   Status addIndexValue(Row& row, const kvstore::KV& data, const std::string& col) {
-    auto vIdLen = this->context_->vIdLen();
+    auto vIdLen = this->vIdLen();
     switch (QueryUtils::toReturnColType(col)) {
       case QueryUtils::ReturnColType::kVid: {
         auto vId = IndexKeyUtils::getIndexVertexID(vIdLen, data.first);
-        if (this->context_->isIntId()) {
+        if (this->isIntId()) {
           row.emplace_back(*reinterpret_cast<const int64_t*>(vId.data()));
         } else {
           row.emplace_back(vId.subpiece(0, vId.find_first_of('\0')).toString());
@@ -302,12 +302,12 @@ class IndexOutputNode final : public IndexNode<T> {
         break;
       }
       case QueryUtils::ReturnColType::kTag: {
-        row.emplace_back(this->context_->tagId_);
+        row.emplace_back(this->context()->tagId_);
         break;
       }
       case QueryUtils::ReturnColType::kSrc: {
         auto src = IndexKeyUtils::getIndexSrcId(vIdLen, data.first);
-        if (this->context_->isIntId()) {
+        if (this->isIntId()) {
           row.emplace_back(*reinterpret_cast<const int64_t*>(src.data()));
         } else {
           row.emplace_back(src.subpiece(0, src.find_first_of('\0')).toString());
@@ -315,7 +315,7 @@ class IndexOutputNode final : public IndexNode<T> {
         break;
       }
       case QueryUtils::ReturnColType::kType: {
-        row.emplace_back(this->context_->edgeType_);
+        row.emplace_back(this->context()->edgeType_);
         break;
       }
       case QueryUtils::ReturnColType::kRank: {
@@ -324,7 +324,7 @@ class IndexOutputNode final : public IndexNode<T> {
       }
       case QueryUtils::ReturnColType::kDst: {
         auto dst = IndexKeyUtils::getIndexDstId(vIdLen, data.first);
-        if (this->context_->isIntId()) {
+        if (this->isIntId()) {
           row.emplace_back(*reinterpret_cast<const int64_t*>(dst.data()));
         } else {
           row.emplace_back(dst.subpiece(0, dst.find_first_of('\0')).toString());
@@ -333,7 +333,7 @@ class IndexOutputNode final : public IndexNode<T> {
       }
       default: {
         auto v = IndexKeyUtils::getValueFromIndexKey(
-            vIdLen, data.first, col, fields_, this->context_->isEdge(), hasNullableCol_);
+            vIdLen, data.first, col, fields_, this->isEdge(), hasNullableCol_);
         row.emplace_back(std::move(v));
       }
     }

--- a/src/storage/exec/IndexOutputNode.h
+++ b/src/storage/exec/IndexOutputNode.h
@@ -302,7 +302,7 @@ class IndexOutputNode final : public IndexNode<T> {
         break;
       }
       case QueryUtils::ReturnColType::kTag: {
-        row.emplace_back(this->context()->tagId_);
+        row.emplace_back(this->context_->tagId_);
         break;
       }
       case QueryUtils::ReturnColType::kSrc: {
@@ -315,7 +315,7 @@ class IndexOutputNode final : public IndexNode<T> {
         break;
       }
       case QueryUtils::ReturnColType::kType: {
-        row.emplace_back(this->context()->edgeType_);
+        row.emplace_back(this->context_->edgeType_);
         break;
       }
       case QueryUtils::ReturnColType::kRank: {

--- a/src/storage/exec/IndexScanNode.h
+++ b/src/storage/exec/IndexScanNode.h
@@ -53,9 +53,8 @@ class IndexScanNode : public IndexNode<T> {
     }
     scanPair_ = scanRet.value();
     std::unique_ptr<kvstore::KVIterator> iter;
-    auto part = this->part(partId);
-    ret = isRangeScan_ ? part.range(scanPair_.first, scanPair_.second, &iter)
-                       : part.prefix(scanPair_.first, &iter);
+    ret = isRangeScan_ ? this->range(partId, scanPair_.first, scanPair_.second, &iter)
+                       : this->prefix(partId, scanPair_.first, &iter);
     if (ret == nebula::cpp2::ErrorCode::SUCCEEDED && iter && iter->valid()) {
       iter_ = IndexNode<T>::iterator(std::move(iter));
     } else {

--- a/src/storage/exec/IndexScanNode.h
+++ b/src/storage/exec/IndexScanNode.h
@@ -22,7 +22,11 @@ class IndexScanNode : public RelNode<T> {
                 IndexID indexId,
                 std::vector<cpp2::IndexColumnHint> columnHints,
                 int64_t limit = -1)
-      : context_(context), indexId_(indexId), columnHints_(std::move(columnHints)), limit_(limit) {
+      : RelNode<T>("IndexScanNode"),
+        context_(context),
+        indexId_(indexId),
+        columnHints_(std::move(columnHints)),
+        limit_(limit) {
     /**
      * columnHints's elements are {scanType = PREFIX|RANGE; beginStr; endStr},
      *                            {scanType = PREFIX|RANGE; beginStr;
@@ -37,7 +41,6 @@ class IndexScanNode : public RelNode<T> {
         break;
       }
     }
-    RelNode<T>::name_ = "IndexScanNode";
   }
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId) override {

--- a/src/storage/exec/IndexVertexNode.h
+++ b/src/storage/exec/IndexVertexNode.h
@@ -23,13 +23,12 @@ class IndexVertexNode final : public RelNode<T> {
                   const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>& schemas,
                   const std::string& schemaName,
                   int64_t limit = -1)
-      : context_(context),
+      : RelNode<T>("IndexVertexNode"),
+        context_(context),
         indexScanNode_(indexScanNode),
         schemas_(schemas),
         schemaName_(schemaName),
-        limit_(limit) {
-    RelNode<T>::name_ = "IndexVertexNode";
-  }
+        limit_(limit) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId) override {
     auto ret = RelNode<T>::doExecute(partId);

--- a/src/storage/exec/RelNode.h
+++ b/src/storage/exec/RelNode.h
@@ -116,12 +116,9 @@ template <typename T>
 class IterateNode : public QueryNode<T>, public StorageIterator {
  public:
   explicit IterateNode(RuntimeContext* context,
-                       IterateNode* node,
-                       const std::string& name = "IterateNode")
+                       const std::string& name = "IterateNode",
+                       IterateNode* node = nullptr)
       : QueryNode<T>(context, name), StorageIterator(), upstream_(node) {}
-
-  explicit IterateNode(RuntimeContext* context, const std::string& name = "IterateNode")
-      : QueryNode<T>(context, name), StorageIterator(), upstream_(nullptr) {}
 
   bool valid() const override { return upstream_->valid(); }
 

--- a/src/storage/exec/RelNode.h
+++ b/src/storage/exec/RelNode.h
@@ -92,8 +92,9 @@ template <typename T>
 class QueryNode : public RelNode<T> {
  public:
   const Value& result() { return result_; }
-
   Value& mutableResult() { return result_; }
+
+  size_t vidLen() const { return context_->vIdLen(); }
 
  protected:
   QueryNode(RuntimeContext* context, const std::string& name)

--- a/src/storage/exec/RelNode.h
+++ b/src/storage/exec/RelNode.h
@@ -131,7 +131,7 @@ class RelNode {
 
   virtual ~RelNode() = default;
 
-  explicit RelNode(RuntimeContext* context = nullptr, const std::string& name = "RelNode")
+  explicit RelNode(const std::string& name = "RelNode", RuntimeContext* context = nullptr)
       : context_(context), name_(name) {}
 
  protected:
@@ -151,7 +151,7 @@ class QueryNode : public RelNode<T> {
   Value& mutableResult() { return result_; }
 
  protected:
-  QueryNode(RuntimeContext* context, const std::string& name) : RelNode<T>(context, name) {}
+  QueryNode(RuntimeContext* context, const std::string& name) : RelNode<T>(name, context) {}
 
   Value result_;
 };

--- a/src/storage/exec/RelNode.h
+++ b/src/storage/exec/RelNode.h
@@ -76,7 +76,7 @@ class RelNode {
   const std::string& name() const { return name_; }
   int32_t latencyInUs() const { return duration_.elapsedInUSec(); }
 
-  GraphSpaceID space() const { return context_->spaceId(); }
+  GraphSpaceID spaceId() const { return context_->spaceId(); }
   size_t vIdLen() const { return context_->vIdLen(); }
   bool isIntId() const { return context_->isIntId(); }
   bool isPlanKilled() const { return context_->isPlanKilled(); }
@@ -94,7 +94,7 @@ class RelNode {
   }
 
   std::string vertexKey(PartitionID partId, VertexID vId) const {
-    return NebulaKeyUtils::vertexKey(this->vIdLen(), partId, vId, context_->tagId_);
+    return NebulaKeyUtils::vertexKey(vIdLen(), partId, vId, context_->tagId_);
   }
 
   std::string edgeKey(PartitionID partId,
@@ -113,20 +113,20 @@ class RelNode {
   }
 
   auto get(PartitionID partId, const std::string& key, std::string* val) const {
-    return kvstore()->get(space(), partId, key, val);
+    return kvstore()->get(spaceId(), partId, key, val);
   }
 
   auto range(PartitionID partId,
              const std::string& begin,
              const std::string& end,
              std::unique_ptr<kvstore::KVIterator>* iter) const {
-    return kvstore()->range(space(), partId, begin, end, iter);
+    return kvstore()->range(spaceId(), partId, begin, end, iter);
   }
 
   auto prefix(PartitionID partId,
               const std::string& prefix,
               std::unique_ptr<kvstore::KVIterator>* iter) const {
-    return kvstore()->prefix(space(), partId, prefix, iter);
+    return kvstore()->prefix(spaceId(), partId, prefix, iter);
   }
 
   virtual ~RelNode() = default;

--- a/src/storage/exec/StorageIterator.h
+++ b/src/storage/exec/StorageIterator.h
@@ -150,7 +150,7 @@ class MultiEdgeIterator : public StorageIterator {
 
 class IndexIterator : public StorageIterator {
  public:
-  explicit IndexIterator(std::unique_ptr<kvstore::KVIterator> iter, size_t vIdLen)
+  IndexIterator(std::unique_ptr<kvstore::KVIterator> iter, size_t vIdLen)
       : iter_(std::move(iter)), vIdLen_(vIdLen) {}
 
   bool valid() const override { return !!iter_ && iter_->valid(); }

--- a/src/storage/exec/TagNode.h
+++ b/src/storage/exec/TagNode.h
@@ -22,24 +22,14 @@ class TagNode final : public IterateNode<VertexID> {
   TagNode(RuntimeContext* context,
           TagContext* ctx,
           TagID tagId,
-          const std::vector<PropContext>* props,
-          StorageExpressionContext* expCtx = nullptr,
-          Expression* exp = nullptr)
-      : context_(context),
-        tagContext_(ctx),
-        tagId_(tagId),
-        props_(props),
-        expCtx_(expCtx),
-        exp_(exp) {
-    UNUSED(expCtx_);
-    UNUSED(exp_);
+          const std::vector<PropContext>* props)
+      : IterateNode<VertexID>(context, "TagNode"), tagContext_(ctx), tagId_(tagId), props_(props) {
     auto schemaIter = tagContext_->schemas_.find(tagId_);
     CHECK(schemaIter != tagContext_->schemas_.end());
     CHECK(!schemaIter->second.empty());
     schemas_ = &(schemaIter->second);
     ttl_ = QueryUtils::getTagTTLInfo(tagContext_, tagId_);
     tagName_ = tagContext_->tagNames_[tagId_];
-    name_ = "TagNode";
   }
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const VertexID& vId) override {
@@ -99,17 +89,14 @@ class TagNode final : public IterateNode<VertexID> {
     valid_ = true;
   }
 
-  RuntimeContext* context_;
-  TagContext* tagContext_;
+  TagContext* tagContext_{nullptr};
   TagID tagId_;
   const std::vector<PropContext>* props_;
-  StorageExpressionContext* expCtx_;
-  Expression* exp_;
-  const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>* schemas_ = nullptr;
+  const std::vector<std::shared_ptr<const meta::NebulaSchemaProvider>>* schemas_{nullptr};
   folly::Optional<std::pair<std::string, int64_t>> ttl_;
   std::string tagName_;
 
-  bool valid_ = false;
+  bool valid_{false};
   std::string key_;
   std::string value_;
   RowReaderWrapper reader_;

--- a/src/storage/exec/TagNode.h
+++ b/src/storage/exec/TagNode.h
@@ -41,8 +41,8 @@ class TagNode final : public IterateNode<VertexID> {
 
     VLOG(1) << "partId " << partId << ", vId " << vId << ", tagId " << tagId_ << ", prop size "
             << props_->size();
-    key_ = NebulaKeyUtils::vertexKey(context_->vIdLen(), partId, vId, tagId_);
-    ret = context_->env()->kvstore_->get(context_->spaceId(), partId, key_, &value_);
+    key_ = NebulaKeyUtils::vertexKey(vIdLen(), partId, vId, tagId_);
+    ret = this->get(partId, key_, &value_);
     if (ret == nebula::cpp2::ErrorCode::SUCCEEDED) {
       resetReader();
       return nebula::cpp2::ErrorCode::SUCCEEDED;

--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -29,17 +29,17 @@ class UpdateNode : public RelNode<T> {
              bool insertable,
              std::vector<std::pair<std::string, std::unordered_set<std::string>>> depPropMap,
              StorageExpressionContext* expCtx,
-             bool isEdge)
-      : context_(context),
+             bool isEdge,
+             const std::string& name = "UpdateNode")
+      : RelNode<T>(name),
+        context_(DCHECK_NOTNULL(context)),
         indexes_(indexes),
         updatedProps_(updatedProps),
         filterNode_(filterNode),
         insertable_(insertable),
         depPropMap_(depPropMap),
         expCtx_(expCtx),
-        isEdge_(isEdge) {
-    RelNode<T>::name_ = "UpdateNode";
-  }
+        isEdge_(isEdge) {}
 
   nebula::cpp2::ErrorCode checkField(const meta::SchemaProviderIf::Field* field) {
     if (!field) {
@@ -163,12 +163,17 @@ class UpdateTagNode : public UpdateNode<VertexID> {
                 std::vector<std::pair<std::string, std::unordered_set<std::string>>> depPropMap,
                 StorageExpressionContext* expCtx,
                 TagContext* tagContext)
-      : UpdateNode<VertexID>(
-            context, indexes, updatedProps, filterNode, insertable, depPropMap, expCtx, false),
-        tagContext_(tagContext) {
-    tagId_ = context_->tagId_;
-    name_ = "UpdateTagNode";
-  }
+      : UpdateNode<VertexID>(context,
+                             indexes,
+                             updatedProps,
+                             filterNode,
+                             insertable,
+                             depPropMap,
+                             expCtx,
+                             false,
+                             "UpdateTagNode"),
+        tagContext_(tagContext),
+        tagId_(context->tagId_) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const VertexID& vId) override {
     CHECK_NOTNULL(context_->env()->kvstore_);
@@ -441,12 +446,17 @@ class UpdateEdgeNode : public UpdateNode<cpp2::EdgeKey> {
                  std::vector<std::pair<std::string, std::unordered_set<std::string>>> depPropMap,
                  StorageExpressionContext* expCtx,
                  EdgeContext* edgeContext)
-      : UpdateNode<cpp2::EdgeKey>(
-            context, indexes, updatedProps, filterNode, insertable, depPropMap, expCtx, true),
-        edgeContext_(edgeContext) {
-    edgeType_ = context_->edgeType_;
-    name_ = "UpdateEdgeNode";
-  }
+      : UpdateNode<cpp2::EdgeKey>(context,
+                                  indexes,
+                                  updatedProps,
+                                  filterNode,
+                                  insertable,
+                                  depPropMap,
+                                  expCtx,
+                                  true,
+                                  "UpdateEdgeNode"),
+        edgeContext_(edgeContext),
+        edgeType_(context->edgeType_) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const cpp2::EdgeKey& edgeKey) override {
     CHECK_NOTNULL(context_->env()->kvstore_);

--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -191,9 +191,9 @@ class UpdateTagNode : public UpdateNode<VertexID> {
       return ret;
     }
 
-    if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+    if (context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
       return nebula::cpp2::ErrorCode::E_INVALID_DATA;
-    } else if (this->context_->resultStat_ == ResultStatus::FILTER_OUT) {
+    } else if (context_->resultStat_ == ResultStatus::FILTER_OUT) {
       return nebula::cpp2::ErrorCode::E_FILTER_OUT;
     }
 
@@ -255,7 +255,7 @@ class UpdateTagNode : public UpdateNode<VertexID> {
   // For insert, condition is always true,
   // Props must have default value or nullable, or set in UpdatedProp_
   nebula::cpp2::ErrorCode insertTagProps(PartitionID partId, const VertexID& vId) {
-    context()->insert_ = true;
+    context_->insert_ = true;
     auto ret = getLatestTagSchemaAndName();
     if (ret != nebula::cpp2::ErrorCode::SUCCEEDED) {
       return ret;
@@ -482,10 +482,10 @@ class UpdateEdgeNode : public UpdateNode<cpp2::EdgeKey> {
           this->exeResult_ = nebula::cpp2::ErrorCode::E_KEY_NOT_FOUND;
           return folly::none;
         }
-        if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+        if (context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
           this->exeResult_ = nebula::cpp2::ErrorCode::E_INVALID_DATA;
           return folly::none;
-        } else if (this->context_->resultStat_ == ResultStatus::FILTER_OUT) {
+        } else if (context_->resultStat_ == ResultStatus::FILTER_OUT) {
           this->exeResult_ = nebula::cpp2::ErrorCode::E_FILTER_OUT;
           return folly::none;
         }
@@ -531,8 +531,8 @@ class UpdateEdgeNode : public UpdateNode<cpp2::EdgeKey> {
       baton.post();
     };
 
-    this->context_->planContext_->env_->kvstore_->asyncAppendBatch(
-        this->context_->planContext_->spaceId_, partId, std::move(batch).value(), callback);
+    context_->planContext_->env_->kvstore_->asyncAppendBatch(
+        context_->planContext_->spaceId_, partId, std::move(batch).value(), callback);
     baton.wait();
     return ret;
   }
@@ -560,7 +560,7 @@ class UpdateEdgeNode : public UpdateNode<cpp2::EdgeKey> {
   // Insert props row,
   // Operator props must have default value or nullable, or set in UpdatedProp_
   nebula::cpp2::ErrorCode insertEdgeProps(const PartitionID partId, const cpp2::EdgeKey& edgeKey) {
-    this->context_->insert_ = true;
+    context_->insert_ = true;
     auto ret = getLatestEdgeSchemaAndName();
     if (ret != nebula::cpp2::ErrorCode::SUCCEEDED) {
       return ret;

--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -191,9 +191,9 @@ class UpdateTagNode : public UpdateNode<VertexID> {
       return ret;
     }
 
-    if (context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+    if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
       return nebula::cpp2::ErrorCode::E_INVALID_DATA;
-    } else if (context_->resultStat_ == ResultStatus::FILTER_OUT) {
+    } else if (this->context_->resultStat_ == ResultStatus::FILTER_OUT) {
       return nebula::cpp2::ErrorCode::E_FILTER_OUT;
     }
 
@@ -226,7 +226,7 @@ class UpdateTagNode : public UpdateNode<VertexID> {
       ret = code;
       baton.post();
     };
-    kvstore()->asyncAppendBatch(this->spaceId(), partId, std::move(batch).value(), callback);
+    this->kvstore()->asyncAppendBatch(this->spaceId(), partId, std::move(batch).value(), callback);
     baton.wait();
     return ret;
   }
@@ -457,7 +457,7 @@ class UpdateEdgeNode : public UpdateNode<cpp2::EdgeKey> {
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const cpp2::EdgeKey& edgeKey) override {
     CHECK_NOTNULL(this->env()->kvstore_);
     auto ret = nebula::cpp2::ErrorCode::SUCCEEDED;
-    IndexCountWrapper wrapper(env());
+    IndexCountWrapper wrapper(this->env());
 
     // Update is read-modify-write, which is an atomic operation.
     std::vector<EMLI> dummyLock = {std::make_tuple(this->spaceId(),
@@ -482,10 +482,10 @@ class UpdateEdgeNode : public UpdateNode<cpp2::EdgeKey> {
           this->exeResult_ = nebula::cpp2::ErrorCode::E_KEY_NOT_FOUND;
           return folly::none;
         }
-        if (context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+        if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
           this->exeResult_ = nebula::cpp2::ErrorCode::E_INVALID_DATA;
           return folly::none;
-        } else if (context_->resultStat_ == ResultStatus::FILTER_OUT) {
+        } else if (this->context_->resultStat_ == ResultStatus::FILTER_OUT) {
           this->exeResult_ = nebula::cpp2::ErrorCode::E_FILTER_OUT;
           return folly::none;
         }

--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -31,7 +31,7 @@ class UpdateNode : public RelNode<T> {
              StorageExpressionContext* expCtx,
              bool isEdge,
              const std::string& name = "UpdateNode")
-      : RelNode<T>(context, name),
+      : RelNode<T>(name, context),
         indexes_(indexes),
         updatedProps_(updatedProps),
         filterNode_(filterNode),

--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -191,9 +191,9 @@ class UpdateTagNode : public UpdateNode<VertexID> {
       return ret;
     }
 
-    if (this->context()->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+    if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
       return nebula::cpp2::ErrorCode::E_INVALID_DATA;
-    } else if (this->context()->resultStat_ == ResultStatus::FILTER_OUT) {
+    } else if (this->context_->resultStat_ == ResultStatus::FILTER_OUT) {
       return nebula::cpp2::ErrorCode::E_FILTER_OUT;
     }
 
@@ -481,10 +481,10 @@ class UpdateEdgeNode : public UpdateNode<cpp2::EdgeKey> {
           this->exeResult_ = nebula::cpp2::ErrorCode::E_KEY_NOT_FOUND;
           return folly::none;
         }
-        if (this->context()->resultStat_ == ResultStatus::ILLEGAL_DATA) {
+        if (this->context_->resultStat_ == ResultStatus::ILLEGAL_DATA) {
           this->exeResult_ = nebula::cpp2::ErrorCode::E_INVALID_DATA;
           return folly::none;
-        } else if (this->context()->resultStat_ == ResultStatus::FILTER_OUT) {
+        } else if (this->context_->resultStat_ == ResultStatus::FILTER_OUT) {
           this->exeResult_ = nebula::cpp2::ErrorCode::E_FILTER_OUT;
           return folly::none;
         }
@@ -530,8 +530,8 @@ class UpdateEdgeNode : public UpdateNode<cpp2::EdgeKey> {
       baton.post();
     };
 
-    this->context()->planContext_->env_->kvstore_->asyncAppendBatch(
-        this->context()->planContext_->spaceId_, partId, std::move(batch).value(), callback);
+    this->context_->planContext_->env_->kvstore_->asyncAppendBatch(
+        this->context_->planContext_->spaceId_, partId, std::move(batch).value(), callback);
     baton.wait();
     return ret;
   }
@@ -559,7 +559,7 @@ class UpdateEdgeNode : public UpdateNode<cpp2::EdgeKey> {
   // Insert props row,
   // Operator props must have default value or nullable, or set in UpdatedProp_
   nebula::cpp2::ErrorCode insertEdgeProps(const PartitionID partId, const cpp2::EdgeKey& edgeKey) {
-    this->context()->insert_ = true;
+    this->context_->insert_ = true;
     auto ret = getLatestEdgeSchemaAndName();
     if (ret != nebula::cpp2::ErrorCode::SUCCEEDED) {
       return ret;

--- a/src/storage/exec/UpdateResultNode.h
+++ b/src/storage/exec/UpdateResultNode.h
@@ -24,13 +24,12 @@ class UpdateResNode : public RelNode<T> {
                 std::vector<Expression*> returnPropsExp,
                 StorageExpressionContext* expCtx,
                 nebula::DataSet* result)
-      : context_(context),
+      : RelNode<T>("UpdateResNode"),
+        context_(context),
         updateNode_(updateNode),
         returnPropsExp_(returnPropsExp),
         expCtx_(expCtx),
-        result_(result) {
-    RelNode<T>::name_ = "UpdateResNode";
-  }
+        result_(result) {}
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const T& vId) override {
     auto ret = RelNode<T>::doExecute(partId, vId);

--- a/src/storage/exec/UpdateResultNode.h
+++ b/src/storage/exec/UpdateResultNode.h
@@ -36,7 +36,7 @@ class UpdateResNode : public RelNode<T> {
       return ret;
     }
 
-    insert_ = this->context()->insert_;
+    insert_ = this->context_->insert_;
 
     // Note: If filtered out, the result of tag prop is old
     result_->colNames.emplace_back("_inserted");

--- a/src/storage/exec/UpdateResultNode.h
+++ b/src/storage/exec/UpdateResultNode.h
@@ -24,7 +24,7 @@ class UpdateResNode : public RelNode<T> {
                 std::vector<Expression*> returnPropsExp,
                 StorageExpressionContext* expCtx,
                 nebula::DataSet* result)
-      : RelNode<T>(context, "UpdateResNode"),
+      : RelNode<T>("UpdateResNode", context),
         updateNode_(updateNode),
         returnPropsExp_(returnPropsExp),
         expCtx_(expCtx),

--- a/src/storage/exec/UpdateResultNode.h
+++ b/src/storage/exec/UpdateResultNode.h
@@ -24,8 +24,7 @@ class UpdateResNode : public RelNode<T> {
                 std::vector<Expression*> returnPropsExp,
                 StorageExpressionContext* expCtx,
                 nebula::DataSet* result)
-      : RelNode<T>("UpdateResNode"),
-        context_(context),
+      : RelNode<T>(context, "UpdateResNode"),
         updateNode_(updateNode),
         returnPropsExp_(returnPropsExp),
         expCtx_(expCtx),
@@ -37,7 +36,7 @@ class UpdateResNode : public RelNode<T> {
       return ret;
     }
 
-    insert_ = context_->insert_;
+    insert_ = this->context()->insert_;
 
     // Note: If filtered out, the result of tag prop is old
     result_->colNames.emplace_back("_inserted");
@@ -61,7 +60,6 @@ class UpdateResNode : public RelNode<T> {
   }
 
  private:
-  RuntimeContext* context_;
   RelNode<T>* updateNode_;
   std::vector<Expression*> returnPropsExp_;
   StorageExpressionContext* expCtx_;

--- a/src/storage/index/LookupBaseProcessor-inl.h
+++ b/src/storage/index/LookupBaseProcessor-inl.h
@@ -162,14 +162,13 @@ bool LookupBaseProcessor<REQ, RESP>::isOutsideIndex(Expression* filter,
  *            +----------+-----------+
  *            +  IndexOutputNode...  +
  *            +----------+-----------+
- **/
-
+ */
 template <typename REQ, typename RESP>
 StatusOr<StoragePlan<IndexID>> LookupBaseProcessor<REQ, RESP>::buildPlan(
     IndexFilterItem* filterItem, nebula::DataSet* result) {
   StoragePlan<IndexID> plan;
-  // TODO(sky) : Limit is not supported yet for de-dup node.
-  //             Related to paging scan, the de-dup execution plan needs to be refactored
+  // TODO(sky): Limit is not supported yet for de-dup node.
+  // Related to paging scan, the de-dup execution plan needs to be refactored
   auto deDup = std::make_unique<DeDupNode<IndexID>>(context_.get(), result, deDupColPos_);
   int32_t filterId = 0;
   std::unique_ptr<IndexOutputNode<IndexID>> out;

--- a/src/storage/index/LookupBaseProcessor-inl.h
+++ b/src/storage/index/LookupBaseProcessor-inl.h
@@ -170,7 +170,7 @@ StatusOr<StoragePlan<IndexID>> LookupBaseProcessor<REQ, RESP>::buildPlan(
   StoragePlan<IndexID> plan;
   // TODO(sky) : Limit is not supported yet for de-dup node.
   //             Related to paging scan, the de-dup execution plan needs to be refactored
-  auto deDup = std::make_unique<DeDupNode<IndexID>>(result, deDupColPos_);
+  auto deDup = std::make_unique<DeDupNode<IndexID>>(context_.get(), result, deDupColPos_);
   int32_t filterId = 0;
   std::unique_ptr<IndexOutputNode<IndexID>> out;
   auto pool = &planContext_->objPool_;

--- a/src/storage/index/LookupBaseProcessor-inl.h
+++ b/src/storage/index/LookupBaseProcessor-inl.h
@@ -461,7 +461,7 @@ void LookupBaseProcessor<REQ, RESP>::profilePlan(StoragePlan<IndexID>& plan) {
   auto& nodes = plan.getNodes();
   std::lock_guard<std::mutex> lck(BaseProcessor<RESP>::profileMut_);
   for (auto& node : nodes) {
-    BaseProcessor<RESP>::profileDetail(node->name_, node->duration_.elapsedInUSec());
+    BaseProcessor<RESP>::profileDetail(node->name(), node->latencyInUs());
   }
 }
 

--- a/src/storage/mutate/UpdateEdgeProcessor.h
+++ b/src/storage/mutate/UpdateEdgeProcessor.h
@@ -56,7 +56,7 @@ class UpdateEdgeProcessor
   void profilePlan(StoragePlan<cpp2::EdgeKey>& plan) {
     auto& nodes = plan.getNodes();
     for (auto& node : nodes) {
-      profileDetail(node->name_, node->duration_.elapsedInUSec());
+      profileDetail(node->name(), node->latencyInUs());
     }
   }
 

--- a/src/storage/mutate/UpdateVertexProcessor.h
+++ b/src/storage/mutate/UpdateVertexProcessor.h
@@ -59,9 +59,8 @@ class UpdateVertexProcessor
     return returnPropsExp_;
   }
   void profilePlan(StoragePlan<VertexID>& plan) {
-    auto& nodes = plan.getNodes();
-    for (auto& node : nodes) {
-      profileDetail(node->name_, node->duration_.elapsedInUSec());
+    for (auto& node : plan.getNodes()) {
+      profileDetail(node->name(), node->latencyInUs());
     }
   }
 

--- a/src/storage/query/GetNeighborsProcessor.cpp
+++ b/src/storage/query/GetNeighborsProcessor.cpp
@@ -178,32 +178,32 @@ folly::Future<std::pair<nebula::cpp2::ErrorCode, PartitionID>> GetNeighborsProce
       });
 }
 
+/**
+ * The StoragePlan looks like this:
+ *              +--------+---------+
+ *              | GetNeighborsNode |
+ *              +--------+---------+
+ *                       |
+ *              +--------+---------+
+ *              |   AggregateNode  |
+ *              +--------+---------+
+ *                       |
+ *              +--------+---------+
+ *              |    FilterNode    |
+ *              +--------+---------+
+ *                       |
+ *              +--------+---------+
+ *          +-->+   HashJoinNode   +<----+
+ *          |   +------------------+     |
+ * +--------+---------+        +---------+--------+
+ * |     TagNodes     |        |     EdgeNodes    |
+ * +------------------+        +------------------+
+ */
 StoragePlan<VertexID> GetNeighborsProcessor::buildPlan(RuntimeContext* context,
                                                        StorageExpressionContext* expCtx,
                                                        nebula::DataSet* result,
                                                        int64_t limit,
                                                        bool random) {
-  /*
-  The StoragePlan looks like this:
-               +--------+---------+
-               | GetNeighborsNode |
-               +--------+---------+
-                        |
-               +--------+---------+
-               |   AggregateNode  |
-               +--------+---------+
-                        |
-               +--------+---------+
-               |    FilterNode    |
-               +--------+---------+
-                        |
-               +--------+---------+
-           +-->+   HashJoinNode   +<----+
-           |   +------------------+     |
-  +--------+---------+        +---------+--------+
-  |     TagNodes     |        |     EdgeNodes    |
-  +------------------+        +------------------+
-  */
   StoragePlan<VertexID> plan;
   std::vector<TagNode*> tags;
   for (const auto& tc : tagContext_.propContexts_) {
@@ -218,8 +218,7 @@ StoragePlan<VertexID> GetNeighborsProcessor::buildPlan(RuntimeContext* context,
     plan.addNode(std::move(edge));
   }
 
-  auto hashJoin =
-      std::make_unique<HashJoinNode>(context, tags, edges, &tagContext_, &edgeContext_, expCtx);
+  auto hashJoin = std::make_unique<HashJoinNode>(context, tags, edges, &edgeContext_, expCtx);
   for (auto* tag : tags) {
     hashJoin->addDependency(tag);
   }

--- a/src/storage/query/GetNeighborsProcessor.cpp
+++ b/src/storage/query/GetNeighborsProcessor.cpp
@@ -457,10 +457,9 @@ nebula::cpp2::ErrorCode GetNeighborsProcessor::checkStatType(
 void GetNeighborsProcessor::onProcessFinished() { resp_.set_vertices(std::move(resultDataSet_)); }
 
 void GetNeighborsProcessor::profilePlan(StoragePlan<VertexID>& plan) {
-  auto& nodes = plan.getNodes();
   std::lock_guard<std::mutex> lck(BaseProcessor<cpp2::GetNeighborsResponse>::profileMut_);
-  for (auto& node : nodes) {
-    profileDetail(node->name_, node->duration_.elapsedInUSec());
+  for (auto& node : plan.getNodes()) {
+    profileDetail(node->name(), node->latencyInUs());
   }
 }
 }  // namespace storage

--- a/src/storage/test/StorageDAGBenchmark.cpp
+++ b/src/storage/test/StorageDAGBenchmark.cpp
@@ -144,9 +144,9 @@ FutureDAG<std::string> fanoutFutureDAG() {
 
 StoragePlan<std::string> fanoutStorageDAG() {
   StoragePlan<std::string> dag;
-  auto out = std::make_unique<RelNode<std::string>>("leaf");
+  auto out = std::make_unique<RelNode<std::string>>(nullptr, "leaf");
   for (size_t i = 0; i < 10; i++) {
-    auto node = std::make_unique<RelNode<std::string>>(folly::to<std::string>(i));
+    auto node = std::make_unique<RelNode<std::string>>(nullptr, folly::to<std::string>(i));
     auto idx = dag.addNode(std::move(node));
     out->addDependency(dag.getNode(idx));
   }

--- a/src/storage/test/StorageDAGBenchmark.cpp
+++ b/src/storage/test/StorageDAGBenchmark.cpp
@@ -144,9 +144,9 @@ FutureDAG<std::string> fanoutFutureDAG() {
 
 StoragePlan<std::string> fanoutStorageDAG() {
   StoragePlan<std::string> dag;
-  auto out = std::make_unique<RelNode<std::string>>(nullptr, "leaf");
+  auto out = std::make_unique<RelNode<std::string>>("leaf");
   for (size_t i = 0; i < 10; i++) {
-    auto node = std::make_unique<RelNode<std::string>>(nullptr, folly::to<std::string>(i));
+    auto node = std::make_unique<RelNode<std::string>>(folly::to<std::string>(i));
     auto idx = dag.addNode(std::move(node));
     out->addDependency(dag.getNode(idx));
   }


### PR DESCRIPTION
* Use initializer list to init `name` field of `storage::RelNode`. 
* Pull the RuntimeContext upto the QueryNode class
* minor improvement of the go validator implementation