### PR TITLE
Condition memory checks on cgroup version.

### DIFF
--- a/src/common/memory/MemoryUtils.cpp
+++ b/src/common/memory/MemoryUtils.cpp
@@ -33,7 +33,8 @@ StatusOr<bool> MemoryUtils::hitsHighWatermark() {
   double available = 0.0, total = 0.0;
   if (FLAGS_containerized) {
     bool cgroupsv2 = FileUtils::exist("/sys/fs/cgroup/cgroup.controllers");
-    std::string statPath = cgroupsv2 ? "/sys/fs/cgroup/memory.stat" : "/sys/fs/cgroup/memory/memory.stat";
+    std::string statPath =
+        cgroupsv2 ? "/sys/fs/cgroup/memory.stat" : "/sys/fs/cgroup/memory/memory.stat";
     FileUtils::FileLineIterator iter(statPath, &reTotalCache);
     uint64_t cacheSize = 0;
     for (; iter.valid(); ++iter) {
@@ -41,12 +42,14 @@ StatusOr<bool> MemoryUtils::hitsHighWatermark() {
       cacheSize += std::stoul(sm[2].str(), NULL);
     }
 
-    std::string limitPath = cgroupsv2 ? "/sys/fs/cgroup/memory.max" : "/sys/fs/cgroup/memory/memory.limit_in_bytes";
+    std::string limitPath =
+        cgroupsv2 ? "/sys/fs/cgroup/memory.max" : "/sys/fs/cgroup/memory/memory.limit_in_bytes";
     auto limitStatus = MemoryUtils::readSysContents(limitPath);
     NG_RETURN_IF_ERROR(limitStatus);
     uint64_t limitInBytes = std::move(limitStatus).value();
 
-    std::string usagePath = cgroupsv2 ? "/sys/fs/cgroup/memory.current" : "/sys/fs/cgroup/memory/memory.usage_in_bytes";
+    std::string usagePath =
+        cgroupsv2 ? "/sys/fs/cgroup/memory.current" : "/sys/fs/cgroup/memory/memory.usage_in_bytes";
     auto usageStatus = MemoryUtils::readSysContents(usagePath);
     NG_RETURN_IF_ERROR(usageStatus);
     uint64_t usageInBytes = std::move(usageStatus).value();

--- a/src/common/memory/MemoryUtils.cpp
+++ b/src/common/memory/MemoryUtils.cpp
@@ -32,18 +32,22 @@ StatusOr<bool> MemoryUtils::hitsHighWatermark() {
   }
   double available = 0.0, total = 0.0;
   if (FLAGS_containerized) {
-    FileUtils::FileLineIterator iter("/sys/fs/cgroup/memory/memory.stat", &reTotalCache);
+    bool cgroupsv2 = FileUtils::exist("/sys/fs/cgroup/cgroup.controllers");
+    std::string statPath = cgroupsv2 ? "/sys/fs/cgroup/memory.stat" : "/sys/fs/cgroup/memory/memory.stat";
+    FileUtils::FileLineIterator iter(statPath, &reTotalCache);
     uint64_t cacheSize = 0;
     for (; iter.valid(); ++iter) {
       auto& sm = iter.matched();
       cacheSize += std::stoul(sm[2].str(), NULL);
     }
 
-    auto limitStatus = MemoryUtils::readSysContents("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+    std::string limitPath = cgroupsv2 ? "/sys/fs/cgroup/memory.max" : "/sys/fs/cgroup/memory/memory.limit_in_bytes";
+    auto limitStatus = MemoryUtils::readSysContents(limitPath);
     NG_RETURN_IF_ERROR(limitStatus);
     uint64_t limitInBytes = std::move(limitStatus).value();
 
-    auto usageStatus = MemoryUtils::readSysContents("/sys/fs/cgroup/memory/memory.usage_in_bytes");
+    std::string usagePath = cgroupsv2 ? "/sys/fs/cgroup/memory.current" : "/sys/fs/cgroup/memory/memory.usage_in_bytes";
+    auto usageStatus = MemoryUtils::readSysContents(usagePath);
     NG_RETURN_IF_ERROR(usageStatus);
     uint64_t usageInBytes = std::move(usageStatus).value();
 


### PR DESCRIPTION
#### What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

#### What does this PR do?
Fixes reading memory stats under cgroup v2.

#### Which issue(s)/PR(s) this PR relates to?

https://github.com/vesoft-inc/nebula/issues/3278
  
#### Special notes for your reviewer, ex. impact of this fix, etc:

memory.max return 'max' as string when no --memory flag provided to container on startup.
What should I do about it?

#### Additional context:


#### Checklist：
- [ ] Documentation affected （Please add the label if documentation needs to be modified.)
- [ ] Incompatible （If it is incompatible, please describe it and add corresponding label.）
- [ ] Need to cherry-pick （If need to cherry-pick to some branches, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes：
Please confirm whether to reflect in release notes and how to describe:
>                                                                 `
