### PR TITLE
move KW_CLEAR to unresolved keyword

### DIFF
--- a/.linters/cpp/checkKeyword.py
+++ b/.linters/cpp/checkKeyword.py
@@ -75,7 +75,6 @@ reserved_key_words = [
     'KW_ADD',
     'KW_CREATE',
     'KW_DROP',
-    'KW_CLEAR',
     'KW_REMOVE',
     'KW_IF',
     'KW_NOT',

--- a/scripts/nebula.service
+++ b/scripts/nebula.service
@@ -234,7 +234,7 @@ function status_daemon {
             port=${GREEN}${port}${NC}
         else
             port=${BLINK}${RED}${port}${NC}
-            if [[$daemon_name == nebula-storaged]]; then
+            if [[ $daemon_name == nebula-storaged ]]; then
                 WARN "${daemon_name} after v3.0.0 will not start service until it is added to cluster."
                 WARN "See Manage Storage hosts:${RED}ADD HOSTS${NC} in https://docs.nebula-graph.io/"
             fi

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -576,6 +576,7 @@ unreserved_keyword
     | KW_MERGE              { $$ = new std::string("merge"); }
     | KW_DIVIDE             { $$ = new std::string("divide"); }
     | KW_RENAME             { $$ = new std::string("rename"); }
+    | KW_CLEAR              { $$ = new std::string("clear"); }
     ;
 
 expression

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -144,7 +144,6 @@ LABEL_FULL_WIDTH            {CN_EN_FULL_WIDTH}{CN_EN_NUM_FULL_WIDTH}*
 "ADD"                       { return TokenType::KW_ADD; }
 "CREATE"                    { return TokenType::KW_CREATE;}
 "DROP"                      { return TokenType::KW_DROP; }
-"CLEAR"                     { return TokenType::KW_CLEAR; } 
 "REMOVE"                    { return TokenType::KW_REMOVE; }
 "IF"                        { return TokenType::KW_IF; }
 "NOT"                       { return TokenType::KW_NOT; }
@@ -308,6 +307,7 @@ LABEL_FULL_WIDTH            {CN_EN_FULL_WIDTH}{CN_EN_NUM_FULL_WIDTH}*
 "MERGE"                     { return TokenType::KW_MERGE; }
 "RENAME"                    { return TokenType::KW_RENAME; }
 "DIVIDE"                    { return TokenType::KW_DIVIDE; }
+"CLEAR"                     { return TokenType::KW_CLEAR; }
 
 "TRUE"                      { yylval->boolval = true; return TokenType::BOOL; }
 "FALSE"                     { yylval->boolval = false; return TokenType::BOOL; }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
KW_CLEAR is used as a keyword, so that users cannot directly use 'clear' as LABEL. Therefore, KW_CLEAR is changed to unresolved keyword here.

## How do you solve it?
move KW_CLEAR to unresolved keyword.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
