### PR TITLE
fix unused variable

### DIFF
--- a/src/storage/exec/IndexScanNode.h
+++ b/src/storage/exec/IndexScanNode.h
@@ -258,7 +258,7 @@ class QualifiedStrategy {
     q.func_ = [suffixSet = Set<std::string>(),
                suffixLength = dedupSuffixLength](const folly::StringPiece& key) mutable -> Result {
       std::string suffix = key.subpiece(key.size() - suffixLength, suffixLength).toString();
-      auto [iter, result] = suffixSet.insert(std::move(suffix));
+      auto result = suffixSet.insert(std::move(suffix)).second;
       return result ? Result::COMPATIBLE : Result::INCOMPATIBLE;
     };
     return q;


### PR DESCRIPTION
#### What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

#### What does this PR do?
fix compilation error

[ 44%] Building CXX object src/graph/optimizer/CMakeFiles/optimizer_obj.dir/OptGroup.cpp.o
In file included from /home/eric.fang/nebula-ent/src/storage/exec/IndexEdgeScanNode.h:8:0,
                 from /home/eric.fang/nebula-ent/src/storage/index/LookupProcessor.cpp:15:
/home/eric.fang/nebula-ent/src/storage/exec/IndexScanNode.h: In lambda function:
/home/eric.fang/nebula-ent/src/storage/exec/IndexScanNode.h:261:25: error: unused variable 'iter' [-Werror=unused-variable]
       auto [iter, result] = suffixSet.insert(std::move(suffix));
                         ^
[ 45%] Building CXX object src/graph/executor/CMakeFiles/executor_obj.dir/query/DedupExecutor.cpp.o
[ 45%] Building CXX object src/storage/CMakeFiles/storage_admin_service_handler.dir/admin/RebuildEdgeIndexTask.cpp.o
cc1plus: all warnings being treated as errors
make[2]: *** [src/storage/CMakeFiles/graph_storage_service_handler.dir/index/LookupProcessor.cpp.o] 错误 1
make[1]: *** [src/storage/CMakeFiles/graph_storage_service_handler.dir/all] 错误 2
make[1]: *** 正在等待未完成的任务....

#### Which issue(s)/PR(s) this PR relates to?

  
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context:


#### Checklist：
- [ ] Documentation affected （Please add the label if documentation needs to be modified.)
- [ ] Incompatible （If it is incompatible, please describe it and add corresponding label.）
- [ ] Need to cherry-pick （If need to cherry-pick to some branches, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes：
Please confirm whether to reflect in release notes and how to describe:
>                                                                 `
