### PR TITLE
disable console pkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ target/
 cluster.id
 pids/
 modules/
-.linters/
 
 # tests
 !tests/Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ target/
 cluster.id
 pids/
 modules/
+.linters/
 
 # tests
 !tests/Makefile

--- a/package/package.sh
+++ b/package/package.sh
@@ -20,7 +20,7 @@
 set -e
 
 version=""
-package_one=ON
+package_one=OFF
 strip_enable="FALSE"
 usage="Usage: ${0} -v <version> -n <ON/OFF> -s <TRUE/FALSE> -g <ON/OFF> -j <jobs> -t <BUILD TYPE>"
 project_dir="$(cd "$(dirname "$0")" && pwd)/.."


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
Temporarily disable packaging of the nebula-console.
The normal packaging process must artificially ensure that both nebula and nebula-console have available and consistent branches before packaging, but due to the dependencies between nebula and nebula-console, some errors will reduce the efficiency of ci.

## How do you solve it?
Just disable the packaging switch related with nebula-console.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
