### PR TITLE
changed label to string

### DIFF
--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -419,7 +419,7 @@ static constexpr size_t kCommentLengthLimit = 256;
 %%
 
 name_label
-    : LABEL { $$ = $1; }
+    : STRING { $$ = new std::string("$1"); }
     | unreserved_keyword { $$ = $1; }
     ;
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

#### What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

#### What problem(s) does this PR solve?
Issue(s) number: #2986

Description:
"When creating user, the username can‘t be a string in double quotes, that's different with password"

#### How do you solve it?
Changed username "name_label" to be stored as a string rather then a label, which should allow for single and double quotes to be a part of the username.

  
#### Special notes for your reviewer, ex. impact of this fix, design document, etc:



#### Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


#### Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
