### PR TITLE
Fix the latency type in the executionResponse

### DIFF
--- a/src/common/graph/ExecutionResponseOps-inl.h
+++ b/src/common/graph/ExecutionResponseOps-inl.h
@@ -34,10 +34,10 @@ struct TccStructTraits<::nebula::ExecutionResponse> {
     if (false) {
     } else if (_fname == "error_code") {
       fid = 1;
-      _ftype = apache::thrift::protocol::T_I64;
+      _ftype = apache::thrift::protocol::T_I32;
     } else if (_fname == "latency_in_us") {
       fid = 2;
-      _ftype = apache::thrift::protocol::T_I32;
+      _ftype = apache::thrift::protocol::T_I64;
     } else if (_fname == "data") {
       fid = 3;
       _ftype = apache::thrift::protocol::T_STRUCT;

--- a/src/common/graph/ExecutionResponseOps-inl.h
+++ b/src/common/graph/ExecutionResponseOps-inl.h
@@ -34,7 +34,7 @@ struct TccStructTraits<::nebula::ExecutionResponse> {
     if (false) {
     } else if (_fname == "error_code") {
       fid = 1;
-      _ftype = apache::thrift::protocol::T_I32;
+      _ftype = apache::thrift::protocol::T_I64;
     } else if (_fname == "latency_in_us") {
       fid = 2;
       _ftype = apache::thrift::protocol::T_I32;
@@ -75,7 +75,7 @@ uint32_t Cpp2Ops<::nebula::ExecutionResponse>::write(Protocol* proto,
                                                      ::nebula::ErrorCode>::write(*proto,
                                                                                  obj->errorCode);
   xfer += proto->writeFieldEnd();
-  xfer += proto->writeFieldBegin("latency_in_us", apache::thrift::protocol::T_I32, 2);
+  xfer += proto->writeFieldBegin("latency_in_us", apache::thrift::protocol::T_I64, 2);
   xfer += ::apache::thrift::detail::pm::protocol_methods<::apache::thrift::type_class::integral,
                                                          int32_t>::write(*proto, obj->latencyInUs);
   xfer += proto->writeFieldEnd();
@@ -134,7 +134,7 @@ _readField_error_code : {
   }
 _readField_latency_in_us : {
   ::apache::thrift::detail::pm::protocol_methods<::apache::thrift::type_class::integral,
-                                                 int32_t>::read(*proto, obj->latencyInUs);
+                                                 int64_t>::read(*proto, obj->latencyInUs);
   isset_latency_in_us = true;
 }
 
@@ -216,7 +216,7 @@ _loop:
       }
     }
     case 2: {
-      if (LIKELY(_readState.fieldType == apache::thrift::protocol::T_I32)) {
+      if (LIKELY(_readState.fieldType == apache::thrift::protocol::T_I64)) {
         goto _readField_latency_in_us;
       } else {
         goto _skip;
@@ -276,7 +276,7 @@ uint32_t Cpp2Ops<::nebula::ExecutionResponse>::serializedSize(
   xfer += ::apache::thrift::detail::pm::protocol_methods<
       ::apache::thrift::type_class::enumeration,
       ::nebula::ErrorCode>::serializedSize<false>(*proto, obj->errorCode);
-  xfer += proto->serializedFieldSize("latency_in_us", apache::thrift::protocol::T_I32, 2);
+  xfer += proto->serializedFieldSize("latency_in_us", apache::thrift::protocol::T_I64, 2);
   xfer += ::apache::thrift::detail::pm::
       protocol_methods<::apache::thrift::type_class::integral, int32_t>::serializedSize<false>(
           *proto, obj->latencyInUs);
@@ -314,7 +314,7 @@ uint32_t Cpp2Ops<::nebula::ExecutionResponse>::serializedSizeZC(
   xfer += ::apache::thrift::detail::pm::protocol_methods<
       ::apache::thrift::type_class::enumeration,
       ::nebula::ErrorCode>::serializedSize<false>(*proto, obj->errorCode);
-  xfer += proto->serializedFieldSize("latency_in_us", apache::thrift::protocol::T_I32, 2);
+  xfer += proto->serializedFieldSize("latency_in_us", apache::thrift::protocol::T_I64, 2);
   xfer += ::apache::thrift::detail::pm::
       protocol_methods<::apache::thrift::type_class::integral, int32_t>::serializedSize<false>(
           *proto, obj->latencyInUs);

--- a/src/common/graph/ExecutionResponseOps-inl.h
+++ b/src/common/graph/ExecutionResponseOps-inl.h
@@ -77,7 +77,7 @@ uint32_t Cpp2Ops<::nebula::ExecutionResponse>::write(Protocol* proto,
   xfer += proto->writeFieldEnd();
   xfer += proto->writeFieldBegin("latency_in_us", apache::thrift::protocol::T_I64, 2);
   xfer += ::apache::thrift::detail::pm::protocol_methods<::apache::thrift::type_class::integral,
-                                                         int32_t>::write(*proto, obj->latencyInUs);
+                                                         int64_t>::write(*proto, obj->latencyInUs);
   xfer += proto->writeFieldEnd();
   if (obj->data != nullptr) {
     xfer += proto->writeFieldBegin("data", apache::thrift::protocol::T_STRUCT, 3);
@@ -278,7 +278,7 @@ uint32_t Cpp2Ops<::nebula::ExecutionResponse>::serializedSize(
       ::nebula::ErrorCode>::serializedSize<false>(*proto, obj->errorCode);
   xfer += proto->serializedFieldSize("latency_in_us", apache::thrift::protocol::T_I64, 2);
   xfer += ::apache::thrift::detail::pm::
-      protocol_methods<::apache::thrift::type_class::integral, int32_t>::serializedSize<false>(
+      protocol_methods<::apache::thrift::type_class::integral, int64_t>::serializedSize<false>(
           *proto, obj->latencyInUs);
   if (obj->data != nullptr) {
     xfer += proto->serializedFieldSize("data", apache::thrift::protocol::T_STRUCT, 3);
@@ -316,7 +316,7 @@ uint32_t Cpp2Ops<::nebula::ExecutionResponse>::serializedSizeZC(
       ::nebula::ErrorCode>::serializedSize<false>(*proto, obj->errorCode);
   xfer += proto->serializedFieldSize("latency_in_us", apache::thrift::protocol::T_I64, 2);
   xfer += ::apache::thrift::detail::pm::
-      protocol_methods<::apache::thrift::type_class::integral, int32_t>::serializedSize<false>(
+      protocol_methods<::apache::thrift::type_class::integral, int64_t>::serializedSize<false>(
           *proto, obj->latencyInUs);
   if (obj->data != nullptr) {
     xfer += proto->serializedFieldSize("data", apache::thrift::protocol::T_STRUCT, 3);

--- a/src/common/graph/Response.h
+++ b/src/common/graph/Response.h
@@ -468,7 +468,7 @@ struct ExecutionResponse {
   }
 
   ErrorCode errorCode{ErrorCode::SUCCEEDED};
-  int32_t latencyInUs{0};
+  int64_t latencyInUs{0};
   std::unique_ptr<nebula::DataSet> data{nullptr};
   std::unique_ptr<std::string> spaceName{nullptr};
   std::unique_ptr<std::string> errorMsg{nullptr};

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -39,7 +39,7 @@ struct ResponseCommon {
     // Only contains the partition that returns error
     1: required list<PartitionResult>   failed_parts,
     // Query latency from storage service
-    2: required i32                     latency_in_us,
+    2: required i64                     latency_in_us,
     3: optional map<string,i32>         latency_detail_us,
 }
 


### PR DESCRIPTION
#### What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

#### What does this PR do?
Fix the latency type in the `executionResponse`. The inconsistent datatype of latency between the definition in `thrift` file and `Response.h` causes client transport `invalid data length`error.

#### Which issue(s)/PR(s) this PR relates to?
This PR https://github.com/vesoft-inc/nebula/pull/2858 only modified the `latency` in the `thrift` file but left other definitions behind.
  
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context:


#### Checklist：
- [ ] Documentation affected （Please add the label if documentation needs to be modified.)
- [ ] Incompatible （If it is incompatible, please describe it and add corresponding label.）
- [ ] Need to cherry-pick （If need to cherry-pick to some branches, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes：
Please confirm whether to reflect in release notes and how to describe:
>                                                                 `
