### PR TITLE
handle the core generated in the `lookup on` command

### DIFF
--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -247,7 +247,10 @@ Expression *ExpressionUtils::rewriteInExpr(const Expression *expr) {
   DCHECK(expr->kind() == Expression::Kind::kRelIn);
   auto pool = expr->getObjPool();
   auto inExpr = static_cast<RelationalExpression *>(expr->clone());
-  auto containerOperands = getContainerExprOperands(inExpr->right());
+  std::vector<Expression *> containerOperands;
+  if (inExpr->kind() == Expression::Kind::kRelIn) {
+    containerOperands = getContainerExprOperands(inExpr->right());
+  }
 
   auto operandSize = containerOperands.size();
   // container has only 1 element, no need to transform to logical expression


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: #3978

#### Description:
When using the lookup on command, if there is only one element in the list where tag.propName in ["xx"], there will be a core generated

just like
```
lookup on click where click.itemid in ["0"] and click.times >= "2015-10-10 10:10:10"
```

coredump msg:
```
#0  0x0000000000ece8e7 in nebula::graph::ExpressionUtils::getContainerExprOperands(nebula::Expression const*) ()
#1  0x0000000000eceddc in nebula::graph::ExpressionUtils::rewriteInExpr(nebula::Expression const*) ()
#2  0x0000000001005819 in nebula::opt::OptimizeEdgeIndexScanByFilterRule::transform(nebula::opt::OptContext*, nebula::opt::MatchedResult const&) const ()
#3  0x0000000000fef55b in nebula::opt::OptGroup::explore(nebula::opt::OptRule const*) ()
#4  0x0000000000fefa21 in nebula::opt::OptGroup::exploreUntilMaxRound(nebula::opt::OptRule const*) ()
#5  0x0000000000fefc6c in nebula::opt::OptGroupNode::explore(nebula::opt::OptRule const*) ()
#6  0x0000000000fef489 in nebula::opt::OptGroup::explore(nebula::opt::OptRule const*) ()
#7  0x0000000000fefa21 in nebula::opt::OptGroup::exploreUntilMaxRound(nebula::opt::OptRule const*) ()
#8  0x0000000000fee445 in nebula::opt::Optimizer::doExploration(nebula::opt::OptContext*, nebula::opt::OptGroup*) ()
#9  0x0000000000fee887 in nebula::opt::Optimizer::findBestPlan(nebula::graph::QueryContext*) ()
#10 0x0000000000f1e89f in nebula::graph::QueryInstance::findBestPlan() ()
#11 0x0000000000f2082a in nebula::graph::QueryInstance::validateAndOptimize() ()
#12 0x0000000000f20ce1 in nebula::graph::QueryInstance::execute() ()
#13 0x0000000000f1b5a2 in nebula::graph::QueryEngine::execute(std::unique_ptr<nebula::graph::RequestContext<nebula::ExecutionResponse>, std::default_delete<nebula::graph::RequestContext<nebula::ExecutionResponse> > >) ()
#14 0x0000000000ef3d49 in nebula::graph::GraphService::future_execute(long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda(nebula::StatusOr<std::shared_ptr<nebula::graph::ClientSession> >)#1}::operator()(nebula::StatusOr<std::shared_ptr<nebula::graph::ClientSession> >) ()
#15 0x0000000000ef48af in _ZN5folly6detail8function14FunctionTraitsIFvRNS_7futures6detail8CoreBaseEONS_8Executor9KeepAliveIS7_EEPNS_17exception_wrapperEEE9callSmallIZNS4_4CoreIN6nebula8StatusOrISt10shared_ptrINSH_5graph13ClientSessionEEEEE11setCallbackIZNS4_10FutureBaseISN_E18thenImplementationIZNOS_6FutureISN_E9thenValueIZNSK_12GraphService14future_executeElRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEUlSN_E_EENST_INS4_19valueCallableResultISN_T_E10value_typeEEEOS17_EUlSA_ONS_3TryISN_EEE_NS4_25tryExecutorCallableResultISN_S1F_vEEEENSt9enable_ifIXntsrNT0_13ReturnsFutureE5valueENS1J_6ReturnEE4typeES1B_S1J_NS4_18InlineContinuationEEUlSA_S1E_E_EEvS1B_OSJ_INS_14RequestContextEES1O_EUlS6_SA_SC_E_EEvS6_SA_SC_RNS1_4DataE ()
#16 0x0000000001df506c in ?? ()
#17 0x0000000001bff887 in virtual thunk to apache::thrift::concurrency::FunctionRunner::run() ()
#18 0x0000000001d0ff53 in apache::thrift::concurrency::ThreadManager::Impl::Worker::run() ()
#19 0x0000000001d13bad in apache::thrift::concurrency::PthreadThread::threadMain(void*) ()
#20 0x00007fea6db13ea5 in start_thread () from /lib64/libpthread.so.0

```
## How do you solve it?
check the Expr kind before getContainerExprOperands

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
