### PR TITLE
[Raft] refactor processAppendLogRequest

### DIFF
--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -254,7 +254,7 @@ struct CheckpointInfo {
     3: binary                path,
 }
 
-// used for raft and drainer
+// used for drainer
 struct LogEntry {
     1: ClusterID cluster;
     2: binary log_str;

--- a/src/interface/raftex.thrift
+++ b/src/interface/raftex.thrift
@@ -46,6 +46,7 @@ enum ErrorCode {
     E_PERSIST_SNAPSHOT_FAILED = -13;
     E_RPC_EXCEPTION = -14;              // An thrift internal exception was thrown
     E_NO_WAL_FOUND = -15;
+    E_APPLY_FAIL = -16;
 }
 
 typedef i64 (cpp.type = "nebula::ClusterID") ClusterID

--- a/src/interface/raftex.thrift
+++ b/src/interface/raftex.thrift
@@ -47,6 +47,7 @@ enum ErrorCode {
     E_RPC_EXCEPTION = -14;              // An thrift internal exception was thrown
     E_NO_WAL_FOUND = -15;
     E_APPLY_FAIL = -16;
+    E_HOST_PAUSED = -17;
 }
 
 typedef i64 (cpp.type = "nebula::ClusterID") ClusterID

--- a/src/interface/raftex.thrift
+++ b/src/interface/raftex.thrift
@@ -74,6 +74,7 @@ struct AskForVoteRequest {
 // Response message for the vote call
 struct AskForVoteResponse {
     1: ErrorCode error_code;
+    2: TermID    current_term;
 }
 
 // Log entries being sent to follower, logId is not included, it could be calculated by

--- a/src/kvstore/Listener.cpp
+++ b/src/kvstore/Listener.cpp
@@ -220,7 +220,7 @@ void Listener::doApply() {
     }
 
     // apply to state machine
-    if (apply(data)) {
+    if (lastApplyId != -1 && apply(data)) {
       std::lock_guard<std::mutex> guard(raftLock_);
       lastApplyLogId_ = lastApplyId;
       persist(committedLogId_, term_, lastApplyLogId_);

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -85,7 +85,7 @@ using RaftClient = thrift::ThriftClientManager<raftex::cpp2::RaftexServiceAsyncC
  *
  *   // extra cleanup work, will be invoked when listener is about to be removed,
  *   // or raft is reset
- *   virtual void cleanup() = 0
+ *   nebula::cpp2::ErrorCode cleanup() = 0
  */
 class Listener : public raftex::RaftPart {
  public:
@@ -111,11 +111,12 @@ class Listener : public raftex::RaftPart {
     return lastApplyLogId_;
   }
 
-  void cleanup() override {
+  nebula::cpp2::ErrorCode cleanup() override {
     CHECK(!raftLock_.try_lock());
     leaderCommitId_ = 0;
     lastApplyLogId_ = 0;
     persist(0, 0, lastApplyLogId_);
+    return nebula::cpp2::ErrorCode::SUCCEEDED;
   }
 
   void resetListener();

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -51,7 +51,8 @@ using RaftClient = thrift::ThriftClientManager<raftex::cpp2::RaftexServiceAsyncC
  *
  *   // For listener, we just return true directly. Another background thread trigger the actual
  *   // apply work, and do it in worker thread, and update lastApplyLogId_
- *   cpp2::Errorcode commitLogs(std::unique_ptr<LogIterator> iter, bool)
+ *   std::tuple<nebula::cpp2::ErrorCode, LogID, TermID>
+ *   commitLogs(std::unique_ptr<LogIterator> iter, bool)
  *
  *   // For most of the listeners, just return true is enough. However, if listener need to be
  *   // aware of membership change, some log type of wal need to be pre-processed, could do it
@@ -158,7 +159,8 @@ class Listener : public raftex::RaftPart {
 
   // For listener, we just return true directly. Another background thread trigger the actual
   // apply work, and do it in worker thread, and update lastApplyLogId_
-  cpp2::ErrorCode commitLogs(std::unique_ptr<LogIterator>, bool) override;
+  std::tuple<nebula::cpp2::ErrorCode, LogID, TermID> commitLogs(std::unique_ptr<LogIterator>,
+                                                                bool) override;
 
   // For most of the listeners, just return true is enough. However, if listener need to be aware
   // of membership change, some log type of wal need to be pre-processed, could do it here.

--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -96,7 +96,8 @@ class Part : public raftex::RaftPart {
 
   void onDiscoverNewLeader(HostAddr nLeader) override;
 
-  cpp2::ErrorCode commitLogs(std::unique_ptr<LogIterator> iter, bool wait) override;
+  std::tuple<nebula::cpp2::ErrorCode, LogID, TermID> commitLogs(std::unique_ptr<LogIterator> iter,
+                                                                bool wait) override;
 
   bool preProcessLog(LogID logId,
                      TermID termId,

--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -113,7 +113,7 @@ class Part : public raftex::RaftPart {
                                        LogID committedLogId,
                                        TermID committedLogTerm);
 
-  void cleanup() override;
+  nebula::cpp2::ErrorCode cleanup() override;
 
   nebula::cpp2::ErrorCode toResultCode(raftex::AppendLogResult res);
 

--- a/src/kvstore/raftex/CMakeLists.txt
+++ b/src/kvstore/raftex/CMakeLists.txt
@@ -1,5 +1,6 @@
 nebula_add_library(
     raftex_obj OBJECT
+    RaftLogIterator.cpp
     RaftPart.cpp
     RaftexService.cpp
     Host.cpp

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -100,6 +100,8 @@ class Host final : public std::enable_shared_from_this<Host> {
 
   ErrorOr<cpp2::ErrorCode, std::shared_ptr<cpp2::AppendLogRequest>> prepareAppendLogRequest();
 
+  cpp2::ErrorCode startSendSnapshot();
+
   bool noRequest() const;
 
   void setResponse(const cpp2::AppendLogResponse& r);

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -79,7 +79,6 @@ class Host final : public std::enable_shared_from_this<Host> {
 
   folly::Future<cpp2::HeartbeatResponse> sendHeartbeat(folly::EventBase* eb,
                                                        TermID term,
-                                                       LogID latestLogId,
                                                        LogID commitLogId,
                                                        TermID lastLogTerm,
                                                        LogID lastLogId);

--- a/src/kvstore/raftex/RaftLogIterator.cpp
+++ b/src/kvstore/raftex/RaftLogIterator.cpp
@@ -19,7 +19,9 @@ RaftLogIterator& RaftLogIterator::operator++() {
   return *this;
 }
 
-bool RaftLogIterator::valid() const { return idx_ < logEntries_.size(); }
+bool RaftLogIterator::valid() const {
+  return idx_ < logEntries_.size();
+}
 
 LogID RaftLogIterator::logId() const {
   DCHECK(valid());

--- a/src/kvstore/raftex/RaftLogIterator.cpp
+++ b/src/kvstore/raftex/RaftLogIterator.cpp
@@ -1,0 +1,45 @@
+/* Copyright (c) 2018 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+#include "kvstore/raftex/RaftLogIterator.h"
+
+#include "common/base/Base.h"
+#include "common/thrift/ThriftTypes.h"
+
+namespace nebula {
+namespace raftex {
+
+RaftLogIterator::RaftLogIterator(LogID firstLogId, std::vector<cpp2::RaftLogEntry> logEntries)
+    : idx_(0), firstLogId_(firstLogId), logEntries_(std::move(logEntries)) {}
+
+RaftLogIterator& RaftLogIterator::operator++() {
+  ++idx_;
+  return *this;
+}
+
+bool RaftLogIterator::valid() const { return idx_ < logEntries_.size(); }
+
+LogID RaftLogIterator::logId() const {
+  DCHECK(valid());
+  return firstLogId_ + idx_;
+}
+
+TermID RaftLogIterator::logTerm() const {
+  DCHECK(valid());
+  return logEntries_.at(idx_).get_log_term();
+}
+
+ClusterID RaftLogIterator::logSource() const {
+  DCHECK(valid());
+  return logEntries_.at(idx_).get_cluster();
+}
+
+folly::StringPiece RaftLogIterator::logMsg() const {
+  DCHECK(valid());
+  return logEntries_.at(idx_).get_log_str();
+}
+
+}  // namespace raftex
+}  // namespace nebula

--- a/src/kvstore/raftex/RaftLogIterator.h
+++ b/src/kvstore/raftex/RaftLogIterator.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2021 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+#pragma once
+
+#include "common/base/Base.h"
+#include "common/utils/LogIterator.h"
+#include "interface/gen-cpp2/raftex_types.h"
+
+namespace nebula {
+namespace raftex {
+
+class RaftLogIterator final : public LogIterator {
+ public:
+  RaftLogIterator(LogID firstLogId, std::vector<cpp2::RaftLogEntry> logEntries);
+
+  RaftLogIterator& operator++() override;
+
+  bool valid() const override;
+
+  LogID logId() const override;
+
+  TermID logTerm() const override;
+
+  ClusterID logSource() const override;
+
+  folly::StringPiece logMsg() const override;
+
+ private:
+  size_t idx_;
+  const LogID firstLogId_;
+  std::vector<cpp2::RaftLogEntry> logEntries_;
+};
+
+}  // namespace raftex
+}  // namespace nebula

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -305,7 +305,7 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
                                                      bool finished) = 0;
 
   // Clean up extra data about the part, usually related to state machine
-  virtual void cleanup() = 0;
+  virtual nebula::cpp2::ErrorCode cleanup() = 0;
 
   void addPeer(const HostAddr& peer);
 

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -550,7 +550,7 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
 
   // To record how long ago when the last leader message received
   time::Duration lastMsgRecvDur_;
-  // To record how long ago when the last log message or heartbeat was sent
+  // To record how long ago when the last log message was sent
   time::Duration lastMsgSentDur_;
   // To record when the last message was accepted by majority peers
   uint64_t lastMsgAcceptedTime_{0};

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -286,9 +286,12 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
   // Check if we can accept candidate's message
   virtual cpp2::ErrorCode checkPeer(const HostAddr& candidate);
 
-  // The inherited classes need to implement this method to commit
-  // a batch of log messages
-  virtual nebula::cpp2::ErrorCode commitLogs(std::unique_ptr<LogIterator> iter, bool wait) = 0;
+  // The inherited classes need to implement this method to commit a batch of log messages.
+  // Return {error code, last commit log id, last commit log term}.
+  // When no logs applied to state machine or error occurs when calling commitLogs,
+  // kNoCommitLogId and kNoCommitLogTerm are returned.
+  virtual std::tuple<nebula::cpp2::ErrorCode, LogID, TermID> commitLogs(
+      std::unique_ptr<LogIterator> iter, bool wait) = 0;
 
   virtual bool preProcessLog(LogID logId,
                              TermID termId,
@@ -533,11 +536,17 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
   // To prevent we have voted more than once in a same term
   TermID votedTerm_{0};
 
-  // The id and term of the last-sent log
+  // As for leader lastLogId_ is the log id which has been replicated to majority peers.
+  // As for follower lastLogId_ is only a latest log id from current leader or any leader of
+  // previous term. Not all logs before lastLogId_ could be applied for follower.
   LogID lastLogId_{0};
   TermID lastLogTerm_{0};
-  // The id for the last globally committed log (from the leader)
+
+  // The last id and term when logs has been applied to state machine
   LogID committedLogId_{0};
+  TermID committedLogTerm_{0};
+  static constexpr LogID kNoCommitLogId{-1};
+  static constexpr TermID kNoCommitLogTerm{-1};
 
   // To record how long ago when the last leader message received
   time::Duration lastMsgRecvDur_;

--- a/src/kvstore/raftex/test/TestShard.cpp
+++ b/src/kvstore/raftex/test/TestShard.cpp
@@ -236,10 +236,11 @@ std::pair<int64_t, int64_t> TestShard::commitSnapshot(const std::vector<std::str
   return std::make_pair(count, size);
 }
 
-void TestShard::cleanup() {
+nebula::cpp2::ErrorCode TestShard::cleanup() {
   folly::RWSpinLock::WriteHolder wh(&lock_);
   data_.clear();
   lastCommittedLogId_ = 0;
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
 size_t TestShard::getNumLogs() const {

--- a/src/kvstore/raftex/test/TestShard.h
+++ b/src/kvstore/raftex/test/TestShard.h
@@ -121,7 +121,7 @@ class TestShard : public RaftPart {
                                              TermID committedLogTerm,
                                              bool finished) override;
 
-  void cleanup() override;
+  nebula::cpp2::ErrorCode cleanup() override;
 
   size_t getNumLogs() const;
   bool getLogMsg(size_t index, folly::StringPiece& msg);

--- a/src/kvstore/raftex/test/TestShard.h
+++ b/src/kvstore/raftex/test/TestShard.h
@@ -78,7 +78,8 @@ class TestShard : public RaftPart {
   void onLeaderReady(TermID term) override;
   void onDiscoverNewLeader(HostAddr) override {}
 
-  nebula::cpp2::ErrorCode commitLogs(std::unique_ptr<LogIterator> iter, bool wait) override;
+  std::tuple<nebula::cpp2::ErrorCode, LogID, TermID> commitLogs(std::unique_ptr<LogIterator> iter,
+                                                                bool wait) override;
 
   bool preProcessLog(LogID, TermID, ClusterID, const std::string& log) override {
     if (!log.empty()) {

--- a/src/kvstore/test/NebulaListenerTest.cpp
+++ b/src/kvstore/test/NebulaListenerTest.cpp
@@ -107,11 +107,12 @@ class DummyListener : public Listener {
     return lastApplyLogId_;
   }
 
-  void cleanup() override {
+  nebula::cpp2::ErrorCode cleanup() override {
     data_.clear();
     leaderCommitId_ = 0;
     lastApplyLogId_ = 0;
     snapshotBatchCount_ = 0;
+    return nebula::cpp2::ErrorCode::SUCCEEDED;
   }
 
  private:

--- a/src/kvstore/wal/WalFileIterator.cpp
+++ b/src/kvstore/wal/WalFileIterator.cpp
@@ -171,7 +171,9 @@ LogIterator& WalFileIterator::operator++() {
   return *this;
 }
 
-bool WalFileIterator::valid() const { return !eof_ && currId_ <= lastId_; }
+bool WalFileIterator::valid() const {
+  return !eof_ && currId_ <= lastId_;
+}
 
 LogID WalFileIterator::logId() const {
   return currId_;

--- a/src/kvstore/wal/WalFileIterator.cpp
+++ b/src/kvstore/wal/WalFileIterator.cpp
@@ -13,13 +13,7 @@ namespace nebula {
 namespace wal {
 
 WalFileIterator::WalFileIterator(std::shared_ptr<FileBasedWal> wal, LogID startId, LogID lastId)
-    : wal_(wal), currId_(startId) {
-  if (lastId >= 0 && lastId <= wal_->lastLogId()) {
-    lastId_ = lastId;
-  } else {
-    lastId_ = wal_->lastLogId();
-  }
-
+    : wal_(wal), lastId_(lastId), currId_(startId) {
   if (currId_ > lastId_) {
     LOG(ERROR) << wal_->idStr_ << "The log " << currId_ << " is out of range, the lastLogId is "
                << lastId_;
@@ -60,11 +54,11 @@ WalFileIterator::WalFileIterator(std::shared_ptr<FileBasedWal> wal, LogID startI
   }
 
   nextFirstId_ = getFirstIdInNextFile();
+  // log in range [startId, lastId] is located in last wal, however, the wal is rollbacked during
+  // building the iterator
   if (currId_ > idRanges_.front().second) {
-    LOG(FATAL) << wal_->idStr_ << "currId_ " << currId_ << ", idRanges.front firstLogId "
-               << idRanges_.front().first << ", idRanges.front lastLogId "
-               << idRanges_.front().second << ", idRanges size " << idRanges_.size() << ", lastId_ "
-               << lastId_ << ", nextFirstId_ " << nextFirstId_;
+    currId_ = lastId_ + 1;
+    return;
   }
 
   if (!idRanges_.empty()) {
@@ -74,18 +68,27 @@ WalFileIterator::WalFileIterator(std::shared_ptr<FileBasedWal> wal, LogID startI
       LogID logId;
       // Read the logID
       int fd = fds_.front();
-      CHECK_EQ(pread(fd, reinterpret_cast<char*>(&logId), sizeof(LogID), currPos_),
-               static_cast<ssize_t>(sizeof(LogID)));
+      if (pread(fd, reinterpret_cast<char*>(&logId), sizeof(LogID), currPos_) !=
+          static_cast<ssize_t>(sizeof(LogID))) {
+        eof_ = true;
+        break;
+      }
       // Read the termID
-      CHECK_EQ(
-          pread(fd, reinterpret_cast<char*>(&currTerm_), sizeof(TermID), currPos_ + sizeof(LogID)),
-          static_cast<ssize_t>(sizeof(TermID)));
+      if (pread(
+              fd, reinterpret_cast<char*>(&currTerm_), sizeof(TermID), currPos_ + sizeof(LogID)) !=
+          static_cast<ssize_t>(sizeof(TermID))) {
+        eof_ = true;
+        break;
+      }
       // Read the log length
-      CHECK_EQ(pread(fd,
-                     reinterpret_cast<char*>(&currMsgLen_),
-                     sizeof(int32_t),
-                     currPos_ + sizeof(LogID) + sizeof(TermID)),
-               static_cast<ssize_t>(sizeof(int32_t)));
+      if (pread(fd,
+                reinterpret_cast<char*>(&currMsgLen_),
+                sizeof(int32_t),
+                currPos_ + sizeof(LogID) + sizeof(TermID)) !=
+          static_cast<ssize_t>(sizeof(int32_t))) {
+        eof_ = true;
+        break;
+      }
       if (logId == currId_) {
         break;
       }
@@ -135,29 +138,40 @@ LogIterator& WalFileIterator::operator++() {
   } else {
     LogID logId;
     int fd = fds_.front();
-    // Read the logID
-    CHECK_EQ(pread(fd, reinterpret_cast<char*>(&logId), sizeof(LogID), currPos_),
-             static_cast<ssize_t>(sizeof(LogID)))
-        << "currPos = " << currPos_;
-    CHECK_EQ(currId_, logId);
-    // Read the termID
-    CHECK_EQ(
-        pread(fd, reinterpret_cast<char*>(&currTerm_), sizeof(TermID), currPos_ + sizeof(LogID)),
-        static_cast<ssize_t>(sizeof(TermID)));
-    // Read the log length
-    CHECK_EQ(pread(fd,
-                   reinterpret_cast<char*>(&currMsgLen_),
-                   sizeof(int32_t),
-                   currPos_ + sizeof(TermID) + sizeof(LogID)),
-             static_cast<ssize_t>(sizeof(int32_t)));
+    do {
+      // Read the logID
+      if (pread(fd, reinterpret_cast<char*>(&logId), sizeof(LogID), currPos_) !=
+          static_cast<ssize_t>(sizeof(LogID))) {
+        LOG(WARNING) << "Failed to read logId currPos = " << currPos_;
+        eof_ = true;
+        break;
+      }
+      CHECK_EQ(currId_, logId);
+      // Read the termID
+      if (pread(
+              fd, reinterpret_cast<char*>(&currTerm_), sizeof(TermID), currPos_ + sizeof(LogID)) !=
+          static_cast<ssize_t>(sizeof(TermID))) {
+        LOG(WARNING) << "Failed to read term currPos = " << currPos_;
+        eof_ = true;
+        break;
+      }
+      // Read the log length
+      if (pread(fd,
+                reinterpret_cast<char*>(&currMsgLen_),
+                sizeof(int32_t),
+                currPos_ + sizeof(TermID) + sizeof(LogID)) !=
+          static_cast<ssize_t>(sizeof(int32_t))) {
+        LOG(WARNING) << "Failed to read log length currPos = " << currPos_;
+        eof_ = true;
+        break;
+      }
+    } while (false);
   }
 
   return *this;
 }
 
-bool WalFileIterator::valid() const {
-  return currId_ <= lastId_;
-}
+bool WalFileIterator::valid() const { return !eof_ && currId_ <= lastId_; }
 
 LogID WalFileIterator::logId() const {
   return currId_;

--- a/src/kvstore/wal/WalFileIterator.h
+++ b/src/kvstore/wal/WalFileIterator.h
@@ -45,6 +45,8 @@ class WalFileIterator final : public LogIterator {
   LogID currId_;
   TermID currTerm_;
 
+  // When there are more wals, nextFirstId_ is the firstLogId in next wal.
+  // When there are not more wals, nextFirstId_ is the current wal's lastLogId + 1
   LogID nextFirstId_;
 
   // [firstId, lastId]
@@ -52,6 +54,8 @@ class WalFileIterator final : public LogIterator {
   std::list<int> fds_;
   int64_t currPos_{0};
   int32_t currMsgLen_{0};
+  // Whether we have encounter end of wal file during building iterator or iterating
+  bool eof_{false};
   mutable std::string currLog_;
 };
 


### PR DESCRIPTION
Change notes:

1. Main change is in  `processAppendLogRequest`

    A brief flow as follows (not exactly same in code):
    ![processAppendLogRequest](https://user-images.githubusercontent.com/13706157/145192889-04dca9c4-c4dc-400a-911f-eb88ae6aab6f.png)

    To achieve this goal, some others need to be modified:
    * In AppendLogRequest, we need to carry each log's term (which is missing previously), so as a proper iterator.
    * For similarity, we need to return `committedLogId` and `committedLogTerm` in resp. But committedLogTerm is missing previously, so I add one.

2. We need to make sure `lastLogId_ == wal_->lastLogId()` in almost every case (except leader is replicating), we did this by calling `wal_->rollbackToLog`, since we handle `AppendLog` correctly, we don't need to rollback anymore, just set `lastLogId_ = wal_->lastLogId()` is enough.
3. All request and resp should carry the term, step down as follower when a higher term found, otherwise we may failed to elect a leader.
4. micor changes: make `RaftPart::cleanup` atomic

