### PR TITLE
Prune properties/no need to collect columns of dedup

### DIFF
--- a/src/graph/planner/plan/PlanNodeVisitor.h
+++ b/src/graph/planner/plan/PlanNodeVisitor.h
@@ -22,7 +22,6 @@ class PlanNodeVisitor {
   virtual void visit(Aggregate *node) = 0;
   virtual void visit(Traverse *node) = 0;
   virtual void visit(AppendVertices *node) = 0;
-  virtual void visit(Dedup *node) = 0;
   virtual void visit(BiJoin *node) = 0;
 };
 

--- a/src/graph/planner/plan/Query.cpp
+++ b/src/graph/planner/plan/Query.cpp
@@ -544,10 +544,6 @@ Dedup::Dedup(QueryContext* qctx, PlanNode* input) : SingleInputNode(qctx, Kind::
   copyInputColNames(input);
 }
 
-void Dedup::accept(PlanNodeVisitor* visitor) {
-  visitor->visit(this);
-}
-
 PlanNode* Dedup::clone() const {
   auto* newDedup = Dedup::make(qctx_, nullptr);
   newDedup->cloneMembers(*this);

--- a/src/graph/planner/plan/Query.h
+++ b/src/graph/planner/plan/Query.h
@@ -1168,8 +1168,6 @@ class Dedup final : public SingleInputNode {
     return qctx->objPool()->add(new Dedup(qctx, input));
   }
 
-  void accept(PlanNodeVisitor* visitor) override;
-
   PlanNode* clone() const override;
 
  private:

--- a/src/graph/visitor/PrunePropertiesVisitor.cpp
+++ b/src/graph/visitor/PrunePropertiesVisitor.cpp
@@ -252,14 +252,6 @@ void PrunePropertiesVisitor::visit(AppendVertices *node) {
   status_ = depsPruneProperties(node->dependencies());
 }
 
-void PrunePropertiesVisitor::visit(Dedup *node) {
-  const auto &colNames = qctx_->symTable()->getVar(node->inputVar())->colNames;
-  for (auto &colName : colNames) {
-    propsUsed_.colsSet.insert(colName);
-  }
-  status_ = depsPruneProperties(node->dependencies());
-}
-
 void PrunePropertiesVisitor::visit(BiJoin *node) {
   for (auto *hashKey : node->hashKeys()) {
     status_ = extractPropsFromExpr(hashKey);

--- a/src/graph/visitor/PrunePropertiesVisitor.h
+++ b/src/graph/visitor/PrunePropertiesVisitor.h
@@ -34,7 +34,6 @@ class PrunePropertiesVisitor final : public PlanNodeVisitor {
   void visit(Aggregate *node) override;
   void visit(Traverse *node) override;
   void visit(AppendVertices *node) override;
-  void visit(Dedup *node) override;
   void visit(BiJoin *node) override;
 
  private:

--- a/tests/tck/features/optimizer/PrunePropertiesRule.feature
+++ b/tests/tck/features/optimizer/PrunePropertiesRule.feature
@@ -130,7 +130,7 @@ Feature: Prune Properties rule
       WITH DISTINCT v, t
       RETURN t
       """
-    Then the result should be, in order:
+    Then the result should be, in any order:
       | t                                  |
       | ("Spurs" :team{name: "Spurs"})     |
       | ("Hornets" :team{name: "Hornets"}) |
@@ -140,7 +140,7 @@ Feature: Prune Properties rule
       WITH DISTINCT v.player.age as age, t
       RETURN t
       """
-    Then the result should be, in order:
+    Then the result should be, in any order:
       | t                                  |
       | ("Spurs" :team{name: "Spurs"})     |
       | ("Hornets" :team{name: "Hornets"}) |

--- a/tests/tck/features/optimizer/PrunePropertiesRule.feature
+++ b/tests/tck/features/optimizer/PrunePropertiesRule.feature
@@ -124,6 +124,26 @@ Feature: Prune Properties rule
       | ("Kyle Anderson" :player{age: 25, name: "Kyle Anderson"})   | 25  |
       | ("Damian Lillard" :player{age: 28, name: "Damian Lillard"}) | 28  |
       | ("Damian Lillard" :player{age: 28, name: "Damian Lillard"}) | 28  |
+    When executing query:
+      """
+      MATCH (v:player{name: "Tony Parker"})-[:serve]->(t:team)
+      WITH DISTINCT v, t
+      RETURN t
+      """
+    Then the result should be, in order:
+      | t                                  |
+      | ("Spurs" :team{name: "Spurs"})     |
+      | ("Hornets" :team{name: "Hornets"}) |
+    When executing query:
+      """
+      MATCH (v:player{name: "Tony Parker"})-[:serve]->(t:team)
+      WITH DISTINCT v.player.age as age, t
+      RETURN t
+      """
+    Then the result should be, in order:
+      | t                                  |
+      | ("Spurs" :team{name: "Spurs"})     |
+      | ("Hornets" :team{name: "Hornets"}) |
 
   Scenario: Multi Path Patterns
     When profiling query:


### PR DESCRIPTION
For vertex/edge, only vid/eid is used to dedup