### PR TITLE
fix #3636

### DIFF
--- a/src/meta/processors/job/JobManager.cpp
+++ b/src/meta/processors/job/JobManager.cpp
@@ -414,12 +414,7 @@ size_t JobManager::jobSize() const {
 }
 
 bool JobManager::try_dequeue(std::pair<JbOp, JobID>& opJobId) {
-  if (highPriorityQueue_->try_dequeue(opJobId)) {
-    return true;
-  } else if (lowPriorityQueue_->try_dequeue(opJobId)) {
-    return true;
-  }
-  return false;
+  return (highPriorityQueue_->try_dequeue(opJobId)) || (lowPriorityQueue_->try_dequeue(opJobId));
 }
 
 void JobManager::enqueue(const JbOp& op, const JobID& jobId, const cpp2::AdminCmd& cmd) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

#### What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

#### What problem(s) does this PR solve?
Issue(s) number:  close #3636

Description:
#3636: detail

The bug: if all balance tasks success and the job is stopped before job status updated, the balance tasks will get muJobFinished_ through call back in the same thread


#### How do you solve it?


  
#### Special notes for your reviewer, ex. impact of this fix, design document, etc:



#### Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
