### PR TITLE
Fix mixed usage of default and optional value definition in thrift

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -345,7 +345,7 @@ bool MetaClient::loadSchemas(GraphSpaceID spaceId,
                                           const cpp2::ColumnDef& col) {
     bool hasDef = col.default_value_ref().has_value();
     auto& colType = col.get_type();
-    size_t len = colType.type_length_ref().has_value() ? *colType.get_type_length() : 0;
+    size_t len = colType.type_length_ref().has_value() ? colType.get_type_length() : 0;
     cpp2::GeoShape geoShape =
         colType.geo_shape_ref().has_value() ? *colType.get_geo_shape() : cpp2::GeoShape::ANY;
     bool nullable = col.nullable_ref().has_value() ? *col.get_nullable() : false;
@@ -1858,7 +1858,7 @@ StatusOr<int32_t> MetaClient::getSpaceVidLen(const GraphSpaceID& spaceId) {
     return Status::Error("Space %d not found", spaceId);
   }
   auto& vidType = spaceIt->second->spaceDesc_.get_vid_type();
-  auto vIdLen = vidType.type_length_ref().has_value() ? *vidType.get_type_length() : 0;
+  auto vIdLen = vidType.type_length_ref().has_value() ? vidType.get_type_length() : 0;
   if (vIdLen <= 0) {
     return Status::Error("Space %d vertexId length invalid", spaceId);
   }

--- a/src/common/utils/IndexKeyUtils.cpp
+++ b/src/common/utils/IndexKeyUtils.cpp
@@ -35,7 +35,7 @@ std::vector<std::string> IndexKeyUtils::encodeValues(
       if (!values[i].isNull()) {
         // string index need to fill with '\0' if length is less than schema
         if (cols[i].type.type == meta::cpp2::PropertyType::FIXED_STRING) {
-          auto len = static_cast<size_t>(*cols[i].type.get_type_length());
+          auto len = static_cast<size_t>(cols[i].type.get_type_length());
           index.append(encodeValue(values[i], len));
         } else {
           index.append(encodeValue(values[i]));
@@ -57,7 +57,7 @@ std::vector<std::string> IndexKeyUtils::encodeValues(
     } else {
       nullableBitSet |= 0x8000;
       auto type = IndexKeyUtils::toValueType(cols.back().type.get_type());
-      indexes.emplace_back(encodeNullValue(type, nullptr));
+      indexes.emplace_back(encodeNullValue(type, cols.back().type.get_type_length()));
     }
   }
   // if has nullable field, append nullableBitSet to the end

--- a/src/common/utils/IndexKeyUtils.h
+++ b/src/common/utils/IndexKeyUtils.h
@@ -57,7 +57,7 @@ class IndexKeyUtils final {
     return Value::Type::__EMPTY__;
   }
 
-  static std::string encodeNullValue(Value::Type type, const int16_t* strLen) {
+  static std::string encodeNullValue(Value::Type type, const int16_t strLen) {
     size_t len = 0;
     switch (type) {
       case Value::Type::INT: {
@@ -73,7 +73,7 @@ class IndexKeyUtils final {
         break;
       }
       case Value::Type::STRING: {
-        len = static_cast<size_t>(*strLen);
+        len = static_cast<size_t>(strLen);
         break;
       }
       case Value::Type::TIME: {
@@ -421,7 +421,7 @@ class IndexKeyUtils final {
           break;
         }
         case Value::Type::STRING: {
-          len = *col.type.get_type_length();
+          len = col.type.get_type_length();
           break;
         }
         case Value::Type::TIME: {

--- a/src/graph/optimizer/OptimizerUtils.cpp
+++ b/src/graph/optimizer/OptimizerUtils.cpp
@@ -468,7 +468,7 @@ Value OptimizerUtils::normalizeValue(const meta::cpp2::ColumnDef& col, const Val
       if (!v.isStr()) {
         return v;
       }
-      auto len = static_cast<size_t>(*col.get_type().get_type_length());
+      auto len = static_cast<size_t>(col.get_type().get_type_length());
       if (v.getStr().size() > len) {
         return Value(v.getStr().substr(0, len));
       } else {

--- a/src/graph/util/SchemaUtil.cpp
+++ b/src/graph/util/SchemaUtil.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<const meta::NebulaSchemaProvider> SchemaUtil::generateSchemaProv
     }
     schemaPtr->addField(col.get_name(),
                         col.get_type().get_type(),
-                        col.type.type_length_ref().value_or(0),
+                        col.type.get_type_length(),
                         col.nullable_ref().value_or(false),
                         hasDef ? defaultValueExpr : nullptr,
                         col.type.geo_shape_ref().value_or(meta::cpp2::GeoShape::ANY));
@@ -259,7 +259,7 @@ StatusOr<DataSet> SchemaUtil::toShowCreateSchema(bool isTag,
 std::string SchemaUtil::typeToString(const meta::cpp2::ColumnTypeDef &col) {
   auto type = apache::thrift::util::enumNameSafe(col.get_type());
   if (col.get_type() == meta::cpp2::PropertyType::FIXED_STRING) {
-    return folly::stringPrintf("%s(%d)", type.c_str(), *col.get_type_length());
+    return folly::stringPrintf("%s(%d)", type.c_str(), col.get_type_length());
   } else if (col.get_type() == meta::cpp2::PropertyType::GEOGRAPHY) {
     auto geoShape = *col.get_geo_shape();
     if (geoShape == meta::cpp2::GeoShape::ANY) {

--- a/src/graph/validator/LookupValidator.cpp
+++ b/src/graph/validator/LookupValidator.cpp
@@ -194,10 +194,10 @@ Status LookupValidator::validateYield() {
     NG_RETURN_IF_ERROR(validateYieldTag());
   }
   if (exprProps_.hasInputVarProperty()) {
-    return Status::SemanticError("unsupport input/variable property expression in yield.");
+    return Status::SemanticError("unsupported input/variable property expression in yield.");
   }
   if (exprProps_.hasSrcDstTagProperty()) {
-    return Status::SemanticError("unsupport src/dst property expression in yield.");
+    return Status::SemanticError("unsupported src/dst property expression in yield.");
   }
   extractExprProps();
   return Status::OK();

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -100,7 +100,7 @@ enum PropertyType {
 struct ColumnTypeDef {
     1: required PropertyType    type,
     // type_length is valid for fixed_string type
-    2: optional i16             type_length = 0,
+    2: required i16             type_length,
     // geo_shape is valid for geography type
     3: optional GeoShape        geo_shape,
 }
@@ -109,7 +109,7 @@ struct ColumnDef {
     1: required binary          name,
     2: required ColumnTypeDef   type,
     3: optional binary          default_value,
-    4: optional bool            nullable = false,
+    4: optional bool            nullable,
     5: optional binary          comment,
 }
 

--- a/src/meta/processors/index/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/index/CreateEdgeIndexProcessor.cpp
@@ -128,9 +128,9 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
     }
     cpp2::ColumnDef col = *iter;
     if (col.type.get_type() == meta::cpp2::PropertyType::FIXED_STRING) {
-      if (*col.type.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
-        LOG(ERROR) << "Unsupport index type lengths greater than " << MAX_INDEX_TYPE_LENGTH << " : "
-                   << field.get_name();
+      if (col.type.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
+        LOG(ERROR) << "Unsupported index type lengths greater than " << MAX_INDEX_TYPE_LENGTH
+                   << " : " << field.get_name();
         handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
         onFinished();
         return;
@@ -143,8 +143,8 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
         return;
       }
       if (*field.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
-        LOG(ERROR) << "Unsupport index type lengths greater than " << MAX_INDEX_TYPE_LENGTH << " : "
-                   << field.get_name();
+        LOG(ERROR) << "Unsupported index type lengths greater than " << MAX_INDEX_TYPE_LENGTH
+                   << " : " << field.get_name();
         handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
         onFinished();
         return;

--- a/src/meta/processors/index/CreateTagIndexProcessor.cpp
+++ b/src/meta/processors/index/CreateTagIndexProcessor.cpp
@@ -126,9 +126,9 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
     }
     cpp2::ColumnDef col = *iter;
     if (col.type.get_type() == meta::cpp2::PropertyType::FIXED_STRING) {
-      if (*col.type.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
-        LOG(ERROR) << "Unsupport index type lengths greater than " << MAX_INDEX_TYPE_LENGTH << " : "
-                   << field.get_name();
+      if (col.type.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
+        LOG(ERROR) << "Unsupported index type lengths greater than " << MAX_INDEX_TYPE_LENGTH
+                   << " : " << field.get_name();
         handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
         onFinished();
         return;
@@ -141,8 +141,8 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
         return;
       }
       if (*field.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
-        LOG(ERROR) << "Unsupport index type lengths greater than " << MAX_INDEX_TYPE_LENGTH << " : "
-                   << field.get_name();
+        LOG(ERROR) << "Unsupported index type lengths greater than " << MAX_INDEX_TYPE_LENGTH
+                   << " : " << field.get_name();
         handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
         onFinished();
         return;

--- a/src/meta/processors/index/FTIndexProcessor.cpp
+++ b/src/meta/processors/index/FTIndexProcessor.cpp
@@ -70,9 +70,9 @@ void CreateFTIndexProcessor::process(const cpp2::CreateFTIndexReq& req) {
     // else if the data type is string,
     // will be truncated to MAX_INDEX_TYPE_LENGTH bytes when data insert.
     if (targetCol->get_type().get_type() == meta::cpp2::PropertyType::FIXED_STRING &&
-        *targetCol->get_type().get_type_length() > MAX_INDEX_TYPE_LENGTH) {
+        targetCol->get_type().get_type_length() > MAX_INDEX_TYPE_LENGTH) {
       LOG(ERROR) << "Unsupported data length more than " << MAX_INDEX_TYPE_LENGTH
-                 << " bytes : " << col << "(" << *targetCol->get_type().get_type_length() << ")";
+                 << " bytes : " << col << "(" << targetCol->get_type().get_type_length() << ")";
       handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
       onFinished();
       return;

--- a/src/meta/processors/schema/SchemaUtil.cpp
+++ b/src/meta/processors/schema/SchemaUtil.cpp
@@ -115,7 +115,7 @@ bool SchemaUtil::checkType(std::vector<cpp2::ColumnDef>& columns) {
             return false;
           }
           auto& colType = column.get_type();
-          size_t typeLen = colType.type_length_ref().value_or(0);
+          size_t typeLen = colType.get_type_length();
           if (value.getStr().size() > typeLen) {
             const auto trimStr = value.getStr().substr(0, typeLen);
             value.setStr(trimStr);

--- a/src/meta/test/ProcessorTest.cpp
+++ b/src/meta/test/ProcessorTest.cpp
@@ -342,7 +342,7 @@ TEST(ProcessorTest, SpaceTest) {
     ASSERT_EQ("default_space", resp.get_item().get_properties().get_space_name());
     ASSERT_EQ(8, resp.get_item().get_properties().get_partition_num());
     ASSERT_EQ(3, resp.get_item().get_properties().get_replica_factor());
-    ASSERT_EQ(8, *resp.get_item().get_properties().get_vid_type().get_type_length());
+    ASSERT_EQ(8, resp.get_item().get_properties().get_vid_type().get_type_length());
     ASSERT_EQ(cpp2::PropertyType::FIXED_STRING,
               resp.get_item().get_properties().get_vid_type().get_type());
     ASSERT_EQ("utf8", resp.get_item().get_properties().get_charset_name());

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -460,7 +460,7 @@ class TestUtils {
     expr = Expression::decode(metaPool, *(*schema.columns_ref())[8].get_default_value());
     ASSERT_EQ(Expression::eval(expr, defaultContext), Value("longlongst"));
     ASSERT_EQ(*(*schema.columns_ref())[8].get_nullable(), false);
-    ASSERT_EQ(*(*schema.columns_ref())[8].get_type().get_type_length(), 10);
+    ASSERT_EQ((*schema.columns_ref())[8].get_type().get_type_length(), 10);
 
     ASSERT_EQ((*schema.columns_ref())[9].get_name(), "col_9");
     ASSERT_EQ((*schema.columns_ref())[9].get_type().get_type(), PropertyType::TIMESTAMP);

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -2322,11 +2322,11 @@ column_spec_list
 
 column_spec
     : name_label type_spec {
-        $$ = new ColumnSpecification($1, $2->type, new ColumnProperties(), $2->type_length_ref().value_or(0), $2->geo_shape_ref().value_or(meta::cpp2::GeoShape::ANY));
+        $$ = new ColumnSpecification($1, $2->type, new ColumnProperties(), $2->get_type_length(), $2->geo_shape_ref().value_or(meta::cpp2::GeoShape::ANY));
         delete $2;
     }
     | name_label type_spec column_properties {
-        $$ = new ColumnSpecification($1, $2->type, $3, $2->type_length_ref().value_or(0), $2->geo_shape_ref().value_or(meta::cpp2::GeoShape::ANY));
+        $$ = new ColumnSpecification($1, $2->type, $3, $2->get_type_length(), $2->geo_shape_ref().value_or(meta::cpp2::GeoShape::ANY));
         delete $2;
     }
     ;

--- a/src/storage/exec/IndexScanNode.h
+++ b/src/storage/exec/IndexScanNode.h
@@ -159,12 +159,12 @@ class IndexScanNode : public RelNode<T> {
   }
 
   // precondition: if type is STRING, strLen must be valid
-  std::string encodeValue(const Value& val, Value::Type type, const int16_t* strLen) {
+  std::string encodeValue(const Value& val, Value::Type type, const int16_t strLen) {
     if (val.isNull()) {
       return IndexKeyUtils::encodeNullValue(type, strLen);
     }
     if (type == Value::Type::STRING) {
-      return IndexKeyUtils::encodeValue(val, *strLen);
+      return IndexKeyUtils::encodeValue(val, strLen);
     } else {
       return IndexKeyUtils::encodeValue(val);
     }


### PR DESCRIPTION
#### What type of PR is this?
- [x] bug
- [ ] feature

#### What this PR does / why we need it?
This PR changes the values defined in the thrift file to be either optional or have an optional value.

The mixed usage of default and optional values in thrift files produces incorrect code.
For example, in the Golang client, the generated code cannot be compiled, and manual modification to the auto-generated code is required, which is a pain.
