### PR TITLE
parse diskPartsKey and add unit test

### DIFF
--- a/src/common/utils/MetaKeyUtils.h
+++ b/src/common/utils/MetaKeyUtils.h
@@ -376,7 +376,11 @@ class MetaKeyUtils final {
 
   static std::unordered_map<std::string, std::pair<std::string, bool>> getSystemTableMaps();
 
-  static GraphSpaceID parseDiskPartsSpace(folly::StringPiece rawData);
+  static GraphSpaceID parseDiskPartsSpace(const folly::StringPiece& rawData);
+
+  static HostAddr parseDiskPartsHost(const folly::StringPiece& rawData);
+
+  static std::string parseDiskPartsPath(const folly::StringPiece& rawData);
 
   static std::string diskPartsPrefix();
 
@@ -384,7 +388,7 @@ class MetaKeyUtils final {
 
   static std::string diskPartsPrefix(HostAddr addr, GraphSpaceID spaceId);
 
-  static std::string diskPartsKey(HostAddr addr, GraphSpaceID spaceId, std::string path);
+  static std::string diskPartsKey(HostAddr addr, GraphSpaceID spaceId, const std::string& path);
 
   static std::string diskPartsVal(const meta::cpp2::PartitionList& partList);
 

--- a/src/common/utils/test/MetaKeyUtilsTest.cpp
+++ b/src/common/utils/test/MetaKeyUtilsTest.cpp
@@ -201,6 +201,17 @@ TEST(MetaKeyUtilsTest, ZoneTest) {
   ASSERT_EQ(nodes, MetaKeyUtils::parseZoneHosts(zoneValue));
 }
 
+TEST(MetaKeyUtilsTest, DiskPathsTest) {
+  HostAddr addr{"192.168.0.1", 1234};
+  GraphSpaceID spaceId = 1;
+  std::string path = "/data/storage/test_part1";
+
+  auto diskPartsKey = MetaKeyUtils::diskPartsKey(addr, spaceId, path);
+  ASSERT_EQ(addr, MetaKeyUtils::parseDiskPartsHost(diskPartsKey));
+  ASSERT_EQ(spaceId, MetaKeyUtils::parseDiskPartsSpace(diskPartsKey));
+  ASSERT_EQ(path, MetaKeyUtils::parseDiskPartsPath(diskPartsKey));
+}
+
 }  // namespace nebula
 
 int main(int argc, char** argv) {

--- a/src/kvstore/test/DiskManagerTest.cpp
+++ b/src/kvstore/test/DiskManagerTest.cpp
@@ -145,6 +145,39 @@ TEST(DiskManagerTest, WalNoSpaceTest) {
   }
 }
 
+TEST(DiskManagerTest, GetDiskPartsTest) {
+  GraphSpaceID spaceId = 1;
+  fs::TempDir disk1("/tmp/get_disk_part_test.XXXXXX");
+  auto path1 = folly::stringPrintf("%s/nebula/%d", disk1.path(), spaceId);
+  boost::filesystem::create_directories(path1);
+  fs::TempDir disk2("/tmp/get_disk_part_test.XXXXXX");
+  auto path2 = folly::stringPrintf("%s/nebula/%d", disk2.path(), spaceId);
+  boost::filesystem::create_directories(path2);
+  GraphSpaceID spaceId2 = 2;
+  fs::TempDir disk3("/tmp/get_disk_part_test.XXXXXX");
+  auto path3 = folly::stringPrintf("%s/nebula/%d", disk3.path(), spaceId2);
+  boost::filesystem::create_directories(path3);
+
+  std::vector<std::string> dataPaths = {disk1.path(), disk2.path(), disk3.path()};
+  DiskManager diskMan(dataPaths);
+  for (PartitionID partId = 1; partId <= 10; partId++) {
+    diskMan.addPartToPath(spaceId, partId, path1);
+  }
+  for (PartitionID partId = 11; partId <= 20; partId++) {
+    diskMan.addPartToPath(spaceId, partId, path2);
+  }
+  for (PartitionID partId = 1; partId <= 10; partId++) {
+    diskMan.addPartToPath(spaceId2, partId, path3);
+  }
+
+  SpaceDiskPartsMap diskParts;
+  diskMan.getDiskParts(diskParts);
+  ASSERT_EQ(2, diskParts.size());
+  ASSERT_EQ(2, diskParts[spaceId].size());
+  ASSERT_EQ(1, diskParts[spaceId2].size());
+  ASSERT_EQ(10, diskParts[spaceId2][path3].get_part_list().size());
+}
+
 }  // namespace kvstore
 }  // namespace nebula
 


### PR DESCRIPTION
#### What type of PR is this?
- [x] bug
- [ ] feature
- [x] enhancement

#### What does this PR do?
add functions to parse host, spaceId and path in diskPartsKey, and fix parseDiskPartsSpace().
add unit test for MetaUtilKeys and DiskManager

#### Which issue(s)/PR(s) this PR relates to?
https://github.com/vesoft-inc/nebula/pull/3369
  
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context:


#### Checklist：
- [ ] Documentation affected （Please add the label if documentation needs to be modified.)
- [ ] Incompatible （If it is incompatible, please describe it and add corresponding label.）
- [ ] Need to cherry-pick （If need to cherry-pick to some branches, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes：
Please confirm whether to reflect in release notes and how to describe:
>                                                                 `
