### PR TITLE
split onElected and onLeaderReady

### DIFF
--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -134,6 +134,8 @@ class Listener : public raftex::RaftPart {
 
   void onElected(TermID) override { LOG(FATAL) << "Should not reach here"; }
 
+  void onLeaderReady(TermID) override { LOG(FATAL) << "Should not reach here"; }
+
   void onDiscoverNewLeader(HostAddr nLeader) override {
     LOG(INFO) << idStr_ << "Find the new leader " << nLeader;
   }

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -176,23 +176,22 @@ void Part::onLostLeadership(TermID term) { VLOG(1) << "Lost the leadership for t
 
 void Part::onElected(TermID term) {
   VLOG(1) << "Being elected as the leader for the term: " << term;
-  if (onElectedCallBacks_.empty()) {
-    return;
-  }
+}
+
+void Part::onLeaderReady(TermID term) {
+  VLOG(1) << "leader ready to server for the term: " << term;
 
   CallbackOptions opt;
   opt.spaceId = spaceId_;
   opt.partId = partId_;
   opt.term = term_;
 
-  for (auto& cb : onElectedCallBacks_) {
+  for (auto& cb : leaderReadyCB_) {
     cb(opt);
   }
 }
 
-void Part::registerOnElected(OnElectedCallBack cb) {
-  onElectedCallBacks_.emplace_back(std::move(cb));
-}
+void Part::registerOnLeaderReady(LeaderReadyCB cb) { leaderReadyCB_.emplace_back(std::move(cb)); }
 
 void Part::onDiscoverNewLeader(HostAddr nLeader) {
   LOG(INFO) << idStr_ << "Find the new leader " << nLeader;

--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -85,6 +85,8 @@ class Part : public raftex::RaftPart {
 
   void onElected(TermID term) override;
 
+  void onLeaderReady(TermID term) override;
+
   void onDiscoverNewLeader(HostAddr nLeader) override;
 
   cpp2::ErrorCode commitLogs(std::unique_ptr<LogIterator> iter, bool wait) override;
@@ -114,15 +116,15 @@ class Part : public raftex::RaftPart {
     TermID term;
   };
 
-  using OnElectedCallBack = std::function<void(const CallbackOptions& opt)>;
-  void registerOnElected(OnElectedCallBack cb);
+  using LeaderReadyCB = std::function<void(const CallbackOptions& opt)>;
+  void registerOnLeaderReady(LeaderReadyCB cb);
 
  protected:
   GraphSpaceID spaceId_;
   PartitionID partId_;
   std::string walPath_;
   NewLeaderCallback newLeaderCb_ = nullptr;
-  std::vector<OnElectedCallBack> onElectedCallBacks_;
+  std::vector<LeaderReadyCB> leaderReadyCB_;
 
  private:
   KVEngine* engine_ = nullptr;

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -269,6 +269,11 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
   // a new leader
   virtual void onElected(TermID term) = 0;
 
+  // called after leader committed first log
+  // (a little bit later onElected)
+  // leader need to set some internal status after elected.
+  virtual void onLeaderReady(TermID term) = 0;
+
   virtual void onDiscoverNewLeader(HostAddr nLeader) = 0;
 
   // Check if we can accept candidate's message

--- a/src/kvstore/raftex/test/TestShard.cpp
+++ b/src/kvstore/raftex/test/TestShard.cpp
@@ -162,6 +162,8 @@ void TestShard::onElected(TermID term) {
   }
 }
 
+void TestShard::onLeaderReady(TermID term) { UNUSED(term); }
+
 nebula::cpp2::ErrorCode TestShard::commitLogs(std::unique_ptr<LogIterator> iter, bool) {
   LogID firstId = -1;
   LogID lastId = -1;

--- a/src/kvstore/raftex/test/TestShard.h
+++ b/src/kvstore/raftex/test/TestShard.h
@@ -72,6 +72,7 @@ class TestShard : public RaftPart {
 
   void onLostLeadership(TermID term) override;
   void onElected(TermID term) override;
+  void onLeaderReady(TermID term) override;
   void onDiscoverNewLeader(HostAddr) override {}
 
   nebula::cpp2::ErrorCode commitLogs(std::unique_ptr<LogIterator> iter, bool wait) override;

--- a/src/storage/transaction/ChainUpdateEdgeProcessorLocal.h
+++ b/src/storage/transaction/ChainUpdateEdgeProcessorLocal.h
@@ -86,6 +86,10 @@ class ChainUpdateEdgeProcessorLocal
   PartitionID partId_;
   int retryLimit_{10};
   TermID termOfPrepare_{-1};
+
+  // set to true when prime insert succeed
+  // in processLocal(), we check this to determine if need to do abort()
+  bool primeInserted_{false};
   std::vector<std::string> kvErased_;
   std::vector<kvstore::KV> kvAppend_;
   folly::Optional<int64_t> ver_{folly::none};


### PR DESCRIPTION
previously transaction register a callback function to Raft,

called at onElected(), to do a partition scan, to check if there is a (double) prime key.

but some raft internal status is not set until leader send its first log. 

which will let the transaction manager scan failed. 

so split the origin onElected to two part(1st still named onElected(), and 2nd named onLeaderReady()). 

and the scan will be called at onLeaderReady.