### PR TITLE
skip heartbeat when role in meta client is not set

### DIFF
--- a/src/clients/meta/MetaClient.h
+++ b/src/clients/meta/MetaClient.h
@@ -185,7 +185,6 @@ struct MetaClientOptions {
   MetaClientOptions(const MetaClientOptions& opt)
       : localHost_(opt.localHost_),
         clusterId_(opt.clusterId_.load()),
-        inStoraged_(opt.inStoraged_),
         serviceName_(opt.serviceName_),
         skipConfig_(opt.skipConfig_),
         role_(opt.role_),
@@ -197,13 +196,12 @@ struct MetaClientOptions {
   HostAddr localHost_{"", 0};
   // Current cluster Id, it is required by storaged only.
   std::atomic<ClusterID> clusterId_{0};
-  // If current client being used in storaged.
-  bool inStoraged_ = false;
   // Current service name, used in StatsManager
   std::string serviceName_ = "";
   // Whether to skip the config manager
   bool skipConfig_ = false;
-  // Host role(graph/meta/storage) using this client
+  // Host role(graph/meta/storage) using this client, and UNKNOWN role will not send heartbeat, used
+  // for tools such as upgrader
   cpp2::HostRole role_ = cpp2::HostRole::UNKNOWN;
   // gitInfoSHA of Host using this client
   std::string gitInfoSHA_{""};


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #3854

#### Description:
The role in meta client is `UNKNOWN` by default, and many tools use the default `MetaClientOptions`, which makes the host info is `Host("", 0)`, and the info will be write to meta if we send heartbeat. 

## How do you solve it?
Just skip heartbeat when role is unknown


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
