### PR TITLE
fix service crash

### DIFF
--- a/src/daemons/MetaDaemon.cpp
+++ b/src/daemons/MetaDaemon.cpp
@@ -53,12 +53,11 @@ DEFINE_int32(meta_http_thread_num, 3, "Number of meta daemon's http thread");
 DEFINE_string(pid_file, "pids/nebula-metad.pid", "File to hold the process id");
 DEFINE_bool(daemonize, true, "Whether run as a daemon process");
 
-static std::unique_ptr<apache::thrift::ThriftServer> gServer;
 static std::unique_ptr<nebula::kvstore::KVStore> gKVStore;
 
-static void signalHandler(int sig);
+static void signalHandler(apache::thrift::ThriftServer* metaServer, int sig);
 static void waitForStop();
-static Status setupSignalHandler();
+static Status setupSignalHandler(apache::thrift::ThriftServer* metaServer);
 #if defined(__x86_64__)
 extern Status setupBreakpad();
 #endif
@@ -189,8 +188,9 @@ int main(int argc, char* argv[]) {
     }
   }
 
+  auto metaServer = std::make_unique<apache::thrift::ThriftServer>();
   // Setup the signal handlers
-  status = setupSignalHandler();
+  status = setupSignalHandler(metaServer.get());
   if (!status.ok()) {
     LOG(ERROR) << status;
     return EXIT_FAILURE;
@@ -215,14 +215,13 @@ int main(int argc, char* argv[]) {
       std::make_shared<nebula::meta::MetaServiceHandler>(gKVStore.get(), metaClusterId());
   LOG(INFO) << "The meta daemon start on " << localhost;
   try {
-    gServer = std::make_unique<apache::thrift::ThriftServer>();
-    gServer->setPort(FLAGS_port);
-    gServer->setIdleTimeout(std::chrono::seconds(0));  // No idle timeout on client connection
-    gServer->setInterface(std::move(handler));
+    metaServer->setPort(FLAGS_port);
+    metaServer->setIdleTimeout(std::chrono::seconds(0));  // No idle timeout on client connection
+    metaServer->setInterface(std::move(handler));
     if (FLAGS_enable_ssl || FLAGS_enable_meta_ssl) {
-      gServer->setSSLConfig(nebula::sslContextConfig());
+      metaServer->setSSLConfig(nebula::sslContextConfig());
     }
-    gServer->serve();  // Will wait until the server shuts down
+    metaServer->serve();  // Will wait until the server shuts down
     waitForStop();
   } catch (const std::exception& e) {
     LOG(ERROR) << "Exception thrown: " << e.what();
@@ -233,19 +232,20 @@ int main(int argc, char* argv[]) {
   return EXIT_SUCCESS;
 }
 
-Status setupSignalHandler() {
+Status setupSignalHandler(apache::thrift::ThriftServer* metaServer) {
   return nebula::SignalHandler::install(
-      {SIGINT, SIGTERM},
-      [](nebula::SignalHandler::GeneralSignalInfo* info) { signalHandler(info->sig()); });
+      {SIGINT, SIGTERM}, [metaServer](nebula::SignalHandler::GeneralSignalInfo* info) {
+        signalHandler(metaServer, info->sig());
+      });
 }
 
-void signalHandler(int sig) {
+void signalHandler(apache::thrift::ThriftServer* metaServer, int sig) {
   switch (sig) {
     case SIGINT:
     case SIGTERM:
       FLOG_INFO("Signal %d(%s) received, stopping this server", sig, ::strsignal(sig));
-      if (gServer) {
-        gServer->stop();
+      if (metaServer) {
+        metaServer->stop();
       }
       break;
     default:

--- a/src/daemons/StorageDaemon.cpp
+++ b/src/daemons/StorageDaemon.cpp
@@ -45,13 +45,11 @@ using nebula::Status;
 using nebula::StatusOr;
 using nebula::network::NetworkUtils;
 
-static void signalHandler(int sig);
-static Status setupSignalHandler();
+static void signalHandler(nebula::storage::StorageServer *storageServer, int sig);
+static Status setupSignalHandler(nebula::storage::StorageServer *storageServer);
 #if defined(__x86_64__)
 extern Status setupBreakpad();
 #endif
-
-std::unique_ptr<nebula::storage::StorageServer> gStorageServer;
 
 int main(int argc, char *argv[]) {
   google::SetVersionString(nebula::versionString());
@@ -150,8 +148,10 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
+  auto storageServer = std::make_unique<nebula::storage::StorageServer>(
+      localhost, metaAddrsRet.value(), paths, FLAGS_wal_path, FLAGS_listener_path);
   // Setup the signal handlers
-  status = setupSignalHandler();
+  status = setupSignalHandler(storageServer.get());
   if (!status.ok()) {
     LOG(ERROR) << status;
     return EXIT_FAILURE;
@@ -172,32 +172,31 @@ int main(int argc, char *argv[]) {
     return EXIT_FAILURE;
   }
 
-  gStorageServer = std::make_unique<nebula::storage::StorageServer>(
-      localhost, metaAddrsRet.value(), paths, FLAGS_wal_path, FLAGS_listener_path);
-  if (!gStorageServer->start()) {
+  if (!storageServer->start()) {
     LOG(ERROR) << "Storage server start failed";
-    gStorageServer->stop();
+    storageServer->stop();
     return EXIT_FAILURE;
   }
 
-  gStorageServer->waitUntilStop();
+  storageServer->waitUntilStop();
   LOG(INFO) << "The storage Daemon stopped";
   return EXIT_SUCCESS;
 }
 
-Status setupSignalHandler() {
+Status setupSignalHandler(nebula::storage::StorageServer *storageServer) {
   return nebula::SignalHandler::install(
-      {SIGINT, SIGTERM},
-      [](nebula::SignalHandler::GeneralSignalInfo *info) { signalHandler(info->sig()); });
+      {SIGINT, SIGTERM}, [storageServer](nebula::SignalHandler::GeneralSignalInfo *info) {
+        signalHandler(storageServer, info->sig());
+      });
 }
 
-void signalHandler(int sig) {
+void signalHandler(nebula::storage::StorageServer *storageServer, int sig) {
   switch (sig) {
     case SIGINT:
     case SIGTERM:
       FLOG_INFO("Signal %d(%s) received, stopping this server", sig, ::strsignal(sig));
-      if (gStorageServer) {
-        gStorageServer->notifyStop();
+      if (storageServer) {
+        storageServer->notifyStop();
       }
       break;
     default:


### PR DESCRIPTION
<!--
Thanks for your contributing!
In order to review PR more efficiently, please add information according to the template.
-->

#### What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

#### What problem does this PR slove?
Issue(s) number: https://github.com/vesoft-inc/nebula/issues/3609

Description:
Service crash when exit.
The crash is caused by the glog lock variable (static variable called `vmodule_lock`) being destructed before thriftServer.

#### Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Perfomance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> Fixed the bug