### PR TITLE
Fix expression rewrite

### DIFF
--- a/conf/nebula-graphd.conf.default
+++ b/conf/nebula-graphd.conf.default
@@ -84,8 +84,9 @@
 # System memory high watermark ratio, cancel the memory checking when the ratio greater than 1.0
 --system_memory_high_watermark_ratio=0.8
 
+########## metrics ##########
+--enable_space_level_metrics=false
+
 ########## experimental feature ##########
 # if use experimental features
 --enable_experimental_feature=false
-
---enable_space_level_metrics=false

--- a/conf/nebula-graphd.conf.production
+++ b/conf/nebula-graphd.conf.production
@@ -83,8 +83,9 @@
 # System memory high watermark ratio, cancel the memory checking when the ratio greater than 1.0
 --system_memory_high_watermark_ratio=0.8
 
+########## metrics ##########
+--enable_space_level_metrics=false
+
 ########## experimental feature ##########
 # if use experimental features
 --enable_experimental_feature=false
-
---enable_space_level_metrics=false

--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -581,11 +581,11 @@ StatusOr<Expression *> ExpressionUtils::filterTransform(const Expression *filter
   }
 
   // Check if any overflow happen before filter tranform
-  auto initilConstFold = foldConstantExpr(filter);
-  NG_RETURN_IF_ERROR(initilConstFold);
+  auto initialConstFold = foldConstantExpr(filter);
+  NG_RETURN_IF_ERROR(initialConstFold);
 
   // Rewrite relational expression
-  auto rewrittenExpr = const_cast<Expression *>(filter);
+  auto rewrittenExpr = initialConstFold.value();
   rewrittenExpr = rewriteRelExpr(rewrittenExpr);
 
   // Fold constant expression

--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -10,8 +10,8 @@
 #include <unordered_set>
 
 #include "common/base/ObjectPool.h"
-#include "common/expression/Expression.h"
 #include "common/expression/ArithmeticExpression.h"
+#include "common/expression/Expression.h"
 #include "common/expression/PropertyExpression.h"
 #include "common/function/AggFunctionManager.h"
 #include "graph/context/QueryContext.h"
@@ -462,7 +462,10 @@ Expression *ExpressionUtils::rewriteRelExpr(const Expression *expr) {
     if (lExpr->isArithmeticExpr()) {
       auto arithmExpr = static_cast<const ArithmeticExpression *>(lExpr);
       checkLeftOperand = checkArithmExpr(arithmExpr);
-    } else if (lExpr->isRelExpr()) {  // for expressions that contain boolean literals
+    } else if (lExpr->isRelExpr() ||
+               lExpr->kind() == Expression::Kind::kLabelAttribute) {  // for expressions that
+                                                                      // contain boolean literals
+                                                                      // such as (v.age <= null)
       checkLeftOperand = true;
     }
     return checkLeftOperand;

--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -942,7 +942,7 @@ Expression::Kind ExpressionUtils::getNegatedArithmeticType(const Expression::Kin
       return Expression::Kind::kMod;
       break;
     default:
-      DLOG(FATAL) << "Invalid arithmetic expression kind: " << static_cast<uint8_t>(kind);
+      LOG(FATAL) << "Invalid arithmetic expression kind: " << static_cast<uint8_t>(kind);
       break;
   }
 }

--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -521,7 +521,7 @@ Expression *ExpressionUtils::rewriteRelExprHelper(const Expression *expr,
     // case Expression::Kind::kMultiply:
     // case Expression::Kind::kDivision:
     default:
-      LOG(FATAL) << "Unsupported expression kind: " << static_cast<uint8_t>(kind);
+      DLOG(ERROR) << "Unsupported expression kind: " << static_cast<uint8_t>(kind);
       break;
   }
 
@@ -529,6 +529,13 @@ Expression *ExpressionUtils::rewriteRelExprHelper(const Expression *expr,
 }
 
 StatusOr<Expression *> ExpressionUtils::filterTransform(const Expression *filter) {
+  // If the filter contains more than one LabelAttribute expr, this filter cannot be pushed down
+  auto LabelAttributeExprs =
+      ExpressionUtils::collectAll(filter, {Expression::Kind::kLabelAttribute});
+  if (LabelAttributeExprs.size() > 1) {
+    return const_cast<Expression *>(filter);
+  }
+
   auto rewrittenExpr = const_cast<Expression *>(filter);
   // Rewrite relational expression
   rewrittenExpr = rewriteRelExpr(rewrittenExpr);

--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -425,12 +425,12 @@ Expression *ExpressionUtils::rewriteRelExpr(const Expression *expr) {
 
     // If the arithExpr has constant expr as member that is a string, do not rewrite
     if (lExpr->kind() == Expression::Kind::kConstant) {
-      if (static_cast<ConstantExpression *>(lExpr)->eval(ctx).isStr()) {
+      if (lExpr->eval(ctx).isStr()) {
         return false;
       }
     }
     if (rExpr->kind() == Expression::Kind::kConstant) {
-      if (static_cast<ConstantExpression *>(rExpr)->eval(ctx).isStr()) {
+      if (rExpr->eval(ctx).isStr()) {
         return false;
       }
     }
@@ -453,7 +453,9 @@ Expression *ExpressionUtils::rewriteRelExpr(const Expression *expr) {
     auto relExpr = static_cast<const RelationalExpression *>(e);
     // Check right operand
     bool checkRightOperand = isEvaluableExpr(relExpr->right());
-    if (!checkRightOperand) return false;
+    if (!checkRightOperand) {
+      return false;
+    }
 
     // Check left operand
     bool checkLeftOperand = false;

--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <queue>
+#include <unordered_set>
 
 #include "common/base/ObjectPool.h"
 #include "common/expression/Expression.h"
@@ -570,9 +571,11 @@ StatusOr<Expression *> ExpressionUtils::filterTransform(const Expression *filter
   // pushed down
   auto propExprs = ExpressionUtils::collectAll(filter, {Expression::Kind::kLabelTagProperty});
   // Deduplicate the list
-  auto dedupPropExprsList =
-      std::unordered_set<const Expression *>(propExprs.begin(), propExprs.end());
-  if (dedupPropExprsList.size() > 1) {
+  std::unordered_set<std::string> dedupPropExprSet;
+  for (auto &iter : propExprs) {
+    dedupPropExprSet.emplace(iter->toString());
+  }
+  if (dedupPropExprSet.size() > 1) {
     return const_cast<Expression *>(filter);
   }
 

--- a/src/graph/visitor/DeduceTypeVisitor.cpp
+++ b/src/graph/visitor/DeduceTypeVisitor.cpp
@@ -44,33 +44,40 @@ static const std::unordered_map<Value::Type, Value> kConstantValues = {
     {Value::Type::DURATION, Value(Duration())},
 };
 
-#define DETECT_BIEXPR_TYPE(OP)                                                             \
-  expr->left()->accept(this);                                                              \
-  if (!ok()) return;                                                                       \
-  auto left = type_;                                                                       \
-  expr->right()->accept(this);                                                             \
-  if (!ok()) return;                                                                       \
-  auto right = type_;                                                                      \
-  auto lhs = kConstantValues.find(left);                                                   \
-  if (lhs == kConstantValues.end()) {                                                      \
-    status_ = Status::SemanticError("Can't find constant value of `%s' when deduce type.", \
-                                    Value::toString(left).c_str());                        \
-    return;                                                                                \
-  }                                                                                        \
-  auto rhs = kConstantValues.find(right);                                                  \
-  if (rhs == kConstantValues.end()) {                                                      \
-    status_ = Status::SemanticError("Can't find constant value of `%s' when deduce type.", \
-                                    Value::toString(right).c_str());                       \
-    return;                                                                                \
-  }                                                                                        \
-  auto detectVal = lhs->second OP rhs->second;                                             \
-  if (detectVal.isBadNull()) {                                                             \
-    std::stringstream ss;                                                                  \
-    ss << "`" << expr->toString() << "' is not a valid expression, "                       \
-       << "can not apply `" << #OP << "' to `" << left << "' and `" << right << "'.";      \
-    status_ = Status::SemanticError(ss.str());                                             \
-    return;                                                                                \
-  }                                                                                        \
+#define DETECT_BIEXPR_TYPE(OP)                                                                  \
+  expr->left()->accept(this);                                                                   \
+  if (!ok()) return;                                                                            \
+  auto left = type_;                                                                            \
+  expr->right()->accept(this);                                                                  \
+  if (!ok()) return;                                                                            \
+  auto right = type_;                                                                           \
+  if (strcmp(#OP, "-") == 0 && (left == Value::Type::STRING || right == Value::Type::STRING)) { \
+    std::stringstream ss;                                                                       \
+    ss << "`" << expr->toString() << "' is not a valid expression, "                            \
+       << "can not apply `" << #OP << "' to `" << left << "' and `" << right << "'.";           \
+    status_ = Status::SemanticError(ss.str());                                                  \
+    return;                                                                                     \
+  }                                                                                             \
+  auto lhs = kConstantValues.find(left);                                                        \
+  if (lhs == kConstantValues.end()) {                                                           \
+    status_ = Status::SemanticError("Can't find constant value of `%s' when deduce type.",      \
+                                    Value::toString(left).c_str());                             \
+    return;                                                                                     \
+  }                                                                                             \
+  auto rhs = kConstantValues.find(right);                                                       \
+  if (rhs == kConstantValues.end()) {                                                           \
+    status_ = Status::SemanticError("Can't find constant value of `%s' when deduce type.",      \
+                                    Value::toString(right).c_str());                            \
+    return;                                                                                     \
+  }                                                                                             \
+  auto detectVal = lhs->second OP rhs->second;                                                  \
+  if (detectVal.isBadNull()) {                                                                  \
+    std::stringstream ss;                                                                       \
+    ss << "`" << expr->toString() << "' is not a valid expression, "                            \
+       << "can not apply `" << #OP << "' to `" << left << "' and `" << right << "'.";           \
+    status_ = Status::SemanticError(ss.str());                                                  \
+    return;                                                                                     \
+  }                                                                                             \
   type_ = detectVal.type()
 
 #define DETECT_NARYEXPR_TYPE(OP)                                                               \

--- a/src/graph/visitor/test/FilterTransformTest.cpp
+++ b/src/graph/visitor/test/FilterTransformTest.cpp
@@ -96,16 +96,16 @@ TEST_F(FilterTransformTest, TestNoRewrite) {
     ASSERT_EQ(res.value()->toString(), expected->toString())
         << res.value()->toString() << " vs. " << expected->toString();
   }
-  // // Do not rewrite if the arithmetic expression contains string/char constant
-  // {
-  //   // (v.name - "ab" < "name")  =>  Unchanged
-  //   auto expr = ltExpr(minusExpr(laExpr("v", "name"), constantExpr("ab")), constantExpr("name"));
-  //   auto res = ExpressionUtils::filterTransform(expr);
-  //   ASSERT(res.ok());
-  //   auto expected = expr;
-  //   ASSERT_EQ(res.value()->toString(), expected->toString())
-  //       << res.value()->toString() << " vs. " << expected->toString();
-  // }
+  // Do not rewrite if the arithmetic expression contains string/char constant
+  {
+    // (v.name - "ab" < "name")  =>  Unchanged
+    auto expr = ltExpr(minusExpr(laExpr("v", "name"), constantExpr("ab")), constantExpr("name"));
+    auto res = ExpressionUtils::filterTransform(expr);
+    ASSERT(res.ok());
+    auto expected = expr;
+    ASSERT_EQ(res.value()->toString(), expected->toString())
+        << res.value()->toString() << " vs. " << expected->toString();
+  }
 }
 
 }  // namespace graph

--- a/src/graph/visitor/test/FilterTransformTest.cpp
+++ b/src/graph/visitor/test/FilterTransformTest.cpp
@@ -27,26 +27,22 @@ TEST_F(FilterTransformTest, TestComplexExprRewrite) {
 // overflow
 // If the expression tranformation causes an overflow, it should not be done.
 TEST_F(FilterTransformTest, TestCalculationOverflow) {
-  // (v.age - 1 < 9223372036854775807)  =>  overflow
+  // (v.age - 1 < 9223372036854775807)  =>  unchanged
   {
     auto expr =
         ltExpr(minusExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(9223372036854775807));
     auto res = ExpressionUtils::filterTransform(expr);
-    auto expected = Status::SemanticError(
-        "result of (9223372036854775807+1) cannot be represented as an "
-        "integer");
-    ASSERT(!res.status().ok());
-    ASSERT_EQ(res.status(), expected) << res.status().toString() << " vs. " << expected.toString();
+    ASSERT(res.ok());
+    auto expected = res.value();
+    ASSERT_EQ(res.value(), expected) << res.value() << " vs. " << expected->toString();
   }
-  // (v.age + 1 < -9223372036854775808)  =>  overflow
+  // (v.age + 1 < -9223372036854775808)  =>  unchanged
   {
     auto expr = ltExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(INT64_MIN));
     auto res = ExpressionUtils::filterTransform(expr);
-    auto expected = Status::SemanticError(
-        "result of (-9223372036854775808-1) cannot be represented as an "
-        "integer");
-    ASSERT(!res.status().ok());
-    ASSERT_EQ(res.status(), expected) << res.status().toString() << " vs. " << expected.toString();
+    ASSERT(res.ok());
+    auto expected = res.value();
+    ASSERT_EQ(res.value(), expected) << res.value() << " vs. " << expected->toString();
   }
   // (v.age - 1 < 9223372036854775807 + 1)  =>  overflow
   {
@@ -56,7 +52,7 @@ TEST_F(FilterTransformTest, TestCalculationOverflow) {
     auto expected = Status::SemanticError(
         "result of (9223372036854775807+1) cannot be represented as an "
         "integer");
-    ASSERT(!res.status().ok());
+    ASSERT(!res.ok());
     ASSERT_EQ(res.status(), expected) << res.status().toString() << " vs. " << expected.toString();
   }
   // (v.age + 1 < -9223372036854775808 - 1)  =>  overflow
@@ -67,40 +63,37 @@ TEST_F(FilterTransformTest, TestCalculationOverflow) {
     auto expected = Status::SemanticError(
         "result of (-9223372036854775808-1) cannot be represented as an "
         "integer");
-    ASSERT(!res.status().ok());
+    ASSERT(!res.ok());
     ASSERT_EQ(res.status(), expected) << res.status().toString() << " vs. " << expected.toString();
   }
-  // !!!(v.age - 1 < 9223372036854775807)  =>  overflow
+  // !!!(v.age - 1 < 9223372036854775807)  =>  unchanged
   {
     auto expr = notExpr(notExpr(notExpr(ltExpr(minusExpr(laExpr("v", "age"), constantExpr(1)),
                                                constantExpr(9223372036854775807)))));
     auto res = ExpressionUtils::filterTransform(expr);
-    auto expected = Status::SemanticError(
-        "result of (9223372036854775807+1) cannot be represented as an "
-        "integer");
-    ASSERT(!res.status().ok());
-    ASSERT_EQ(res.status(), expected) << res.status().toString() << " vs. " << expected.toString();
+    ASSERT(res.ok());
+    auto expected = res.value();
+    ASSERT_EQ(res.value(), expected) << res.value()->toString() << " vs. " << expected->toString();
   }
-  // !!!(v.age + 1 < -9223372036854775808)  =>  overflow
+  // !!!(v.age + 1 < -9223372036854775808)  =>  unchanged
   {
     auto expr = notExpr(notExpr(
         notExpr(ltExpr(addExpr(laExpr("v", "age"), constantExpr(1)), constantExpr(INT64_MIN)))));
     auto res = ExpressionUtils::filterTransform(expr);
-    auto expected = Status::SemanticError(
-        "result of (-9223372036854775808-1) cannot be represented as an "
-        "integer");
-    ASSERT(!res.status().ok());
-    ASSERT_EQ(res.status(), expected) << res.status().toString() << " vs. " << expected.toString();
+    ASSERT(res.ok());
+    auto expected = res.value();
+    ASSERT_EQ(res.value(), expected) << res.value()->toString() << " vs. " << expected->toString();
   }
 }
 
 TEST_F(FilterTransformTest, TestNoRewrite) {
   // (v.age - 1 < v2.age + 2)  =>  Unchanged
   auto expr = ltExpr(minusExpr(laExpr("v", "age"), constantExpr(1)),
-                     addExpr(laExpr("v", "age"), constantExpr(40)));
+                     addExpr(laExpr("v2", "age"), constantExpr(40)));
   auto res = ExpressionUtils::filterTransform(expr);
-  auto expected = expr;
-  ASSERT_EQ(*res.value(), *expected) << res.value()->toString() << " vs. " << expected->toString();
+  ASSERT(res.ok());
+  auto expected = res.value();
+  ASSERT_EQ(res.value(), expected) << res.value()->toString() << " vs. " << expected->toString();
 }
 
 }  // namespace graph

--- a/src/graph/visitor/test/RewriteRelExprVisitorTest.cpp
+++ b/src/graph/visitor/test/RewriteRelExprVisitorTest.cpp
@@ -234,5 +234,23 @@ TEST_F(RewriteRelExprVisitorTest, TestContainer) {
   }
 }
 
+TEST_F(RewriteRelExprVisitorTest, TestArithmeticalExprWithStr) {
+  // Do not rewrite if the arithmetic expression contains string/char constant
+  {
+    // (v.name - "ab" < "name")  =>  Unchanged
+    auto expr = ltExpr(minusExpr(laExpr("v", "name"), constantExpr("ab")), constantExpr("name"));
+    auto res = ExpressionUtils::rewriteRelExpr(expr);
+    auto expected = expr;
+    ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
+  }
+  {
+    // (v.name + "ab" < "name")  =>  Unchanged
+    auto expr = ltExpr(addExpr(laExpr("v", "name"), constantExpr("ab")), constantExpr("name"));
+    auto res = ExpressionUtils::rewriteRelExpr(expr);
+    auto expected = expr;
+    ASSERT_EQ(*res, *expected) << res->toString() << " vs. " << expected->toString();
+  }
+}
+
 }  // namespace graph
 }  // namespace nebula

--- a/tests/tck/features/match/Base.IntVid.feature
+++ b/tests/tck/features/match/Base.IntVid.feature
@@ -575,3 +575,15 @@ Feature: Basic match
       RETURN count(names)
       """
     Then a SemanticError should be raised at runtime: To get the property of the vertex in `v3.name', should use the format `var.tag.prop'
+
+  Scenario: filter is not a valid expression
+    When executing query:
+      """
+      MATCH (v:player) WHERE v.player.name-'n'=="Tim Duncann" RETURN v
+      """
+    Then a SemanticError should be raised at runtime: `(v.player.name-"n")' is not a valid expression, can not apply `-' to `__EMPTY__' and `STRING'.
+    When executing query:
+      """
+      MATCH (v:player) WHERE v.player.name+'n'=="Tim Duncann" RETURN v
+      """
+    Then the execution should be successful

--- a/tests/tck/features/match/Base.IntVid.feature
+++ b/tests/tck/features/match/Base.IntVid.feature
@@ -586,4 +586,6 @@ Feature: Basic match
       """
       MATCH (v:player) WHERE v.player.name+'n'=="Tim Duncann" RETURN v
       """
-    Then the execution should be successful
+    Then the result should be, in any order:
+      | v                                                                                                          |
+      | ("Tim Duncan":bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"}) |

--- a/tests/tck/features/match/Base.feature
+++ b/tests/tck/features/match/Base.feature
@@ -685,3 +685,15 @@ Feature: Basic match
       RETURN count(names)
       """
     Then a SemanticError should be raised at runtime: To get the property of the vertex in `v3.name', should use the format `var.tag.prop'
+
+  Scenario: filter is not a valid expression
+    When executing query:
+      """
+      MATCH (v:player) WHERE v.player.name-'n'=="Tim Duncann" RETURN v
+      """
+    Then a SemanticError should be raised at runtime: `(v.player.name-"n")' is not a valid expression, can not apply `-' to `__EMPTY__' and `STRING'.
+    When executing query:
+      """
+      MATCH (v:player) WHERE v.player.name+'n'=="Tim Duncann" RETURN v
+      """
+    Then the execution should be successful

--- a/tests/tck/features/match/Base.feature
+++ b/tests/tck/features/match/Base.feature
@@ -696,4 +696,6 @@ Feature: Basic match
       """
       MATCH (v:player) WHERE v.player.name+'n'=="Tim Duncann" RETURN v
       """
-    Then the execution should be successful
+    Then the result should be, in any order:
+      | v                                                                                                          |
+      | ("Tim Duncan":bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"}) |

--- a/tests/tck/features/match/SeekById.feature
+++ b/tests/tck/features/match/SeekById.feature
@@ -243,7 +243,7 @@ Feature: Match seek by id
       WHERE (id(v) + '') == 'James Harden'
       RETURN v.player.name AS Name
       """
-    Then a SemanticError should be raised at runtime:
+    Then a ExecutionError should be raised at runtime: Scan vertices or edges need to specify a limit number, or limit number can not push down.
     When executing query:
       """
       MATCH (v)


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

#### What type of PR is this?
- [x] bug
- [ ] feature
- [x] enhancement

#### What problem does this PR solve?
Issue(s) number: 
Fix https://github.com/vesoft-inc/nebula/issues/3248

Description:
This PR fixes `filterTransform()` and adds cases.


#### How do you slove it?
1. Do not transfer the filter expression if it contains 2 different tagProp expressions i.e. `v.player.name =="abc" && v.player.age == 30`
2. Fix expression overflow check. Do not rewrite the expression if it would cause an overflow.
3. Refactor `rewriteRelExpr()`
4. Return semantic error when the non-addition arithmetic expression contains strings.



#### Special notes for your reviewer, ex. impact of this fix, design document, etc:

```
(root@nebula) [nba]> match (v:player) where v.player.name+'n'=="Tim Duncann" return v
+-----------------------------------------------------+
| v                                                   |
+-----------------------------------------------------+
| ("Tim Duncan" :player{age: 42, name: "Tim Duncan"}) |
+-----------------------------------------------------+
Got 1 rows (time spent 5509/5861 us)

Fri, 31 Dec 2021 22:51:01 CST

(root@nebula) [NBA]> match (v:player) where v.player.name-'n'=="Tim Duncann" return v
`(v.player.name-"n")' is not a valid expression, can not apply `-' to `__EMPTY__' and `STRING'.

Fri, 31 Dec 2021 22:51:08 CST
```

#### Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Perfomance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
