### PR TITLE
Fix crush caused by OptimizeTagIndexScanByFilterRule

### DIFF
--- a/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
+++ b/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
@@ -5,6 +5,8 @@
 
 #include "graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.h"
 
+#include <cstddef>
+
 #include "graph/context/QueryContext.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"
@@ -119,21 +121,27 @@ StatusOr<TransformResult> OptimizeTagIndexScanByFilterRule::transform(
   }
 
   // case2: logical AND expr
-  if (condition->kind() == ExprKind::kLogicalAnd) {
+  size_t operandIndex = 0;
+  if (conditionType == ExprKind::kLogicalAnd) {
     for (auto& operand : static_cast<const LogicalExpression*>(condition)->operands()) {
       if (operand->kind() == ExprKind::kRelIn) {
         auto inExpr = static_cast<RelationalExpression*>(operand);
-        // Do not apply this rule if the IN expr has a valid index or it has only 1 element in the
-        // list
+        // Do not apply this rule if the IN expr has a valid index or it has more than 1 element in
+        // the list
         if (static_cast<ListExpression*>(inExpr->right())->size() > 1) {
           return TransformResult::noTransform();
         } else {
-          transformedExpr = graph::ExpressionUtils::rewriteInExpr(condition);
+          // If the inner IN expr has only 1 element, rewrite it to an relEQ expression and there is
+          // no need to check wether it has a index
+          auto relEqExpr = graph::ExpressionUtils::rewriteInExpr(inExpr);
+          static_cast<LogicalExpression*>(transformedExpr)->setOperand(operandIndex, relEqExpr);
+          continue;
         }
         if (OptimizerUtils::relExprHasIndex(inExpr, indexItems)) {
           return TransformResult::noTransform();
         }
       }
+      ++operandIndex;
     }
   }
 

--- a/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
+++ b/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
@@ -5,8 +5,6 @@
 
 #include "graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.h"
 
-#include <cstddef>
-
 #include "graph/context/QueryContext.h"
 #include "graph/optimizer/OptContext.h"
 #include "graph/optimizer/OptGroup.h"

--- a/tests/tck/features/lookup/TagIndexFullScan.feature
+++ b/tests/tck/features/lookup/TagIndexFullScan.feature
@@ -160,6 +160,20 @@ Feature: Lookup tag index full scan
       | 3  | Project   | 4            |               |
       | 4  | IndexScan | 0            |               |
       | 0  | Start     |              |               |
+    # c AND (a IN b) where b contains only 1 element
+    # (https://github.com/vesoft-inc/nebula/issues/3524)
+    When profiling query:
+      """
+      LOOKUP ON player WHERE player.age IN [40] AND player.name == "Kobe Bryant" YIELD id(vertex) as id, player.age
+      """
+    Then the result should be, in any order:
+      | id            | player.age |
+      | "Kobe Bryant" | 40         |
+    And the execution plan should be:
+      | id | name               | dependencies | operator info |
+      | 3  | Project            | 4            |               |
+      | 4  | TagIndexPrefixScan | 0            |               |
+      | 0  | Start              |              |               |
 
   Scenario: Tag with complex relational IN filter
     Given an empty graph


### PR DESCRIPTION
#### What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

#### What does this PR do?
Fix crash caused by filter stated in https://github.com/vesoft-inc/nebula/issues/3524

#### Which issue(s)/PR(s) this PR relates to?
Close https://github.com/vesoft-inc/nebula/issues/3524
  
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context/ Design document:


#### Checklist:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the corresponding label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory

#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
>                                                                 `
