### PR TITLE
replace STRING to name_label for zone's name

### DIFF
--- a/src/parser/MaintainSentences.cpp
+++ b/src/parser/MaintainSentences.cpp
@@ -426,22 +426,22 @@ std::string MergeZoneSentence::toString() const {
   buf.reserve(128);
   buf += "MERGE ZONE ";
   buf += zoneNames_->toString();
-  buf += " INTO \"";
+  buf += " INTO `";
   buf += *zoneName_;
-  buf += "\"";
+  buf += "`";
   return buf;
 }
 
 std::string DropZoneSentence::toString() const {
-  return folly::stringPrintf("DROP ZONE \"%s\"", zoneName_.get()->c_str());
+  return folly::stringPrintf("DROP ZONE `%s`", zoneName_.get()->c_str());
 }
 
 std::string DivideZoneSentence::toString() const {
   std::string buf;
   buf.reserve(128);
-  buf += "DIVIDE ZONE \"";
+  buf += "DIVIDE ZONE `";
   buf += *zoneName_;
-  buf += "\" INTO ";
+  buf += "` INTO ";
   buf += zoneItems_->toString();
   return buf;
 }
@@ -449,16 +449,16 @@ std::string DivideZoneSentence::toString() const {
 std::string RenameZoneSentence::toString() const {
   std::string buf;
   buf.reserve(128);
-  buf += "RENAME ZONE \"";
+  buf += "RENAME ZONE `";
   buf += *originalZoneName_;
-  buf += "\" TO \"";
+  buf += "` TO `";
   buf += *zoneName_;
-  buf += "\"";
+  buf += "`";
   return buf;
 }
 
 std::string DescribeZoneSentence::toString() const {
-  return folly::stringPrintf("DESCRIBE ZONE \"%s\"", zoneName_.get()->c_str());
+  return folly::stringPrintf("DESCRIBE ZONE `%s`", zoneName_.get()->c_str());
 }
 
 std::string ShowZonesSentence::toString() const {
@@ -471,12 +471,12 @@ std::string AddHostsIntoZoneSentence::toString() const {
   buf += "ADD HOSTS ";
   buf += address_->toString();
   if (isNew_) {
-    buf += " INTO NEW ZONE \"";
+    buf += " INTO NEW ZONE `";
   } else {
-    buf += " INTO ZONE \"";
+    buf += " INTO ZONE `";
   }
   buf += *zoneName_;
-  buf += "\"";
+  buf += "`";
   return buf;
 }
 

--- a/src/parser/Sentence.h
+++ b/src/parser/Sentence.h
@@ -216,9 +216,9 @@ class ZoneNameList final {
   std::string toString() const {
     std::string buf;
     for (const auto &zone : zones_) {
-      buf += "\"";
+      buf += "`";
       buf += *zone;
-      buf += "\"";
+      buf += "`";
       buf += ",";
     }
     if (!zones_.empty()) {
@@ -243,9 +243,9 @@ class ZoneItem final {
 
   std::string toString() const {
     std::string buf;
-    buf += "\"";
+    buf += "`";
     buf += *zone_;
-    buf += "\"";
+    buf += "`";
     buf += " (";
     buf += hosts_->toString();
     buf += ")";

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -2813,10 +2813,10 @@ add_hosts_sentence
     : KW_ADD KW_HOSTS host_list {
         $$ = new AddHostsSentence($3);
     }
-    | KW_ADD KW_HOSTS host_list KW_INTO KW_ZONE STRING {
+    | KW_ADD KW_HOSTS host_list KW_INTO KW_ZONE name_label {
         $$ = new AddHostsIntoZoneSentence($3, $6, false);
     }
-    | KW_ADD KW_HOSTS host_list KW_INTO KW_NEW KW_ZONE STRING {
+    | KW_ADD KW_HOSTS host_list KW_INTO KW_NEW KW_ZONE name_label {
         $$ = new AddHostsIntoZoneSentence($3, $7, true);
     }
     ;
@@ -2829,19 +2829,19 @@ drop_hosts_sentence
 
 
 merge_zone_sentence
-    : KW_MERGE KW_ZONE zone_name_list KW_INTO STRING {
+    : KW_MERGE KW_ZONE zone_name_list KW_INTO name_label {
         $$ = new MergeZoneSentence($3, $5);
     }
     ;
 
 drop_zone_sentence
-    : KW_DROP KW_ZONE STRING {
+    : KW_DROP KW_ZONE name_label {
         $$ = new DropZoneSentence($3);
     }
     ;
 
 zone_item
-    : STRING L_PAREN host_list R_PAREN {
+    : name_label L_PAREN host_list R_PAREN {
         $$ = new nebula::ZoneItem($1, $3);
     }
     ;
@@ -2858,22 +2858,22 @@ zone_item_list
     ;
 
 divide_zone_sentence
-    : KW_DIVIDE KW_ZONE STRING KW_INTO zone_item_list {
+    : KW_DIVIDE KW_ZONE name_label KW_INTO zone_item_list {
         $$ = new DivideZoneSentence($3, $5);
     }
     ;
 
 rename_zone_sentence
-    : KW_RENAME KW_ZONE STRING KW_TO STRING {
+    : KW_RENAME KW_ZONE name_label KW_TO name_label {
         $$ = new RenameZoneSentence($3, $5);
     }
     ;
 
 desc_zone_sentence
-    : KW_DESCRIBE KW_ZONE STRING {
+    : KW_DESCRIBE KW_ZONE name_label {
         $$ = new DescribeZoneSentence($3);
     }
-    | KW_DESC KW_ZONE STRING {
+    | KW_DESC KW_ZONE name_label {
         $$ = new DescribeZoneSentence($3);
     }
     ;
@@ -3495,11 +3495,11 @@ show_config_item
     ;
 
 zone_name_list
-    : STRING {
+    : name_label {
         $$ = new ZoneNameList();
         $$->addZone($1);
     }
-    | zone_name_list COMMA STRING {
+    | zone_name_list COMMA name_label {
         $$ = $1;
         $$->addZone($3);
     }

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -231,24 +231,24 @@ TEST_F(ParserTest, SpaceOperation) {
   {
     std::string query =
         "CREATE SPACE default_space(partition_num=9, replica_factor=3) "
-        "ON \"zone_0\"";
+        "ON zone_0";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
     std::string query =
         "CREATE SPACE default_space(partition_num=9, replica_factor=3) "
-        "ON \"zone_0\",\"zone_1\",\"zone_2\"";
+        "ON zone_0,zone_1,zone_2";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "CREATE SPACE default_space ON \"zone_0\"";
+    std::string query = "CREATE SPACE default_space ON zone_0";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "CREATE SPACE default_space ON \"zone_0\",\"zone_1\",\"zone_2\"";
+    std::string query = "CREATE SPACE default_space ON `zone_0`,`zone_1`,`zone_2`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
@@ -2806,129 +2806,129 @@ TEST_F(ParserTest, Zone) {
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "ADD HOSTS 127.0.0.1:8989 INTO ZONE \"zone_0\"";
+    std::string query = "ADD HOSTS 127.0.0.1:8989 INTO ZONE `zone_0`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "ADD HOSTS 127.0.0.1:8989 INTO NEW ZONE \"zone_0\"";
+    std::string query = "ADD HOSTS 127.0.0.1:8989 INTO NEW ZONE `zone_0`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "ADD HOSTS 127.0.0.1:8989 INTO ZONE \"default_zone_127.0.0.1_8988\"";
+    std::string query = "ADD HOSTS 127.0.0.1:8989 INTO ZONE `default_zone_127.0.0.1_8988`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "ADD HOSTS 127.0.0.1:8989 INTO NEW ZONE \"default_zone_127.0.0.1_8988\"";
+    std::string query = "ADD HOSTS 127.0.0.1:8989 INTO NEW ZONE `default_zone_127.0.0.1_8988`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "ADD HOSTS 127.0.0.1:8988,127.0.0.1:8989 INTO ZONE \"zone_0\"";
+    std::string query = "ADD HOSTS 127.0.0.1:8988,127.0.0.1:8989 INTO ZONE `zone_0`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "ADD HOSTS 127.0.0.1:8988,127.0.0.1:8989 INTO NEW ZONE \"zone_0\"";
+    std::string query = "ADD HOSTS 127.0.0.1:8988,127.0.0.1:8989 INTO NEW ZONE `zone_0`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
     std::string query =
         "ADD HOSTS 127.0.0.1:8988,127.0.0.1:8989 INTO ZONE"
-        " \"default_zone_127.0.0.1_8988\"";
+        " `default_zone_127.0.0.1_8988`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
     std::string query =
         "ADD HOSTS 127.0.0.1:8988,127.0.0.1:8989 INTO NEW ZONE"
-        " \"default_zone_127.0.0.1_8988\"";
+        " `default_zone_127.0.0.1_8988`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "DESC ZONE \"default_zone_127.0.0.1_8988\"";
+    std::string query = "DESC ZONE `default_zone_127.0.0.1_8988`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "DESC ZONE \"zone_0\"";
+    std::string query = "DESC ZONE `zone_0`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "DESCRIBE ZONE \"zone_0\"";
+    std::string query = "DESCRIBE ZONE `zone_0`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "DESCRIBE ZONE \"default_zone_127.0.0.1_8988\"";
+    std::string query = "DESCRIBE ZONE `default_zone_127.0.0.1_8988`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "DROP ZONE \"zone_0\"";
+    std::string query = "DROP ZONE `zone_0`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "DROP ZONE \"default_zone_127.0.0.1_8988\"";
+    std::string query = "DROP ZONE `default_zone_127.0.0.1_8988`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "MERGE ZONE \"zone_1\",\"zone_2\" INTO \"zone\"";
+    std::string query = "MERGE ZONE `zone_1`,`zone_2` INTO `zone`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
-    std::string query = "MERGE ZONE \"zone_1\",\"zone_2\" INTO \"zone_1\"";
-    auto result = parse(query);
-    ASSERT_TRUE(result.ok()) << result.status();
-  }
-  {
-    std::string query =
-        "MERGE ZONE \"default_zone_127.0.0.1_8988\",\"default_zone_127.0.0.1_8989\""
-        "INTO \"zone_1\"";
+    std::string query = "MERGE ZONE `zone_1`,`zone_2` INTO `zone_1`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
     std::string query =
-        "MERGE ZONE \"default_zone_127.0.0.1_8988\",\"default_zone_127.0.0.1_8989\""
-        "INTO \"default_zone_127.0.0.1_8989\"";
-    auto result = parse(query);
-    ASSERT_TRUE(result.ok()) << result.status();
-  }
-  {
-    std::string query = "RENAME ZONE \"default_zone_127.0.0.1_8989\" TO \"new_name\"";
-    auto result = parse(query);
-    ASSERT_TRUE(result.ok()) << result.status();
-  }
-  {
-    std::string query = "RENAME ZONE \"old_name\" TO \"new_name\"";
-    auto result = parse(query);
-    ASSERT_TRUE(result.ok()) << result.status();
-  }
-  {
-    std::string query = "RENAME ZONE \"default_zone_127.0.0.1_8989\" TO \"new_name\"";
+        "MERGE ZONE `default_zone_127.0.0.1_8988`,`default_zone_127.0.0.1_8989`"
+        "INTO `zone_1`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
     std::string query =
-        "DIVIDE ZONE \"zone_0\" INTO \"z_1\" (127.0.0.1:8988) "
-        " \"z_2\" (127.0.0.1:8989)";
+        "MERGE ZONE `default_zone_127.0.0.1_8988`,`default_zone_127.0.0.1_8989`"
+        "INTO `default_zone_127.0.0.1_8989`";
+    auto result = parse(query);
+    ASSERT_TRUE(result.ok()) << result.status();
+  }
+  {
+    std::string query = "RENAME ZONE `default_zone_127.0.0.1_8989` TO `new_name`";
+    auto result = parse(query);
+    ASSERT_TRUE(result.ok()) << result.status();
+  }
+  {
+    std::string query = "RENAME ZONE `old_name` TO `new_name`";
+    auto result = parse(query);
+    ASSERT_TRUE(result.ok()) << result.status();
+  }
+  {
+    std::string query = "RENAME ZONE `default_zone_127.0.0.1_8989` TO `new_name`";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }
   {
     std::string query =
-        "DIVIDE ZONE \"zone_0\" INTO \"z_1\" (127.0.0.1:8986,127.0.0.1:8987)"
-        " \"z_2\" (127.0.0.1:8988,127.0.0.1:8989)";
+        "DIVIDE ZONE zone_0 INTO `z_1` (127.0.0.1:8988) "
+        " `z_2` (127.0.0.1:8989)";
+    auto result = parse(query);
+    ASSERT_TRUE(result.ok()) << result.status();
+  }
+  {
+    std::string query =
+        "DIVIDE ZONE `zone_0` INTO `z_1` (127.0.0.1:8986,127.0.0.1:8987)"
+        " `z_2` (127.0.0.1:8988,127.0.0.1:8989)";
     auto result = parse(query);
     ASSERT_TRUE(result.ok()) << result.status();
   }

--- a/tests/tck/features/admin/Hosts.feature
+++ b/tests/tck/features/admin/Hosts.feature
@@ -46,12 +46,12 @@ Feature: Admin hosts
     Then a SemanticError should be raised at runtime: space vid_type must be specified explicitly
     When executing query:
       """
-      CREATE SPACE space_without_vid_type(partition_num=9, replica_factor=3) on "default_zone";
+      CREATE SPACE space_without_vid_type(partition_num=9, replica_factor=3) on default_zone;
       """
     Then a SemanticError should be raised at runtime: Create space with zone is unsupported
     When executing query:
       """
-      CREATE SPACE space_without_vid_type on "default_zone";
+      CREATE SPACE space_without_vid_type on default_zone;
       """
     Then a SemanticError should be raised at runtime: Create space with zone is unsupported
     When executing query:


### PR DESCRIPTION
till now, we should use STRING to represent a zone, 
e.g.  create space test (...) on "zone1","zone2"  ,  we should always use double quotation mark, the original reason of using STRING is to handle some illegal name like "127.0.0.1zone_1111", and this pr https://github.com/vesoft-inc/nebula/pull/3424 could solve the problem. for legal name, we don't need to use double quotation mark.
e.g   create space test (...) on zone1, zone2
and for illegal name, we could do it like this 
create space test (...) on \`127.0.0.1zone_1111\`, \`127.0.0.1zone_2222\`

#### What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

#### What problem(s) does this PR solve?
Issue(s) number: 

Description:


#### How do you solve it?


  
#### Special notes for your reviewer, ex. impact of this fix, design document, etc:



#### Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
