### PR TITLE
Param MATCH vid seek fix

### DIFF
--- a/src/graph/planner/match/VertexIdSeek.cpp
+++ b/src/graph/planner/match/VertexIdSeek.cpp
@@ -36,7 +36,7 @@ bool VertexIdSeek::matchNode(NodeContext *nodeCtx) {
     return false;
   }
 
-  VidExtractVisitor vidExtractVisitor;
+  VidExtractVisitor vidExtractVisitor(matchClauseCtx->qctx);
   matchClauseCtx->where->filter->accept(&vidExtractVisitor);
   auto vidResult = vidExtractVisitor.moveVidPattern();
   if (vidResult.spec != VidExtractVisitor::VidPattern::Special::kInUsed) {

--- a/src/graph/visitor/VidExtractVisitor.cpp
+++ b/src/graph/visitor/VidExtractVisitor.cpp
@@ -2,6 +2,7 @@
  *
  * This source code is licensed under Apache 2.0 License.
  */
+#include "graph/context/QueryContext.h"
 
 #include "graph/visitor/VidExtractVisitor.h"
 
@@ -153,7 +154,7 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
     }
     if (expr->left()->kind() != Expression::Kind::kFunctionCall ||
         expr->right()->kind() != Expression::Kind::kList ||
-        !ExpressionUtils::isEvaluableExpr(expr->right())) {
+        !ExpressionUtils::isEvaluableExpr(expr->right(), qctx_)) {
       vidPattern_ = VidPattern{};
       return;
     }

--- a/src/graph/visitor/VidExtractVisitor.cpp
+++ b/src/graph/visitor/VidExtractVisitor.cpp
@@ -166,6 +166,7 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
     }
 
     auto rightListValue = expr->right()->eval(graph::QueryExpressionContext(qctx_->ectx())());
+    DCHECK(rightListValue.isList());
     vidPattern_ = VidPattern{VidPattern::Special::kInUsed,
                              {{fCallExpr->args()->args().front()->toString(),
                                {VidPattern::Vids::Kind::kIn, rightListValue.getList()}}}};

--- a/src/graph/visitor/VidExtractVisitor.cpp
+++ b/src/graph/visitor/VidExtractVisitor.cpp
@@ -2,10 +2,9 @@
  *
  * This source code is licensed under Apache 2.0 License.
  */
-#include "graph/context/QueryContext.h"
-
 #include "graph/visitor/VidExtractVisitor.h"
 
+#include "graph/context/QueryContext.h"
 #include "graph/util/ExpressionUtils.h"
 
 namespace nebula {
@@ -167,10 +166,9 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
     }
 
     auto rightListValue = expr->right()->eval(graph::QueryExpressionContext(qctx_->ectx())());
-    vidPattern_ =
-        VidPattern{VidPattern::Special::kInUsed,
-                   {{fCallExpr->args()->args().front()->toString(),
-                     {VidPattern::Vids::Kind::kIn, rightListValue.getList()}}}};
+    vidPattern_ = VidPattern{VidPattern::Special::kInUsed,
+                             {{fCallExpr->args()->args().front()->toString(),
+                               {VidPattern::Vids::Kind::kIn, rightListValue.getList()}}}};
   } else if (expr->kind() == Expression::Kind::kRelEQ) {
     // id(V) == vid
     if (expr->left()->kind() == Expression::Kind::kLabelAttribute) {
@@ -206,15 +204,15 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
         return;
       }
       vidPattern_ = VidPattern{VidPattern::Special::kInUsed,
-                              {{fCallExpr->args()->args().front()->toString(),
-                                {VidPattern::Vids::Kind::kIn, List({constExpr->value()})}}}};
+                               {{fCallExpr->args()->args().front()->toString(),
+                                 {VidPattern::Vids::Kind::kIn, List({constExpr->value()})}}}};
     } else if (expr->right()->kind() == Expression::Kind::kVar &&
                ExpressionUtils::isEvaluableExpr(expr->right(), qctx_)) {
       auto rValue = expr->right()->eval(graph::QueryExpressionContext(qctx_->ectx())());
       if (SchemaUtil::isValidVid(rValue)) {
         vidPattern_ = VidPattern{VidPattern::Special::kInUsed,
-                    {{fCallExpr->args()->args().front()->toString(),
-                      {VidPattern::Vids::Kind::kIn, List({rValue})}}}};
+                                 {{fCallExpr->args()->args().front()->toString(),
+                                   {VidPattern::Vids::Kind::kIn, List({rValue})}}}};
         return;
       } else {
         vidPattern_ = VidPattern{};

--- a/src/graph/visitor/VidExtractVisitor.cpp
+++ b/src/graph/visitor/VidExtractVisitor.cpp
@@ -166,12 +166,11 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
       return;
     }
 
-    auto *listExpr = static_cast<ListExpression *>(expr->right());
-    QueryExpressionContext ctx;
+    auto rightListValue = expr->right()->eval(graph::QueryExpressionContext(qctx_->ectx())());
     vidPattern_ =
         VidPattern{VidPattern::Special::kInUsed,
                    {{fCallExpr->args()->args().front()->toString(),
-                     {VidPattern::Vids::Kind::kIn, listExpr->eval(ctx(nullptr)).getList()}}}};
+                     {VidPattern::Vids::Kind::kIn, rightListValue.getList()}}}};
   } else if (expr->kind() == Expression::Kind::kRelEQ) {
     // id(V) == vid
     if (expr->left()->kind() == Expression::Kind::kLabelAttribute) {

--- a/src/graph/visitor/VidExtractVisitor.cpp
+++ b/src/graph/visitor/VidExtractVisitor.cpp
@@ -152,7 +152,8 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
       return;
     }
     if (expr->left()->kind() != Expression::Kind::kFunctionCall ||
-        expr->right()->kind() != Expression::Kind::kList ||
+        !(expr->right()->kind() == Expression::Kind::kList ||
+          expr->right()->kind() == Expression::Kind::kAttribute) ||
         !ExpressionUtils::isEvaluableExpr(expr->right(), qctx_)) {
       vidPattern_ = VidPattern{};
       return;

--- a/src/graph/visitor/VidExtractVisitor.cpp
+++ b/src/graph/visitor/VidExtractVisitor.cpp
@@ -189,7 +189,8 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
     }
     if (expr->left()->kind() != Expression::Kind::kFunctionCall ||
         (expr->right()->kind() != Expression::Kind::kConstant &&
-         expr->right()->kind() != Expression::Kind::kVar)) {
+         expr->right()->kind() != Expression::Kind::kVar &&
+         expr->right()->kind() != Expression::Kind::kSubscript)) {
       vidPattern_ = VidPattern{};
       return;
     }
@@ -208,7 +209,8 @@ void VidExtractVisitor::visit(RelationalExpression *expr) {
       vidPattern_ = VidPattern{VidPattern::Special::kInUsed,
                                {{fCallExpr->args()->args().front()->toString(),
                                  {VidPattern::Vids::Kind::kIn, List({constExpr->value()})}}}};
-    } else if (expr->right()->kind() == Expression::Kind::kVar &&
+    } else if ((expr->right()->kind() == Expression::Kind::kVar ||
+                expr->right()->kind() == Expression::Kind::kSubscript) &&
                ExpressionUtils::isEvaluableExpr(expr->right(), qctx_)) {
       auto rValue = expr->right()->eval(graph::QueryExpressionContext(qctx_->ectx())());
       if (SchemaUtil::isValidVid(rValue)) {

--- a/src/graph/visitor/VidExtractVisitor.h
+++ b/src/graph/visitor/VidExtractVisitor.h
@@ -10,6 +10,8 @@
 
 #include "common/expression/ExprVisitor.h"
 #include "graph/util/SchemaUtil.h"
+#include "graph/context/QueryContext.h"
+
 
 namespace nebula {
 
@@ -25,7 +27,7 @@ namespace graph {
 //    other vid make it eval to TRUE!
 class VidExtractVisitor final : public ExprVisitor {
  public:
-  VidExtractVisitor() = default;
+  VidExtractVisitor(const QueryContext *qctx = nullptr) : qctx_(qctx) {};
 
   struct VidPattern {
     enum class Special {
@@ -110,6 +112,7 @@ class VidExtractVisitor final : public ExprVisitor {
   void visitBinaryExpr(BinaryExpression *expr);
 
   VidPattern vidPattern_{};
+  const QueryContext *qctx_{nullptr};
 };
 
 std::ostream &operator<<(std::ostream &os, const VidExtractVisitor::VidPattern &vp);

--- a/src/graph/visitor/VidExtractVisitor.h
+++ b/src/graph/visitor/VidExtractVisitor.h
@@ -9,9 +9,8 @@
 #include <memory>
 
 #include "common/expression/ExprVisitor.h"
-#include "graph/util/SchemaUtil.h"
 #include "graph/context/QueryContext.h"
-
+#include "graph/util/SchemaUtil.h"
 
 namespace nebula {
 

--- a/src/graph/visitor/VidExtractVisitor.h
+++ b/src/graph/visitor/VidExtractVisitor.h
@@ -27,7 +27,7 @@ namespace graph {
 //    other vid make it eval to TRUE!
 class VidExtractVisitor final : public ExprVisitor {
  public:
-  VidExtractVisitor(const QueryContext *qctx = nullptr) : qctx_(qctx) {};
+  explicit VidExtractVisitor(const QueryContext *qctx = nullptr) : qctx_(qctx) {}
 
   struct VidPattern {
     enum class Special {

--- a/tests/tck/features/yield/parameter.feature
+++ b/tests/tck/features/yield/parameter.feature
@@ -36,6 +36,14 @@ Feature: Parameter
       | "Manu Ginobili" |
     When executing query:
       """
+      MATCH (v) WHERE id(v) == $p7.a.b.d[4]
+      RETURN id(v) AS v
+      """
+    Then the result should be, in any order:
+      | v            |
+      | "Tim Duncan" |
+    When executing query:
+      """
       MATCH (v) WHERE id(v) IN $p7.a.b.d
       RETURN id(v) AS v
       """

--- a/tests/tck/features/yield/parameter.feature
+++ b/tests/tck/features/yield/parameter.feature
@@ -5,7 +5,7 @@ Feature: Parameter
 
   Background:
     Given a graph with space named "nba"
-    Given parameters: {"p1":1,"p2":true,"p3":"Tim Duncan","p4":3.3,"p5":[1,true,3],"p6":{"a":3,"b":false,"c":"Tim Duncan"},"p7":{"a":{"b":{"c":"Tim Duncan","d":[1,2,3,true,"Tim Duncan"]}}}}
+    Given parameters: {"p1":1,"p2":true,"p3":"Tim Duncan","p4":3.3,"p5":[1,true,3],"p6":{"a":3,"b":false,"c":"Tim Duncan"},"p7":{"a":{"b":{"c":"Tim Duncan","d":[1,2,3,true,"Tim Duncan"]}}}, "p8":"Manu Ginobili"}
 
   Scenario: return parameters
     When executing query:
@@ -17,6 +17,23 @@ Feature: Parameter
       | 2    | false | "Tim Duncanef" | 4.1  | [1,true,3] | 3    | true |
 
   Scenario: cypher with parameters
+    When executing query:
+      """
+      MATCH (v) WHERE id(v)==$p3
+      RETURN id(v) AS v
+      """
+    Then the result should be, in any order:
+      | v            |
+      | "Tim Duncan" |
+    When executing query:
+      """
+      MATCH (v) WHERE id(v) IN [$p3,$p8]
+      RETURN id(v) AS v
+      """
+    Then the result should be, in any order:
+      | v               |
+      | "Tim Duncan"    |
+      | "Manu Ginobili" |
     When executing query:
       """
       MATCH (v:player)-[:like]->(n) WHERE id(v)==$p3 and n.player.age>$p1+29

--- a/tests/tck/features/yield/parameter.feature
+++ b/tests/tck/features/yield/parameter.feature
@@ -5,7 +5,7 @@ Feature: Parameter
 
   Background:
     Given a graph with space named "nba"
-    Given parameters: {"p1":1,"p2":true,"p3":"Tim Duncan","p4":3.3,"p5":[1,true,3],"p6":{"a":3,"b":false,"c":"Tim Duncan"},"p7":{"a":{"b":{"c":"Tim Duncan","d":[1,2,3,true,"Tim Duncan"]}}}, "p8":"Manu Ginobili"}
+    Given parameters: {"p1":1,"p2":true,"p3":"Tim Duncan","p4":3.3,"p5":[1,true,3],"p6":{"a":3,"b":false,"c":"Tim Duncan"},"p7":{"a":{"b":{"c":"Tim Duncan","d":[1,2,3,true,"Tim Duncan"]}}},"p8":"Manu Ginobili"}
 
   Scenario: return parameters
     When executing query:
@@ -34,6 +34,14 @@ Feature: Parameter
       | v               |
       | "Tim Duncan"    |
       | "Manu Ginobili" |
+    When executing query:
+      """
+      MATCH (v) WHERE id(v) IN $p7.a.b.d
+      RETURN id(v) AS v
+      """
+    Then the result should be, in any order:
+      | v            |
+      | "Tim Duncan" |
     When executing query:
       """
       MATCH (v:player)-[:like]->(n) WHERE id(v)==$p3 and n.player.age>$p1+29


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: #3982

#### Description:
Fixed this case:

```cypher
:param p3 => "player100"
:param p8 => "player101"
:param p7 => {"a":{"b":{"c":"Tim Duncan","d":[1,2,3,true,"player100"]}}}

      MATCH (v) WHERE id(v) == $p3
      RETURN id(v) AS v

      MATCH (v) WHERE id(v) IN [$p3,$p8]
      RETURN id(v) AS v

      MATCH (v) WHERE id(v) == $p7.a.b.d[4]
      RETURN id(v) AS v

      MATCH (v) WHERE id(v) IN $p7.a.b.d
      RETURN id(v) AS v
```

## How do you solve it?

To make right part of the expression evaluated in `src/graph/visitor/VidExtractVisitor.cpp`

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [x] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....

Fixed the bug on parameters for `id(n) == $var ` , `id(n) IN [$var]`, `id(n) == $var.foo.bar`, `id(n) IN $var.foo.bar`