### PR TITLE
Ignore useless folders related to git for docker images building

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -36,3 +36,9 @@ Testing/
 target/
 cluster.id
 pids/
+
+# git
+.git/
+.github/
+.linters/
+tests/


### PR DESCRIPTION
Speed up `COPY` steps when building docker images