### PR TITLE
Fix the issue that the query results will still contain the expired e…

### DIFF
--- a/src/storage/query/QueryBaseProcessor-inl.h
+++ b/src/storage/query/QueryBaseProcessor-inl.h
@@ -176,7 +176,7 @@ void QueryBaseProcessor<REQ, RESP>::buildEdgeTTLInfo() {
     auto ttlInfo = edgeSchema->getTTLInfo();
     if (ttlInfo.ok()) {
       VLOG(2) << "Add ttl col " << ttlInfo.value().first << " of edge " << edgeType;
-      edgeContext_.ttlInfo_.emplace(edgeType, std::move(ttlInfo).value());
+      edgeContext_.ttlInfo_.emplace(std::abs(edgeType), std::move(ttlInfo).value());
     }
   }
 }

--- a/src/storage/test/GetNeighborsTest.cpp
+++ b/src/storage/test/GetNeighborsTest.cpp
@@ -1039,8 +1039,8 @@ TEST(GetNeighborsTest, TtlTest) {
     ASSERT_EQ(5, (*resp.vertices_ref()).rows[0].values.size());
     ASSERT_EQ("Spurs", (*resp.vertices_ref()).rows[0].values[0].getStr());
     ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[1].type());
-    ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[2].type());
-    ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[3].type());
+    ASSERT_EQ(Value::Type::LIST, (*resp.vertices_ref()).rows[0].values[2].type()); //team still exists (team hasn't set ttl)
+    ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[3].type()); //- serve expired
     ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[4].type());
   }
   {

--- a/src/storage/test/GetNeighborsTest.cpp
+++ b/src/storage/test/GetNeighborsTest.cpp
@@ -933,6 +933,7 @@ TEST(GetNeighborsTest, TtlTest) {
   auto threadPool = std::make_shared<folly::IOThreadPoolExecutor>(4);
 
   TagID player = 1;
+  TagID team = 2;
   EdgeType serve = 101;
 
   {
@@ -952,6 +953,24 @@ TEST(GetNeighborsTest, TtlTest) {
 
     ASSERT_EQ(0, (*resp.result_ref()).failed_parts.size());
     // vId, stat, player, serve, expr
+    QueryTestUtils::checkResponse(*resp.vertices_ref(), vertices, over, tags, edges, 1, 5);
+  }
+  {
+    LOG(INFO) << "InEdgeReturnAllProperty";
+    std::vector<VertexID> vertices = {"Spurs"};
+    std::vector<EdgeType> over = {-serve};
+    std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+    std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+    tags.emplace_back(team, std::vector<std::string>{"name"});
+    edges.emplace_back(-serve, std::vector<std::string>{"playerName", "startYear", "teamCareer"});
+    auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
+
+    auto* processor = GetNeighborsProcessor::instance(env, nullptr, threadPool.get());
+    auto fut = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(fut).get();
+    ASSERT_EQ(0, (*resp.result_ref()).failed_parts.size());
+    // vId, stat, team, - serve, expr
     QueryTestUtils::checkResponse(*resp.vertices_ref(), vertices, over, tags, edges, 1, 5);
   }
   {
@@ -994,6 +1013,31 @@ TEST(GetNeighborsTest, TtlTest) {
     // vId, stat, player, serve, expr
     ASSERT_EQ(5, (*resp.vertices_ref()).rows[0].values.size());
     ASSERT_EQ("Tim Duncan", (*resp.vertices_ref()).rows[0].values[0].getStr());
+    ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[1].type());
+    ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[2].type());
+    ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[3].type());
+    ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[4].type());
+  }
+  {
+    LOG(INFO) << "InEdgeReturnAllProperty";
+    std::vector<VertexID> vertices = {"Spurs"};
+    std::vector<EdgeType> over = {-serve};
+    std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+    std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+    tags.emplace_back(team, std::vector<std::string>{"name"});
+    edges.emplace_back(-serve, std::vector<std::string>{"playerName", "startYear", "teamCareer"});
+    auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
+
+    auto* processor = GetNeighborsProcessor::instance(env, nullptr, threadPool.get());
+    auto fut = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(fut).get();
+
+    ASSERT_EQ(0, (*resp.result_ref()).failed_parts.size());
+    ASSERT_EQ(1, (*resp.vertices_ref()).rows.size());
+    // vId, stat, team, - serve, expr
+    ASSERT_EQ(5, (*resp.vertices_ref()).rows[0].values.size());
+    ASSERT_EQ("Spurs", (*resp.vertices_ref()).rows[0].values[0].getStr());
     ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[1].type());
     ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[2].type());
     ASSERT_EQ(Value::Type::__EMPTY__, (*resp.vertices_ref()).rows[0].values[3].type());


### PR DESCRIPTION
Fix an issue that the query results still contain the expired edges when use go reversely

#### What type of PR is this?
- [ ] bug

#### What does this PR do?


#### Which issue(s)/PR(s) this PR relates to?

  
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context/ Design document:


#### Checklist:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the corresponding label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory

#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
>                                                                 `
