### PR TITLE
fix initialization of pointer member

### DIFF
--- a/src/graph/visitor/DeduceTypeVisitor.h
+++ b/src/graph/visitor/DeduceTypeVisitor.h
@@ -93,8 +93,8 @@ class DeduceTypeVisitor final : public ExprVisitor {
     return type == Value::Type::NULLVALUE || type == Value::Type::__EMPTY__;
   }
 
-  const QueryContext *qctx_;
-  const ValidateContext *vctx_;
+  const QueryContext *qctx_{nullptr};
+  const ValidateContext *vctx_{nullptr};
   const ColsDef &inputs_;
   GraphSpaceID space_;
   Status status_;


### PR DESCRIPTION

If the pointer member is not initialized, compilation in release mode may cause memory access errors.