### PR TITLE
add notifyStop() for metaClient

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -86,6 +86,7 @@ MetaClient::MetaClient(std::shared_ptr<folly::IOThreadPoolExecutor> ioThreadPool
 }
 
 MetaClient::~MetaClient() {
+  notifyStop();
   stop();
   delete sessionMap_.load();
   delete killedPlans_.load();
@@ -142,13 +143,18 @@ bool MetaClient::waitForMetadReady(int count, int retryIntervalSecs) {
   return ready_;
 }
 
-void MetaClient::stop() {
+void MetaClient::notifyStop() {
   if (bgThread_ != nullptr) {
     bgThread_->stop();
+  }
+  isRunning_ = false;
+}
+
+void MetaClient::stop() {
+  if (bgThread_ != nullptr) {
     bgThread_->wait();
     bgThread_.reset();
   }
-  isRunning_ = false;
 }
 
 void MetaClient::heartBeatThreadFunc() {

--- a/src/clients/meta/MetaClient.h
+++ b/src/clients/meta/MetaClient.h
@@ -239,6 +239,8 @@ class MetaClient {
 
   bool waitForMetadReady(int count = -1, int retryIntervalSecs = FLAGS_heartbeat_interval_secs);
 
+  void notifyStop();
+
   void stop();
 
   void registerListener(MetaChangedListener* listener) {

--- a/src/mock/MockCluster.h
+++ b/src/mock/MockCluster.h
@@ -94,9 +94,11 @@ class MockCluster {
 
   void stop() {
     if (metaClient_) {
+      metaClient_->notifyStop();
       metaClient_->stop();
     }
     if (lMetaClient_) {
+      metaClient_->notifyStop();
       lMetaClient_->stop();
     }
     if (metaKV_) {

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -363,6 +363,9 @@ void StorageServer::notifyStop() {
     serverStatus_ = STATUS_STOPPED;
     cvStop_.notify_one();
   }
+  if (metaClient_) {
+    metaClient_->notifyStop();
+  }
 }
 
 void StorageServer::stop() {
@@ -396,7 +399,8 @@ void StorageServer::stop() {
     taskMgr_->shutdown();
   }
   if (metaClient_) {
-    metaClient_->stop();
+    metaClient_->notifyStop();
+    // metaClient_->stop();
   }
   if (kvstore_) {
     kvstore_.reset();

--- a/src/storage/StorageServer.cpp
+++ b/src/storage/StorageServer.cpp
@@ -400,7 +400,6 @@ void StorageServer::stop() {
   }
   if (metaClient_) {
     metaClient_->notifyStop();
-    // metaClient_->stop();
   }
   if (kvstore_) {
     kvstore_.reset();

--- a/src/tools/storage-perf/StoragePerfTool.cpp
+++ b/src/tools/storage-perf/StoragePerfTool.cpp
@@ -142,6 +142,7 @@ class Perf {
       t.join();
     }
 
+    mClient_->notifyStop();
     mClient_->stop();
     threadPool_->stop();
     LOG(INFO) << "Total time cost " << duration.elapsedInMSec() << "ms, "


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

#### What type of PR is this?
- [X ] bug
- [ ] feature
- [ ] enhancement

#### What problem(s) does this PR solve?
Issue(s) number: 

Description:

It is reported if not "add host" metaClient will stuck at "waitForMetaready()" and can't stop. 
This pr try to fix this. 

#### How do you solve it?

waitForMetaready() will detect a flag in each loop, before retry. Set this flag. 
  
#### Special notes for your reviewer, ex. impact of this fix, design document, etc:

Because no UT call metaClient.notifyStop() before, and it is hard to know which UT will affect by this, just run CI 

#### Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
