### PR TITLE
Revert "Add version for nightly."

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,11 +36,8 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.16.7'
-      - name: Set github sha outputs
-        id: github_sha
-        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - name: package
-        run: ./package/package.sh -v nightly-${{ steps.github_sha.outputs.sha_short }}
+        run: ./package/package.sh
       - name: output some vars
         id: vars
         env:


### PR DESCRIPTION
Reverts vesoft-inc/nebula#4006

Since package.sh already has a version [time]-nightly, this is not necessary.