### PR TITLE
Add show local sessions command

### DIFF
--- a/src/graph/executor/admin/SessionExecutor.cpp
+++ b/src/graph/executor/admin/SessionExecutor.cpp
@@ -5,6 +5,7 @@
 
 #include "graph/executor/admin/SessionExecutor.h"
 
+#include "common/session/SessionManager.h"
 #include "graph/context/QueryContext.h"
 #include "graph/planner/plan/Admin.h"
 #include "interface/gen-cpp2/common_types.h"
@@ -18,9 +19,8 @@ folly::Future<Status> ShowSessionsExecutor::execute() {
   auto *showNode = asNode<ShowSessions>(node());
   if (showNode->isSetSessionID()) {
     return getSession(showNode->getSessionId());
-  } else {
-    return listSessions();
   }
+  return showNode->isLocalCommand() ? listLocalSessions() : listSessions();
 }
 
 folly::Future<Status> ShowSessionsExecutor::listSessions() {
@@ -31,6 +31,7 @@ folly::Future<Status> ShowSessionsExecutor::listSessions() {
           return Status::Error("Show sessions failed: %s.", resp.status().toString().c_str());
         }
         auto sessions = resp.value().get_sessions();
+        // Construct result column names
         DataSet result({"SessionId",
                         "UserName",
                         "SpaceName",
@@ -40,19 +41,26 @@ folly::Future<Status> ShowSessionsExecutor::listSessions() {
                         "Timezone",
                         "ClientIp"});
         for (auto &session : sessions) {
-          Row row;
-          row.emplace_back(session.get_session_id());
-          row.emplace_back(session.get_user_name());
-          row.emplace_back(session.get_space_name());
-          row.emplace_back(microSecToDateTime(session.get_create_time()));
-          row.emplace_back(microSecToDateTime(session.get_update_time()));
-          row.emplace_back(network::NetworkUtils::toHostsStr({session.get_graph_addr()}));
-          row.emplace_back(session.get_timezone());
-          row.emplace_back(session.get_client_ip());
-          result.emplace_back(std::move(row));
+          addSessions(session, result);
         }
         return finish(ResultBuilder().value(Value(std::move(result))).build());
       });
+}
+
+folly::Future<Status> ShowSessionsExecutor::listLocalSessions() {
+  auto localSessions = qctx_->rctx()->sessionMgr()->getSessionFromLocalCache();
+  DataSet result({"SessionId",
+                  "UserName",
+                  "SpaceName",
+                  "CreateTime",
+                  "UpdateTime",
+                  "GraphAddr",
+                  "Timezone",
+                  "ClientIp"});
+  for (auto &session : localSessions) {
+    addSessions(session, result);
+  }
+  return finish(ResultBuilder().value(Value(std::move(result))).build());
 }
 
 folly::Future<Status> ShowSessionsExecutor::getSession(SessionID sessionId) {
@@ -64,18 +72,32 @@ folly::Future<Status> ShowSessionsExecutor::getSession(SessionID sessionId) {
               "Get session `%ld' failed: %s.", sessionId, resp.status().toString().c_str());
         }
         auto session = resp.value().get_session();
-        DataSet result({"VariableName", "Value"});
-        result.emplace_back(Row({"SessionID", session.get_session_id()}));
-        result.emplace_back(Row({"UserName", session.get_user_name()}));
-        result.emplace_back(Row({"SpaceName", session.get_space_name()}));
-        result.emplace_back(Row({"CreateTime", microSecToDateTime(session.get_create_time())}));
-        result.emplace_back(Row({"UpdateTime", microSecToDateTime(session.get_update_time())}));
-        result.emplace_back(
-            Row({"GraphAddr", network::NetworkUtils::toHostsStr({session.get_graph_addr()})}));
-        result.emplace_back(Row({"Timezone", session.get_timezone()}));
-        result.emplace_back(Row({"ClientIp", session.get_client_ip()}));
+
+        // Construct result column names
+        DataSet result({"SessionId",
+                        "UserName",
+                        "SpaceName",
+                        "CreateTime",
+                        "UpdateTime",
+                        "GraphAddr",
+                        "Timezone",
+                        "ClientIp"});
+        addSessions(session, result);
         return finish(ResultBuilder().value(Value(std::move(result))).build());
       });
+}
+
+void ShowSessionsExecutor::addSessions(const meta::cpp2::Session &session, DataSet &dataSet) const {
+  Row row;
+  row.emplace_back(session.get_session_id());
+  row.emplace_back(session.get_user_name());
+  row.emplace_back(session.get_space_name());
+  row.emplace_back(microSecToDateTime(session.get_create_time()));
+  row.emplace_back(microSecToDateTime(session.get_update_time()));
+  row.emplace_back(network::NetworkUtils::toHostsStr({session.get_graph_addr()}));
+  row.emplace_back(session.get_timezone());
+  row.emplace_back(session.get_client_ip());
+  dataSet.emplace_back(std::move(row));
 }
 
 folly::Future<Status> UpdateSessionExecutor::execute() {

--- a/src/graph/executor/admin/SessionExecutor.cpp
+++ b/src/graph/executor/admin/SessionExecutor.cpp
@@ -5,7 +5,6 @@
 
 #include "graph/executor/admin/SessionExecutor.h"
 
-#include "common/session/SessionManager.h"
 #include "graph/context/QueryContext.h"
 #include "graph/planner/plan/Admin.h"
 #include "interface/gen-cpp2/common_types.h"

--- a/src/graph/executor/admin/SessionExecutor.h
+++ b/src/graph/executor/admin/SessionExecutor.h
@@ -21,11 +21,16 @@ class ShowSessionsExecutor final : public Executor {
   folly::Future<Status> execute() override;
 
  private:
+  // List sessions in the cluster
   folly::Future<Status> listSessions();
+  // List sessions in the current graph node
+  folly::Future<Status> listLocalSessions();
 
   folly::Future<Status> getSession(SessionID sessionId);
+  // Add session info into dataset
+  void addSessions(const meta::cpp2::Session &session, DataSet &dataSet) const;
 
-  DateTime microSecToDateTime(int64_t microSec) {
+  DateTime microSecToDateTime(const int64_t microSec) const {
     auto dateTime = time::TimeConversion::unixSecondsToDateTime(microSec / 1000000);
     dateTime.microsec = microSec % 1000000;
     return dateTime;

--- a/src/graph/planner/plan/Admin.h
+++ b/src/graph/planner/plan/Admin.h
@@ -1174,8 +1174,8 @@ class ShowSessions final : public SingleInputNode {
   bool isSetSessionID() const {
     return isSetSessionID_;
   }
-  bool isLocalCommand() const { 
-    return isLocalCommand_; 
+  bool isLocalCommand() const {
+    return isLocalCommand_;
   }
   SessionID getSessionId() const {
     return sessionId_;

--- a/src/graph/planner/plan/Admin.h
+++ b/src/graph/planner/plan/Admin.h
@@ -1165,14 +1165,18 @@ class ShowSessions final : public SingleInputNode {
   static ShowSessions* make(QueryContext* qctx,
                             PlanNode* input,
                             bool isSetSessionID,
-                            SessionID sessionId) {
-    return qctx->objPool()->add(new ShowSessions(qctx, input, isSetSessionID, sessionId));
+                            SessionID sessionId,
+                            bool isLocalCommand) {
+    return qctx->objPool()->add(
+        new ShowSessions(qctx, input, isSetSessionID, sessionId, isLocalCommand));
   }
 
   bool isSetSessionID() const {
     return isSetSessionID_;
   }
-
+  bool isLocalCommand() const { 
+    return isLocalCommand_; 
+  }
   SessionID getSessionId() const {
     return sessionId_;
   }
@@ -1181,15 +1185,18 @@ class ShowSessions final : public SingleInputNode {
   explicit ShowSessions(QueryContext* qctx,
                         PlanNode* input,
                         bool isSetSessionID,
-                        SessionID sessionId)
+                        SessionID sessionId,
+                        bool isLocalCommand)
       : SingleInputNode(qctx, Kind::kShowSessions, input) {
-    isSetSessionID_ = isSetSessionID;
     sessionId_ = sessionId;
+    isSetSessionID_ = isSetSessionID;
+    isLocalCommand_ = isLocalCommand;
   }
 
  private:
-  bool isSetSessionID_{false};
   SessionID sessionId_{-1};
+  bool isSetSessionID_{false};
+  bool isLocalCommand_{false};
 };
 
 class UpdateSession final : public SingleInputNode {

--- a/src/graph/session/GraphSessionManager.cpp
+++ b/src/graph/session/GraphSessionManager.cpp
@@ -96,6 +96,15 @@ folly::Future<StatusOr<std::shared_ptr<ClientSession>>> GraphSessionManager::fin
   return metaClient_->getSession(id).via(runner).thenValue(addSession);
 }
 
+std::vector<meta::cpp2::Session> GraphSessionManager::getSessionFromLocalCache() const {
+  std::vector<meta::cpp2::Session> sessions;
+  sessions.reserve(activeSessions_.size());
+  for (auto& it : activeSessions_) {
+    sessions.emplace_back(it.second->getSession());
+  }
+  return sessions;
+}
+
 folly::Future<StatusOr<std::shared_ptr<ClientSession>>> GraphSessionManager::createSession(
     const std::string userName, const std::string clientIp, folly::Executor* runner) {
   auto createCB = [this,

--- a/src/graph/session/GraphSessionManager.h
+++ b/src/graph/session/GraphSessionManager.h
@@ -14,6 +14,7 @@
 #include "common/thrift/ThriftTypes.h"
 #include "graph/session/ClientSession.h"
 #include "interface/gen-cpp2/GraphService.h"
+#include "interface/gen-cpp2/meta_types.h"
 
 /**
  * GraphSessionManager manages the client sessions, e.g. create new, find
@@ -59,6 +60,9 @@ class GraphSessionManager final : public SessionManager<ClientSession> {
    * Find an existing session
    */
   std::shared_ptr<ClientSession> findSessionFromCache(SessionID id);
+
+  // get all seesions in the local cache
+  std::vector<meta::cpp2::Session> getSessionFromLocalCache() const;
 
  private:
   folly::Future<StatusOr<std::shared_ptr<ClientSession>>> findSessionFromMetad(

--- a/src/graph/validator/AdminValidator.cpp
+++ b/src/graph/validator/AdminValidator.cpp
@@ -558,8 +558,11 @@ Status SignOutTSServiceValidator::toPlan() {
 
 Status ShowSessionsValidator::toPlan() {
   auto sentence = static_cast<ShowSessionsSentence *>(sentence_);
-  auto *node =
-      ShowSessions::make(qctx_, nullptr, sentence->isSetSessionID(), sentence->getSessionID());
+  auto *node = ShowSessions::make(qctx_,
+                                  nullptr,
+                                  sentence->isSetSessionID(),
+                                  sentence->getSessionID(),
+                                  sentence->isLocalCommand());
   root_ = node;
   tail_ = root_;
   return Status::OK();

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -1074,33 +1074,6 @@ struct Session {
     10: map<common.ExecutionPlanID, QueryDesc>(cpp.template = "std::unordered_map") queries;
 }
 
-struct SessionContext {
-    // 1) The authorization identifier.
-    1: common.SessionID session_id,
-    // 2) The principal identified by the authorization identifier.
-    2: binary user_name,
-    // 3) The time zone identifier.
-    3: i32 timezone,
-    // 4) The session schema that is a GQL-schema.
-    
-    // 5) The session graph that is a graph.
-    5: binary space_name,
-    // 6) The session parameters that constitute a context parameter dictionary.
-    6: map<binary, common.Value>(cpp.template = "std::unordered_map") param_dict,
-    // 7) The session parameter flags that constitute a dictionary that associates
-    // each session parameter with its parameter flag.
-    // Flag controlling whether a session parameter may be overridden by another
-    // request parameter with the same name or modified by a later
-    // GQL-request in the same GQL-session
-    7: map<binary, common.Value>(cpp.template = "std::unordered_map") param_falgs,
-    // 8) The current transaction that is an optional GQL-transaction.
-    // (TODO) transaction is unimplemented
-    // 9) The request context that is an optional GQL-request context.
-    // (TODO) This part is currently conflicts with the implementation of RequestCommon
-    // 10) The termination flag that is a Boolean value.
-    8: bool is_terminated = false;
-}
-
 struct CreateSessionReq {
     1: binary               user,
     2: common.HostAddr      graph_addr,

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -1074,6 +1074,33 @@ struct Session {
     10: map<common.ExecutionPlanID, QueryDesc>(cpp.template = "std::unordered_map") queries;
 }
 
+struct SessionContext {
+    // 1) The authorization identifier.
+    1: common.SessionID session_id,
+    // 2) The principal identified by the authorization identifier.
+    2: binary user_name,
+    // 3) The time zone identifier.
+    3: i32 timezone,
+    // 4) The session schema that is a GQL-schema.
+    
+    // 5) The session graph that is a graph.
+    5: binary space_name,
+    // 6) The session parameters that constitute a context parameter dictionary.
+    6: map<binary, common.Value>(cpp.template = "std::unordered_map") param_dict,
+    // 7) The session parameter flags that constitute a dictionary that associates
+    // each session parameter with its parameter flag.
+    // Flag controlling whether a session parameter may be overridden by another
+    // request parameter with the same name or modified by a later
+    // GQL-request in the same GQL-session
+    7: map<binary, common.Value>(cpp.template = "std::unordered_map") param_falgs,
+    // 8) The current transaction that is an optional GQL-transaction.
+    // (TODO) transaction is unimplemented
+    // 9) The request context that is an optional GQL-request context.
+    // (TODO) This part is currently conflicts with the implementation of RequestCommon
+    // 10) The termination flag that is a Boolean value.
+    8: bool is_terminated = false;
+}
+
 struct CreateSessionReq {
     1: binary               user,
     2: common.HostAddr      graph_addr,

--- a/src/parser/AdminSentences.cpp
+++ b/src/parser/AdminSentences.cpp
@@ -373,13 +373,14 @@ std::string ShowSessionsSentence::toString() const {
   if (isSetSessionID()) {
     return folly::stringPrintf("SHOW SESSION %ld", sessionId_);
   }
+  if (isLocalCommand()) return "SHOW LOCAL SESSIONS";
   return "SHOW SESSIONS";
 }
 
 std::string ShowQueriesSentence::toString() const {
   std::string buf = "SHOW";
-  if (isAll()) {
-    buf += " ALL";
+  if (!isAll()) {
+    buf += " LOCAL";
   }
   buf += " QUERIES";
   return buf;

--- a/src/parser/AdminSentences.h
+++ b/src/parser/AdminSentences.h
@@ -717,8 +717,17 @@ class ShowSessionsSentence final : public Sentence {
     setSessionId_ = true;
   }
 
+  explicit ShowSessionsSentence(bool isLocalCommand) {
+    kind_ = Kind::kShowSessions;
+    isLocalCommand_ = isLocalCommand;
+  }
+
   bool isSetSessionID() const {
     return setSessionId_;
+  }
+
+  bool isLocalCommand() const {
+    return isLocalCommand_;
   }
 
   SessionID getSessionID() const {
@@ -730,6 +739,7 @@ class ShowSessionsSentence final : public Sentence {
  private:
   SessionID sessionId_{0};
   bool setSessionId_{false};
+  bool isLocalCommand_{false};
 };
 
 class ShowQueriesSentence final : public Sentence {

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -3282,10 +3282,10 @@ job_concurrency
     ;
 
 show_queries_sentence
-    : KW_SHOW KW_QUERIES {
+    : KW_SHOW KW_LOCAL KW_QUERIES {
         $$ = new ShowQueriesSentence();
     }
-    | KW_SHOW KW_ALL KW_QUERIES {
+    | KW_SHOW KW_QUERIES {
         $$ = new ShowQueriesSentence(true);
     }
     ;

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -201,6 +201,7 @@ static constexpr size_t kCommentLengthLimit = 256;
 %token KW_TEXT KW_SEARCH KW_CLIENTS KW_SIGN KW_SERVICE KW_TEXT_SEARCH
 %token KW_ANY KW_SINGLE KW_NONE
 %token KW_REDUCE
+%token KW_LOCAL
 %token KW_SESSIONS KW_SESSION
 %token KW_KILL KW_QUERY KW_QUERIES KW_TOP
 %token KW_GEOGRAPHY KW_POINT KW_LINESTRING KW_POLYGON
@@ -533,6 +534,7 @@ unreserved_keyword
     | KW_S2_MAX_CELLS       { $$ = new std::string("s2_max_cells"); }
     | KW_SESSION            { $$ = new std::string("session"); }
     | KW_SESSIONS           { $$ = new std::string("sessions"); }
+    | KW_LOCAL              { $$ = new std::string("local"); }
     | KW_SAMPLE             { $$ = new std::string("sample"); }
     | KW_QUERIES            { $$ = new std::string("queries"); }
     | KW_QUERY              { $$ = new std::string("query"); }
@@ -3378,8 +3380,13 @@ show_sentence
     | KW_SHOW KW_FULLTEXT KW_INDEXES {
         $$ = new ShowFTIndexesSentence();
     }
+    // List sessions in the cluster
     | KW_SHOW KW_SESSIONS {
         $$ = new ShowSessionsSentence();
+    }
+    // List sessions in the current graph node
+    | KW_SHOW KW_LOCAL KW_SESSIONS {
+        $$ = new ShowSessionsSentence(true);
     }
     | KW_SHOW KW_SESSION legal_integer {
         $$ = new ShowSessionsSentence($3);

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -269,6 +269,7 @@ LABEL_FULL_WIDTH            {CN_EN_FULL_WIDTH}{CN_EN_NUM_FULL_WIDTH}*
 "COMMENT"                   { return TokenType::KW_COMMENT; }
 "S2_MAX_LEVEL"              { return TokenType::KW_S2_MAX_LEVEL; }
 "S2_MAX_CELLS"              { return TokenType::KW_S2_MAX_CELLS; }
+"LOCAL"                     { return TokenType::KW_LOCAL; }
 "SESSIONS"                  { return TokenType::KW_SESSIONS; }
 "SESSION"                   { return TokenType::KW_SESSION; }
 "SAMPLE"                    { return TokenType::KW_SAMPLE; }
@@ -512,7 +513,7 @@ LABEL_FULL_WIDTH            {CN_EN_FULL_WIDTH}{CN_EN_NUM_FULL_WIDTH}*
                                  * including the non-ascii ones, which are negative
                                  * in terms of type of `signed char'. At the same time, because
                                  * Bison translates all negative tokens to EOF(i.e. YY_NULL),
-                                 * so we have to cast illegal characters to type of `unsinged char'
+                                 * so we have to cast illegal characters to type of `unsigned char'
                                  * This will make Bison receive an unknown token, which leads to
                                  * a syntax error.
                                  *

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -3138,6 +3138,12 @@ TEST_F(ParserTest, SessionTest) {
     ASSERT_EQ(result.value()->toString(), "SHOW SESSIONS");
   }
   {
+    std::string query = "SHOW LOCAL SESSIONS";
+    auto result = parse(query);
+    ASSERT_TRUE(result.ok()) << result.status();
+    ASSERT_EQ(result.value()->toString(), "SHOW LOCAL SESSIONS");
+  }
+  {
     std::string query = "SHOW SESSION 123";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
@@ -3185,10 +3191,10 @@ TEST_F(ParserTest, ShowAndKillQueryTest) {
     ASSERT_EQ(result.value()->toString(), "SHOW QUERIES");
   }
   {
-    std::string query = "SHOW ALL QUERIES";
+    std::string query = "SHOW LOCAL QUERIES";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
-    ASSERT_EQ(result.value()->toString(), "SHOW ALL QUERIES");
+    ASSERT_EQ(result.value()->toString(), "SHOW LOCAL QUERIES");
   }
   {
     std::string query = "KILL QUERY (plan=123)";

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,14 +115,18 @@ def class_fixture_variables():
     """save class scope fixture, used for session update.
     """
     # cluster is the instance of NebulaService
+    # current_session is the session currently using
+    # sessions is a list of all sessions in the cluster
     res = dict(
         pool=None,
-        session=None,
+        current_session=None,
         cluster=None,
+        sessions=[],
     )
     yield res
-    if res["session"] is not None:
-        res["session"].release()
+    for sess in res["sessions"]:
+        if sess is not None:
+            sess.release()
     if res["pool"] is not None:
         res["pool"].close()
     if res["cluster"] is not None:
@@ -176,8 +180,8 @@ def session_from_second_conn_pool(conn_pool_to_second_graph_service, pytestconfi
 
 @pytest.fixture(scope="class")
 def session(session_from_first_conn_pool, class_fixture_variables):
-    if class_fixture_variables.get('session', None) is not None:
-        return class_fixture_variables.get('session')
+    if class_fixture_variables.get('current_session', None) is not None:
+        return class_fixture_variables.get('current_session')
     return session_from_first_conn_pool
 
 

--- a/tests/job/test_session.py
+++ b/tests/job/test_session.py
@@ -197,9 +197,9 @@ class TestSession(NebulaTestSuite):
     def test_out_of_max_connections(self):
         resp = self.execute('SHOW SESSIONS')
         self.check_resp_succeeded(resp)
-        current_sessions = len(resp.rows())
+        sessions = len(resp.rows())
 
-        resp = self.execute('UPDATE CONFIGS graph:max_allowed_connections = {}'.format(current_sessions))
+        resp = self.execute('UPDATE CONFIGS graph:max_allowed_connections = {}'.format(sessions))
         self.check_resp_succeeded(resp)
         time.sleep(3)
 

--- a/tests/job/test_session.py
+++ b/tests/job/test_session.py
@@ -9,7 +9,6 @@ import sys
 import time
 import pytest
 import concurrent
-import pdb
 
 from nebula2.fbthrift.transport import TSocket
 from nebula2.fbthrift.transport import TTransport

--- a/tests/tck/conftest.py
+++ b/tests/tck/conftest.py
@@ -298,14 +298,14 @@ def given_nebulacluster_with_param(
     class_fixture_variables,
     pytestconfig,
 ):
-    grpahd_param, metad_param, storaged_param = {}, {}, {}
+    graphd_param, metad_param, storaged_param = {}, {}, {}
     if params is not None:
         for param in params.splitlines():
             module, config = param.strip().split(":")
             assert module.lower() in ["graphd", "storaged", "metad"]
             key, value = config.strip().split("=")
             if module.lower() == "graphd":
-                grpahd_param[key] = value
+                graphd_param[key] = value
             elif module.lower() == "storaged":
                 storaged_param[key] = value
             else:
@@ -323,7 +323,7 @@ def given_nebulacluster_with_param(
         int(graphd_num),
     )
     for process in nebula_svc.graphd_processes:
-        process.update_param(grpahd_param)
+        process.update_param(graphd_param)
     for process in nebula_svc.storaged_processes:
         process.update_param(storaged_param)
     for process in nebula_svc.metad_processes:
@@ -338,7 +338,8 @@ def given_nebulacluster_with_param(
     graph_port = nebula_svc.graphd_processes[0].tcp_port
     pool = get_conn_pool(graph_ip, graph_port)
     sess = pool.get_session(user, password)
-    class_fixture_variables["session"] = sess
+    class_fixture_variables["current_session"] = sess
+    class_fixture_variables["sessions"].append(sess)
     class_fixture_variables["cluster"] = nebula_svc
     class_fixture_variables["pool"] = pool
 
@@ -355,7 +356,8 @@ def when_login_graphd(graph, user, password, class_fixture_variables, pytestconf
     sess = pool.get_session(user, password)
     # do not release original session, as we may have cases to test multiple sessions.
     # connection could be released after cluster stopped.
-    class_fixture_variables["session"] = sess
+    class_fixture_variables["current_session"] = sess
+    class_fixture_variables["sessions"].append(sess)
     class_fixture_variables["pool"] = pool
 
 @when(parse("executing query:\n{query}"))

--- a/tests/tck/features/admin/Sessions.feature
+++ b/tests/tck/features/admin/Sessions.feature
@@ -1,7 +1,6 @@
 # Copyright (c) 2021 vesoft inc. All rights reserved.
 #
 # This source code is licensed under Apache 2.0 License.
-@aiee
 Feature: Test sessions
 
   Background:
@@ -71,17 +70,3 @@ Feature: Test sessions
     Then the result should contain, replace the holders with cluster info:
       | SessionId | UserName | SpaceName    | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp            |
       | /\d+/     | "root"   | "root_space" | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[0].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |
-    # When executing query with user user1 with password nebula1:
-    #   """
-    #   SHOW LOCAL SESSIONS;
-    #   """
-    # Then the result should contain, replace the holders with cluster info:
-    #   | SessionId | UserName | SpaceName    | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp            |
-    #   | /\d+/     | "user1"   | "" | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[1].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |
-    # # When executing query with user user2 with password nebula2:
-    #   """
-    #   SHOW LOCAL SESSIONS;
-    #   """
-    # Then the result should contain, replace the holders with cluster info:
-    #   | SessionId | UserName | SpaceName    | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp            |
-    #   | /\d+/     | "user2"   | "" | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[2].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |

--- a/tests/tck/features/admin/Sessions.feature
+++ b/tests/tck/features/admin/Sessions.feature
@@ -13,12 +13,12 @@ Feature: Test sessions
       SHOW SESSIONS;
       """
     Then the result should contain:
-      | SessionId | UserName | SpaceName | CreateTime | UpdateTime | GraphAddr | Timezone | ClientIp         |
-      | /\d+/     | "root"   | ""        | /.*/       | /.*/       | /.*/      | 0        | /.*(127.0.0.1)$/ |
+      | SessionId | UserName | SpaceName | CreateTime | UpdateTime | GraphAddr | Timezone | ClientIp            |
+      | /\d+/     | "root"   | ""        | /.*/       | /.*/       | /.*/      | 0        | /.*(127\.0\.0\.1)$/ |
     When executing query:
       """
       CREATE USER user1 WITH PASSWORD 'nebula1';
-      CREATE SPACE s1(vid_type=int);
+      CREATE SPACE IF NOT EXISTS s1(vid_type=int);
       USE s1;
       """
     Then the execution should be successful
@@ -29,33 +29,59 @@ Feature: Test sessions
       SHOW SESSIONS;
       """
     Then the result should contain, replace the holders with cluster info:
-      | SessionId | UserName | SpaceName | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp    |
-      | /\d+/     | "root"   | "s1"      | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[0].tcp_port}" | 0        | "127.0.0.1" |
-      | /\d+/     | "user1"  | ""        | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[1].tcp_port}" | 0        | "127.0.0.1" |
+      | SessionId | UserName | SpaceName | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp            |
+      | /\d+/     | "root"   | "s1"      | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[0].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |
+      | /\d+/     | "user1"  | ""        | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[1].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |
 
-  # Scenario: Show local sessions
-  #   When executing query:
-  #     """
-  #     SHOW SESSIONS;
-  #     """
-  #   Then the result should contain:
-  #     | SessionId | UserName | SpaceName | CreateTime | UpdateTime | GraphAddr | Timezone | ClientIp    |
-  #     | /\d+/     | "root"   | ""        | /.*/       | /.*/       | /.*/      | 0        | "127.0.0.1" |
-  #   When executing query:
-  #     """
-  #     CREATE USER user1 WITH PASSWORD 'nebula1';
-  #     CREATE SPACE graph1_s1(vid_type=int);
-  #     CREATE USER user2 WITH PASSWORD 'nebula2';
-  #     CREATE SPACE graph2_s1(vid_type=int);
-  #     USE s1;
-  #     """
-  #   Then the execution should be successful
-  #   And wait 3 seconds
-  #   When login "graphd[1]" with "user1" and "nebula1"
-  #   And executing query:
-  #     """
-  #     SHOW LCOAL SESSIONS;
-  #     """
-  #   Then the result should contain, replace the holders with cluster info:
-  #     | SessionId | UserName | SpaceName   | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp    |
-  #     | /\d+/     | "root"   | "graph1_s1" | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[0].tcp_port}" | 0        | "127.0.0.1" |
+  Scenario: Show local sessions
+    When executing query:
+      """
+      SHOW SESSIONS;
+      """
+    Then the result should contain:
+      | SessionId | UserName | SpaceName | CreateTime | UpdateTime | GraphAddr | Timezone | ClientIp            |
+      | /\d+/     | "root"   | ""        | /.*/       | /.*/       | /.*/      | 0        | /.*(127\.0\.0\.1)$/ |
+    When executing query:
+      """
+      CREATE USER IF NOT EXISTS user1 WITH PASSWORD 'nebula1';
+      CREATE USER IF NOT EXISTS user2 WITH PASSWORD 'nebula2';
+      CREATE SPACE IF NOT EXISTS root_space(vid_type=int);
+      USE root_space;
+      """
+    Then the execution should be successful
+    And wait 3 seconds
+    When login "graphd[1]" with "user1" and "nebula1"
+    Then the execution should be successful
+    When login "graphd[2]" with "user2" and "nebula2"
+    Then the execution should be successful
+    And wait 3 seconds
+    When executing query:
+      """
+      SHOW SESSIONS;
+      """
+    Then the result should contain, replace the holders with cluster info:
+      | SessionId | UserName | SpaceName    | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp            |
+      | /\d+/     | "root"   | "root_space" | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[0].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |
+      | /\d+/     | "user1"  | ""           | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[1].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |
+      | /\d+/     | "user2"  | ""           | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[2].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |
+    When executing query:
+      """
+      SHOW LOCAL SESSIONS;
+      """
+    Then the result should contain, replace the holders with cluster info:
+      | SessionId | UserName | SpaceName    | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp            |
+      | /\d+/     | "root"   | "root_space" | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[0].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |
+    # When executing query with user user1 with password nebula1:
+    #   """
+    #   SHOW LOCAL SESSIONS;
+    #   """
+    # Then the result should contain, replace the holders with cluster info:
+    #   | SessionId | UserName | SpaceName    | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp            |
+    #   | /\d+/     | "user1"   | "" | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[1].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |
+    # # When executing query with user user2 with password nebula2:
+    #   """
+    #   SHOW LOCAL SESSIONS;
+    #   """
+    # Then the result should contain, replace the holders with cluster info:
+    #   | SessionId | UserName | SpaceName    | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp            |
+    #   | /\d+/     | "user2"   | "" | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[2].tcp_port}" | 0        | /.*(127\.0\.0\.1)$/ |

--- a/tests/tck/features/admin/Sessions.feature
+++ b/tests/tck/features/admin/Sessions.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 vesoft inc. All rights reserved.
 #
 # This source code is licensed under Apache 2.0 License.
+@aiee
 Feature: Test sessions
 
   Background:
@@ -28,6 +29,33 @@ Feature: Test sessions
       SHOW SESSIONS;
       """
     Then the result should contain, replace the holders with cluster info:
-      | SessionId | UserName | SpaceName | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp         |
-      | /\d+/     | "root"   | "s1"      | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[0].tcp_port}" | 0        | /.*(127.0.0.1)$/ |
-      | /\d+/     | "user1"  | ""        | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[1].tcp_port}" | 0        | /.*(127.0.0.1)$/ |
+      | SessionId | UserName | SpaceName | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp    |
+      | /\d+/     | "root"   | "s1"      | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[0].tcp_port}" | 0        | "127.0.0.1" |
+      | /\d+/     | "user1"  | ""        | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[1].tcp_port}" | 0        | "127.0.0.1" |
+
+  # Scenario: Show local sessions
+  #   When executing query:
+  #     """
+  #     SHOW SESSIONS;
+  #     """
+  #   Then the result should contain:
+  #     | SessionId | UserName | SpaceName | CreateTime | UpdateTime | GraphAddr | Timezone | ClientIp    |
+  #     | /\d+/     | "root"   | ""        | /.*/       | /.*/       | /.*/      | 0        | "127.0.0.1" |
+  #   When executing query:
+  #     """
+  #     CREATE USER user1 WITH PASSWORD 'nebula1';
+  #     CREATE SPACE graph1_s1(vid_type=int);
+  #     CREATE USER user2 WITH PASSWORD 'nebula2';
+  #     CREATE SPACE graph2_s1(vid_type=int);
+  #     USE s1;
+  #     """
+  #   Then the execution should be successful
+  #   And wait 3 seconds
+  #   When login "graphd[1]" with "user1" and "nebula1"
+  #   And executing query:
+  #     """
+  #     SHOW LCOAL SESSIONS;
+  #     """
+  #   Then the result should contain, replace the holders with cluster info:
+  #     | SessionId | UserName | SpaceName   | CreateTime | UpdateTime | GraphAddr                                           | Timezone | ClientIp    |
+  #     | /\d+/     | "root"   | "graph1_s1" | /.*/       | /.*/       | "127.0.0.1:${cluster.graphd_processes[0].tcp_port}" | 0        | "127.0.0.1" |

--- a/tests/tck/slowquery/KillSlowQueryViaDiffrentService.feature
+++ b/tests/tck/slowquery/KillSlowQueryViaDiffrentService.feature
@@ -16,26 +16,26 @@ Feature: Slow Query Test
   Scenario: Show all queries and kill all slow queries at second graph service
     When executing query via graph 1:
       """
-      SHOW QUERIES
+      SHOW LOCAL QUERIES
       """
     Then the execution should be successful
     When executing query via graph 1:
       """
-      SHOW ALL QUERIES
+      SHOW QUERIES
       """
     Then the execution should be successful
     # In case that rebuild indexes cost too much time.
     And wait 10 seconds
     When executing query via graph 1:
       """
-      SHOW ALL QUERIES
+      SHOW QUERIES
       """
     Then the result should be, in order:
       | SessionID | ExecutionPlanID | User   | Host | StartTime | DurationInUSec | Status    | Query                                                           |
       | /\d+/     | /\d+/           | "root" | /.*/ | /.*/      | /\d+/          | "RUNNING" | "GO 100000 STEPS FROM \"Tim Duncan\" OVER like YIELD like._dst" |
     When executing query via graph 1:
       """
-      SHOW ALL QUERIES
+      SHOW QUERIES
       | YIELD $-.SessionID AS sid, $-.ExecutionPlanID AS eid, $-.DurationInUSec AS dur
       WHERE $-.DurationInUSec > 1000000 AND $-.`Query` CONTAINS "GO 100000 STEPS";
       """
@@ -74,7 +74,7 @@ Feature: Slow Query Test
     Then an SemanticError should be raised at runtime: `$-.eid', not exist prop `eid'
     When executing query via graph 1:
       """
-      SHOW ALL QUERIES
+      SHOW QUERIES
       | YIELD $-.SessionID AS sid, $-.`Query` AS eid, $-.DurationInUSec AS dur WHERE $-.DurationInUSec > 10000000
       | ORDER BY $-.dur
       | KILL QUERY (session=$-.sid, plan=$-.eid)
@@ -82,7 +82,7 @@ Feature: Slow Query Test
     Then an SemanticError should be raised at runtime: $-.eid, Session ID must be an integer but was STRING
     When executing query via graph 1:
       """
-      SHOW ALL QUERIES
+      SHOW QUERIES
       | YIELD $-.SessionID AS sid, $-.ExecutionPlanID AS eid, $-.DurationInUSec AS dur
       WHERE $-.DurationInUSec > 1000000 AND $-.`Query` CONTAINS "GO"
       | ORDER BY $-.dur

--- a/tests/tck/slowquery/KillSlowQueryViaSameService.feature
+++ b/tests/tck/slowquery/KillSlowQueryViaSameService.feature
@@ -16,26 +16,26 @@ Feature: Slow Query Test
   Scenario: Show all queries and kill all slow queries
     When executing query:
       """
-      SHOW QUERIES
+      SHOW LOCAL QUERIES
       """
     Then the execution should be successful
     When executing query:
       """
-      SHOW ALL QUERIES
+      SHOW QUERIES
       """
     Then the execution should be successful
     # In case that rebuild indexes cost too much time.
     And wait 10 seconds
     When executing query:
       """
-      SHOW ALL QUERIES
+      SHOW QUERIES
       """
     Then the result should be, in order:
       | SessionID | ExecutionPlanID | User   | Host | StartTime | DurationInUSec | Status    | Query                                                           |
       | /\d+/     | /\d+/           | "root" | /.*/ | /.*/      | /\d+/          | "RUNNING" | "GO 100000 STEPS FROM \"Tim Duncan\" OVER like YIELD like._dst" |
     When executing query:
       """
-      SHOW ALL QUERIES
+      SHOW QUERIES
       | YIELD $-.SessionID AS sid, $-.ExecutionPlanID AS eid, $-.DurationInUSec AS dur
       WHERE $-.DurationInUSec > 1000000 AND $-.`Query` CONTAINS "GO 100000 STEPS";
       """
@@ -74,7 +74,7 @@ Feature: Slow Query Test
     Then an SemanticError should be raised at runtime: `$-.eid', not exist prop `eid'
     When executing query:
       """
-      SHOW ALL QUERIES
+      SHOW QUERIES
       | YIELD $-.SessionID AS sid, $-.`Query` AS eid, $-.DurationInUSec AS dur WHERE $-.DurationInUSec > 10000000
       | ORDER BY $-.dur
       | KILL QUERY (session=$-.sid, plan=$-.eid)
@@ -82,7 +82,7 @@ Feature: Slow Query Test
     Then an SemanticError should be raised at runtime: $-.eid, Session ID must be an integer but was STRING
     When executing query:
       """
-      SHOW ALL QUERIES
+      SHOW QUERIES
       | YIELD $-.SessionID AS sid, $-.ExecutionPlanID AS eid, $-.DurationInUSec AS dur
       WHERE $-.DurationInUSec > 1000000 AND $-.`Query` CONTAINS "GO"
       | ORDER BY $-.dur


### PR DESCRIPTION
#### What type of PR is this?
- [ ] bug
- [x] feature
- [x] enhancement

#### What does this PR do?
1. Add `SHOW LOCAL SESSIONS` command to list the sessions of the current graph node
2. [**Incompatibility**] Deprecate `SHOW ALL QUERIES`. Now `SHOW QUERIES` lists all queries in the whole cluster and `SHOW LOCAL QUERIES` lists all queries in the current graph node.


#### Which issue(s)/PR(s) this PR relates to?
Depends on https://github.com/vesoft-inc/nebula/pull/3486 
Close https://github.com/vesoft-inc/nebula/issues/3547
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context/ Design document:


#### Checklist:
- [x] Documentation affected (Please add the label if documentation needs to be modified.)
- [x] Incompatibility (If it breaks the compatibility, please describe it and add the corresponding label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory

#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
>                                                                 `
