### PR TITLE
treat E_RAFT_UNKNOWN_APPEND_LOG as succeeded

### DIFF
--- a/src/storage/transaction/ChainAddEdgesLocalProcessor.cpp
+++ b/src/storage/transaction/ChainAddEdgesLocalProcessor.cpp
@@ -156,6 +156,11 @@ void ChainAddEdgesLocalProcessor::doRpc(folly::Promise<Code>&& promise,
 
   std::move(f).thenTry([=, p = std::move(promise)](auto&& t) mutable {
     rcRemote_ = t.hasValue() ? t.value() : Code::E_RPC_FAILURE;
+    // we treat it E_RAFT_UNKNOWN_APPEND_LOG as SUCCEEDED
+    // please check this error in RaftPart.cpp for more details
+    if (rcRemote_ == Code::E_RAFT_UNKNOWN_APPEND_LOG) {
+      rcRemote_ = Code::SUCCEEDED;
+    }
     switch (rcRemote_) {
       case Code::E_LEADER_CHANGED:
         doRpc(std::move(p), std::move(req), ++retry);

--- a/src/storage/transaction/ChainDeleteEdgesLocalProcessor.cpp
+++ b/src/storage/transaction/ChainDeleteEdgesLocalProcessor.cpp
@@ -198,6 +198,11 @@ void ChainDeleteEdgesLocalProcessor::doRpc(folly::Promise<Code>&& promise,
 
   std::move(f).thenTry([=, p = std::move(promise)](auto&& t) mutable {
     rcRemote_ = t.hasValue() ? t.value() : Code::E_RPC_FAILURE;
+    // we treat it E_RAFT_UNKNOWN_APPEND_LOG as SUCCEEDED
+    // please check this error in RaftPart.cpp for more details
+    if (rcRemote_ == Code::E_RAFT_UNKNOWN_APPEND_LOG) {
+      rcRemote_ = Code::SUCCEEDED;
+    }
     switch (rcRemote_) {
       case Code::E_LEADER_CHANGED:
         doRpc(std::move(p), std::move(req), ++retry);

--- a/src/storage/transaction/ChainUpdateEdgeLocalProcessor.cpp
+++ b/src/storage/transaction/ChainUpdateEdgeLocalProcessor.cpp
@@ -154,6 +154,11 @@ void ChainUpdateEdgeLocalProcessor::doRpc(folly::Promise<Code>&& promise, int re
     std::move(f)
         .thenTry([=, p = std::move(promise)](auto&& t) mutable {
           rcRemote_ = t.hasValue() ? t.value() : Code::E_RPC_FAILURE;
+          // we treat it E_RAFT_UNKNOWN_APPEND_LOG as SUCCEEDED
+          // please check this error in RaftPart.cpp for more details
+          if (rcRemote_ == Code::E_RAFT_UNKNOWN_APPEND_LOG) {
+            rcRemote_ = Code::SUCCEEDED;
+          }
           switch (rcRemote_) {
             case Code::E_LEADER_CHANGED:
               doRpc(std::move(p), ++retry);


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?

#### Issue(s) number: 

[Edge prop mismatch #3030](https://github.com/vesoft-inc/nebula/issues/3030)

#### Description:

When committing a log. (insert an edge)
If a leader change happened after raft leader succeed replicate logs to majority.
Raft will report  leader changed. 

This will let the caller of raft think that operation failed. 

But actually, this log will be committed eventually. Because the new leader has this log. 

## How do you solve it?

First I import a new error code for this status:
https://github.com/vesoft-inc/nebula/pull/3880

And now, in this pr, when toss meet this new error code, it will treat it as succeeded. 

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> No need to mention it. just fix a bug. 
