### PR TITLE
Try to improve the performance of appendVertices

### DIFF
--- a/src/graph/executor/query/AppendVerticesExecutor.cpp
+++ b/src/graph/executor/query/AppendVerticesExecutor.cpp
@@ -70,6 +70,12 @@ Status AppendVerticesExecutor::handleResp(
   auto *av = asNode<AppendVertices>(node());
   auto *vFilter = av->vFilter();
   QueryExpressionContext ctx(qctx()->ectx());
+
+  auto inputIter = qctx()->ectx()->getResult(av->inputVar()).iter();
+  DataSet ds;
+  ds.colNames = av->colNames();
+  ds.rows.reserve(inputIter->size());
+
   for (auto &resp : rpcResp.responses()) {
     if (resp.props_ref().has_value()) {
       auto iter = PropIter(std::make_shared<Value>(std::move(*resp.props_ref())));
@@ -80,26 +86,28 @@ Status AppendVerticesExecutor::handleResp(
             continue;
           }
         }
-        map.emplace(iter.getColumn(kVid), iter.getVertex());
+        if (!av->trackPrevPath()) {  // eg. MATCH (v:Person) RETURN v
+          Row row;
+          row.values.emplace_back(iter.getVertex());
+          ds.rows.emplace_back(std::move(row));
+        } else {
+          map.emplace(iter.getColumn(kVid), iter.getVertex());
+        }
       }
     }
   }
 
-  auto iter = qctx()->ectx()->getResult(av->inputVar()).iter();
-  auto *src = av->src();
+  if (!av->trackPrevPath()) {
+    return finish(ResultBuilder().value(Value(std::move(ds))).state(state).build());
+  }
 
-  DataSet ds;
-  ds.colNames = av->colNames();
-  ds.rows.reserve(iter->size());
-  for (; iter->valid(); iter->next()) {
-    auto dstFound = map.find(src->eval(ctx(iter.get())));
+  auto *src = av->src();
+  for (; inputIter->valid(); inputIter->next()) {
+    auto dstFound = map.find(src->eval(ctx(inputIter.get())));
     if (dstFound == map.end()) {
       continue;
     }
-    Row row;
-    if (av->trackPrevPath()) {
-      row = *iter->row();
-    }
+    Row row = *inputIter->row();
     row.values.emplace_back(dstFound->second);
     ds.rows.emplace_back(std::move(row));
   }

--- a/tests/tck/features/match/Base.feature
+++ b/tests/tck/features/match/Base.feature
@@ -704,7 +704,7 @@ Feature: Basic match
     When executing query:
       """
       USE nba;
-      MATCH (n:player) RETURN n LIMIT 1;
+      MATCH (n:player) WHERE id(n) == "Boris Diaw" RETURN n;
       """
     Then the result should be, in any order:
       | n                                                   |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
The case `0-hop`, 3.0's performance is much lower than 2.6
```
MATCH (v: Person) return v
```
While the case `1-hop` and `2-hop`, 3.0's performance is flat with 2.0
The execution plans are here:
[2.6.txt](https://github.com/vesoft-inc/nebula/files/8020543/2.6.txt)
[3.0.txt](https://github.com/vesoft-inc/nebula/files/8020544/3.0.txt)
