### PR TITLE
Schema support mixed Chinese and English

### DIFF
--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -213,7 +213,7 @@ static constexpr size_t kCommentLengthLimit = 256;
 %token <boolval> BOOL
 %token <intval> INTEGER
 %token <doubleval> DOUBLE
-%token <strval> STRING VARIABLE LABEL IPV4 CHINESE_LABEL
+%token <strval> STRING VARIABLE LABEL IPV4 UTF8_LABEL
 
 %type <strval> name_label unreserved_keyword predicate_name
 %type <expr> expression
@@ -406,7 +406,7 @@ static constexpr size_t kCommentLengthLimit = 256;
 
 name_label
     : LABEL { $$ = $1; }
-    | CHINESE_LABEL { $$ = $1; }
+    | UTF8_LABEL { $$ = $1; }
     | unreserved_keyword { $$ = $1; }
     ;
 

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -213,7 +213,7 @@ static constexpr size_t kCommentLengthLimit = 256;
 %token <boolval> BOOL
 %token <intval> INTEGER
 %token <doubleval> DOUBLE
-%token <strval> STRING VARIABLE LABEL IPV4 UTF8_LABEL
+%token <strval> STRING VARIABLE LABEL IPV4
 
 %type <strval> name_label unreserved_keyword predicate_name
 %type <expr> expression
@@ -406,7 +406,6 @@ static constexpr size_t kCommentLengthLimit = 256;
 
 name_label
     : LABEL { $$ = $1; }
-    | UTF8_LABEL { $$ = $1; }
     | unreserved_keyword { $$ = $1; }
     ;
 

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -47,7 +47,10 @@ U                           [\x80-\xbf]
 U2                          [\xc2-\xdf]
 U3                          [\xe0-\xef]
 U4                          [\xf0-\xf4]
-CHINESE_LABEL               ({U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U})+
+CHINESE                     {U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U}
+CN_EN                       {CHINESE}|[a-zA-Z]
+CN_EN_NUM                   {CHINESE}|[_a-zA-Z0-9]
+UTF8_LABEL                  {CN_EN}{CN_EN_NUM}+
 
 %%
 
@@ -471,7 +474,7 @@ CHINESE_LABEL               ({U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U})+
                                 // Must match /* */
                                 throw GraphParser::syntax_error(*yylloc, "unterminated comment");
                             }
-\`{CHINESE_LABEL}\`         {
+\`{UTF8_LABEL}\`            {
                                 yylval->strval = new std::string(yytext + 1, yyleng - 2);
                                 if (yylval->strval->size() > MAX_STRING) {
                                     auto error = "Out of range of the LABEL length, "
@@ -480,7 +483,7 @@ CHINESE_LABEL               ({U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U})+
                                     delete yylval->strval;
                                     throw GraphParser::syntax_error(*yylloc, error);
                                 }
-                                return TokenType::CHINESE_LABEL;
+                                return TokenType::UTF8_LABEL;
                             }
 .                           {
                                 /**

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -36,7 +36,6 @@ IS_NOT_NULL                 (IS{blanks}NOT{blanks}NULL)
 IS_EMPTY                    (IS{blanks}EMPTY)
 IS_NOT_EMPTY                (IS{blanks}NOT{blanks}EMPTY)
 
-LABEL                       ([a-zA-Z][_a-zA-Z0-9]*)
 DEC                         ([0-9])
 EXP                         ([eE][-+]?[0-9]+)
 HEX                         ([0-9a-fA-F])
@@ -50,7 +49,7 @@ U4                          [\xf0-\xf4]
 CHINESE                     {U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U}
 CN_EN                       {CHINESE}|[a-zA-Z]
 CN_EN_NUM                   {CHINESE}|[_a-zA-Z0-9]
-UTF8_LABEL                  {CN_EN}{CN_EN_NUM}+
+LABEL                       {CN_EN}{CN_EN_NUM}*      
 
 %%
 
@@ -473,17 +472,6 @@ UTF8_LABEL                  {CN_EN}{CN_EN_NUM}+
 <COMMENT><<EOF>>            {
                                 // Must match /* */
                                 throw GraphParser::syntax_error(*yylloc, "unterminated comment");
-                            }
-\`{UTF8_LABEL}\`            {
-                                yylval->strval = new std::string(yytext + 1, yyleng - 2);
-                                if (yylval->strval->size() > MAX_STRING) {
-                                    auto error = "Out of range of the LABEL length, "
-                                                  "the  max length of LABEL is " +
-                                                  std::to_string(MAX_STRING) + ":";
-                                    delete yylval->strval;
-                                    throw GraphParser::syntax_error(*yylloc, error);
-                                }
-                                return TokenType::UTF8_LABEL;
                             }
 .                           {
                                 /**

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -44,12 +44,18 @@ IP_OCTET                    ([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])
 
 U                           [\x80-\xbf]
 U2                          [\xc2-\xdf]
-U3                          [\xe0-\xef]
+U3                          [\xe0-\xee]
 U4                          [\xf0-\xf4]
 CHINESE                     {U2}{U}|{U3}{U}{U}|{U4}{U}{U}{U}
 CN_EN                       {CHINESE}|[a-zA-Z]
 CN_EN_NUM                   {CHINESE}|[_a-zA-Z0-9]
-LABEL                       {CN_EN}{CN_EN_NUM}*      
+LABEL                       {CN_EN}{CN_EN_NUM}*
+
+U3_FULL_WIDTH               [\xe0-\xef]
+CHINESE_FULL_WIDTH          {U2}{U}|{U3_FULL_WIDTH}{U}{U}|{U4}{U}{U}{U}
+CN_EN_FULL_WIDTH            {CHINESE_FULL_WIDTH}|[a-zA-Z]
+CN_EN_NUM_FULL_WIDTH        {CHINESE_FULL_WIDTH}|[_a-zA-Z0-9 ]
+LABEL_FULL_WIDTH            {CN_EN_FULL_WIDTH}{CN_EN_NUM_FULL_WIDTH}*
 
 %%
 
@@ -472,6 +478,17 @@ LABEL                       {CN_EN}{CN_EN_NUM}*
 <COMMENT><<EOF>>            {
                                 // Must match /* */
                                 throw GraphParser::syntax_error(*yylloc, "unterminated comment");
+                            }
+\`{LABEL_FULL_WIDTH}\`      {
+                                yylval->strval = new std::string(yytext + 1, yyleng - 2);
+                                if (yylval->strval->size() > MAX_STRING) {
+                                    auto error = "Out of range of the LABEL length, "
+                                                  "the  max length of LABEL is " +
+                                                  std::to_string(MAX_STRING) + ":";
+                                    delete yylval->strval;
+                                    throw GraphParser::syntax_error(*yylloc, error);
+                                }
+                                return TokenType::LABEL;
                             }
 .                           {
                                 /**

--- a/tests/tck/features/schema/Schema.feature
+++ b/tests/tck/features/schema/Schema.feature
@@ -834,6 +834,19 @@ Feature: Insert string vid of vertex and edge
       | "时间" | "timestamp" | "YES" | EMPTY   | EMPTY   |
     When executing query:
       """
+      CREATE TAG `队伍s2`(`名s字ss1` string);
+      """
+    Then the execution should be successful
+    # desc cn-en mixed tag
+    When executing query:
+      """
+      DESCRIBE TAG `队伍s2`
+      """
+    Then the result should be, in any order:
+      | Field      | Type     | Null  | Default | Comment |
+      | "名s字ss1" | "string" | "YES" | EMPTY   | EMPTY   |
+    When executing query:
+      """
       DROP SPACE issue2009;
       """
     Then the execution should be successful

--- a/tests/tck/features/schema/Schema.feature
+++ b/tests/tck/features/schema/Schema.feature
@@ -772,9 +772,9 @@ Feature: Insert string vid of vertex and edge
     # chinese tag without quote mark
     When executing query:
       """
-      CREATE TAG 队伍( 名字 string);
+      CREATE TAG 队伍withoutQuote( 名字 string);
       """
-    Then a SyntaxError should be raised at runtime:
+    Then the execution should be successful
     # chinese tag and chinese prop
     When executing query:
       """
@@ -834,13 +834,13 @@ Feature: Insert string vid of vertex and edge
       | "时间" | "timestamp" | "YES" | EMPTY   | EMPTY   |
     When executing query:
       """
-      CREATE TAG `队伍s2`(`名s字ss1` string);
+      CREATE TAG `队伍 s2；`(`名s字ss1` string);
       """
     Then the execution should be successful
     # desc cn-en mixed tag
     When executing query:
       """
-      DESCRIBE TAG `队伍s2`
+      DESCRIBE TAG `队伍 s2；`
       """
     Then the result should be, in any order:
       | Field      | Type     | Null  | Default | Comment |


### PR DESCRIPTION
#### What type of PR is this?
- [ ] bug
- [x] feature
- [ ] enhancement

#### What does this PR do?
Schema support mixed Chinese and English
```
# Directly support utf-8 / English / Number
CREATE TAG  队伍(名s字ss1 string);

# Using backquote support UTF-8 / English / Number / Full-width Charactor / Blank
CREATE TAG `队   伍；`(`名s字ss1` string);
```

#### Which issue(s)/PR(s) this PR relates to?
close #3426 
  
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context:


#### Checklist：
- [x] Documentation affected （Please add the label if documentation needs to be modified.)
- [ ] Incompatible （If it is incompatible, please describe it and add corresponding label.）
- [ ] Need to cherry-pick （If need to cherry-pick to some branches, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes：
Please confirm whether to reflect in release notes and how to describe:
>                                                                 `
