### PR TITLE
remove learner parts when removing space

### DIFF
--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -581,8 +581,10 @@ class NebulaStore : public KVStore, public Handler {
    *
    * @param spaceId
    * @param partId
+   * @param needLock if lock_ has already been locked, we need
+   * to set needLock as false, or we set it as true
    */
-  void removePart(GraphSpaceID spaceId, PartitionID partId) override;
+  void removePart(GraphSpaceID spaceId, PartitionID partId, bool needLock = true) override;
 
   /**
    * @brief Retrive the leader distribution

--- a/src/kvstore/PartManager.h
+++ b/src/kvstore/PartManager.h
@@ -77,7 +77,7 @@ class Handler {
    * @param spaceId
    * @param partId
    */
-  virtual void removePart(GraphSpaceID spaceId, PartitionID partId) = 0;
+  virtual void removePart(GraphSpaceID spaceId, PartitionID partId, bool needLock = true) = 0;
 
   /**
    * @brief Add a partition as listener


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
till now storage remove space by meta info, which does not contain learner, so the learner parts still exist after remove the space,  this will cause core in next balance.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
