### PR TITLE
Unify raft error code

### DIFF
--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -419,9 +419,7 @@ enum ErrorCode {
     E_FIELD_UNSET                     = -3007,
     // Value exceeds the range of type
     E_OUT_OF_RANGE                    = -3008,
-    // Atomic operation failed
-    E_ATOMIC_OP_FAILED                = -3009,
-    E_DATA_CONFLICT_ERROR             = -3010, // data conflict, for index write without toss.
+    E_DATA_CONFLICT_ERROR             = -3010,     // data conflict, for index write without toss.
 
     E_WRITE_STALLED                   = -3011,
 
@@ -474,25 +472,29 @@ enum ErrorCode {
     E_WORKER_ID_FAILED                = -3062,
 
     // 35xx for storaged raft
-    E_RAFT_UNKNOWN_PART               = -3500;
+    E_RAFT_UNKNOWN_PART               = -3500,
     // Raft consensus errors
-    E_RAFT_LOG_GAP                    = -3501;
-    E_RAFT_LOG_STALE                  = -3502;
-    E_RAFT_TERM_OUT_OF_DATE           = -3503;
+    E_RAFT_LOG_GAP                    = -3501,
+    E_RAFT_LOG_STALE                  = -3502,
+    E_RAFT_TERM_OUT_OF_DATE           = -3503,
     // Raft state errors
-    E_RAFT_WAITING_SNAPSHOT           = -3511;
-    E_RAFT_BAD_STATE                  = -3512;
-    E_RAFT_WRONG_LEADER               = -3513;
-    E_RAFT_NOT_READY                  = -3514;
-    E_RAFT_BAD_ROLE                   = -3515,
+    E_RAFT_WAITING_SNAPSHOT           = -3511,
+    E_RAFT_SENDING_SNAPSHOT           = -3512,
+    E_RAFT_INVALID_PEER               = -3513,
+    E_RAFT_NOT_READY                  = -3514,
+    E_RAFT_STOPPED                    = -3515,
+    E_RAFT_BAD_ROLE                   = -3516,
     // Local errors
-    E_RAFT_WAL_FAIL                   = -3521;
-    E_RAFT_HOST_STOPPED               = -3522;
-    E_RAFT_TOO_MANY_REQUESTS          = -3523;
-    E_RAFT_PERSIST_SNAPSHOT_FAILED    = -3524;
-    E_RAFT_RPC_EXCEPTION              = -3525;
-    E_RAFT_NO_WAL_FOUND               = -3526;
-    E_RAFT_HOST_PAUSED                = -3527;
+    E_RAFT_WAL_FAIL                   = -3521,
+    E_RAFT_HOST_STOPPED               = -3522,
+    E_RAFT_TOO_MANY_REQUESTS          = -3523,
+    E_RAFT_PERSIST_SNAPSHOT_FAILED    = -3524,
+    E_RAFT_RPC_EXCEPTION              = -3525,
+    E_RAFT_NO_WAL_FOUND               = -3526,
+    E_RAFT_HOST_PAUSED                = -3527,
+    E_RAFT_WRITE_BLOCKED              = -3528,
+    E_RAFT_BUFFER_OVERFLOW            = -3529,
+    E_RAFT_ATOMIC_OP_FAILED           = -3530,
 
     E_UNKNOWN                         = -8000,
 } (cpp.enum_strict)

--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -473,5 +473,26 @@ enum ErrorCode {
     // get worker id
     E_WORKER_ID_FAILED                = -3062,
 
+    // 35xx for storaged raft
+    E_RAFT_UNKNOWN_PART               = -3500;
+    // Raft consensus errors
+    E_RAFT_LOG_GAP                    = -3501;
+    E_RAFT_LOG_STALE                  = -3502;
+    E_RAFT_TERM_OUT_OF_DATE           = -3503;
+    // Raft state errors
+    E_RAFT_WAITING_SNAPSHOT           = -3511;
+    E_RAFT_BAD_STATE                  = -3512;
+    E_RAFT_WRONG_LEADER               = -3513;
+    E_RAFT_NOT_READY                  = -3514;
+    E_RAFT_BAD_ROLE                   = -3515,
+    // Local errors
+    E_RAFT_WAL_FAIL                   = -3521;
+    E_RAFT_HOST_STOPPED               = -3522;
+    E_RAFT_TOO_MANY_REQUESTS          = -3523;
+    E_RAFT_PERSIST_SNAPSHOT_FAILED    = -3524;
+    E_RAFT_RPC_EXCEPTION              = -3525;
+    E_RAFT_NO_WAL_FOUND               = -3526;
+    E_RAFT_HOST_PAUSED                = -3527;
+
     E_UNKNOWN                         = -8000,
 } (cpp.enum_strict)

--- a/src/interface/raftex.thrift
+++ b/src/interface/raftex.thrift
@@ -22,33 +22,6 @@ enum Status {
     WAITING_SNAPSHOT    = 3; // Waiting for the snapshot.
 } (cpp.enum_strict)
 
-enum ErrorCode {
-    SUCCEEDED = 0;
-
-    E_UNKNOWN_PART = -1;
-
-    // Raft consensus errors
-    E_LOG_GAP = -2;
-    E_LOG_STALE = -3;
-    E_TERM_OUT_OF_DATE = -4;
-
-    // Raft state errors
-    E_WAITING_SNAPSHOT = -5;            // The follower is waiting a snapshot
-    E_BAD_STATE = -6;
-    E_WRONG_LEADER = -7;
-    E_NOT_READY = -8;
-    E_BAD_ROLE = -9,
-
-    // Local errors
-    E_WAL_FAIL = -10;
-    E_HOST_STOPPED = -11;
-    E_TOO_MANY_REQUESTS = -12;
-    E_PERSIST_SNAPSHOT_FAILED = -13;
-    E_RPC_EXCEPTION = -14;              // An thrift internal exception was thrown
-    E_NO_WAL_FOUND = -15;
-    E_APPLY_FAIL = -16;
-    E_HOST_PAUSED = -17;
-}
 
 typedef i64 (cpp.type = "nebula::ClusterID") ClusterID
 typedef i32 (cpp.type = "nebula::GraphSpaceID") GraphSpaceID
@@ -73,8 +46,8 @@ struct AskForVoteRequest {
 
 // Response message for the vote call
 struct AskForVoteResponse {
-    1: ErrorCode error_code;
-    2: TermID    current_term;
+    1: common.ErrorCode error_code;
+    2: TermID           current_term;
 }
 
 // Log entries being sent to follower, logId is not included, it could be calculated by
@@ -98,13 +71,13 @@ struct AppendLogRequest {
 }
 
 struct AppendLogResponse {
-    1: ErrorCode    error_code;
-    2: TermID       current_term;
-    3: string       leader_addr;
-    4: Port         leader_port;
-    5: LogID        committed_log_id;
-    6: LogID        last_matched_log_id;
-    7: TermID       last_matched_log_term;
+    1: common.ErrorCode error_code;
+    2: TermID           current_term;
+    3: string           leader_addr;
+    4: Port             leader_port;
+    5: LogID            committed_log_id;
+    6: LogID            last_matched_log_id;
+    7: TermID           last_matched_log_term;
 }
 
 struct SendSnapshotRequest {
@@ -133,17 +106,17 @@ struct HeartbeatRequest {
 }
 
 struct HeartbeatResponse {
-    1: ErrorCode    error_code;
-    2: TermID       current_term;
-    3: string       leader_addr;
-    4: Port         leader_port;
-    5: LogID        committed_log_id;
-    6: LogID        last_log_id;
-    7: TermID       last_log_term;
+    1: common.ErrorCode error_code;
+    2: TermID           current_term;
+    3: string           leader_addr;
+    4: Port             leader_port;
+    5: LogID            committed_log_id;
+    6: LogID            last_log_id;
+    7: TermID           last_log_term;
 }
 
 struct SendSnapshotResponse {
-    1: ErrorCode    error_code;
+    1: common.ErrorCode error_code;
 }
 
 struct GetStateRequest {
@@ -152,14 +125,14 @@ struct GetStateRequest {
 }
 
 struct GetStateResponse {
-    1: ErrorCode    error_code;
-    2: Role         role;
-    3: TermID       term;
-    4: bool         is_leader;
-    5: LogID        committed_log_id;
-    6: LogID        last_log_id;
-    7: TermID       last_log_term;
-    8: Status       status;
+    1: common.ErrorCode error_code;
+    2: Role             role;
+    3: TermID           term;
+    4: bool             is_leader;
+    5: LogID            committed_log_id;
+    6: LogID            last_log_id;
+    7: TermID           last_log_term;
+    8: Status           status;
 }
 
 service RaftexService {

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -149,13 +149,13 @@ class Listener : public raftex::RaftPart {
     LOG(INFO) << idStr_ << "Find the new leader " << nLeader;
   }
 
-  raftex::cpp2::ErrorCode checkPeer(const HostAddr& candidate) override {
+  nebula::cpp2::ErrorCode checkPeer(const HostAddr& candidate) override {
     CHECK(!raftLock_.try_lock());
     if (peers_.find(candidate) == peers_.end()) {
       LOG(WARNING) << idStr_ << "The candidate " << candidate << " is not in my peers";
-      return raftex::cpp2::ErrorCode::E_WRONG_LEADER;
+      return nebula::cpp2::ErrorCode::E_RAFT_WRONG_LEADER;
     }
-    return raftex::cpp2::ErrorCode::SUCCEEDED;
+    return nebula::cpp2::ErrorCode::SUCCEEDED;
   }
 
   // For listener, we just return true directly. Another background thread trigger the actual

--- a/src/kvstore/Listener.h
+++ b/src/kvstore/Listener.h
@@ -153,7 +153,7 @@ class Listener : public raftex::RaftPart {
     CHECK(!raftLock_.try_lock());
     if (peers_.find(candidate) == peers_.end()) {
       LOG(WARNING) << idStr_ << "The candidate " << candidate << " is not in my peers";
-      return nebula::cpp2::ErrorCode::E_RAFT_WRONG_LEADER;
+      return nebula::cpp2::ErrorCode::E_RAFT_INVALID_PEER;
     }
     return nebula::cpp2::ErrorCode::SUCCEEDED;
   }

--- a/src/kvstore/Part.cpp
+++ b/src/kvstore/Part.cpp
@@ -17,8 +17,6 @@ DEFINE_int32(cluster_id, 0, "A unique id for each cluster");
 namespace nebula {
 namespace kvstore {
 
-using nebula::raftex::AppendLogResult;
-
 Part::Part(GraphSpaceID spaceId,
            PartitionID partId,
            HostAddr localAddr,
@@ -69,104 +67,96 @@ void Part::asyncPut(folly::StringPiece key, folly::StringPiece value, KVCallback
   std::string log = encodeMultiValues(OP_PUT, key, value);
 
   appendAsync(FLAGS_cluster_id, std::move(log))
-      .thenValue([this, callback = std::move(cb)](AppendLogResult res) mutable {
-        callback(this->toResultCode(res));
-      });
+      .thenValue(
+          [callback = std::move(cb)](nebula::cpp2::ErrorCode code) mutable { callback(code); });
 }
 
 void Part::asyncAppendBatch(std::string&& batch, KVCallback cb) {
   appendAsync(FLAGS_cluster_id, std::move(batch))
-      .thenValue([this, callback = std::move(cb)](AppendLogResult res) mutable {
-        callback(this->toResultCode(res));
-      });
+      .thenValue(
+          [callback = std::move(cb)](nebula::cpp2::ErrorCode code) mutable { callback(code); });
 }
 
 void Part::asyncMultiPut(const std::vector<KV>& keyValues, KVCallback cb) {
   std::string log = encodeMultiValues(OP_MULTI_PUT, keyValues);
 
   appendAsync(FLAGS_cluster_id, std::move(log))
-      .thenValue([this, callback = std::move(cb)](AppendLogResult res) mutable {
-        callback(this->toResultCode(res));
-      });
+      .thenValue(
+          [callback = std::move(cb)](nebula::cpp2::ErrorCode code) mutable { callback(code); });
 }
 
 void Part::asyncRemove(folly::StringPiece key, KVCallback cb) {
   std::string log = encodeSingleValue(OP_REMOVE, key);
 
   appendAsync(FLAGS_cluster_id, std::move(log))
-      .thenValue([this, callback = std::move(cb)](AppendLogResult res) mutable {
-        callback(this->toResultCode(res));
-      });
+      .thenValue(
+          [callback = std::move(cb)](nebula::cpp2::ErrorCode code) mutable { callback(code); });
 }
 
 void Part::asyncMultiRemove(const std::vector<std::string>& keys, KVCallback cb) {
   std::string log = encodeMultiValues(OP_MULTI_REMOVE, keys);
 
   appendAsync(FLAGS_cluster_id, std::move(log))
-      .thenValue([this, callback = std::move(cb)](AppendLogResult res) mutable {
-        callback(this->toResultCode(res));
-      });
+      .thenValue(
+          [callback = std::move(cb)](nebula::cpp2::ErrorCode code) mutable { callback(code); });
 }
 
 void Part::asyncRemoveRange(folly::StringPiece start, folly::StringPiece end, KVCallback cb) {
   std::string log = encodeMultiValues(OP_REMOVE_RANGE, start, end);
 
   appendAsync(FLAGS_cluster_id, std::move(log))
-      .thenValue([this, callback = std::move(cb)](AppendLogResult res) mutable {
-        callback(this->toResultCode(res));
-      });
+      .thenValue(
+          [callback = std::move(cb)](nebula::cpp2::ErrorCode code) mutable { callback(code); });
 }
 
 void Part::sync(KVCallback cb) {
-  sendCommandAsync("").thenValue([this, callback = std::move(cb)](AppendLogResult res) mutable {
-    callback(this->toResultCode(res));
-  });
+  sendCommandAsync("").thenValue(
+      [callback = std::move(cb)](nebula::cpp2::ErrorCode code) mutable { callback(code); });
 }
 
 void Part::asyncAtomicOp(raftex::AtomicOp op, KVCallback cb) {
   atomicOpAsync(std::move(op))
-      .thenValue([this, callback = std::move(cb)](AppendLogResult res) mutable {
-        callback(this->toResultCode(res));
-      });
+      .thenValue(
+          [callback = std::move(cb)](nebula::cpp2::ErrorCode code) mutable { callback(code); });
 }
 
 void Part::asyncAddLearner(const HostAddr& learner, KVCallback cb) {
   std::string log = encodeHost(OP_ADD_LEARNER, learner);
   sendCommandAsync(std::move(log))
-      .thenValue([callback = std::move(cb), learner, this](AppendLogResult res) mutable {
+      .thenValue([callback = std::move(cb), learner, this](nebula::cpp2::ErrorCode code) mutable {
         LOG(INFO) << idStr_ << "add learner " << learner
-                  << ", result: " << static_cast<int32_t>(this->toResultCode(res));
-        callback(this->toResultCode(res));
+                  << ", result: " << apache::thrift::util::enumNameSafe(code);
+        callback(code);
       });
 }
 
 void Part::asyncTransferLeader(const HostAddr& target, KVCallback cb) {
   std::string log = encodeHost(OP_TRANS_LEADER, target);
   sendCommandAsync(std::move(log))
-      .thenValue([callback = std::move(cb), target, this](AppendLogResult res) mutable {
+      .thenValue([callback = std::move(cb), target, this](nebula::cpp2::ErrorCode code) mutable {
         LOG(INFO) << idStr_ << "transfer leader to " << target
-                  << ", result: " << static_cast<int32_t>(this->toResultCode(res));
-        callback(this->toResultCode(res));
+                  << ", result: " << apache::thrift::util::enumNameSafe(code);
+        callback(code);
       });
 }
 
 void Part::asyncAddPeer(const HostAddr& peer, KVCallback cb) {
   std::string log = encodeHost(OP_ADD_PEER, peer);
   sendCommandAsync(std::move(log))
-      .thenValue([callback = std::move(cb), peer, this](AppendLogResult res) mutable {
+      .thenValue([callback = std::move(cb), peer, this](nebula::cpp2::ErrorCode code) mutable {
         LOG(INFO) << idStr_ << "add peer " << peer
-                  << ", result: " << static_cast<int32_t>(this->toResultCode(res));
-        callback(this->toResultCode(res));
+                  << ", result: " << apache::thrift::util::enumNameSafe(code);
+        callback(code);
       });
 }
 
 void Part::asyncRemovePeer(const HostAddr& peer, KVCallback cb) {
   std::string log = encodeHost(OP_REMOVE_PEER, peer);
   sendCommandAsync(std::move(log))
-      .thenValue([callback = std::move(cb), peer, this](AppendLogResult res) mutable {
+      .thenValue([callback = std::move(cb), peer, this](nebula::cpp2::ErrorCode code) mutable {
         LOG(INFO) << idStr_ << "remove peer " << peer
-                  << ", result: " << static_cast<int32_t>(this->toResultCode(res));
-        callback(this->toResultCode(res));
+                  << ", result: " << apache::thrift::util::enumNameSafe(code);
+        callback(code);
       });
 }
 
@@ -517,25 +507,6 @@ nebula::cpp2::ErrorCode Part::cleanup() {
   }
   return engine_->commitBatchWrite(
       std::move(batch), FLAGS_rocksdb_disable_wal, FLAGS_rocksdb_wal_sync, true);
-}
-
-// TODO(pandasheep) unify raft errorcode
-nebula::cpp2::ErrorCode Part::toResultCode(raftex::AppendLogResult res) {
-  switch (res) {
-    case raftex::AppendLogResult::SUCCEEDED:
-      return nebula::cpp2::ErrorCode::SUCCEEDED;
-    case raftex::AppendLogResult::E_NOT_A_LEADER:
-      return nebula::cpp2::ErrorCode::E_LEADER_CHANGED;
-    case raftex::AppendLogResult::E_WRITE_BLOCKING:
-      return nebula::cpp2::ErrorCode::E_CHECKPOINT_BLOCKED;
-    case raftex::AppendLogResult::E_ATOMIC_OP_FAILURE:
-      return nebula::cpp2::ErrorCode::E_ATOMIC_OP_FAILED;
-    case raftex::AppendLogResult::E_BUFFER_OVERFLOW:
-      return nebula::cpp2::ErrorCode::E_CONSENSUS_ERROR;
-    default:
-      LOG(ERROR) << idStr_ << "Consensus error " << static_cast<int32_t>(res);
-      return nebula::cpp2::ErrorCode::E_CONSENSUS_ERROR;
-  }
 }
 
 }  // namespace kvstore

--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -115,8 +115,6 @@ class Part : public raftex::RaftPart {
 
   nebula::cpp2::ErrorCode cleanup() override;
 
-  nebula::cpp2::ErrorCode toResultCode(raftex::AppendLogResult res);
-
  public:
   struct CallbackOptions {
     GraphSpaceID spaceId;

--- a/src/kvstore/raftex/Host.cpp
+++ b/src/kvstore/raftex/Host.cpp
@@ -214,7 +214,7 @@ void Host::appendLogsInternal(folly::EventBase* eb, std::shared_ptr<cpp2::Append
             return;
           }
           // Usually the peer is not in proper state, for example:
-          // E_RAFT_UNKNOWN_PART/E_RAFT_BAD_STATE/E_RAFT_NOT_READY/E_RAFT_WAITING_SNAPSHOT
+          // E_RAFT_UNKNOWN_PART/E_RAFT_STOPPED/E_RAFT_NOT_READY/E_RAFT_WAITING_SNAPSHOT
           // In this case, nothing changed, just return the error
           default: {
             LOG_EVERY_N(ERROR, 100)

--- a/src/kvstore/raftex/Host.cpp
+++ b/src/kvstore/raftex/Host.cpp
@@ -43,18 +43,18 @@ void Host::waitForStop() {
   LOG(INFO) << idStr_ << "The host has been stopped!";
 }
 
-cpp2::ErrorCode Host::canAppendLog() const {
+nebula::cpp2::ErrorCode Host::canAppendLog() const {
   CHECK(!lock_.try_lock());
   if (stopped_) {
     VLOG(2) << idStr_ << "The host is stopped, just return";
-    return cpp2::ErrorCode::E_HOST_STOPPED;
+    return nebula::cpp2::ErrorCode::E_RAFT_HOST_STOPPED;
   }
 
   if (paused_) {
     VLOG(2) << idStr_ << "The host is paused, due to losing leadership";
-    return cpp2::ErrorCode::E_HOST_PAUSED;
+    return nebula::cpp2::ErrorCode::E_RAFT_HOST_PAUSED;
   }
-  return cpp2::ErrorCode::SUCCEEDED;
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
 folly::Future<cpp2::AskForVoteResponse> Host::askForVote(const cpp2::AskForVoteRequest& req,
@@ -64,7 +64,7 @@ folly::Future<cpp2::AskForVoteResponse> Host::askForVote(const cpp2::AskForVoteR
     if (stopped_) {
       VLOG(2) << idStr_ << "The Host is not in a proper status, do not send";
       cpp2::AskForVoteResponse resp;
-      resp.error_code_ref() = cpp2::ErrorCode::E_HOST_STOPPED;
+      resp.error_code_ref() = nebula::cpp2::ErrorCode::E_RAFT_HOST_STOPPED;
       return resp;
     }
   }
@@ -89,7 +89,7 @@ folly::Future<cpp2::AppendLogResponse> Host::appendLogs(folly::EventBase* eb,
 
     if (UNLIKELY(sendingSnapshot_)) {
       LOG_EVERY_N(INFO, 500) << idStr_ << "The target host is waiting for a snapshot";
-      res = cpp2::ErrorCode::E_WAITING_SNAPSHOT;
+      res = nebula::cpp2::ErrorCode::E_RAFT_WAITING_SNAPSHOT;
     } else if (requestOnGoing_) {
       // buffer incoming request to pendingReq_
       if (cachingPromise_.size() <= FLAGS_max_outstanding_requests) {
@@ -97,11 +97,11 @@ folly::Future<cpp2::AppendLogResponse> Host::appendLogs(folly::EventBase* eb,
         return cachingPromise_.getFuture();
       } else {
         LOG_EVERY_N(INFO, 200) << idStr_ << "Too many requests are waiting, return error";
-        res = cpp2::ErrorCode::E_TOO_MANY_REQUESTS;
+        res = nebula::cpp2::ErrorCode::E_RAFT_TOO_MANY_REQUESTS;
       }
     }
 
-    if (res != cpp2::ErrorCode::SUCCEEDED) {
+    if (res != nebula::cpp2::ErrorCode::SUCCEEDED) {
       VLOG(2) << idStr_ << "The host is not in a proper status, just return";
       cpp2::AppendLogResponse r;
       r.error_code_ref() = res;
@@ -168,16 +168,16 @@ void Host::appendLogsInternal(folly::EventBase* eb, std::shared_ptr<cpp2::Append
             << ", commitLogId " << resp.get_committed_log_id() << ", lastLogIdSent_ "
             << self->lastLogIdSent_ << ", lastLogTermSent_ " << self->lastLogTermSent_;
         switch (resp.get_error_code()) {
-          case cpp2::ErrorCode::SUCCEEDED:
-          case cpp2::ErrorCode::E_LOG_GAP:
-          case cpp2::ErrorCode::E_LOG_STALE: {
+          case nebula::cpp2::ErrorCode::SUCCEEDED:
+          case nebula::cpp2::ErrorCode::E_RAFT_LOG_GAP:
+          case nebula::cpp2::ErrorCode::E_RAFT_LOG_STALE: {
             VLOG(2) << self->idStr_ << "AppendLog request sent successfully";
 
             std::shared_ptr<cpp2::AppendLogRequest> newReq;
             {
               std::lock_guard<std::mutex> g(self->lock_);
               auto res = self->canAppendLog();
-              if (res != cpp2::ErrorCode::SUCCEEDED) {
+              if (res != nebula::cpp2::ErrorCode::SUCCEEDED) {
                 cpp2::AppendLogResponse r;
                 r.error_code_ref() = res;
                 self->setResponse(r);
@@ -214,7 +214,7 @@ void Host::appendLogsInternal(folly::EventBase* eb, std::shared_ptr<cpp2::Append
             return;
           }
           // Usually the peer is not in proper state, for example:
-          // E_UNKNOWN_PART/E_BAD_STATE/E_NOT_READY/E_WAITING_SNAPSHOT
+          // E_RAFT_UNKNOWN_PART/E_RAFT_BAD_STATE/E_RAFT_NOT_READY/E_RAFT_WAITING_SNAPSHOT
           // In this case, nothing changed, just return the error
           default: {
             LOG_EVERY_N(ERROR, 100)
@@ -232,7 +232,7 @@ void Host::appendLogsInternal(folly::EventBase* eb, std::shared_ptr<cpp2::Append
                  [self = shared_from_this(), req](TransportException&& ex) {
                    VLOG(2) << self->idStr_ << ex.what();
                    cpp2::AppendLogResponse r;
-                   r.error_code_ref() = cpp2::ErrorCode::E_RPC_EXCEPTION;
+                   r.error_code_ref() = nebula::cpp2::ErrorCode::E_RAFT_RPC_EXCEPTION;
                    {
                      std::lock_guard<std::mutex> g(self->lock_);
                      if (ex.getType() == TransportException::TIMED_OUT) {
@@ -254,7 +254,7 @@ void Host::appendLogsInternal(folly::EventBase* eb, std::shared_ptr<cpp2::Append
       .thenError(folly::tag_t<std::exception>{}, [self = shared_from_this()](std::exception&& ex) {
         VLOG(2) << self->idStr_ << ex.what();
         cpp2::AppendLogResponse r;
-        r.error_code_ref() = cpp2::ErrorCode::E_RPC_EXCEPTION;
+        r.error_code_ref() = nebula::cpp2::ErrorCode::E_RAFT_RPC_EXCEPTION;
         {
           std::lock_guard<std::mutex> g(self->lock_);
           self->setResponse(r);
@@ -264,7 +264,8 @@ void Host::appendLogsInternal(folly::EventBase* eb, std::shared_ptr<cpp2::Append
       });
 }
 
-ErrorOr<cpp2::ErrorCode, std::shared_ptr<cpp2::AppendLogRequest>> Host::prepareAppendLogRequest() {
+ErrorOr<nebula::cpp2::ErrorCode, std::shared_ptr<cpp2::AppendLogRequest>>
+Host::prepareAppendLogRequest() {
   CHECK(!lock_.try_lock());
   VLOG(2) << idStr_ << "Prepare AppendLogs request from Log " << lastLogIdSent_ + 1 << " to "
           << logIdToSend_;
@@ -279,7 +280,7 @@ ErrorOr<cpp2::ErrorCode, std::shared_ptr<cpp2::AppendLogRequest>> Host::prepareA
         << idStr_ << "My lastLogId in wal is " << part_->wal()->lastLogId()
         << ", but you are seeking " << lastLogIdSent_ + 1
         << ", so i have nothing to send, logIdToSend_ = " << logIdToSend_;
-    return cpp2::ErrorCode::E_NO_WAL_FOUND;
+    return nebula::cpp2::ErrorCode::E_RAFT_NO_WAL_FOUND;
   }
 
   auto it = part_->wal()->iterator(lastLogIdSent_ + 1, logIdToSend_);
@@ -307,16 +308,16 @@ ErrorOr<cpp2::ErrorCode, std::shared_ptr<cpp2::AppendLogRequest>> Host::prepareA
     if (!it->valid() && (lastLogIdSent_ + static_cast<int64_t>(logs.size()) != logIdToSend_)) {
       LOG_IF(INFO, FLAGS_trace_raft)
           << idStr_ << "Can't find log in wal, logIdToSend_ = " << logIdToSend_;
-      return cpp2::ErrorCode::E_NO_WAL_FOUND;
+      return nebula::cpp2::ErrorCode::E_RAFT_NO_WAL_FOUND;
     }
     req->log_str_list_ref() = std::move(logs);
     return req;
   } else {
-    return cpp2::ErrorCode::E_NO_WAL_FOUND;
+    return nebula::cpp2::ErrorCode::E_RAFT_NO_WAL_FOUND;
   }
 }
 
-cpp2::ErrorCode Host::startSendSnapshot() {
+nebula::cpp2::ErrorCode Host::startSendSnapshot() {
   CHECK(!lock_.try_lock());
   if (!sendingSnapshot_) {
     LOG(INFO) << idStr_ << "Can't find log " << lastLogIdSent_ + 1 << " in wal, send the snapshot"
@@ -345,7 +346,7 @@ cpp2::ErrorCode Host::startSendSnapshot() {
   } else {
     LOG_EVERY_N(INFO, 100) << idStr_ << "The snapshot req is in queue, please wait for a moment";
   }
-  return cpp2::ErrorCode::E_WAITING_SNAPSHOT;
+  return nebula::cpp2::ErrorCode::E_RAFT_WAITING_SNAPSHOT;
 }
 
 folly::Future<cpp2::AppendLogResponse> Host::sendAppendLogRequest(
@@ -355,7 +356,7 @@ folly::Future<cpp2::AppendLogResponse> Host::sendAppendLogRequest(
   {
     std::lock_guard<std::mutex> g(lock_);
     auto res = canAppendLog();
-    if (res != cpp2::ErrorCode::SUCCEEDED) {
+    if (res != nebula::cpp2::ErrorCode::SUCCEEDED) {
       LOG(WARNING) << idStr_ << "The Host is not in a proper status, do not send";
       cpp2::AppendLogResponse resp;
       resp.error_code_ref() = res;
@@ -395,7 +396,7 @@ folly::Future<cpp2::HeartbeatResponse> Host::sendHeartbeat(
         VLOG(3) << self->idStr_ << "heartbeat call got response";
         if (t.hasException()) {
           cpp2::HeartbeatResponse resp;
-          resp.error_code_ref() = cpp2::ErrorCode::E_RPC_EXCEPTION;
+          resp.error_code_ref() = nebula::cpp2::ErrorCode::E_RAFT_RPC_EXCEPTION;
           pro.setValue(std::move(resp));
           return;
         } else {
@@ -412,7 +413,7 @@ folly::Future<cpp2::HeartbeatResponse> Host::sendHeartbeatRequest(
   {
     std::lock_guard<std::mutex> g(lock_);
     auto res = canAppendLog();
-    if (res != cpp2::ErrorCode::SUCCEEDED) {
+    if (res != nebula::cpp2::ErrorCode::SUCCEEDED) {
       LOG(WARNING) << idStr_ << "The Host is not in a proper status, do not send";
       cpp2::HeartbeatResponse resp;
       resp.error_code_ref() = res;

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -97,7 +97,7 @@ class Host final : public std::enable_shared_from_this<Host> {
   }
 
  private:
-  cpp2::ErrorCode canAppendLog() const;
+  nebula::cpp2::ErrorCode canAppendLog() const;
 
   folly::Future<cpp2::AppendLogResponse> sendAppendLogRequest(
       folly::EventBase* eb, std::shared_ptr<cpp2::AppendLogRequest> req);
@@ -107,9 +107,10 @@ class Host final : public std::enable_shared_from_this<Host> {
   folly::Future<cpp2::HeartbeatResponse> sendHeartbeatRequest(
       folly::EventBase* eb, std::shared_ptr<cpp2::HeartbeatRequest> req);
 
-  ErrorOr<cpp2::ErrorCode, std::shared_ptr<cpp2::AppendLogRequest>> prepareAppendLogRequest();
+  ErrorOr<nebula::cpp2::ErrorCode, std::shared_ptr<cpp2::AppendLogRequest>>
+  prepareAppendLogRequest();
 
-  cpp2::ErrorCode startSendSnapshot();
+  nebula::cpp2::ErrorCode startSendSnapshot();
 
   bool noRequest() const;
 

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -15,6 +15,7 @@
 #include "common/time/Duration.h"
 #include "common/utils/LogIterator.h"
 #include "interface/gen-cpp2/RaftexServiceAsyncClient.h"
+#include "interface/gen-cpp2/common_types.h"
 #include "interface/gen-cpp2/raftex_types.h"
 #include "kvstore/Common.h"
 #include "kvstore/DiskManager.h"
@@ -284,7 +285,7 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
   virtual void onDiscoverNewLeader(HostAddr nLeader) = 0;
 
   // Check if we can accept candidate's message
-  virtual cpp2::ErrorCode checkPeer(const HostAddr& candidate);
+  virtual nebula::cpp2::ErrorCode checkPeer(const HostAddr& candidate);
 
   // The inherited classes need to implement this method to commit a batch of log messages.
   // Return {error code, last commit log id, last commit log term}.
@@ -330,7 +331,7 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
   const char* roleStr(Role role) const;
 
   template <typename REQ>
-  cpp2::ErrorCode verifyLeader(const REQ& req);
+  nebula::cpp2::ErrorCode verifyLeader(const REQ& req);
 
   /*****************************************************************
    *

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -34,21 +34,6 @@ class FileBasedWal;
 
 namespace raftex {
 
-enum class AppendLogResult {
-  SUCCEEDED = 0,
-  E_ATOMIC_OP_FAILURE = -1,
-  E_NOT_A_LEADER = -2,
-  E_STOPPED = -3,
-  E_NOT_READY = -4,
-  E_BUFFER_OVERFLOW = -5,
-  E_WAL_FAILURE = -6,
-  E_TERM_OUT_OF_DATE = -7,
-  E_SENDING_SNAPSHOT = -8,
-  E_INVALID_PEER = -9,
-  E_NOT_ENOUGH_ACKS = -10,
-  E_WRITE_BLOCKING = -11,
-};
-
 enum class LogType {
   NORMAL = 0x00,
   ATOMIC_OP = 0x01,
@@ -174,23 +159,23 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
    *
    * If the source == -1, the current clusterId will be used
    ****************************************************************/
-  folly::Future<AppendLogResult> appendAsync(ClusterID source, std::string log);
+  folly::Future<nebula::cpp2::ErrorCode> appendAsync(ClusterID source, std::string log);
 
   /****************************************************************
    * Run the op atomically.
    ***************************************************************/
-  folly::Future<AppendLogResult> atomicOpAsync(AtomicOp op);
+  folly::Future<nebula::cpp2::ErrorCode> atomicOpAsync(AtomicOp op);
 
   /**
    * Asynchronously send one command.
    * */
-  folly::Future<AppendLogResult> sendCommandAsync(std::string log);
+  folly::Future<nebula::cpp2::ErrorCode> sendCommandAsync(std::string log);
 
   /**
    * Check if the peer has catched up data from leader. If leader is sending the
    * snapshot, the method will return false.
    * */
-  AppendLogResult isCatchedUp(const HostAddr& peer);
+  nebula::cpp2::ErrorCode isCatchedUp(const HostAddr& peer);
 
   bool linkCurrentWAL(const char* newPath);
 
@@ -380,16 +365,16 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
 
   // Check whether new logs can be appended
   // Pre-condition: The caller needs to hold the raftLock_
-  AppendLogResult canAppendLogs();
+  nebula::cpp2::ErrorCode canAppendLogs();
 
   // Also check if term has changed
   // Pre-condition: The caller needs to hold the raftLock_
-  AppendLogResult canAppendLogs(TermID currTerm);
+  nebula::cpp2::ErrorCode canAppendLogs(TermID currTerm);
 
-  folly::Future<AppendLogResult> appendLogAsync(ClusterID source,
-                                                LogType logType,
-                                                std::string log,
-                                                AtomicOp cb = nullptr);
+  folly::Future<nebula::cpp2::ErrorCode> appendLogAsync(ClusterID source,
+                                                        LogType logType,
+                                                        std::string log,
+                                                        AtomicOp cb = nullptr);
 
   void appendLogsInternal(AppendLogsIterator iter, TermID termId);
 
@@ -415,7 +400,7 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
   // counted in
   std::vector<std::shared_ptr<Host>> followers() const;
 
-  bool checkAppendLogResult(AppendLogResult res);
+  bool checkAppendLogResult(nebula::cpp2::ErrorCode res);
 
   void updateQuorum();
 
@@ -512,13 +497,13 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
   mutable std::mutex logsLock_;
   std::atomic_bool replicatingLogs_{false};
   std::atomic_bool bufferOverFlow_{false};
-  PromiseSet<AppendLogResult> cachingPromise_;
+  PromiseSet<nebula::cpp2::ErrorCode> cachingPromise_;
   LogCache logs_;
 
   // Partition level lock to synchronize the access of the partition
   mutable std::mutex raftLock_;
 
-  PromiseSet<AppendLogResult> sendingPromise_;
+  PromiseSet<nebula::cpp2::ErrorCode> sendingPromise_;
 
   Status status_;
   Role role_;

--- a/src/kvstore/raftex/RaftexService.cpp
+++ b/src/kvstore/raftex/RaftexService.cpp
@@ -181,7 +181,7 @@ void RaftexService::getState(cpp2::GetStateResponse& resp, const cpp2::GetStateR
     part->getState(resp);
   } else {
     resp.term_ref() = -1;
-    resp.error_code_ref() = cpp2::ErrorCode::E_UNKNOWN_PART;
+    resp.error_code_ref() = nebula::cpp2::ErrorCode::E_RAFT_UNKNOWN_PART;
   }
 }
 
@@ -189,7 +189,7 @@ void RaftexService::askForVote(cpp2::AskForVoteResponse& resp, const cpp2::AskFo
   auto part = findPart(req.get_space(), req.get_part());
   if (!part) {
     // Not found
-    resp.error_code_ref() = cpp2::ErrorCode::E_UNKNOWN_PART;
+    resp.error_code_ref() = nebula::cpp2::ErrorCode::E_RAFT_UNKNOWN_PART;
     return;
   }
 
@@ -200,7 +200,7 @@ void RaftexService::appendLog(cpp2::AppendLogResponse& resp, const cpp2::AppendL
   auto part = findPart(req.get_space(), req.get_part());
   if (!part) {
     // Not found
-    resp.error_code_ref() = cpp2::ErrorCode::E_UNKNOWN_PART;
+    resp.error_code_ref() = nebula::cpp2::ErrorCode::E_RAFT_UNKNOWN_PART;
     return;
   }
 
@@ -212,7 +212,7 @@ void RaftexService::sendSnapshot(cpp2::SendSnapshotResponse& resp,
   auto part = findPart(req.get_space(), req.get_part());
   if (!part) {
     // Not found
-    resp.error_code_ref() = cpp2::ErrorCode::E_UNKNOWN_PART;
+    resp.error_code_ref() = nebula::cpp2::ErrorCode::E_RAFT_UNKNOWN_PART;
     return;
   }
 
@@ -226,7 +226,7 @@ void RaftexService::async_eb_heartbeat(
   auto part = findPart(req.get_space(), req.get_part());
   if (!part) {
     // Not found
-    resp.error_code_ref() = cpp2::ErrorCode::E_UNKNOWN_PART;
+    resp.error_code_ref() = nebula::cpp2::ErrorCode::E_RAFT_UNKNOWN_PART;
     callback->result(resp);
     return;
   }

--- a/src/kvstore/raftex/SnapshotManager.cpp
+++ b/src/kvstore/raftex/SnapshotManager.cpp
@@ -72,7 +72,7 @@ folly::Future<StatusOr<std::pair<LogID, TermID>>> SnapshotManager::sendSnapshot(
             // occupied.
             try {
               auto resp = std::move(f).get();
-              if (resp.get_error_code() == cpp2::ErrorCode::SUCCEEDED) {
+              if (resp.get_error_code() == nebula::cpp2::ErrorCode::SUCCEEDED) {
                 VLOG(1) << part->idStr_ << "has sended count " << totalCount;
                 if (status == SnapshotStatus::DONE) {
                   LOG(INFO) << part->idStr_ << "Finished, totalCount " << totalCount

--- a/src/kvstore/raftex/test/LogAppendTest.cpp
+++ b/src/kvstore/raftex/test/LogAppendTest.cpp
@@ -88,11 +88,11 @@ TEST(LogAppend, MultiThreadAppend) {
       for (int j = 1; j <= numLogs; ++j) {
         do {
           auto fut = leader->appendAsync(0, folly::stringPrintf("Log %03d for t%d", j, i));
-          if (fut.isReady() && fut.value() == AppendLogResult::E_BUFFER_OVERFLOW) {
+          if (fut.isReady() && fut.value() == nebula::cpp2::ErrorCode::E_RAFT_BUFFER_OVERFLOW) {
             LOG(FATAL) << "Should not reach here";
           } else if (j == numLogs) {
             // Only wait on the last log message
-            ASSERT_EQ(AppendLogResult::SUCCEEDED, std::move(fut).get());
+            ASSERT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, std::move(fut).get());
           }
           break;
         } while (true);

--- a/src/kvstore/raftex/test/LogCASTest.cpp
+++ b/src/kvstore/raftex/test/LogCASTest.cpp
@@ -210,8 +210,8 @@ TEST_F(LogCASTest, EmptyTest) {
     LOG(INFO) << "return empty string for atomic operation!";
     folly::Baton<> baton;
     leader_->atomicOpAsync([log = std::move(log)]() mutable { return std::string(""); })
-        .thenValue([&baton](AppendLogResult res) {
-          ASSERT_EQ(AppendLogResult::SUCCEEDED, res);
+        .thenValue([&baton](nebula::cpp2::ErrorCode res) {
+          ASSERT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, res);
           baton.post();
         });
     baton.wait();
@@ -220,8 +220,8 @@ TEST_F(LogCASTest, EmptyTest) {
     LOG(INFO) << "return none string for atomic operation!";
     folly::Baton<> baton;
     leader_->atomicOpAsync([log = std::move(log)]() mutable { return folly::none; })
-        .thenValue([&baton](AppendLogResult res) {
-          ASSERT_EQ(AppendLogResult::E_ATOMIC_OP_FAILURE, res);
+        .thenValue([&baton](nebula::cpp2::ErrorCode res) {
+          ASSERT_EQ(nebula::cpp2::ErrorCode::E_RAFT_ATOMIC_OP_FAILED, res);
           baton.post();
         });
     baton.wait();

--- a/src/storage/admin/AdminProcessor.h
+++ b/src/storage/admin/AdminProcessor.h
@@ -274,19 +274,19 @@ class WaitingForCatchUpDataProcessor : public BaseProcessor<cpp2::AdminExecResp>
                   << ", part " << partId << ", remaining " << retry << " retry times"
                   << ", result " << static_cast<int32_t>(res);
         switch (res) {
-          case raftex::AppendLogResult::SUCCEEDED:
+          case nebula::cpp2::ErrorCode::SUCCEEDED:
             onFinished();
             return;
-          case raftex::AppendLogResult::E_INVALID_PEER:
+          case nebula::cpp2::ErrorCode::E_RAFT_INVALID_PEER:
             this->pushResultCode(nebula::cpp2::ErrorCode::E_INVALID_PEER, partId);
             onFinished();
             return;
-          case raftex::AppendLogResult::E_NOT_A_LEADER: {
+          case nebula::cpp2::ErrorCode::E_LEADER_CHANGED: {
             handleLeaderChanged(spaceId, partId);
             onFinished();
             return;
           }
-          case raftex::AppendLogResult::E_SENDING_SNAPSHOT:
+          case nebula::cpp2::ErrorCode::E_RAFT_SENDING_SNAPSHOT:
             LOG(INFO) << "Space " << spaceId << ", partId " << partId
                       << " is still sending snapshot, please wait...";
             break;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

#### What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

#### What problem(s) does this PR solve?
Issue(s) number: 

Description:
This is a prepare to adjust log level later. Previously we have an extra `ErrorCode` in `raftex.thrift`, which is unified to `common.ErrorCode` as well. And there in another "code" (notorious `AppendLogResult`) in RaftPart, this PR also removed it.

All raft error code is unified now.

#### How do you solve it?


  
#### Special notes for your reviewer, ex. impact of this fix, design document, etc:



#### Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [x] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes:

No related