### PR TITLE
cherry pick: Fix create fulltext index failed (#3747)

### DIFF
--- a/src/meta/processors/index/FTIndexProcessor.cpp
+++ b/src/meta/processors/index/FTIndexProcessor.cpp
@@ -100,7 +100,9 @@ void CreateFTIndexProcessor::process(const cpp2::CreateFTIndexReq& req) {
       onFinished();
       return;
     }
-    if (index.get_depend_schema() == indexItem.get_depend_schema()) {
+    // Because tagId/edgeType is the space range, judge the spaceId and schemaId
+    if (index.get_space_id() == indexItem.get_space_id() &&
+        index.get_depend_schema() == indexItem.get_depend_schema()) {
       LOG(ERROR) << "Depends on the same schema , index : " << indexName;
       handleErrorCode(nebula::cpp2::ErrorCode::E_EXISTED);
       onFinished();

--- a/src/meta/test/IndexProcessorTest.cpp
+++ b/src/meta/test/IndexProcessorTest.cpp
@@ -1585,6 +1585,15 @@ void mockSchemas(kvstore::KVStore* kv) {
   schemas.emplace_back(MetaServiceUtils::schemaEdgeKey(1, edgeType, ver),
                        MetaServiceUtils::schemaVal("test_edge", srcsch));
 
+  // space 2
+  schemas.emplace_back(MetaServiceUtils::indexTagKey(2, "test_tag"), tagIdVal);
+  schemas.emplace_back(MetaServiceUtils::schemaTagKey(2, tagId, ver),
+                       MetaServiceUtils::schemaVal("test_tag", srcsch));
+
+  schemas.emplace_back(MetaServiceUtils::indexEdgeKey(2, "test_edge"), edgeTypeVal);
+  schemas.emplace_back(MetaServiceUtils::schemaEdgeKey(2, edgeType, ver),
+                       MetaServiceUtils::schemaVal("test_edge", srcsch));
+
   folly::Baton<true, std::atomic> baton;
   kv->asyncMultiPut(0, 0, std::move(schemas), [&](nebula::cpp2::ErrorCode code) {
     ASSERT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, code);
@@ -1597,6 +1606,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
   fs::TempDir rootPath("/tmp/CreateFTIndexTest.XXXXXX");
   auto kv = MockCluster::initMetaKV(rootPath.path());
   TestUtils::assembleSpace(kv.get(), 1, 1);
+  TestUtils::assembleSpace(kv.get(), 2, 1, 1, 1, true);
   mockSchemas(kv.get());
   for (auto id : {5, 6}) {
     // expected error. column col_fixed_string_2 is fixed_string,
@@ -1654,7 +1664,7 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
       } else {
         schemaId.set_edge_type(6);
       }
-      index.set_space_id(2);
+      index.set_space_id(3);
       index.set_depend_schema(std::move(schemaId));
       index.set_fields({"col_string"});
       req.set_fulltext_index_name("test_ft_index");
@@ -1851,6 +1861,63 @@ TEST(IndexProcessorTest, CreateFTIndexTest) {
     processor->process(req);
     auto resp = std::move(f).get();
     ASSERT_EQ(nebula::cpp2::ErrorCode::E_INDEX_NOT_FOUND, resp.get_code());
+  }
+
+  // expected success
+  // Different spaces, the same tag name(same tagId), create full-text indexes with different names.
+  {
+    {
+      for (auto i = 0; i < 2; ++i) {
+        cpp2::CreateFTIndexReq req;
+        cpp2::FTIndex index;
+        nebula::cpp2::SchemaID schemaId;
+        schemaId.set_tag_id(5);
+        index.set_space_id(i + 1);
+        index.set_depend_schema(std::move(schemaId));
+        index.set_fields({"col_string", "col_fixed_string_1"});
+        req.set_fulltext_index_name(folly::stringPrintf("ft_tag_index_space%d", i + 1));
+        req.set_index(std::move(index));
+
+        auto* processor = CreateFTIndexProcessor::instance(kv.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+        ASSERT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+      }
+    }
+    {
+      cpp2::ListFTIndexesReq req;
+      auto* processor = ListFTIndexesProcessor::instance(kv.get());
+      auto f = processor->getFuture();
+      processor->process(req);
+      auto resp = std::move(f).get();
+      ASSERT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+      auto indexes = resp.get_indexes();
+      ASSERT_EQ(2, indexes.size());
+      for (auto i = 0u; i < indexes.size(); ++i) {
+        auto key = folly::stringPrintf("ft_tag_index_space%u", i + 1);
+        auto iter = indexes.find(key);
+        ASSERT_NE(indexes.end(), iter);
+        std::vector<std::string> fields = {"col_string", "col_fixed_string_1"};
+        ASSERT_EQ(fields, iter->second.get_fields());
+        ASSERT_EQ(i + 1, iter->second.get_space_id());
+        nebula::cpp2::SchemaID schemaId;
+        schemaId.tag_id_ref() = 5;
+        ASSERT_EQ(schemaId, iter->second.get_depend_schema());
+      }
+    }
+    {
+      for (auto i = 0; i < 2; ++i) {
+        cpp2::DropFTIndexReq req;
+        req.set_space_id(i + 1);
+        req.set_fulltext_index_name(folly::stringPrintf("ft_tag_index_space%d", i + 1));
+        auto* processor = DropFTIndexProcessor::instance(kv.get());
+        auto f = processor->getFuture();
+        processor->process(req);
+        auto resp = std::move(f).get();
+        ASSERT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+      }
+    }
   }
 }
 
@@ -2297,7 +2364,6 @@ TEST(ProcessorTest, IndexIdInSpaceRangeTest) {
     ASSERT_EQ(14, resp.get_id().get_index_id());
   }
 }
-
 }  // namespace meta
 }  // namespace nebula
 

--- a/src/meta/test/TestUtils.h
+++ b/src/meta/test/TestUtils.h
@@ -217,16 +217,25 @@ class TestUtils {
                             GraphSpaceID id,
                             int32_t partitionNum,
                             int32_t replica = 1,
-                            int32_t totalHost = 1) {
+                            int32_t totalHost = 1,
+                            bool multispace = false) {
     // mock the part distribution like create space
     cpp2::SpaceDesc properties;
-    properties.set_space_name("test_space");
-    properties.set_partition_num(partitionNum);
-    properties.set_replica_factor(replica);
-    auto spaceVal = MetaServiceUtils::spaceVal(properties);
+    if (multispace) {
+      properties.space_name_ref() = folly::stringPrintf("test_space_%d", id);
+    } else {
+      properties.space_name_ref() = "test_space";
+    }
+    properties.partition_num_ref() = partitionNum;
+    properties.replica_factor_ref() = replica;
     std::vector<nebula::kvstore::KV> data;
-    data.emplace_back(MetaServiceUtils::indexSpaceKey("test_space"),
-                      std::string(reinterpret_cast<const char*>(&id), sizeof(GraphSpaceID)));
+    if (multispace) {
+      data.emplace_back(MetaServiceUtils::indexSpaceKey(folly::stringPrintf("test_space_%d", id)),
+                        std::string(reinterpret_cast<const char*>(&id), sizeof(GraphSpaceID)));
+    } else {
+      data.emplace_back(MetaServiceUtils::indexSpaceKey("test_space"),
+                        std::string(reinterpret_cast<const char*>(&id), sizeof(GraphSpaceID)));
+    }
     data.emplace_back(MetaServiceUtils::spaceKey(id), MetaServiceUtils::spaceVal(properties));
 
     std::vector<HostAddr> allHosts;


### PR DESCRIPTION
* fix bug: the same tagId/edgetype under different spaces, failed to create fulltext indexes

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

#### What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

#### What problem(s) does this PR solve?
Issue(s) number: 

Description:
cherry pick  https://github.com/vesoft-inc/nebula/pull/3747

#### How do you solve it?


  
#### Special notes for your reviewer, ex. impact of this fix, design document, etc:



#### Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
