### PR TITLE
fix ingest 0 file error in upgrade tool 3.0

### DIFF
--- a/src/tools/db-upgrade/DbUpgrader.cpp
+++ b/src/tools/db-upgrade/DbUpgrader.cpp
@@ -991,9 +991,12 @@ void UpgraderSpace::doProcessV3() {
   while (unFinishedPart_ != 0) {
     sleep(10);
   }
-  auto code = readEngine_->ingest(ingest_sst_file_, true);
-  if (code != ::nebula::cpp2::ErrorCode::SUCCEEDED) {
-    LOG(FATAL) << "Faild upgrade 2:3 when ingest sst file:" << static_cast<int>(code);
+
+  if (ingest_sst_file_.size() != 0) {
+    auto code = readEngine_->ingest(ingest_sst_file_, true);
+    if (code != ::nebula::cpp2::ErrorCode::SUCCEEDED) {
+      LOG(FATAL) << "Faild upgrade 2:3 when ingest sst file:" << static_cast<int>(code);
+    }
   }
   readEngine_->put(NebulaKeyUtils::dataVersionKey(), NebulaKeyUtilsV3::dataVersionValue());
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
fix upgrade tool 3.0,
When there is no tag under the space, the upgrade tool core.
coredump as follows:
 
```
I20220221 15:28:40.337662 281523 DbUpgrader.cpp:1081] Copy space id 133 wal file begin
I20220221 15:28:40.548403 281523 DbUpgrader.cpp:1228] Copy space id 133 wal file success
I20220221 15:28:40.548442 281523 DbUpgrader.cpp:1072] Path /data/nebula/storaged_backup space id 133 compaction begin
E20220221 15:28:41.543736 281518 RocksEngine.cpp:426] Ingest Failed: Invalid argument: external_files[0] is empty
F20220221 15:28:41.543795 281518 DbUpgrader.cpp:996] Faild upgrade 2:3 when ingest sst file:-8000
*** Check failure stack trace: ***
*** Aborted at 1645428522 (Unix time, try 'date -d @1645428522') ***
*** Signal 6 (SIGABRT) (0x449aa) received by PID 281002 (pthread TID 0x7f8c679ff700) (linux TID 281518) (maybe from PID 281002, UID 0) (code: -6), stack trace: ***
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly10symbolizer17getStackTraceSafeEPmm+0x31)[0x24ca151]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly10symbolizer21SafeStackTracePrinter15printStackTraceEb+0x26)[0x24c1656]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader[0x24bf5e7]
/lib64/libpthread.so.0(+0xf5df)[0x7f8c7da795df]
/lib64/libc.so.6(gsignal+0x37)[0x7f8c7d6dc1f7]
/lib64/libc.so.6(abort+0x147)[0x7f8c7d6dd8e7]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader[0x24f2e59]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader[0x24f5f53]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader[0x24f2928]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader[0x24f6608]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN6nebula7storage13UpgraderSpace11doProcessV3Ev+0x317)[0x1101f37]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN6nebula7storage10DbUpgrader7doSpaceEv+0x191)[0x11099f1]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly18ThreadPoolExecutor7runTaskERKSt10shared_ptrINS0_6ThreadEEONS0_4TaskE+0x137)[0x24098f7]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader[0x23fc10e]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly9EventBase20FunctionLoopCallback15runLoopCallbackEv+0xa)[0x2473d6a]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly9EventBase16runLoopCallbacksERN5boost9intrusive4listINS0_12LoopCallbackEJNS2_18constant_time_sizeILb0EEEEEE+0x109)[0x246c959]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly9EventBase16runLoopCallbacksEv+0x86)[0x246c9e6]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly9EventBase8loopBodyEib+0x1d2)[0x246ec92]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly9EventBase4loopEv+0x3d)[0x246f81d]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly9EventBase11loopForeverEv+0x17)[0x2472457]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly20IOThreadPoolExecutor9threadRunESt10shared_ptrINS_18ThreadPoolExecutor6ThreadEE+0x338)[0x23fcaf8]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader(_ZN5folly6detail8function14FunctionTraitsIFvvEE7callBigISt5_BindIFMNS_18ThreadPoolExecutorEFvSt10shared_ptrINS7_6ThreadEEEPS7_SA_EEEEvRNS1_4DataE+0x46)[0x240b066]
./nebula-graph-3.0.0.el7.x86_64/bin/db_upgrader[0x2a1fe9f]
/lib64/libpthread.so.0(+0x7e24)[0x7f8c7da71e24]
/lib64/libc.so.6(clone+0x6c)[0x7f8c7d79f34c]
(safe mode, symbolizer not available)
Aborted
You have mail in /var/spool/mail/root
```

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
