### PR TITLE
Disable duplicate insertion.

### DIFF
--- a/src/graph/validator/test/QueryValidatorTest.cpp
+++ b/src/graph/validator/test/QueryValidatorTest.cpp
@@ -1161,21 +1161,20 @@ TEST_F(QueryValidatorTest, TestMaxAllowedStatements) {
 
 TEST_F(QueryValidatorTest, TestMaxAllowedQuerySize) {
   FLAGS_max_allowed_query_size = 256;
-  std::string query = "INSERT VERTEX person(name, age) VALUES ";
-  std::string value = "\"person_1\":(\"person_1\", 1),";
+  std::string query = "SHOW SPACES; ";
+  std::string value = "SHOW SPACES; ";
   int count = (FLAGS_max_allowed_query_size - query.size()) / value.size();
   std::string values;
   values.reserve(FLAGS_max_allowed_query_size);
   for (int i = 0; i < count; ++i) {
     values.append(value);
   }
-  values.erase(values.size() - 1);
   query += values;
   EXPECT_TRUE(checkResult(query));
-  query.append(",\"person_2\":(\"person_2\", 2);");
+  query.append("SHOW SPACES;");
   auto result = checkResult(query);
   EXPECT_FALSE(result);
-  EXPECT_EQ(std::string(result.message()), "SyntaxError: Query is too large (282 > 256).");
+  EXPECT_EQ(std::string(result.message()), "SyntaxError: Query is too large (259 > 256).");
   FLAGS_max_allowed_query_size = 4194304;
 }
 

--- a/tests/tck/features/insert/Insert.IntVid.feature
+++ b/tests/tck/features/insert/Insert.IntVid.feature
@@ -120,6 +120,16 @@ Feature: Insert int vid of vertex and edge
         hash("Laura")->hash("sun_school"):(timestamp("2300-01-01T10:00:00"), now()+3600*24*365*3);
       """
     Then a ExecutionError should be raised at runtime:
+    When executing query:
+      """
+      INSERT EDGE schoolmate(likeness, nickname) VALUES hash("Tony")->hash("Mack")@1:(1, ""), hash("Tony")->hash("Mack")@1:(3, "nick");
+      """
+    Then a SemanticError should be raised at runtime: Can't insert duplicate edges in one statement.
+    When executing query:
+      """
+      INSERT VERTEX person(name, age) VALUES hash("Tom"):(NULL, 12), hash("Tom"):("Tom", 22)
+      """
+    Then a SemanticError should be raised at runtime: Can't insert duplicate vertices in one statement.
     And drop the used space
 
   Scenario: insert vertex unordered order prop vertex succeeded

--- a/tests/tck/features/insert/Insert.feature
+++ b/tests/tck/features/insert/Insert.feature
@@ -454,6 +454,16 @@ Feature: Insert string vid of vertex and edge
     Then the result should be, in any order:
       | $$.person.name | $$.person.age | schoolmate.likeness |
       | 'Mack'         | 21            | 3                   |
+    When executing query:
+      """
+      INSERT EDGE schoolmate(likeness, nickname) VALUES "Tony"->"Mack"@1:(1, ""), "Tony"->"Mack"@1:(3, "nick");
+      """
+    Then a SemanticError should be raised at runtime: Can't insert duplicate edges in one statement.
+    When executing query:
+      """
+      INSERT VERTEX person(name, age) VALUES "Tom":(NULL, 12), "Tom":("Tom", 22)
+      """
+    Then a SemanticError should be raised at runtime: Can't insert duplicate vertices in one statement.
     Then drop the used space
 
   Scenario: insert vertex and edge test by the 2.0 new type

--- a/tests/tck/features/insert/InsertIfNotExists.feature
+++ b/tests/tck/features/insert/InsertIfNotExists.feature
@@ -28,8 +28,7 @@ Feature: Insert vertex and edge with if not exists
         person(name, age)
       VALUES
         "Conan":("Conan", 10),
-        "Yao":("Yao", 11),
-        "Conan":("Conan", 11);
+        "Yao":("Yao", 11);
       """
     Then the execution should be successful
     # check vertex result with fetch
@@ -223,9 +222,8 @@ Feature: Insert vertex and edge with if not exists
       INSERT VERTEX IF NOT EXISTS
         person
       VALUES
-        "Conan":("Conan", 10),
-        "Yao":("Yao", 11),
         "Conan":("Conan", 11),
+        "Yao":("Yao", 11),
         "Tom":("Tom", 3);
       """
     Then the execution should be successful

--- a/tests/tck/features/lookup/LookUp.feature
+++ b/tests/tck/features/lookup/LookUp.feature
@@ -840,7 +840,6 @@ Feature: LookUpTest_Vid_String
         "104":("yyy", 28),
         "105":("zzz", 21),
         "106":("kkk", 21),
-        "121":("Useless", 60),
         "121":("Useless", 20);
         INSERT VERTEX
           team(name)


### PR DESCRIPTION
#### What type of PR is this?
- [x] bug
- [ ] feature

#### Which issue(s) this PR fixes:
close https://github.com/vesoft-inc/nebula/issues/3193
（If it is requirement, issue(s) number must be listed.）

#### What this PR does / why we need it?
The storage don't support duplicate insertion. So if we allow user do it, the result isn't what they expect.
  
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context:


#### Checklist：
- [x] Documentation affected （If need to modify document, please label it.)
- [x] Incompatible （If it is incompatile, please describle it and label it.）
- [ ] Need to cherry pick （If need to cherry pick to some branchs, please label the destination version(s).)
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory



#### Release notes：
Please confirm whether to reflect in release notes and how to describe:
>Disable insert duplicate vertices or edges in one statement.                                                                 `
