### PR TITLE
return __NULL__ when try to getProp a non-exist vid

### DIFF
--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -31,6 +31,17 @@ class GetTagPropNode : public QueryNode<VertexID> {
       return ret;
     }
 
+    // if none of the tag node valid, do not emplace the row
+    if (!std::any_of(tagNodes_.begin(), tagNodes_.end(), [](const auto& tagNode) {
+          return tagNode->valid();
+        })) {
+      auto key = NebulaKeyUtils::vertexPrefix(context_->vIdLen(), partId, vId);
+      std::unique_ptr<kvstore::KVIterator> iter;
+      auto rc = context_->env()->kvstore_->prefix(context_->spaceId(), partId, key, &iter);
+      if (rc != nebula::cpp2::ErrorCode::SUCCEEDED || !iter->valid()) {
+        return nebula::cpp2::ErrorCode::SUCCEEDED;
+      }
+    }
 
     List row;
     // vertexId is the first column

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -33,6 +33,12 @@ class GetTagPropNode : public QueryNode<VertexID> {
 
 
     List row;
+    // vertexId is the first column
+    if (context_->isIntId()) {
+      row.emplace_back(*reinterpret_cast<const int64_t*>(vId.data()));
+    } else {
+      row.emplace_back(vId);
+    }
     auto vIdLen = context_->vIdLen();
     auto isIntId = context_->isIntId();
     for (auto* tagNode : tagNodes_) {
@@ -45,16 +51,10 @@ class GetTagPropNode : public QueryNode<VertexID> {
             }
             return nebula::cpp2::ErrorCode::SUCCEEDED;
           },
-          [&row, vIdLen, isIntId, vId, this](
+          [&row, vIdLen, isIntId](
               folly::StringPiece key,
               RowReader* reader,
               const std::vector<PropContext>* props) -> nebula::cpp2::ErrorCode {
-            // vertexId is the first column
-            if (context_->isIntId()) {
-              row.emplace_back(*reinterpret_cast<const int64_t*>(vId.data()));
-            } else {
-              row.emplace_back(vId);
-            }
             if (!QueryUtils::collectVertexProps(key, vIdLen, isIntId, reader, props, row).ok()) {
               return nebula::cpp2::ErrorCode::E_TAG_PROP_NOT_FOUND;
             }

--- a/src/storage/exec/GetPropNode.h
+++ b/src/storage/exec/GetPropNode.h
@@ -26,16 +26,21 @@ class GetTagPropNode : public QueryNode<VertexID> {
   }
 
   nebula::cpp2::ErrorCode doExecute(PartitionID partId, const VertexID& vId) override {
-    auto vidPrefix = NebulaKeyUtils::vertexPrefix(context_->vIdLen(), partId, vId);
-    std::unique_ptr<kvstore::KVIterator> iter;
-    auto rc = context_->env()->kvstore_->prefix(context_->spaceId(), partId, vidPrefix, &iter);
-    if (rc == nebula::cpp2::ErrorCode::SUCCEEDED && !iter->valid()) {
-      return nebula::cpp2::ErrorCode::SUCCEEDED;
-    }
-
     auto ret = RelNode::doExecute(partId, vId);
     if (ret != nebula::cpp2::ErrorCode::SUCCEEDED) {
       return ret;
+    }
+
+    // if none of the tag node valid, do not emplace the row
+    if (!std::any_of(tagNodes_.begin(), tagNodes_.end(), [](const auto& tagNode) {
+          return tagNode->valid();
+        })) {
+      auto key = NebulaKeyUtils::vertexPrefix(context_->vIdLen(), partId, vId);
+      std::unique_ptr<kvstore::KVIterator> iter;
+      auto rc = context_->env()->kvstore_->prefix(context_->spaceId(), partId, key, &iter);
+      if (rc != nebula::cpp2::ErrorCode::SUCCEEDED || !iter->valid()) {
+        return nebula::cpp2::ErrorCode::SUCCEEDED;
+      }
     }
 
     List row;


### PR DESCRIPTION
```sql
create space ttt(partition_num=1, replica_factor=1, vid_type = FIXED_STRING(30));
CREATE TAG t1(a string, b int);
INSERT VERTEX t1(a, b) VALUE "player100":("Hello", 100);
fetch prop on t1 "player1000";
```

previously, if we try to fetch a non-exist vid's props. we got an empty output.
```
(root@nebula) [ttt]> fetch prop on t1 "player888";
+-----------+
| vertices_ |
+-----------+
+-----------+
Got 1 rows (time spent 2207/2657 us)
```

now as discussed, return a row has a value NULL.
```
(root@nebula) [ttt]> fetch prop on t1 "player888";
+-----------+
| vertices_ |
+-----------+
| __NULL__  |
+-----------+
Got 1 rows (time spent 2207/2657 us)
```