### PR TITLE
fix crash when drop space

### DIFF
--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -124,8 +124,8 @@ RocksEngine::RocksEngine(GraphSpaceID spaceId,
   }
   CHECK(status.ok()) << status.ToString();
   db_.reset(db);
-  partsNum_ = allParts().size();
   extractorLen_ = sizeof(PartitionID) + vIdLen;
+  partsNum_ = allParts().size();
   LOG(INFO) << "open rocksdb on " << path;
 
   backup();

--- a/src/kvstore/test/RocksEngineTest.cpp
+++ b/src/kvstore/test/RocksEngineTest.cpp
@@ -734,6 +734,8 @@ TEST(RebuildPrefixBloomFilter, RebuildPrefixBloomFilter) {
       EXPECT_EQ("123", value);
     };
 
+    auto checkSystemPart = [&]() { EXPECT_EQ(10, engine->allParts().size()); };
+
     checkVertexPrefix(1, "1");
     checkVertexPrefix(1, "2");
     checkVertexPrefix(2, "3");
@@ -748,11 +750,16 @@ TEST(RebuildPrefixBloomFilter, RebuildPrefixBloomFilter) {
     checkEdgePartPrefix(2);
     checkRangeWithPartPrefix(1);
     checkRangeWithPartPrefix(2);
+    checkSystemPart();
     checkSystemCommit(1);
     checkSystemCommit(2);
   };
 
   auto writeData = [&engine] {
+    for (PartitionID partId = 1; partId <= 10; partId++) {
+      engine->addPart(partId);
+    }
+
     LOG(INFO) << "Write some data";
     std::vector<KV> data;
     for (TagID tagId = 0; tagId < 10; tagId++) {


### PR DESCRIPTION
Reproduce procedure:
1. **use the latest configuration file**
2. clean all data (maybe not necessary)
3. start up the cluster, create a space
4. wait until all leader elected in `show hosts` 
5. stop and reboot the cluster
6. drop the space, storage will crash later