### PR TITLE
Fix service crash caused by connecting using a pre-v2.6.0 client

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -2313,8 +2313,6 @@ Status MetaClient::authCheckFromCache(const std::string& account,
                        "please update the client.",
                        clientIp.toString()));
   }
-  // clear the key
-  // clientAddrMap_.erase(clientAddrIt);
 
   folly::rcu_reader guard;
   const auto& metadata = *metadata_.load();

--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -2486,6 +2486,11 @@ folly::Future<StatusOr<bool>> MetaClient::heartbeat() {
     }
   }
 
+  // TTL for clientAddrMap
+  // If multiple connections are created but do not authenticate, the clientAddr_ will keep growing.
+  // This is to clear the clientAddr_ regularly.
+  clientAddr_.clear();
+
   // info used in the agent, only set once
   // TOOD(spw): if we could add data path(disk) dynamicly in the future, it should be
   // reported every time it changes

--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -2293,25 +2293,10 @@ std::vector<cpp2::RoleItem> MetaClient::getRolesByUserFromCache(const std::strin
   return iter->second;
 }
 
-Status MetaClient::authCheckFromCache(const std::string& account,
-                                      const std::string& password,
-                                      const HostAddr& clientIp) {
+Status MetaClient::authCheckFromCache(const std::string& account, const std::string& password) {
   // Check meta service status
   if (!ready_) {
     return Status::Error("Meta Service not ready");
-  }
-
-  // TODO(Aiee) This is a walkround to address the problem that using a lower version(< v2.6.0)
-  // client to connect with higher version(>= v3.0.0) Nebula service will cause a crash.
-  //
-  // Only the clients since v2.6.0 will call verifyVersion(), thus we could determine whether the
-  // client version is lower than v2.6.0
-  auto clientAddrIt = clientAddrMap_.find(clientIp);
-  if (clientAddrIt == clientAddrMap_.end()) {
-    return Status::Error(
-        folly::sformat("The version of the client sending request from {} is lower than v2.6.0, "
-                       "please update the client.",
-                       clientIp.toString()));
   }
 
   folly::rcu_reader guard;

--- a/src/clients/meta/MetaClient.h
+++ b/src/clients/meta/MetaClient.h
@@ -571,9 +571,7 @@ class MetaClient {
 
   std::vector<cpp2::RoleItem> getRolesByUserFromCache(const std::string& user);
 
-  Status authCheckFromCache(const std::string& account,
-                            const std::string& password,
-                            const HostAddr& clientIp);
+  Status authCheckFromCache(const std::string& account, const std::string& password);
 
   StatusOr<TermID> getTermFromCache(GraphSpaceID spaceId, PartitionID);
 
@@ -818,7 +816,7 @@ class MetaClient {
   NameIndexMap tagNameIndexMap_;
   NameIndexMap edgeNameIndexMap_;
 
-  // TODO(Aiee) This is a walkround to address the problem that using a lower version(< v2.6.0)
+  // TODO(Aiee) This is a walkaround to address the problem that using a lower version(< v2.6.0)
   // client to connect with higher version(>= v3.0.0) Nebula service will cause a crash.
   //
   // The key here is the host of the client that sends the request, and the value indicates the

--- a/src/graph/service/GraphService.cpp
+++ b/src/graph/service/GraphService.cpp
@@ -24,7 +24,8 @@
 namespace nebula {
 namespace graph {
 
-const int64_t clientAddrTimeout = 60;
+// The default value is 28800 seconds
+const int64_t clientAddrTimeout = FLAGS_client_idle_timeout_secs;
 
 Status GraphService::init(std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor,
                           const HostAddr& hostAddr) {
@@ -253,7 +254,8 @@ folly::Future<cpp2::VerifyClientVersionResp> GraphService::future_verifyClientVe
   auto clientAddr = HostAddr(peer->getAddressStr(), peer->getPort());
 
   auto ttlTimestamp = time::WallClock::fastNowInSec() + clientAddrTimeout;
-  metaClient_->getClientAddrMap().insert(clientAddr, ttlTimestamp);
+  auto clientAddrMap = &metaClient_->getClientAddrMap();
+  clientAddrMap->insert_or_assign(clientAddr, ttlTimestamp);
   return folly::makeFuture<cpp2::VerifyClientVersionResp>(std::move(resp));
 }
 }  // namespace graph

--- a/src/graph/service/GraphService.h
+++ b/src/graph/service/GraphService.h
@@ -54,7 +54,7 @@ class GraphService final : public cpp2::GraphServiceSvIf {
   std::unique_ptr<meta::MetaClient> metaClient_;
 
  private:
-  Status auth(const std::string& username, const std::string& password);
+  Status auth(const std::string& username, const std::string& password, const HostAddr& clientIp);
 
   std::unique_ptr<GraphSessionManager> sessionManager_;
   std::unique_ptr<QueryEngine> queryEngine_;

--- a/src/graph/service/PasswordAuthenticator.cpp
+++ b/src/graph/service/PasswordAuthenticator.cpp
@@ -13,7 +13,16 @@ PasswordAuthenticator::PasswordAuthenticator(meta::MetaClient* client) {
 }
 
 Status PasswordAuthenticator::auth(const std::string& user, const std::string& password) {
-  return metaClient_->authCheckFromCache(user, password);
+  UNUSED(user);
+  UNUSED(password);
+  return Status::Error(
+      "Should not be called, this interface is implemented to override the parent class");
+}
+
+Status PasswordAuthenticator::auth(const std::string& user,
+                                   const std::string& password,
+                                   const HostAddr& clientIp) {
+  return metaClient_->authCheckFromCache(user, password, clientIp);
 }
 
 }  // namespace graph

--- a/src/graph/service/PasswordAuthenticator.cpp
+++ b/src/graph/service/PasswordAuthenticator.cpp
@@ -13,16 +13,7 @@ PasswordAuthenticator::PasswordAuthenticator(meta::MetaClient* client) {
 }
 
 Status PasswordAuthenticator::auth(const std::string& user, const std::string& password) {
-  UNUSED(user);
-  UNUSED(password);
-  return Status::Error(
-      "Should not be called, this interface is implemented to override the parent class");
-}
-
-Status PasswordAuthenticator::auth(const std::string& user,
-                                   const std::string& password,
-                                   const HostAddr& clientIp) {
-  return metaClient_->authCheckFromCache(user, password, clientIp);
+  return metaClient_->authCheckFromCache(user, password);
 }
 
 }  // namespace graph

--- a/src/graph/service/PasswordAuthenticator.h
+++ b/src/graph/service/PasswordAuthenticator.h
@@ -16,7 +16,14 @@ class PasswordAuthenticator final : public Authenticator {
  public:
   explicit PasswordAuthenticator(meta::MetaClient* client);
 
+  // This interface is only implemented to override the parent class and should not be called
   Status auth(const std::string& user, const std::string& password) override;
+
+  // TODO(Aiee) This is a walkround to address the problem that using a lower version(< v2.6.0)
+  // client to connect with higher version(>= v3.0.0) Nebula service will cause a crash.
+  //
+  // clientIP here is used to check whether the client version is lower than v2.6.0
+  Status auth(const std::string& user, const std::string& password, const HostAddr& clientIp);
 
  private:
   meta::MetaClient* metaClient_;

--- a/src/graph/service/PasswordAuthenticator.h
+++ b/src/graph/service/PasswordAuthenticator.h
@@ -16,14 +16,8 @@ class PasswordAuthenticator final : public Authenticator {
  public:
   explicit PasswordAuthenticator(meta::MetaClient* client);
 
-  // This interface is only implemented to override the parent class and should not be called
+  // Authenticates the user by checking the user/password cache in the meta
   Status auth(const std::string& user, const std::string& password) override;
-
-  // TODO(Aiee) This is a walkround to address the problem that using a lower version(< v2.6.0)
-  // client to connect with higher version(>= v3.0.0) Nebula service will cause a crash.
-  //
-  // clientIP here is used to check whether the client version is lower than v2.6.0
-  Status auth(const std::string& user, const std::string& password, const HostAddr& clientIp);
 
  private:
   meta::MetaClient* metaClient_;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Fix https://github.com/vesoft-inc/nebula/issues/3935
#### Description:
Fix service crash caused by connecting using a pre-v2.6.0 client.

Error message when connecting the v3.0.0 Nebula service with v2.5.0 console:
```
> ./nebula-console -addr 192.168.8.6 -port 29562 -u root -p nebula
2022/02/24 22:01:21 [INFO] connection pool is initialized successfully
2022/02/24 22:01:21 Fail to create a new session from connection pool, fail to authenticate, error: The version of the client sending request from "::ffff:192.168.8.6":49722 is lower than v2.6.0, please update the client.
panic: Fail to create a new session from connection pool, fail to authenticate, error: The version of the client sending request from "::ffff:192.168.8.6":49722 is lower than v2.6.0, please update the client.

goroutine 1 [running]:
log.Panicf(0x655651, 0x35, 0xc00010de78, 0x1, 0x1)
        /usr/local/go/src/log/log.go:361 +0xc5
```

## How do you solve it?
Add a flag in `mataClient` to record whether the client triggered `verifyClientVersion()`. If the client called `verifyClientVersion`, the client has a version >= `v2.6.0`. Otherwise the client version is lower than `v2.5.0`.

When doing `auth()`, check the IP address of the client to see if the client is later than `v2.5.0`. Return an error if the client version is lower than `v2.5.0`.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [x] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
