### PR TITLE
Fix: exec time calculated twice

### DIFF
--- a/src/graph/executor/query/TraverseExecutor.cpp
+++ b/src/graph/executor/query/TraverseExecutor.cpp
@@ -140,7 +140,6 @@ void TraverseExecutor::addStats(RpcResponse& resp, int64_t getNbrTimeInUSec) {
 }
 
 folly::Future<Status> TraverseExecutor::handleResponse(RpcResponse&& resps) {
-  SCOPED_TIMER(&execTime_);
   auto result = handleCompleteness(resps, FLAGS_accept_partial_success);
   if (!result.ok()) {
     return folly::makeFuture<Status>(std::move(result).status());


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

![1647324748001_E814DDC6-3A34-4eb3-B609-07F0D862BDD3](https://user-images.githubusercontent.com/90179377/158320437-fdf42b2e-d47a-40bb-ba7d-c51139aa0105.png)



## How do you solve it?

Remove redundant scope timer.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
