### PR TITLE
Fix service crash caused by using function call as a part of the filter in `LOOKUP`

### DIFF
--- a/src/common/function/FunctionManager.cpp
+++ b/src/common/function/FunctionManager.cpp
@@ -456,7 +456,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["abs"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -478,21 +478,21 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["bit_and"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value { return args[0].get() & args[1].get(); };
   }
   {
     auto &attr = functions_["bit_or"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value { return args[0].get() | args[1].get(); };
   }
   {
     auto &attr = functions_["bit_xor"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value { return args[0].get() ^ args[1].get(); };
   }
   {
@@ -500,7 +500,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["floor"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -523,7 +523,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["ceil"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -546,7 +546,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["round"];
     attr.minArity_ = 1;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -575,7 +575,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["sqrt"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -606,7 +606,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["cbrt"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -629,7 +629,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["hypot"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (args[0].get().isNumeric() && args[1].get().isNumeric()) {
         auto x = args[0].get().isInt() ? args[0].get().getInt() : args[0].get().getFloat();
@@ -644,7 +644,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["pow"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (args[0].get().isNumeric() && args[1].get().isNumeric()) {
         auto base = args[0].get().isInt() ? args[0].get().getInt() : args[0].get().getFloat();
@@ -663,7 +663,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["e"];
     attr.minArity_ = 0;
     attr.maxArity_ = 0;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       UNUSED(args);
       return M_E;
@@ -674,7 +674,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["exp"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -697,7 +697,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["exp2"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -720,7 +720,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["log"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -751,7 +751,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["log2"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -782,7 +782,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["log10"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -813,7 +813,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["pi"];
     attr.minArity_ = 0;
     attr.maxArity_ = 0;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       UNUSED(args);
       return M_PI;
@@ -824,7 +824,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["radians"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -845,7 +845,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["sin"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -867,7 +867,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["asin"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -889,7 +889,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["cos"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -911,7 +911,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["acos"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -933,7 +933,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["tan"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -955,7 +955,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["atan"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -977,7 +977,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["sign"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1001,7 +1001,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["rand"];
     attr.minArity_ = 0;
     attr.maxArity_ = 0;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       UNUSED(args);
       return folly::Random::randDouble01();
@@ -1012,7 +1012,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["rand32"];
     attr.minArity_ = 0;
     attr.maxArity_ = 2;
-    attr.isPure_ = false;
+    setCompleteNonPure(attr);
     attr.body_ = [](const auto &args) -> Value {
       if (args.empty()) {
         auto value = folly::Random::rand32();
@@ -1049,7 +1049,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["rand64"];
     attr.minArity_ = 0;
     attr.maxArity_ = 2;
-    attr.isPure_ = false;
+    setCompleteNonPure(attr);
     attr.body_ = [](const auto &args) -> Value {
       if (args.empty()) {
         return static_cast<int64_t>(folly::Random::rand64());
@@ -1080,7 +1080,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["now"];
     attr.minArity_ = 0;
     attr.maxArity_ = 0;
-    attr.isPure_ = false;
+    setCompleteNonPure(attr);
     attr.body_ = [](const auto &args) -> Value {
       UNUSED(args);
       return ::time(NULL);
@@ -1090,7 +1090,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["strcasecmp"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (args[0].get().isStr() && args[1].get().isStr()) {
         return static_cast<int64_t>(
@@ -1103,7 +1103,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["lower"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1125,7 +1125,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["upper"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1149,7 +1149,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["length"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1173,7 +1173,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["trim"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1193,7 +1193,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["ltrim"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1213,7 +1213,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["rtrim"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1233,7 +1233,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["left"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1261,7 +1261,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["right"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1293,7 +1293,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["replace"];
     attr.minArity_ = 3;
     attr.maxArity_ = 3;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (args[0].get().isNull() || args[1].get().isNull() || args[2].get().isNull()) {
         return Value::kNullValue;
@@ -1311,7 +1311,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["reverse"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1338,7 +1338,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["split"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1371,7 +1371,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["tostring"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE:
@@ -1412,35 +1412,35 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["toboolean"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value { return Value(args[0].get()).toBool(); };
   }
   {
     auto &attr = functions_["tofloat"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value { return Value(args[0].get()).toFloat(); };
   }
   {
     auto &attr = functions_["tointeger"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value { return Value(args[0].get()).toInt(); };
   }
   {
     auto &attr = functions_["toset"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value { return Value(args[0].get()).toSet(); };
   }
   {
     auto &attr = functions_["lpad"];
     attr.minArity_ = 3;
     attr.maxArity_ = 3;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (args[0].get().isStr() && args[1].get().isInt() && args[2].get().isStr()) {
         auto value = args[0].get().getStr();
@@ -1469,7 +1469,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["rpad"];
     attr.minArity_ = 3;
     attr.maxArity_ = 3;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (args[0].get().isStr() && args[1].get().isInt() && args[2].get().isStr()) {
         auto value = args[0].get().getStr();
@@ -1499,7 +1499,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["substr"];
     attr.minArity_ = 2;
     attr.maxArity_ = 3;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       auto argSize = args.size();
       if (args[0].get().isNull()) {
@@ -1534,7 +1534,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["hash"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE:
@@ -1561,7 +1561,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["udf_is_in"];
     attr.minArity_ = 2;
     attr.maxArity_ = INT64_MAX;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       return std::find(args.begin() + 1, args.end(), args[0].get()) != args.end();
     };
@@ -1570,7 +1570,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["near"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       // auto result = geo::GeoFilter::near(args);
       // if (!result.ok()) {
@@ -1587,7 +1587,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["cos_similarity"];
     attr.minArity_ = 2;
     attr.maxArity_ = INT64_MAX;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (args.size() % 2 != 0) {
         LOG(ERROR) << "The number of arguments must be even.";
@@ -1621,7 +1621,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["size"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE:
@@ -1658,7 +1658,8 @@ FunctionManager::FunctionManager() {
     // 1 for string or map
     attr.minArity_ = 0;
     attr.maxArity_ = 1;
-    attr.isPure_ = false;
+    attr.isPure_[0] = false;
+    attr.isPure_[1] = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args.size()) {
         case 0: {
@@ -1696,7 +1697,8 @@ FunctionManager::FunctionManager() {
     // 1 for string or map
     attr.minArity_ = 0;
     attr.maxArity_ = 1;
-    attr.isPure_ = false;
+    attr.isPure_[0] = false;
+    attr.isPure_[1] = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args.size()) {
         case 0: {
@@ -1730,7 +1732,8 @@ FunctionManager::FunctionManager() {
     // 1 for string or map
     attr.minArity_ = 0;
     attr.maxArity_ = 1;
-    attr.isPure_ = false;
+    attr.isPure_[0] = false;
+    attr.isPure_[1] = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args.size()) {
         case 0: {
@@ -1762,7 +1765,8 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["timestamp"];
     attr.minArity_ = 0;
     attr.maxArity_ = 1;
-    attr.isPure_ = false;
+    attr.isPure_[0] = false;
+    attr.isPure_[1] = true;
     attr.body_ = [](const auto &args) -> Value {
       if (args.empty()) {
         return ::time(NULL);
@@ -1778,7 +1782,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["range"];
     attr.minArity_ = 2;
     attr.maxArity_ = 3;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isInt() || !args[1].get().isInt()) {
         return Value::kNullBadType;
@@ -1808,7 +1812,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["id"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1827,7 +1831,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["tags"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1851,7 +1855,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["properties"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1882,7 +1886,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["type"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1901,7 +1905,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["typeid"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1920,7 +1924,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["src"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1940,7 +1944,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["dst"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1960,7 +1964,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["none_direct_dst"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -1995,7 +1999,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["rank"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -2014,7 +2018,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["startnode"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -2036,7 +2040,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["endnode"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -2062,7 +2066,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["head"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -2081,7 +2085,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["last"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -2100,7 +2104,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["coalesce"];
     attr.minArity_ = 1;
     attr.maxArity_ = INT64_MAX;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       for (size_t i = 0; i < args.size(); ++i) {
         if (args[i].get().type() != Value::Type::NULLVALUE) {
@@ -2114,7 +2118,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["keys"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       std::set<std::string> tmp;
       switch (args[0].get().type()) {
@@ -2154,7 +2158,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["nodes"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -2179,7 +2183,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["tail"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -2202,7 +2206,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["relationships"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       switch (args[0].get().type()) {
         case Value::Type::NULLVALUE: {
@@ -2236,7 +2240,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["hassameedgeinpath"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isPath()) {
         return Value::kNullBadType;
@@ -2249,7 +2253,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["hassamevertexinpath"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isPath()) {
         return Value::kNullBadType;
@@ -2262,7 +2266,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["reversepath"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isPath()) {
         return Value::kNullBadType;
@@ -2276,7 +2280,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["datasetrowcol"];
     attr.minArity_ = 3;
     attr.maxArity_ = 3;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isDataSet() || !args[1].get().isInt() ||
           !(args[2].get().isInt() || args[2].get().isStr())) {
@@ -2307,7 +2311,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["concat"];
     attr.minArity_ = 1;
     attr.maxArity_ = INT64_MAX;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       std::stringstream os;
       for (size_t i = 0; i < args.size(); ++i) {
@@ -2355,7 +2359,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["concat_ws"];
     attr.minArity_ = 2;
     attr.maxArity_ = INT64_MAX;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (args[0].get().isNull() || !args[0].get().isStr()) {
         return Value::kNullValue;
@@ -2393,7 +2397,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["st_point"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isNumeric() || !args[1].get().isNumeric()) {
         return Value::kNullBadType;
@@ -2409,7 +2413,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["st_geogfromtext"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isStr()) {
         return Value::kNullBadType;
@@ -2447,7 +2451,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["st_astext"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isGeography()) {
         return Value::kNullBadType;
@@ -2474,7 +2478,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["st_centroid"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isGeography()) {
         return Value::kNullBadType;
@@ -2487,7 +2491,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["st_isvalid"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isGeography()) {
         return Value::kNullBadType;
@@ -2500,7 +2504,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["st_intersects"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isGeography() || !args[1].get().isGeography()) {
         return Value::kNullBadType;
@@ -2513,7 +2517,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["st_covers"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isGeography() || !args[1].get().isGeography()) {
         return Value::kNullBadType;
@@ -2525,7 +2529,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["st_coveredby"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isGeography() || !args[1].get().isGeography()) {
         return Value::kNullBadType;
@@ -2538,7 +2542,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["st_dwithin"];
     attr.minArity_ = 3;
     attr.maxArity_ = 4;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isGeography() || !args[1].get().isGeography() ||
           !args[2].get().isNumeric()) {
@@ -2563,7 +2567,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["st_distance"];
     attr.minArity_ = 2;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isGeography() || !args[1].get().isGeography()) {
         return Value::kNullBadType;
@@ -2576,7 +2580,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["s2_cellidfrompoint"];
     attr.minArity_ = 1;
     attr.maxArity_ = 2;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isGeography()) {
         return Value::kNullBadType;
@@ -2607,7 +2611,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["s2_coveringcellids"];
     attr.minArity_ = 1;
     attr.maxArity_ = 5;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       if (!args[0].get().isGeography()) {
         return Value::kNullBadType;
@@ -2672,14 +2676,14 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["is_edge"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value { return args[0].get().isEdge(); };
   }
   {
     auto &attr = functions_["duration"];
     attr.minArity_ = 1;
     attr.maxArity_ = 1;
-    attr.isPure_ = true;
+    attr.isAlwaysPure_ = true;
     attr.body_ = [](const auto &args) -> Value {
       const auto &arg = args[0].get();
       switch (arg.type()) {
@@ -2720,7 +2724,14 @@ Status FunctionManager::find(const std::string &func, const size_t arity) {
 /*static*/ StatusOr<bool> FunctionManager::getIsPure(const std::string &func, size_t arity) {
   auto result = instance().getInternal(func, arity);
   NG_RETURN_IF_ERROR(result);
-  return result.value().isPure_;
+  auto attr = std::move(result.value());
+
+  if (attr.isAlwaysPure_) {
+    return true;
+  }
+
+  // If the function is not always pure, lookup the map to find purity.
+  return attr.isPure_.at(arity);
 }
 
 /*static*/ StatusOr<const FunctionManager::FunctionAttributes> FunctionManager::getInternal(

--- a/src/common/function/FunctionManager.h
+++ b/src/common/function/FunctionManager.h
@@ -64,13 +64,30 @@ class FunctionManager final {
                                              const std::vector<Value::Type> &argsType);
 
  private:
+  // The attributes of the function call
   struct FunctionAttributes final {
     size_t minArity_{0};
     size_t maxArity_{0};
-    // pure means same input same result
-    bool isPure_{true};
+    // Pure means if the function takes the same input, it returns the same result
+    // The key here is the number of arity, and the key represents whether the function is pure for
+    // that number of arity.
+    // For example, timestamp() is non-pure because it returns the current timestamp, while
+    // timestamp(1) is pure because the output is always 1.
+    std::unordered_map<size_t, bool> isPure_;
+    // The flag indicates whether the function is always pure.
+    // Some functions allow using int64_max as the maxArity_, so add isAlwaysPure_ to avoid
+    // allocating huge amount of memory for these functions.
+    bool isAlwaysPure_{false};
     Function body_;
   };
+
+  // Sets the function to NON-pure for all numbers of arity it take, which means the function is
+  // always NON-pure.
+  void setCompleteNonPure(FunctionAttributes &attr) {
+    for (auto i = attr.minArity_; i <= attr.maxArity_; i++) {
+      attr.isPure_[i] = false;
+    }
+  }
 
   /**
    * FunctionManager functions as a singleton, since the dynamic loading is

--- a/src/common/function/FunctionManager.h
+++ b/src/common/function/FunctionManager.h
@@ -84,7 +84,7 @@ class FunctionManager final {
   // Sets the function to NON-pure for all numbers of arity it take, which means the function is
   // always NON-pure.
   void setCompleteNonPure(FunctionAttributes &attr) {
-    for (auto i = attr.minArity_; i <= attr.maxArity_; i++) {
+    for (auto i = attr.minArity_; i <= attr.maxArity_; ++i) {
       attr.isPure_[i] = false;
     }
   }

--- a/src/common/function/test/FunctionManagerTest.cpp
+++ b/src/common/function/test/FunctionManagerTest.cpp
@@ -13,6 +13,7 @@
 #include "common/datatypes/Path.h"
 #include "common/datatypes/Set.h"
 #include "common/datatypes/Vertex.h"
+#include "common/expression/FunctionCallExpression.h"
 #include "common/function/FunctionManager.h"
 #include "common/time/TimeUtils.h"
 #include "common/time/TimezoneInfo.h"
@@ -1906,6 +1907,36 @@ TEST_F(FunctionManagerTest, DataSetRowCol) {
     TEST_FUNCTION(
         dataSetRowCol, std::vector<Value>({datasetValue, Value(1), Value(2)}), Value("456"));
   }
+}
+
+TEST_F(FunctionManagerTest, PurityTest) {
+  // Always non-pure
+  auto result = FunctionManager::getIsPure("now", 0);
+  ASSERT_TRUE(result.ok() && result.value() == false);
+
+  // Always pure
+  result = FunctionManager::getIsPure("coalesce", 1);
+  ASSERT_TRUE(result.ok() && result.value() == true);
+  result = FunctionManager::getIsPure("coalesce", 100);
+  ASSERT_TRUE(result.ok() && result.value() == true);
+  result = FunctionManager::getIsPure("coalesce", INT64_MAX);
+  ASSERT_TRUE(result.ok() && result.value() == true);
+
+  // Not always pure, purity depends on arity number
+  result = FunctionManager::getIsPure("time", 0);
+  ASSERT_TRUE(result.ok() && result.value() == false);
+  result = FunctionManager::getIsPure("time", 1);
+  ASSERT_TRUE(result.ok() && result.value() == true);
+
+  result = FunctionManager::getIsPure("timestamp", 0);
+  ASSERT_TRUE(result.ok() && result.value() == false);
+  result = FunctionManager::getIsPure("timestamp", 1);
+  ASSERT_TRUE(result.ok() && result.value() == true);
+
+  result = FunctionManager::getIsPure("date", 0);
+  ASSERT_TRUE(result.ok() && result.value() == false);
+  result = FunctionManager::getIsPure("date", 1);
+  ASSERT_TRUE(result.ok() && result.value() == true);
 }
 
 }  // namespace nebula

--- a/src/graph/optimizer/OptimizerUtils.cpp
+++ b/src/graph/optimizer/OptimizerUtils.cpp
@@ -105,12 +105,13 @@ StatusOr<ScoredColumnHint> selectRelExprIndex(const ColumnDef& field,
   }
 
   auto right = expr->right();
-  if (expr->kind() == Expression::Kind::kRelIn) {  // container expressions
-    DCHECK(right->isContainerExpr());
-  } else {  // other expressions
-    DCHECK(right->kind() == Expression::Kind::kConstant);
-  }
 
+  // At this point all foldable expressions should already be folded.
+  if (right->kind() != Expression::Kind::kConstant) {
+    return Status::Error("The expression %s cannot be used to generate a index column hint",
+                         right->toString().c_str());
+  }
+  DCHECK(right->kind() == Expression::Kind::kConstant);
   const auto& value = static_cast<const ConstantExpression*>(right)->value();
 
   ScoredColumnHint hint;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula/issues/4097
#### Description:
There is a bug in the constant folding of function call expressions like `date('2022-03-25')` when checking purity.

## How do you solve it?
Fix purity checking by bonding purity to the number of arity of the function


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
