### PR TITLE
if leader changed during raft::appendLog() RPC, use a different error code

### DIFF
--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -479,6 +479,7 @@ enum ErrorCode {
     E_RAFT_LOG_GAP                    = -3501,
     E_RAFT_LOG_STALE                  = -3502,
     E_RAFT_TERM_OUT_OF_DATE           = -3503,
+    E_RAFT_UNKNOWN_APPEND_LOG         = -3504,
     // Raft state errors
     E_RAFT_WAITING_SNAPSHOT           = -3511,
     E_RAFT_SENDING_SNAPSHOT           = -3512,

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -880,7 +880,12 @@ void RaftPart::processAppendLogResponses(const AppendLogResponses& resps,
       leader_ = HostAddr("", 0);
       lastLogId_ = wal_->lastLogId();
       lastLogTerm_ = wal_->lastLogTerm();
-      res = nebula::cpp2::ErrorCode::E_RAFT_TERM_OUT_OF_DATE;
+      // It is nature to return E_RAFT_TERM_OUT_OF_DATE or LEADER_CHANGE
+      // here, but this will make caller believe this append failed
+      // however, this log is replicated to followers(written in WAL)
+      // and those followers may become leader (use that WAL)
+      // which means this log may actully commit succeeded.
+      res = nebula::cpp2::ErrorCode::E_RAFT_UNKNOWN_APPEND_LOG;
     }
   }
   if (!checkAppendLogResult(res)) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

It is nature to return E_RAFT_TERM_OUT_OF_DATE or LEADER_CHANGE
when raft check leader, but this will make caller believe the append failed.

however, this log is replicated to followers(written in follower's WAL)
and the follower may become leader (use that WAL)
which means this log may eventually commit succeeded.


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

n/a
