### PR TITLE
small fix for EvaluableExprVisitor

### DIFF
--- a/src/graph/visitor/EvaluableExprVisitor.h
+++ b/src/graph/visitor/EvaluableExprVisitor.h
@@ -56,6 +56,14 @@ class EvaluableExprVisitor : public ExprVisitorImpl {
 
   void visit(SubscriptRangeExpression *) override { isEvaluable_ = false; }
 
+  void visitBinaryExpr(BinaryExpression *expr) override {
+    expr->left()->accept(this);
+    // Evaluable sub-expression should be obscured by the non-evaluable sub-expression.
+    if (isEvaluable_) {
+      expr->right()->accept(this);
+    }
+  }
+
   bool isEvaluable_{true};
 };
 


### PR DESCRIPTION
#### What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

#### What does this PR do?
Fix `EvaluableExprVisitor::visitBinaryExpr`.

#### Additional context:
That is same as `FindAnyNonEvaluableLeafExpr`. 
Can the implementation of `EvaluableExprVisitor` be unified to `FindVisitor`?

#### Checklist：
- [ ] Documentation affected （Please add the label if documentation needs to be modified.)
- [ ] Incompatible （If it is incompatible, please describe it and add corresponding label.）
- [ ] Need to cherry-pick （If need to cherry-pick to some branches, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes：
No need to change.