### PR TITLE
Fix cmake statobj for standalone version

### DIFF
--- a/src/daemons/CMakeLists.txt
+++ b/src/daemons/CMakeLists.txt
@@ -200,7 +200,9 @@ nebula_add_executable(
         SetupLogging.cpp
         SetupBreakpad.cpp
     OBJECTS
-        $<TARGET_OBJECTS:stats_def_obj>
+        $<TARGET_OBJECTS:graph_stats_obj>
+        $<TARGET_OBJECTS:meta_client_stats_obj>
+        $<TARGET_OBJECTS:storage_client_stats_obj>
         $<TARGET_OBJECTS:util_obj>
         $<TARGET_OBJECTS:service_obj>
         $<TARGET_OBJECTS:graph_session_obj>

--- a/src/daemons/StandAloneDaemon.cpp
+++ b/src/daemons/StandAloneDaemon.cpp
@@ -21,6 +21,7 @@
 #include "common/ssl/SSLConfig.h"
 #include "common/time/TimezoneInfo.h"
 #include "common/utils/MetaKeyUtils.h"
+#include "daemons/SetupLogging.h"
 #include "folly/ScopeGuard.h"
 #include "graph/service/GraphFlags.h"
 #include "graph/service/GraphService.h"
@@ -52,7 +53,6 @@ void printHelp(const char *prog);
 void stopAllDaemon();
 static void signalHandler(int sig);
 static Status setupSignalHandler();
-extern Status setupLogging();
 #if defined(__x86_64__)
 extern Status setupBreakpad();
 #endif
@@ -112,7 +112,7 @@ int main(int argc, char *argv[]) {
   nebula::initStorageStats();
 
   // Setup logging
-  auto status = setupLogging();
+  auto status = setupLogging(argv[0]);
   if (!status.ok()) {
     LOG(ERROR) << status;
     return EXIT_FAILURE;

--- a/src/daemons/StandAloneDaemon.cpp
+++ b/src/daemons/StandAloneDaemon.cpp
@@ -24,7 +24,7 @@
 #include "folly/ScopeGuard.h"
 #include "graph/service/GraphFlags.h"
 #include "graph/service/GraphService.h"
-#include "graph/stats/StatsDef.h"
+#include "graph/stats/GraphStats.h"
 #include "meta/MetaServiceHandler.h"
 #include "meta/MetaVersionMan.h"
 #include "meta/RootUserMan.h"
@@ -32,7 +32,9 @@
 #include "meta/http/MetaHttpIngestHandler.h"
 #include "meta/http/MetaHttpReplaceHostHandler.h"
 #include "meta/processors/job/JobManager.h"
+#include "meta/stats/MetaStats.h"
 #include "storage/StorageServer.h"
+#include "storage/stats/StorageStats.h"
 #include "version/Version.h"
 #include "webservice/WebService.h"
 
@@ -105,7 +107,9 @@ int main(int argc, char *argv[]) {
   if (FLAGS_enable_ssl || FLAGS_enable_graph_ssl || FLAGS_enable_meta_ssl) {
     folly::ssl::init();
   }
-  nebula::initCounters();
+  nebula::initGraphStats();
+  nebula::initMetaStats();
+  nebula::initStorageStats();
 
   // Setup logging
   auto status = setupLogging();
@@ -437,7 +441,7 @@ void setupThreadManager() {
   int numThreads =
       FLAGS_num_worker_threads > 0 ? FLAGS_num_worker_threads : gServer->getNumIOWorkerThreads();
   std::shared_ptr<apache::thrift::concurrency::ThreadManager> threadManager(
-      PriorityThreadManager::newPriorityThreadManager(numThreads, false /*stats*/));
+      PriorityThreadManager::newPriorityThreadManager(numThreads));
   threadManager->setNamePrefix("executor");
   threadManager->start();
   gServer->setThreadManager(threadManager);


### PR DESCRIPTION
#### What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

#### What does this PR do?
Fix standalone cmake.
storage_common_obj is splited into 
        $<TARGET_OBJECTS:graph_stats_obj>
        $<TARGET_OBJECTS:meta_client_stats_obj>
        $<TARGET_OBJECTS:storage_client_stats_obj>
Which is not applyed into standalone version

#### Which issue(s)/PR(s) this PR relates to?

  
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context/ Design document:


#### Checklist:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the corresponding label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory

#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
>                                                                 `
