### PR TITLE
Fix optimizer symbols.

### DIFF
--- a/src/graph/context/Symbols.cpp
+++ b/src/graph/context/Symbols.cpp
@@ -41,6 +41,7 @@ SymbolTable::SymbolTable(ObjectPool* objPool) {
 
 Variable* SymbolTable::newVariable(std::string name) {
   VLOG(1) << "New variable for: " << name;
+  DCHECK(vars_.find(name) == vars_.end());
   auto* variable = objPool_->makeAndAdd<Variable>(name);
   addVar(std::move(name), variable);
   return variable;

--- a/src/graph/optimizer/OptGroup.h
+++ b/src/graph/optimizer/OptGroup.h
@@ -44,6 +44,10 @@ class OptGroup final {
   double getCost() const;
   const graph::PlanNode *getPlan() const;
 
+  const std::string &outputVar() const {
+    return outputVar_;
+  }
+
  private:
   explicit OptGroup(OptContext *ctx) noexcept;
 
@@ -54,6 +58,8 @@ class OptGroup final {
   OptContext *ctx_{nullptr};
   std::list<OptGroupNode *> groupNodes_;
   std::vector<const OptRule *> exploredRules_;
+  // The output variable should be same across the whole group.
+  std::string outputVar_;
 };
 
 class OptGroupNode final {
@@ -101,6 +107,9 @@ class OptGroupNode final {
   Status explore(const OptRule *rule);
   double getCost() const;
   const graph::PlanNode *getPlan() const;
+
+  // Build input relationship by dependencies.
+  void rebuildInputRelationship(const std::vector<OptGroup *> &boundary);
 
  private:
   OptGroupNode(graph::PlanNode *node, const OptGroup *group) noexcept;

--- a/src/graph/optimizer/OptRule.h
+++ b/src/graph/optimizer/OptRule.h
@@ -30,6 +30,8 @@ class OptGroup;
 struct MatchedResult {
   const OptGroupNode *node{nullptr};
   std::vector<MatchedResult> dependencies;
+  // Boundary of the whole matched result, aka the dependencies of leaf node in MatchedResult.
+  std::vector<OptGroup *> boundary_;
 
   // params       | plan node
   // -------------+------------
@@ -40,6 +42,9 @@ struct MatchedResult {
   // {0, 1, 0}    | this->dependencies[1].dependencies[0]
   // {0, 1, 0, 1} | this->dependencies[1].dependencies[0].dependencies[1]
   const graph::PlanNode *planNode(const std::vector<int32_t> &pos = {}) const;
+
+  // Check is input group boundary of current matched result
+  void collectBoundary(std::vector<OptGroup *> &boundary) const;
 };
 
 // Match plan node by trait or kind of plan node.
@@ -85,6 +90,9 @@ class OptRule {
       static TransformResult kNoTrans{false, false, {}};
       return kNoTrans;
     }
+
+    // Build input relationship by dependencies.
+    void rebuildInputRelationship(const std::vector<OptGroup *> &boundary);
 
     bool eraseCurr{false};
     bool eraseAll{false};

--- a/src/graph/optimizer/rule/CollapseProjectRule.cpp
+++ b/src/graph/optimizer/rule/CollapseProjectRule.cpp
@@ -109,6 +109,7 @@ StatusOr<OptRule::TransformResult> CollapseProjectRule::transform(
 
   // 4. rebuild OptGroupNode
   newProj->setInputVar(projBelow->inputVar());
+  newProj->setOutputVar(projAbove->outputVar());
   auto* newGroupNode = OptGroupNode::create(octx, newProj, projGroup);
   newGroupNode->setDeps(groupNodeBelow->dependencies());
 

--- a/src/graph/optimizer/rule/GetEdgesTransformRule.cpp
+++ b/src/graph/optimizer/rule/GetEdgesTransformRule.cpp
@@ -68,6 +68,7 @@ StatusOr<OptRule::TransformResult> GetEdgesTransformRule::transform(
 
   auto newAppendVertices = appendVertices->clone();
   auto colSize = appendVertices->colNames().size();
+  newAppendVertices->setOutputVar(appendVertices->outputVar());
   newAppendVertices->setColNames(
       {appendVertices->colNames()[colSize - 2], appendVertices->colNames()[colSize - 1]});
   auto newAppendVerticesGroupNode =

--- a/src/graph/optimizer/rule/IndexScanRule.cpp
+++ b/src/graph/optimizer/rule/IndexScanRule.cpp
@@ -81,6 +81,7 @@ StatusOr<OptRule::TransformResult> IndexScanRule::transform(OptContext* ctx,
   const auto* oldIN = groupNode->node();
   DCHECK_EQ(oldIN->kind(), graph::PlanNode::Kind::kIndexScan);
   auto* newIN = static_cast<IndexScan*>(oldIN->clone());
+  newIN->setOutputVar(oldIN->outputVar());
   newIN->setIndexQueryContext(std::move(iqctx));
   auto newGroupNode = OptGroupNode::create(ctx, newIN, groupNode->group());
   if (groupNode->dependencies().size() != 1) {

--- a/src/graph/optimizer/rule/MergeGetNbrsAndDedupRule.cpp
+++ b/src/graph/optimizer/rule/MergeGetNbrsAndDedupRule.cpp
@@ -44,6 +44,7 @@ StatusOr<OptRule::TransformResult> MergeGetNbrsAndDedupRule::transform(
     newGN->setDedup();
   }
   newGN->setInputVar(dedup->inputVar());
+  newGN->setOutputVar(gn->outputVar());
   auto newOptGV = OptGroupNode::create(octx, newGN, optGN->group());
   for (auto dep : optDedup->dependencies()) {
     newOptGV->dependsOn(dep);

--- a/src/graph/optimizer/rule/MergeGetNbrsAndProjectRule.cpp
+++ b/src/graph/optimizer/rule/MergeGetNbrsAndProjectRule.cpp
@@ -66,6 +66,7 @@ StatusOr<OptRule::TransformResult> MergeGetNbrsAndProjectRule::transform(
   auto srcExpr = column->expr()->clone();
   newGN->setSrc(srcExpr);
   newGN->setInputVar(project->inputVar());
+  newGN->setOutputVar(gn->outputVar());
   auto newOptGV = OptGroupNode::create(ctx, newGN, optGN->group());
   for (auto dep : optProj->dependencies()) {
     newOptGV->dependsOn(dep);

--- a/src/graph/optimizer/rule/MergeGetVerticesAndDedupRule.cpp
+++ b/src/graph/optimizer/rule/MergeGetVerticesAndDedupRule.cpp
@@ -43,6 +43,7 @@ StatusOr<OptRule::TransformResult> MergeGetVerticesAndDedupRule::transform(
     newGV->setDedup();
   }
   newGV->setInputVar(dedup->inputVar());
+  newGV->setOutputVar(gv->outputVar());
   auto newOptGV = OptGroupNode::create(ctx, newGV, optGV->group());
   for (auto dep : optDedup->dependencies()) {
     newOptGV->dependsOn(dep);

--- a/src/graph/optimizer/rule/MergeGetVerticesAndProjectRule.cpp
+++ b/src/graph/optimizer/rule/MergeGetVerticesAndProjectRule.cpp
@@ -65,6 +65,7 @@ StatusOr<OptRule::TransformResult> MergeGetVerticesAndProjectRule::transform(
   auto srcExpr = column->expr()->clone();
   newGV->setSrc(srcExpr);
   newGV->setInputVar(project->inputVar());
+  newGV->setOutputVar(gv->outputVar());
   auto newOptGV = OptGroupNode::create(ctx, newGV, optGV->group());
   for (auto dep : optProj->dependencies()) {
     newOptGV->dependsOn(dep);

--- a/src/graph/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -66,7 +66,6 @@ StatusOr<OptRule::TransformResult> PushFilterDownGetNbrsRule::transform(
   if (remainedExpr != nullptr) {
     auto newFilter = Filter::make(qctx, nullptr, remainedExpr);
     newFilter->setOutputVar(filter->outputVar());
-    newFilter->setInputVar(filter->inputVar());
     newFilterGroupNode = OptGroupNode::create(ctx, newFilter, filterGroupNode->group());
   }
 

--- a/src/graph/optimizer/rule/PushFilterDownScanVerticesRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownScanVerticesRule.cpp
@@ -53,6 +53,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownScanVerticesRule::transform(
 
   auto remainedExpr = std::move(visitor).remainedExpr();
   OptGroupNode *newFilterGroupNode = nullptr;
+  // PlanNode *newFilter = nullptr;
   if (remainedExpr != nullptr) {
     auto newFilter = Filter::make(qctx, nullptr, remainedExpr);
     newFilter->setOutputVar(filter->outputVar());
@@ -74,6 +75,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownScanVerticesRule::transform(
     // Filter(A&&B)<-ScanVertices(C) => Filter(A)<-ScanVertices(B&&C)
     auto newGroup = OptGroup::create(ctx);
     newSvGroupNode = newGroup->makeGroupNode(newSV);
+    // newFilter->setInputVar(newSV->outputVar());
     newFilterGroupNode->dependsOn(newGroup);
   } else {
     // Filter(A)<-ScanVertices(C) => ScanVertices(A&&C)

--- a/src/graph/optimizer/rule/PushLimitDownGetNeighborsRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownGetNeighborsRule.cpp
@@ -50,6 +50,7 @@ StatusOr<OptRule::TransformResult> PushLimitDownGetNeighborsRule::transform(
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
+  newLimit->setOutputVar(limit->outputVar());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newGn = static_cast<GetNeighbors *>(gn->clone());

--- a/src/graph/optimizer/rule/PushLimitDownIndexScanRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownIndexScanRule.cpp
@@ -58,6 +58,7 @@ StatusOr<OptRule::TransformResult> PushLimitDownIndexScanRule::transform(
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
+  newLimit->setOutputVar(limit->outputVar());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newIndexScan = static_cast<IndexScan *>(indexScan->clone());

--- a/src/graph/optimizer/rule/PushLimitDownProjectRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownProjectRule.cpp
@@ -42,18 +42,17 @@ StatusOr<OptRule::TransformResult> PushLimitDownProjectRule::transform(
 
   auto newLimit = static_cast<Limit *>(limit->clone());
   auto newLimitGroup = OptGroup::create(octx);
-  auto newLimitGroupNode = newLimitGroup->makeGroupNode(newLimit);
   auto projInputVar = proj->inputVar();
-  newLimit->setOutputVar(proj->outputVar());
   newLimit->setInputVar(projInputVar);
   auto *varPtr = octx->qctx()->symTable()->getVar(projInputVar);
   DCHECK(!!varPtr);
   newLimit->setColNames(varPtr->colNames);
+  auto newLimitGroupNode = newLimitGroup->makeGroupNode(newLimit);
 
   auto newProj = static_cast<Project *>(proj->clone());
-  auto newProjGroupNode = OptGroupNode::create(octx, newProj, limitGroupNode->group());
   newProj->setOutputVar(limit->outputVar());
   newProj->setInputVar(newLimit->outputVar());
+  auto newProjGroupNode = OptGroupNode::create(octx, newProj, limitGroupNode->group());
 
   newProjGroupNode->dependsOn(const_cast<OptGroup *>(newLimitGroupNode->group()));
   for (auto dep : projGroupNode->dependencies()) {

--- a/src/graph/optimizer/rule/PushLimitDownScanAppendVerticesRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownScanAppendVerticesRule.cpp
@@ -73,6 +73,7 @@ StatusOr<OptRule::TransformResult> PushLimitDownScanAppendVerticesRule::transfor
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
+  newLimit->setOutputVar(limit->outputVar());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newAppendVertices = static_cast<AppendVertices *>(appendVertices->clone());

--- a/src/graph/optimizer/rule/PushLimitDownScanEdgesAppendVerticesRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownScanEdgesAppendVerticesRule.cpp
@@ -77,6 +77,7 @@ StatusOr<OptRule::TransformResult> PushLimitDownScanEdgesAppendVerticesRule::tra
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
+  newLimit->setOutputVar(limit->outputVar());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newAppendVertices = static_cast<AppendVertices *>(appendVertices->clone());

--- a/src/graph/optimizer/rule/PushStepLimitDownGetNeighborsRule.cpp
+++ b/src/graph/optimizer/rule/PushStepLimitDownGetNeighborsRule.cpp
@@ -51,6 +51,7 @@ StatusOr<OptRule::TransformResult> PushStepLimitDownGetNeighborsRule::transform(
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
+  newLimit->setOutputVar(limit->outputVar());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newGn = static_cast<GetNeighbors *>(gn->clone());

--- a/src/graph/optimizer/rule/PushStepSampleDownGetNeighborsRule.cpp
+++ b/src/graph/optimizer/rule/PushStepSampleDownGetNeighborsRule.cpp
@@ -49,6 +49,7 @@ StatusOr<OptRule::TransformResult> PushStepSampleDownGetNeighborsRule::transform
   }
 
   auto newSample = static_cast<Sample *>(sample->clone());
+  newSample->setOutputVar(sample->outputVar());
   auto newSampleGroupNode = OptGroupNode::create(octx, newSample, sampleGroupNode->group());
 
   auto newGn = static_cast<GetNeighbors *>(gn->clone());

--- a/src/graph/optimizer/rule/PushTopNDownIndexScanRule.cpp
+++ b/src/graph/optimizer/rule/PushTopNDownIndexScanRule.cpp
@@ -92,6 +92,7 @@ StatusOr<OptRule::TransformResult> PushTopNDownIndexScanRule::transform(
   }
 
   auto newTopN = static_cast<TopN *>(topN->clone());
+  newTopN->setOutputVar(topN->outputVar());
   auto newtopNGroupNode = OptGroupNode::create(octx, newTopN, topNGroupNode->group());
 
   auto newProject = static_cast<Project *>(project->clone());

--- a/src/graph/optimizer/rule/PushVFilterDownScanVerticesRule.cpp
+++ b/src/graph/optimizer/rule/PushVFilterDownScanVerticesRule.cpp
@@ -91,7 +91,6 @@ StatusOr<OptRule::TransformResult> PushVFilterDownScanVerticesRule::transform(
   auto newAppendVertices = appendVertices->clone();
   newAppendVertices->setVertexFilter(remainedExpr);
   newAppendVertices->setOutputVar(appendVertices->outputVar());
-  newAppendVertices->setInputVar(appendVertices->inputVar());
   newAppendVerticesGroupNode =
       OptGroupNode::create(ctx, newAppendVertices, appendVerticesGroupNode->group());
 

--- a/src/graph/planner/plan/PlanNode.h
+++ b/src/graph/planner/plan/PlanNode.h
@@ -217,21 +217,16 @@ class PlanNode {
 
   void setOutputVar(const std::string& var);
 
-  const std::string& outputVar(size_t index = 0) const {
-    return outputVarPtr(index)->name;
+  const std::string& outputVar() const {
+    return outputVarPtr()->name;
   }
 
-  Variable* outputVarPtr(size_t index = 0) const {
-    DCHECK_LT(index, outputVars_.size());
-    return outputVars_[index];
-  }
-
-  const std::vector<Variable*>& outputVars() const {
-    return outputVars_;
+  Variable* outputVarPtr() const {
+    return outputVar_;
   }
 
   const std::vector<std::string>& colNames() const {
-    return outputVarPtr(0)->colNames;
+    return outputVarPtr()->colNames;
   }
 
   void setId(int64_t id) {
@@ -315,7 +310,8 @@ class PlanNode {
   void cloneMembers(const PlanNode& node) {
     // TODO maybe shall copy cost_ and dependencies_ too
     inputVars_ = node.inputVars_;
-    outputVars_ = node.outputVars_;
+    // OutputVar will generated in constructor
+    setColNames(node.colNames());
   }
 
   QueryContext* qctx_{nullptr};
@@ -324,7 +320,7 @@ class PlanNode {
   double cost_{0.0};
   std::vector<const PlanNode*> dependencies_;
   std::vector<Variable*> inputVars_;
-  std::vector<Variable*> outputVars_;
+  Variable* outputVar_;
   // nested loop layers of current node
   std::size_t loopLayers_{0};
   bool deleted_{false};

--- a/src/graph/scheduler/AsyncMsgNotifyBasedScheduler.cpp
+++ b/src/graph/scheduler/AsyncMsgNotifyBasedScheduler.cpp
@@ -12,6 +12,7 @@ namespace graph {
 
 AsyncMsgNotifyBasedScheduler::AsyncMsgNotifyBasedScheduler(QueryContext* qctx) : Scheduler() {
   qctx_ = qctx;
+  query_ = qctx->rctx()->query();
 }
 
 folly::Future<Status> AsyncMsgNotifyBasedScheduler::schedule() {

--- a/src/graph/scheduler/AsyncMsgNotifyBasedScheduler.h
+++ b/src/graph/scheduler/AsyncMsgNotifyBasedScheduler.h
@@ -63,6 +63,8 @@ class AsyncMsgNotifyBasedScheduler final : public Scheduler {
   folly::Future<Status> execute(Executor* executor) const;
 
   QueryContext* qctx_{nullptr};
+  // used for debugging when core on runtime
+  std::string query_;
 };
 }  // namespace graph
 }  // namespace nebula


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #3826 

#### Description:
Add two constraints to optimizer:
1. One OptGroup will share same output variable
2. There is no overlap output variable between OptGroup

And add one implicit transform:
1. The transformed result of optimizer rule will rebuild input relationship by dependencies.

And some improvement:
1. PlanNode clone will generate new output variable and use it
2. PlanNode only need one output variable so change it from vector to scalar.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
