### PR TITLE
save client version

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -3554,6 +3554,7 @@ bool MetaClient::checkIsPlanKilled(SessionID sessionId, ExecutionPlanID planId) 
 
 Status MetaClient::verifyVersion() {
   auto req = cpp2::VerifyClientVersionReq();
+  req.set_build_version(getOriginVersion());
   req.set_host(options_.localHost_);
   folly::Promise<StatusOr<cpp2::VerifyClientVersionResp>> promise;
   auto future = promise.getFuture();

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -1123,8 +1123,9 @@ struct VerifyClientVersionResp {
 
 
 struct VerifyClientVersionReq {
-    1: required binary version = common.version;
+    1: required binary client_version = common.version;
     2: common.HostAddr host;
+    3: binary build_version;
 }
 
 service MetaService {

--- a/src/meta/processors/admin/VerifyClientVersionProcessor.cpp
+++ b/src/meta/processors/admin/VerifyClientVersionProcessor.cpp
@@ -18,16 +18,17 @@ void VerifyClientVersionProcessor::process(const cpp2::VerifyClientVersionReq& r
   std::unordered_set<std::string> whiteList;
   folly::splitTo<std::string>(
       ":", FLAGS_client_white_list, std::inserter(whiteList, whiteList.begin()));
-  if (FLAGS_enable_client_white_list && whiteList.find(req.get_version()) == whiteList.end()) {
+  if (FLAGS_enable_client_white_list &&
+      whiteList.find(req.get_client_version()) == whiteList.end()) {
     resp_.set_code(nebula::cpp2::ErrorCode::E_CLIENT_SERVER_INCOMPATIBLE);
     resp_.set_error_msg(folly::stringPrintf(
         "Meta client version(%s) is not accepted, current meta client white list: %s.",
-        req.get_version().c_str(),
+        req.get_client_version().c_str(),
         FLAGS_client_white_list.c_str()));
   } else {
-    auto host = req.get_host();
+    const auto& host = req.get_host();
     auto versionKey = MetaKeyUtils::versionKey(host);
-    auto versionVal = MetaKeyUtils::versionVal(req.get_version().c_str());
+    auto versionVal = MetaKeyUtils::versionVal(req.get_build_version().c_str());
     std::vector<kvstore::KV> versionData;
     versionData.emplace_back(std::move(versionKey), std::move(versionVal));
     doSyncPut(versionData);

--- a/src/meta/test/VerifyClientVersionTest.cpp
+++ b/src/meta/test/VerifyClientVersionTest.cpp
@@ -20,7 +20,8 @@ TEST(VerifyClientVersionTest, VersionTest) {
   std::unique_ptr<kvstore::KVStore> kv(MockCluster::initMetaKV(rootPath.path()));
   {
     auto req = cpp2::VerifyClientVersionReq();
-    req.set_version("1.0.1");
+    req.set_client_version("1.0.1");
+    req.set_build_version("1.0.1-nightly");
     auto* processor = VerifyClientVersionProcessor::instance(kv.get());
     auto f = processor->getFuture();
     processor->process(req);


### PR DESCRIPTION
#### What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

#### What does this PR do?
There are two versions here. 
One is the protocol version in thrift, which is used to verify compatibility through the whitelist; 
the other is the packaged version, which is tag or datetime-nightly.

+-------------+-------+----------+-----------+--------------+----------------+
 | Host               | Port     | Status      | Role            | Git Info Sha     | Version               |
+-------------+-------+----------+-----------+--------------+----------------+
 | "127.0.0.1"     | 21079 | "ONLINE" | "STORAGE" | "75f11121"    | "datetime-nightly" |
+-------------+-------+----------+-----------+--------------+----------------+

#### Which issue(s)/PR(s) this PR relates to?
closes #3479 
  
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context/ Design document:


#### Checklist:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the corresponding label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory

#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
>                                                                 `
