### PR TITLE
keep consistent with 2.6.x

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: ./.github/actions/tagname-action
         id: tag
       - name: package
-        run: ./package/package.sh -v ${{ steps.tag.outputs.tag }} -t RelWithDebInfo -r OFF -p ON -s TRUE
+        run: ./package/package.sh -v ${{ steps.tag.outputs.tagnum }} -t RelWithDebInfo -r OFF -p ON -s TRUE
       - name: output some vars
         run: |
           tar zcf ${{ env.CPACK_DIR }}/nebula-${{ steps.tag.outputs.tagnum }}.tar.gz --exclude=${{ env.BUILD_DIR }} ./*


### PR DESCRIPTION
in 2.6.x, nebula version is `2.6.2`, not `v2.6.2`
because we use code in package.sh
```
 version=$(git describe --exact-match --abbrev=0 --tags | sed 's/^v//')
```

```
[vesoft@qa-60 tmp]$ nebula-graph-2.6.2.el7.x86_64/bin/nebula-graphd --version
nebula-graphd version 2.6.2, Git: d113f4a, Build Time: Jan 26 2022 16:57:25
This source code is licensed under Apache 2.0 License.
```

but now in v3 
```
[vesoft@qa-tools nebula_multiple_sf1]$ ./nebula1/bin/nebula-graphd --version
nebula-graphd version v3.0.0, Git: af99990, Build Time: Jan 27 2022 22:47:10
This source code is licensed under Apache 2.0 License
```