### PR TITLE
refactor stats manager for safe and performance

### DIFF
--- a/src/common/stats/CMakeLists.txt
+++ b/src/common/stats/CMakeLists.txt
@@ -7,5 +7,12 @@ nebula_add_library(
     OBJECT
     StatsManager.cpp
 )
-
+nebula_add_library(
+    metrics_obj
+    OBJECT
+    Metrics.cpp
+    Histogram.cpp
+    Counter.cpp
+    Gauge.cpp
+)
 nebula_add_subdirectory(test)

--- a/src/common/stats/Counter.cpp
+++ b/src/common/stats/Counter.cpp
@@ -1,0 +1,118 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+#include "common/stats/Counter.h"
+
+#include "folly/synchronization/Rcu.h"
+namespace nebula {
+namespace stats {
+Counter::Counter(const std::string& name)
+    : globalElement_(name,
+                     "",
+                     Series(60,
+                            {
+                                std::chrono::seconds(5),
+                                std::chrono::seconds(60),
+                                std::chrono::seconds(600),
+                                std::chrono::seconds(3600),
+                            })) {}
+void Counter::addValue(int64_t value) {
+  std::unique_lock<std::mutex> lck(globalElement_.mut);
+  globalElement_.series.addValue(std::chrono::seconds(::nebula::time::WallClock::fastNowInSec()),
+                                 value);
+}
+void Counter::addValue(const std::string& label, int64_t value) {
+  bool needCreate = false;
+  {
+    folly::rcu_reader guard;
+    auto& map = *labelMap_.load();
+    auto iter = map.find(label);
+    if (LIKELY(iter != map.end())) {
+      auto& element = *(iter->second);
+      std::unique_lock<std::mutex> lck(element.mut);
+      element.series.addValue(std::chrono::seconds(::nebula::time::WallClock::fastNowInSec()),
+                              value);
+    } else {
+      needCreate = true;
+    }
+  }
+  if (UNLIKELY(needCreate)) {
+    std::unique_lock<std::mutex> lck(writeMut_);
+    auto originMap = labelMap_.load();
+    auto iter = originMap->find(label);
+    if (LIKELY(iter == originMap->end())) {
+      auto newMap = new LabelMap(*originMap);
+      auto element = new Element(globalElement_.name, label, globalElement_.series);
+      element->series.addValue(std::chrono::seconds(::nebula::time::WallClock::fastNowInSec()),
+                               value);
+      newMap->insert({label, element});
+      labelMap_.store(newMap);
+      folly::rcu_retire(originMap);
+    } else {
+      auto& element = *(iter->second);
+      std::unique_lock<std::mutex> elementLock(element.mut);
+      element.series.addValue(std::chrono::seconds(::nebula::time::WallClock::fastNowInSec()),
+                              value);
+    }
+  }
+}
+bool Counter::removeLabel(const std::string& label) {
+  LabelMap* originMap = nullptr;
+  Element* element = nullptr;
+  {
+    std::unique_lock<std::mutex> lck(writeMut_);
+    originMap = labelMap_.load();
+    auto iter = originMap->find(label);
+    if (iter == originMap->end()) {
+      return false;
+    }
+    element = iter->second;
+    auto newMap = new LabelMap(*originMap);
+    newMap->erase(label);
+    labelMap_.store(newMap);
+  }
+  folly::synchronize_rcu();
+  delete originMap;
+  delete element;
+  return true;
+}
+void Counter::read(MetricsReader& reader) {
+  readElement(reader, globalElement_);
+  folly::rcu_reader guard;
+  auto& map = *labelMap_.load();
+  for (auto& [name, ele] : map) {
+    readElement(reader, *ele);
+  }
+}
+void Counter::readElement(MetricsReader& reader, const Element& element) {
+  std::string prefix = element.name;
+  if (!element.label.empty()) {
+    prefix += "{" + element.label + "}";
+  }
+  auto& series = element.series;
+  reader.append(prefix + ".avg" + ".5", series.template avg<int64_t>(0))
+      .append(prefix + ".avg" + ".60", series.template avg<int64_t>(1))
+      .append(prefix + ".avg" + ".600", series.template avg<int64_t>(2))
+      .append(prefix + ".avg" + ".3600", series.template avg<int64_t>(3));
+  reader.append(prefix + ".sum" + ".5", series.sum(0))
+      .append(prefix + ".sum" + ".60", series.sum(1))
+      .append(prefix + ".sum" + ".600", series.sum(2))
+      .append(prefix + ".sum" + ".3600", series.sum(3));
+  reader.append(prefix + ".rate" + ".5", series.template rate(0))
+      .append(prefix + ".rate" + ".60", series.template rate(1))
+      .append(prefix + ".rate" + ".600", series.template rate(2))
+      .append(prefix + ".rate" + ".3600", series.template rate(3));
+  reader.append(prefix + ".count" + ".5", series.count(0))
+      .append(prefix + ".count" + ".60", series.count(1))
+      .append(prefix + ".count" + ".600", series.count(2))
+      .append(prefix + ".count" + ".3600", series.count(3));
+}
+Counter::Element::Element(const std::string& elementName,
+                          const std::string& elementLabel,
+                          const Counter::Series& elementSeries)
+    : name(elementName), label(elementLabel), series(elementSeries) {
+  this->series.clear();
+}
+}  // namespace stats
+}  // namespace nebula

--- a/src/common/stats/Counter.h
+++ b/src/common/stats/Counter.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+#pragma once
+#include <chrono>
+
+#include "common/stats/MetricsReader.h"
+#include "common/time/WallClock.h"
+#include "folly/Likely.h"
+#include "folly/container/F14Map.h"
+#include "folly/stats/MultiLevelTimeSeries.h"
+namespace nebula {
+namespace stats {
+// sum: 时间段内总和
+// count: 时间段内次数
+// rate: sum/时间段大小
+// avg: sum/count
+class Counter {
+ public:
+  explicit Counter(const std::string& name);
+  void addValue(int64_t value);
+  void addValue(const std::string& label, int64_t value);
+  bool removeLabel(const std::string& label);
+  void read(MetricsReader& reader);
+
+ private:
+  using Series = folly::MultiLevelTimeSeries<int64_t>;
+  struct Element {
+    Element() = default;
+    Element(const std::string& elementName,
+            const std::string& elementLabel,
+            const Counter::Series& elementSeries);
+    std::string name;
+    std::string label;
+    std::mutex mut;
+    Counter::Series series;
+  };
+  using LabelMap = folly::F14FastMap<std::string, Element*>;
+  std::atomic<LabelMap*> labelMap_;
+  std::mutex writeMut_;
+  Element globalElement_;
+  void readElement(MetricsReader& reader, const Element& element);
+};
+}  // namespace stats
+}  // namespace nebula

--- a/src/common/stats/Gauge.cpp
+++ b/src/common/stats/Gauge.cpp
@@ -1,0 +1,60 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+#include "common/stats/Gauge.h"
+
+namespace nebula {
+namespace stats {
+Gauge::Gauge(const std::string& name, Callback&& callback)
+    : globalElement_(name, "", std::move(callback)) {}
+bool Gauge::addLabel(const std::string& label, Callback&& callback) {
+  std::unique_lock<std::mutex> lck(writeMut_);
+  auto originMap = labelMap_.load();
+  auto newMap = new LabelMap(*originMap);
+  (*newMap)[label] = new Element(globalElement_.name, label, std::move(callback));
+  labelMap_.store(newMap);
+  folly::rcu_retire(originMap);
+  return true;
+}
+bool Gauge::removeLabel(const std::string& label) {
+  LabelMap* originMap = nullptr;
+  Element* element = nullptr;
+  {
+    std::unique_lock<std::mutex> lck(writeMut_);
+    originMap = labelMap_.load();
+    auto iter = originMap->find(label);
+    if (iter == originMap->end()) {
+      return false;
+    }
+    element = iter->second;
+    auto newMap = new LabelMap(*originMap);
+    newMap->erase(label);
+  }
+  folly::synchronize_rcu();
+  delete originMap;
+  delete element;
+  return true;
+}
+void Gauge::read(MetricsReader& reader) {
+  readElement(reader, globalElement_);
+  folly::rcu_reader guard;
+  auto& map = *labelMap_.load();
+  for (auto& [label, ele] : map) {
+    readElement(reader, *ele);
+  }
+}
+Gauge::Element::Element(const std::string& elementName,
+                        const std::string& elementLabel,
+                        Callback&& elementCallback)
+    : name(elementName), label(elementLabel), callback(std::move(elementCallback)) {}
+void Gauge::readElement(MetricsReader& reader, const Element& ele) {
+  std::string prefix = ele.name;
+  if (!ele.label.empty()) {
+    prefix += "{" + ele.label + "}";
+  }
+  reader.append(prefix, ele.callback());
+}
+}  // namespace stats
+
+}  // namespace nebula

--- a/src/common/stats/Gauge.h
+++ b/src/common/stats/Gauge.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+#pragma once
+#include <functional>
+#include <mutex>
+
+#include "common/stats/MetricsReader.h"
+#include "folly/container/F14Map.h"
+#include "folly/synchronization/Rcu.h"
+
+namespace nebula {
+namespace stats {
+class Gauge {
+ public:
+  using Callback = std::function<std::string()>;
+  Gauge() = default;
+  Gauge(const std::string& name, Callback&& callback);
+  bool addLabel(const std::string& label, Callback&& callback);
+  bool removeLabel(const std::string& label);
+  void read(MetricsReader& reader);
+
+ private:
+  struct Element {
+    Element() = default;
+    Element(const std::string& elementName,
+            const std::string& elementLabel,
+            Callback&& elementCallback);
+    std::string name;
+    std::string label;
+    std::mutex mut;
+    Gauge::Callback callback;
+  };
+  using LabelMap = folly::F14FastMap<std::string, Element*>;
+  std::atomic<LabelMap*> labelMap_;
+  std::mutex writeMut_;
+  Element globalElement_;
+  void readElement(MetricsReader& reader, const Element& ele);
+};
+}  // namespace stats
+}  // namespace nebula

--- a/src/common/stats/Histogram.cpp
+++ b/src/common/stats/Histogram.cpp
@@ -1,0 +1,137 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+#include "common/stats/Histogram.h"
+
+namespace nebula {
+namespace stats {
+Histogram::Histogram(const std::string& name, int64_t bucketSize, int64_t min, int64_t max)
+    : globalElement_(name,
+                     "",
+                     Series(bucketSize,
+                            min,
+                            max,
+                            folly::MultiLevelTimeSeries<int64_t>(60,
+                                                                 {
+                                                                     std::chrono::seconds(5),
+                                                                     std::chrono::seconds(60),
+                                                                     std::chrono::seconds(600),
+                                                                     std::chrono::seconds(3600),
+                                                                 }))) {}
+
+void Histogram::addValue(int64_t value) {
+  std::unique_lock<std::mutex> lck(globalElement_.mut);
+  globalElement_.series.addValue(std::chrono::seconds(::nebula::time::WallClock::fastNowInSec()),
+                                 value);
+}
+void Histogram::addValue(const std::string& label, int64_t value) {
+  bool needCreate = false;
+  {
+    folly::rcu_reader guard;
+    auto& map = *labelMap_.load();
+    auto iter = map.find(label);
+    if (LIKELY(iter != map.end())) {
+      auto& element = *(iter->second);
+      std::unique_lock<std::mutex> lck(element.mut);
+      element.series.addValue(std::chrono::seconds(::nebula::time::WallClock::fastNowInSec()),
+                              value);
+    } else {
+      needCreate = true;
+    }
+  }
+  if (UNLIKELY(needCreate)) {
+    std::unique_lock<std::mutex> lck(writeMut_);
+    auto originMap = labelMap_.load();
+    auto iter = originMap->find(label);
+    if (LIKELY(iter == originMap->end())) {
+      auto newMap = new LabelMap(*originMap);
+      auto element = new Element(globalElement_.name, label, globalElement_.series);
+      element->series.addValue(std::chrono::seconds(::nebula::time::WallClock::fastNowInSec()),
+                               value);
+      newMap->insert({label, element});
+      labelMap_.store(newMap);
+      folly::rcu_retire(originMap);
+    } else {
+      auto& element = *(iter->second);
+      std::unique_lock<std::mutex> elementLock(element.mut);
+      element.series.addValue(std::chrono::seconds(::nebula::time::WallClock::fastNowInSec()),
+                              value);
+    }
+  }
+}
+bool Histogram::removeLabel(const std::string& label) {
+  LabelMap* originMap = nullptr;
+  Element* element = nullptr;
+  {
+    std::unique_lock<std::mutex> lck(writeMut_);
+    originMap = labelMap_.load();
+    auto iter = originMap->find(label);
+    if (iter == originMap->end()) {
+      return false;
+    }
+    element = iter->second;
+    auto newMap = new LabelMap(*originMap);
+    newMap->erase(label);
+    labelMap_.store(newMap);
+  }
+  folly::synchronize_rcu();
+  delete originMap;
+  delete element;
+  return true;
+}
+void Histogram::read(MetricsReader& reader) {
+  readElement(reader, globalElement_);
+  folly::rcu_reader guard;
+  auto& map = *labelMap_.load();
+  for (auto& [name, ele] : map) {
+    readElement(reader, *ele);
+  }
+}
+void Histogram::readElement(MetricsReader& reader, const Histogram::Element& element) {
+  std::string prefix = element.name;
+  if (element.label.empty()) {
+    prefix += "{" + element.label + "}";
+  }
+  auto& series = element.series;
+  reader.append(prefix + ".avg" + ".5", series.template avg<int64_t>(0))
+      .append(prefix + ".avg" + ".60", series.template avg<int64_t>(1))
+      .append(prefix + ".avg" + ".600", series.template avg<int64_t>(2))
+      .append(prefix + ".avg" + ".3600", series.template avg<int64_t>(3));
+  reader.append(prefix + ".sum" + ".5", series.sum(0))
+      .append(prefix + ".sum" + ".60", series.sum(1))
+      .append(prefix + ".sum" + ".600", series.sum(2))
+      .append(prefix + ".sum" + ".3600", series.sum(3));
+  reader.append(prefix + ".rate" + ".5", series.template rate(0))
+      .append(prefix + ".rate" + ".60", series.template rate(1))
+      .append(prefix + ".rate" + ".600", series.template rate(2))
+      .append(prefix + ".rate" + ".3600", series.template rate(3));
+  reader.append(prefix + ".count" + ".5", series.count(0))
+      .append(prefix + ".count" + ".60", series.count(1))
+      .append(prefix + ".count" + ".600", series.count(2))
+      .append(prefix + ".count" + ".3600", series.count(3));
+  reader.append(prefix + ".p50" + ".5", series.getPercentileEstimate(0.5, 0))
+      .append(prefix + ".p50" + ".60", series.getPercentileEstimate(0.5, 1))
+      .append(prefix + ".p50" + ".600", series.getPercentileEstimate(0.5, 2))
+      .append(prefix + ".p50" + ".3600", series.getPercentileEstimate(0.5, 3));
+  reader.append(prefix + ".p90" + ".5", series.getPercentileEstimate(0.9, 0))
+      .append(prefix + ".p90" + ".60", series.getPercentileEstimate(0.9, 1))
+      .append(prefix + ".p90" + ".600", series.getPercentileEstimate(0.9, 2))
+      .append(prefix + ".p90" + ".3600", series.getPercentileEstimate(0.9, 3));
+  reader.append(prefix + ".p99" + ".5", series.getPercentileEstimate(0.99, 0))
+      .append(prefix + ".p99" + ".60", series.getPercentileEstimate(0.99, 1))
+      .append(prefix + ".p99" + ".600", series.getPercentileEstimate(0.99, 2))
+      .append(prefix + ".p99" + ".3600", series.getPercentileEstimate(0.99, 3));
+  reader.append(prefix + ".p999" + ".5", series.getPercentileEstimate(0.999, 0))
+      .append(prefix + ".p999" + ".60", series.getPercentileEstimate(0.999, 1))
+      .append(prefix + ".p999" + ".600", series.getPercentileEstimate(0.999, 2))
+      .append(prefix + ".p999" + ".3600", series.getPercentileEstimate(0.999, 3));
+}
+Histogram::Element::Element(const std::string& elementName,
+                            const std::string& elementLabel,
+                            const Histogram::Series& elementSeries)
+    : name(elementName), label(elementLabel), series(elementSeries) {
+  this->series.clear();
+}
+}  // namespace stats
+}  // namespace nebula

--- a/src/common/stats/Histogram.h
+++ b/src/common/stats/Histogram.h
@@ -1,0 +1,45 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+#pragma once
+
+#include <chrono>
+
+#include "common/stats/MetricsReader.h"
+#include "common/time/WallClock.h"
+#include "folly/container/F14Map.h"
+#include "folly/stats/MultiLevelTimeSeries.h"
+#include "folly/stats/TimeseriesHistogram.h"
+#include "folly/synchronization/Rcu.h"
+namespace nebula {
+namespace stats {
+class Histogram {
+ public:
+  Histogram() = default;
+  Histogram(const std::string& name, int64_t bucketSize, int64_t min, int64_t max);
+  void addValue(int64_t value);
+  void addValue(const std::string& label, int64_t value);
+  bool removeLabel(const std::string& label);
+  void read(MetricsReader& reader);
+
+ private:
+  using Series = folly::TimeseriesHistogram<int64_t>;
+  struct Element {
+    Element() = default;
+    Element(const std::string& elementName,
+            const std::string& elementLabel,
+            const Histogram::Series& elementSeries);
+    std::string name;
+    std::string label;
+    std::mutex mut;
+    Histogram::Series series;
+  };
+  using LabelMap = folly::F14FastMap<std::string, Element*>;
+  std::atomic<LabelMap*> labelMap_;
+  std::mutex writeMut_;
+  Element globalElement_;
+  void readElement(MetricsReader& reader, const Element& element);
+};
+}  // namespace stats
+}  // namespace nebula

--- a/src/common/stats/Metrics.cpp
+++ b/src/common/stats/Metrics.cpp
@@ -1,0 +1,57 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+#include "common/stats/Metrics.h"
+
+namespace nebula {
+namespace stats {
+Metrics* Metrics::instance_ = new Metrics;
+void Metrics::registerCounter(const std::string& name) {
+  counterMap_[name] = new Counter(name);
+}
+void Metrics::registerHistogram(const std::string& name,
+                                int64_t bucketSize,
+                                int64_t min,
+                                int64_t max) {
+  histogramMap_[name] = new Histogram(name, bucketSize, min, max);
+}
+void Metrics::registerGauge(const std::string& name, Gauge::Callback&& callback) {
+  gaugeMap_[name] = new Gauge(name, std::move(callback));
+}
+
+void Metrics::counter(const std::string& name, int64_t value) {
+  auto iter = counterMap_.find(name);
+  CHECK(iter != counterMap_.end());
+  iter->second->addValue(value);
+}
+void Metrics::counter(const std::string& name, const std::string& label, int64_t value) {
+  auto iter = counterMap_.find(name);
+  CHECK(iter != counterMap_.end());
+  iter->second->addValue(label, value);
+}
+void Metrics::histogram(const std::string& name, int64_t value) {
+  auto iter = histogramMap_.find(name);
+  CHECK(iter != histogramMap_.end());
+  iter->second->addValue(value);
+}
+void Metrics::histogram(const std::string& name, const std::string& label, int64_t value) {
+  auto iter = histogramMap_.find(name);
+  CHECK(iter != histogramMap_.end());
+  iter->second->addValue(label, value);
+}
+void Metrics::readAll(MetricsReader& reader) {
+  for (auto& [name, counter] : counterMap_) {
+    counter->read(reader);
+  }
+  for (auto& [name, histogram] : histogramMap_) {
+    histogram->read(reader);
+  }
+  for (auto& [name, gauge] : gaugeMap_) {
+    gauge->read(reader);
+  }
+}
+
+}  // namespace stats
+
+}  // namespace nebula

--- a/src/common/stats/Metrics.h
+++ b/src/common/stats/Metrics.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+#pragma once
+#include <array>
+#include <functional>
+
+#include "common/stats/Counter.h"
+#include "common/stats/Gauge.h"
+#include "common/stats/Histogram.h"
+#include "folly/container/F14Map.h"
+namespace nebula {
+namespace stats {
+class Metrics {
+ public:
+  static Metrics& getInstance() {
+    return *instance_;
+  }
+  ~Metrics() = default;
+
+  // register
+  void registerCounter(const std::string& name);
+  void registerHistogram(const std::string& name, int64_t bucketSize, int64_t min, int64_t max);
+  void registerGauge(const std::string& name, Gauge::Callback&& callback);
+
+  // write
+  void counter(const std::string& name, int64_t value = 1);
+  void counter(const std::string& name, const std::string& labels, int64_t value = 1);
+  void histogram(const std::string& name, int64_t value);
+  void histogram(const std::string& name, const std::string& labels, int64_t value);
+  void gauge(const std::string& name, const std::string& label, Gauge::Callback&& callback);
+
+  // read
+  void readAll(MetricsReader& reader);
+
+ private:
+  static Metrics* instance_;
+  folly::F14FastMap<std::string, Counter*> counterMap_;
+  folly::F14FastMap<std::string, Histogram*> histogramMap_;
+  folly::F14FastMap<std::string, Gauge*> gaugeMap_;
+};
+}  // namespace stats
+}  // namespace nebula

--- a/src/common/stats/MetricsReader.h
+++ b/src/common/stats/MetricsReader.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+#pragma once
+#include <sstream>
+namespace nebula {
+namespace stats {
+class MetricsReader {
+ public:
+  template <typename ValueType>
+  MetricsReader& append(const std::string& name, ValueType value) {
+    stream_ << name << value;
+    return *this;
+  }
+
+ private:
+  std::ostringstream stream_;
+};
+}  // namespace stats
+}  // namespace nebula

--- a/src/common/stats/test/CMakeLists.txt
+++ b/src/common/stats/test/CMakeLists.txt
@@ -65,3 +65,17 @@ nebula_add_executable(
     LIBRARIES
         follybenchmark boost_regex
 )
+nebula_add_executable(
+    NAME 
+        metrics_bm
+    SOURCES
+        MetricsBenchmark.cpp
+    OBJECTS
+        $<TARGET_OBJECTS:metrics_obj>
+        $<TARGET_OBJECTS:datatypes_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:wkt_wkb_io_obj>
+    LIBRARIES
+        follybenchmark boost_regex
+)

--- a/src/common/stats/test/MetricsBenchmark.cpp
+++ b/src/common/stats/test/MetricsBenchmark.cpp
@@ -1,0 +1,43 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+#include "common/stats/Metrics.h"
+#include "folly/Benchmark.h"
+
+using nebula::stats::Metrics;
+
+void metricsBenchmark(const std::string& name, uint32_t numThreads, uint32_t iters) {
+  std::vector<std::thread> threads;
+  for (uint32_t i = 0; i < numThreads; i++) {
+    auto itersInThread =
+        i == 0 ? iters - (iters / numThreads) * (numThreads - 1) : iters / numThreads;
+    threads.emplace_back([&name, itersInThread]() {
+      for (uint32_t k = 0; k < itersInThread; k++) {
+        Metrics::getInstance().counter(name);
+      }
+    });
+  }
+  for (size_t i = 0; i < numThreads; i++) {
+    threads[i].join();
+  }
+}
+
+BENCHMARK(METRICS_COUNTER_1T, iters) {
+  metricsBenchmark("test_name", 1, iters);
+}
+BENCHMARK(METRICS_COUNTER_8T, iters) {
+  metricsBenchmark("test_name", 1, iters);
+}
+BENCHMARK(METRICS_COUNTER_32T, iters) {
+  metricsBenchmark("test_name", 1, iters);
+}
+BENCHMARK(METRICS_COUNTER_64T, iters) {
+  metricsBenchmark("test_name", 1, iters);
+}
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv, true);
+  Metrics::getInstance().registerCounter("test_name");
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
In this PR, I refactor the hole StatsManager.

Function:
1. The API directly distinguishes between counter type metrics and histogram type metrics, and adds gauge type metrics
2. RCU is used to replace the read-write lock. This will have a very large performance improvement.
3. Metrics is registered during initialization. However, it supports dynamic addition and deletion of labels. A good trade-off is made between performance and ease of use.
4. Rename statsmanager to metrics

Safe:
Remove all previous thread unsafe hidden dangers. However, the cost is that the read performance will be slightly reduced, but the write performance will be better than before.

In addition, because the stats related classes provided by folly are thread unsafe, we need additional locks when writing to multiple threads. This can become a performance bottleneck. After a simple test, the limit QPS of a single counter / histogram under a single thread is 2 million, and the limit under 64 threads is 1 million. In terms of throughput, it is enough. However, in the multithreading scenario, the sys occupation of the system CPU will become very, very high.

If you want to further optimize the performance, you can use ThreadLocal. This implementation is very complex. However, because the write QPS of metrics is much larger than the read QPS, the multi and scalability will become very good.




#### Issue(s) number: 
#3869 
#### Description:


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
