### PR TITLE
fix add hosts

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -724,6 +724,8 @@ void MetaClient::getResponse(Request req,
               } else if (resp.get_code() == nebula::cpp2::ErrorCode::E_CLIENT_SERVER_INCOMPATIBLE) {
                 pro.setValue(respGen(std::move(resp)));
                 return;
+              } else if (resp.get_code() == nebula::cpp2::ErrorCode::E_MACHINE_NOT_FOUND) {
+                updateLeader();
               }
               pro.setValue(this->handleResponse(resp));
             });  // then


### PR DESCRIPTION
#### What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

#### What does this PR do?

if  the storage does not register to the cluster, it would return `E_MACHINE_NOT_FOUND`, and would always send heartbeat to the follower.
a little ugly

1. if run `add host` with the storage, it will be ok after updateLeader.
2. if not, it would always update leader, and send heartbeat to meta randomly.

