### PR TITLE
Fix stats init order

### DIFF
--- a/src/daemons/GraphDaemon.cpp
+++ b/src/daemons/GraphDaemon.cpp
@@ -60,7 +60,6 @@ int main(int argc, char *argv[]) {
   if (FLAGS_enable_ssl || FLAGS_enable_graph_ssl || FLAGS_enable_meta_ssl) {
     folly::ssl::init();
   }
-  nebula::initGraphStats();
 
   if (FLAGS_flagfile.empty()) {
     printHelp(argv[0]);
@@ -89,6 +88,8 @@ int main(int argc, char *argv[]) {
     LOG(ERROR) << status;
     return EXIT_FAILURE;
   }
+
+  nebula::initGraphStats();
 
   if (FLAGS_daemonize) {
     status = ProcessUtils::daemonize(pidPath);

--- a/src/daemons/StandAloneDaemon.cpp
+++ b/src/daemons/StandAloneDaemon.cpp
@@ -107,9 +107,6 @@ int main(int argc, char *argv[]) {
   if (FLAGS_enable_ssl || FLAGS_enable_graph_ssl || FLAGS_enable_meta_ssl) {
     folly::ssl::init();
   }
-  nebula::initGraphStats();
-  nebula::initMetaStats();
-  nebula::initStorageStats();
 
   // Setup logging
   auto status = setupLogging(argv[0]);
@@ -133,6 +130,10 @@ int main(int argc, char *argv[]) {
     LOG(ERROR) << status;
     return EXIT_FAILURE;
   }
+
+  nebula::initGraphStats();
+  nebula::initMetaStats();
+  nebula::initStorageStats();
 
   if (FLAGS_daemonize) {
     google::SetStderrLogging(google::FATAL);


### PR DESCRIPTION
#### What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

#### What does this PR do?

Fix Graph and Standalone: InitStat's should be done after glog is inited.

#### Which issue(s)/PR(s) this PR relates to?

  
#### Special notes for your reviewer, ex. impact of this fix, etc:


#### Additional context/ Design document:


#### Checklist:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the corresponding label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory

#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
>                                                                 `
