### PR TITLE
fix bug stop job before it start

### DIFF
--- a/src/meta/processors/job/JobDescription.cpp
+++ b/src/meta/processors/job/JobDescription.cpp
@@ -77,7 +77,7 @@ bool JobDescription::setStatus(Status newStatus, bool force) {
     return false;
   }
   status_ = newStatus;
-  if (newStatus == Status::RUNNING) {
+  if (newStatus == Status::RUNNING || (newStatus == Status::STOPPED && startTime_ == 0)) {
     startTime_ = std::time(nullptr);
   }
   if (JobStatus::laterThan(newStatus, Status::RUNNING)) {

--- a/src/meta/processors/job/JobManager.h
+++ b/src/meta/processors/job/JobManager.h
@@ -281,6 +281,7 @@ class JobManager : public boost::noncopyable, public nebula::cpp::NonMovable {
   AdminClient* adminClient_{nullptr};
 
   std::map<GraphSpaceID, std::mutex> muReportFinish_;
+  // Start & stop & finish a job need mutual exclusion
   // The reason of using recursive_mutex is that, it's possible for a meta job try to get this lock
   // in finish-callback in the same thread with runJobInternal
   std::map<GraphSpaceID, std::recursive_mutex> muJobFinished_;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
this pr is to solve two points:
1.  if stop a job quickly when schedule is going to start the job, it may:
    the job does not exist in runningJobs_ , but exist in inFlightJobs_, so we can't create a new one even if we stopped it.
2. the start time of the job is 0 before starting, so it would always be expired through the calculation of duration, the job's info  would be erased and we can't see it in show list.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
