### PR TITLE
Fix flex warning about default rule

### DIFF
--- a/src/common/time/parser/datetime_scanner.lex
+++ b/src/common/time/parser/datetime_scanner.lex
@@ -1,6 +1,6 @@
 %option c++
 %option yyclass="DatetimeScanner"
-%option nodefault noyywrap
+%option noyywrap
 %option never-interactive
 %option yylineno
 %option case-sensitive


### PR DESCRIPTION
#### What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

#### What does this PR do?

Fixed the warning introduced by #3179 

reference: https://stackoverflow.com/questions/1622493/bison-build-warning-s-option-given-but-default-rule-can-be-matched