### PR TITLE
Fix lambda capture bug in GraphStorageLocalServer

### DIFF
--- a/src/storage/GraphStorageLocalServer.cpp
+++ b/src/storage/GraphStorageLocalServer.cpp
@@ -5,18 +5,23 @@
 
 #include "GraphStorageLocalServer.h"
 
+#include <folly/ExceptionWrapper.h>
 #include <unistd.h>
 
 #include "common/base/Base.h"
 #include "storage/GraphStorageServiceHandler.h"
 
-#define LOCAL_RETURN_FUTURE(threadManager, respType, callFunc)                                    \
-  auto promise = std::make_shared<folly::Promise<respType>>();                                    \
-  auto f = promise->getFuture();                                                                  \
-  threadManager->add([&, promise] {                                                               \
-    std::dynamic_pointer_cast<GraphStorageServiceHandler>(handler_)->callFunc(request).thenValue( \
-        [promise](respType&& resp) { promise->setValue(std::move(resp)); });                      \
-  });                                                                                             \
+using folly::exception_wrapper;
+
+#define LOCAL_RETURN_FUTURE(RespType, callFunc)                                                  \
+  auto promise = std::make_shared<folly::Promise<RespType>>();                                   \
+  auto f = promise->getFuture();                                                                 \
+  threadManager_->add([this, promise, request] {                                                 \
+    std::dynamic_pointer_cast<GraphStorageServiceHandler>(handler_)                              \
+        ->callFunc(std::move(request))                                                           \
+        .thenValue([promise](RespType&& resp) { promise->setValue(std::move(resp)); })           \
+        .thenError([promise](exception_wrapper&& ex) { promise->setException(std::move(ex)); }); \
+  });                                                                                            \
   return f;
 
 namespace nebula::storage {
@@ -55,102 +60,102 @@ void GraphStorageLocalServer::stop() {
 
 folly::Future<cpp2::GetNeighborsResponse> GraphStorageLocalServer::future_getNeighbors(
     const cpp2::GetNeighborsRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::GetNeighborsResponse, future_getNeighbors);
+  LOCAL_RETURN_FUTURE(cpp2::GetNeighborsResponse, future_getNeighbors);
 }
 
 folly::Future<cpp2::ExecResponse> GraphStorageLocalServer::future_addVertices(
     const cpp2::AddVerticesRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ExecResponse, future_addVertices);
+  LOCAL_RETURN_FUTURE(cpp2::ExecResponse, future_addVertices);
 }
 
 folly::Future<cpp2::ExecResponse> GraphStorageLocalServer::future_chainAddEdges(
     const cpp2::AddEdgesRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ExecResponse, future_chainAddEdges);
+  LOCAL_RETURN_FUTURE(cpp2::ExecResponse, future_chainAddEdges);
 }
 
 folly::Future<cpp2::ExecResponse> GraphStorageLocalServer::future_addEdges(
     const cpp2::AddEdgesRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ExecResponse, future_addEdges);
+  LOCAL_RETURN_FUTURE(cpp2::ExecResponse, future_addEdges);
 }
 
 folly::Future<cpp2::GetPropResponse> GraphStorageLocalServer::future_getProps(
     const cpp2::GetPropRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::GetPropResponse, future_getProps);
+  LOCAL_RETURN_FUTURE(cpp2::GetPropResponse, future_getProps);
 }
 
 folly::Future<cpp2::ExecResponse> GraphStorageLocalServer::future_deleteEdges(
     const cpp2::DeleteEdgesRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ExecResponse, future_deleteEdges);
+  LOCAL_RETURN_FUTURE(cpp2::ExecResponse, future_deleteEdges);
 }
 
 folly::Future<cpp2::ExecResponse> GraphStorageLocalServer::future_chainDeleteEdges(
     const cpp2::DeleteEdgesRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ExecResponse, future_chainDeleteEdges);
+  LOCAL_RETURN_FUTURE(cpp2::ExecResponse, future_chainDeleteEdges);
 }
 
 folly::Future<cpp2::ExecResponse> GraphStorageLocalServer::future_deleteVertices(
     const cpp2::DeleteVerticesRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ExecResponse, future_deleteVertices);
+  LOCAL_RETURN_FUTURE(cpp2::ExecResponse, future_deleteVertices);
 }
 
 folly::Future<cpp2::ExecResponse> GraphStorageLocalServer::future_deleteTags(
     const cpp2::DeleteTagsRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ExecResponse, future_deleteTags);
+  LOCAL_RETURN_FUTURE(cpp2::ExecResponse, future_deleteTags);
 }
 
 folly::Future<cpp2::UpdateResponse> GraphStorageLocalServer::future_updateVertex(
     const cpp2::UpdateVertexRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::UpdateResponse, future_updateVertex);
+  LOCAL_RETURN_FUTURE(cpp2::UpdateResponse, future_updateVertex);
 }
 
 folly::Future<cpp2::UpdateResponse> GraphStorageLocalServer::future_chainUpdateEdge(
     const cpp2::UpdateEdgeRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::UpdateResponse, future_chainUpdateEdge);
+  LOCAL_RETURN_FUTURE(cpp2::UpdateResponse, future_chainUpdateEdge);
 }
 
 folly::Future<cpp2::UpdateResponse> GraphStorageLocalServer::future_updateEdge(
     const cpp2::UpdateEdgeRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::UpdateResponse, future_updateEdge);
+  LOCAL_RETURN_FUTURE(cpp2::UpdateResponse, future_updateEdge);
 }
 
 folly::Future<cpp2::GetUUIDResp> GraphStorageLocalServer::future_getUUID(
     const cpp2::GetUUIDReq& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::GetUUIDResp, future_getUUID);
+  LOCAL_RETURN_FUTURE(cpp2::GetUUIDResp, future_getUUID);
 }
 
 folly::Future<cpp2::LookupIndexResp> GraphStorageLocalServer::future_lookupIndex(
     const cpp2::LookupIndexRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::LookupIndexResp, future_lookupIndex);
+  LOCAL_RETURN_FUTURE(cpp2::LookupIndexResp, future_lookupIndex);
 }
 
 folly::Future<cpp2::GetNeighborsResponse> GraphStorageLocalServer::future_lookupAndTraverse(
     const cpp2::LookupAndTraverseRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::GetNeighborsResponse, future_lookupAndTraverse);
+  LOCAL_RETURN_FUTURE(cpp2::GetNeighborsResponse, future_lookupAndTraverse);
 }
 
 folly::Future<cpp2::ScanResponse> GraphStorageLocalServer::future_scanVertex(
     const cpp2::ScanVertexRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ScanResponse, future_scanVertex);
+  LOCAL_RETURN_FUTURE(cpp2::ScanResponse, future_scanVertex);
 }
 
 folly::Future<cpp2::ScanResponse> GraphStorageLocalServer::future_scanEdge(
     const cpp2::ScanEdgeRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ScanResponse, future_scanEdge);
+  LOCAL_RETURN_FUTURE(cpp2::ScanResponse, future_scanEdge);
 }
 
 folly::Future<cpp2::KVGetResponse> GraphStorageLocalServer::future_get(
     const cpp2::KVGetRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::KVGetResponse, future_get);
+  LOCAL_RETURN_FUTURE(cpp2::KVGetResponse, future_get);
 }
 
 folly::Future<cpp2::ExecResponse> GraphStorageLocalServer::future_put(
     const cpp2::KVPutRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ExecResponse, future_put);
+  LOCAL_RETURN_FUTURE(cpp2::ExecResponse, future_put);
 }
 
 folly::Future<cpp2::ExecResponse> GraphStorageLocalServer::future_remove(
     const cpp2::KVRemoveRequest& request) {
-  LOCAL_RETURN_FUTURE(threadManager_, cpp2::ExecResponse, future_remove);
+  LOCAL_RETURN_FUTURE(cpp2::ExecResponse, future_remove);
 }
 
 }  // namespace nebula::storage


### PR DESCRIPTION
This will crash the daemon

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

The request object in lambda function is captured by reference, this will crash the server when this async interface finishes to run and the task in threadManager haven't be executed.


## How do you solve it?

Captured by copy.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
