### PR TITLE
change default variables in release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           go-version: '^1.16.7'
       - name: package
-        run: ./package/package.sh
+        run: ./package/package.sh -t Release -r ON -p OFF -s FALSE -k OFF
       - name: output some vars
         id: vars
         env:

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -45,7 +45,7 @@ jobs:
       - id: tag
         run: echo ::set-output name=tagnum::${{ github.event.inputs.version }}
       - name: package
-        run: ./package/package.sh -v ${{ steps.tag.outputs.tagnum }} -t RelWithDebInfo -r OFF -p ON -s TRUE -k ON
+        run: ./package/package.sh -v ${{ steps.tag.outputs.tagnum }}
       - name: output some vars
         run: |
           tar zcf ${{ env.CPACK_DIR }}/nebula-graph-${{ steps.tag.outputs.tagnum }}.tar.gz --exclude=${{ env.BUILD_DIR }} ./*

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,12 @@
 FROM vesoft/nebula-dev:centos7 as builder
 
-ARG BRANCH=master
+ENV BUILD_IN_DOCKER TRUE
 ARG VERSION=
 
 COPY . /home/nebula/BUILD
 
 RUN cd /home/nebula/BUILD/package \
-  && ./package.sh -n OFF -v "${VERSION}" -b ${BRANCH} -t RelWithDebInfo -s TRUE -c OFF -k ON 
+  && ./package.sh -v "${VERSION}"
 FROM centos:7 as graphd
 
 COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-common.rpm /usr/local/nebula/nebula-common.rpm

--- a/docker/Dockerfile.graphd
+++ b/docker/Dockerfile.graphd
@@ -1,12 +1,12 @@
 FROM vesoft/nebula-dev:centos7 as builder
 
-ARG BRANCH=master
+ENV BUILD_IN_DOCKER TRUE
 ARG VERSION=
 
 COPY . /home/nebula/BUILD
 
 RUN cd /home/nebula/BUILD/package \
-  && ./package.sh -n OFF -v "${VERSION}" -b ${BRANCH} -t RelWithDebInfo -s TRUE -c OFF -k ON 
+  && ./package.sh -v "${VERSION}"
 
 FROM centos:7
 

--- a/docker/Dockerfile.metad
+++ b/docker/Dockerfile.metad
@@ -1,12 +1,12 @@
 FROM vesoft/nebula-dev:centos7 as builder
 
-ARG BRANCH=master
+ENV BUILD_IN_DOCKER TRUE
 ARG VERSION=
 
 COPY . /home/nebula/BUILD
 
 RUN cd /home/nebula/BUILD/package \
-  && ./package.sh -n OFF -v "${VERSION}" -b ${BRANCH} -t RelWithDebInfo -s TRUE -c OFF -k ON 
+  && ./package.sh -v "${VERSION}"
 
 FROM centos:7
 

--- a/docker/Dockerfile.storaged
+++ b/docker/Dockerfile.storaged
@@ -1,12 +1,12 @@
 FROM vesoft/nebula-dev:centos7 as builder
 
-ARG BRANCH=master
+ENV BUILD_IN_DOCKER TRUE
 ARG VERSION=
 
 COPY . /home/nebula/BUILD
 
 RUN cd /home/nebula/BUILD/package \
-  && ./package.sh -n OFF -v "${VERSION}" -b ${BRANCH} -t RelWithDebInfo -s TRUE -c OFF -k ON 
+  && ./package.sh -v "${VERSION}"
 
 FROM centos:7
 

--- a/docker/Dockerfile.tools
+++ b/docker/Dockerfile.tools
@@ -1,12 +1,12 @@
 FROM vesoft/nebula-dev:centos7 as builder
 
-ARG BRANCH=master
+ENV BUILD_IN_DOCKER TRUE
 ARG VERSION=
 
 COPY . /home/nebula/BUILD
 
 RUN cd /home/nebula/BUILD/package \
-  && ./package.sh -n OFF -v "${VERSION}" -b ${BRANCH} -t RelWithDebInfo -s TRUE -c OFF -k ON 
+  && ./package.sh -v "${VERSION}"
 
 FROM centos:7
 

--- a/package/package.sh
+++ b/package/package.sh
@@ -19,26 +19,44 @@
 
 set -e
 
-version=""
-package_one=ON
-strip_enable="FALSE"
 usage="Usage: ${0} -v <version> -n <ON/OFF> -s <TRUE/FALSE> -g <ON/OFF> -j <jobs> -t <BUILD TYPE>"
 project_dir="$(cd "$(dirname "$0")" && pwd)/.."
 build_dir=${project_dir}/pkg-build
-enablesanitizer="OFF"
-static_sanitizer="OFF"
-build_type="Release"
-build_console="OFF"
-branch=$(git rev-parse --abbrev-ref HEAD)
-jobs=$(nproc)
-enable_compressed_debug_info=ON
-dump_symbols="OFF"
-dump_syms_tool_dir=
-system_name=
 install_prefix=/usr/local/nebula
-enable_breakpad="OFF"
 
-while getopts v:n:s:b:d:t:r:p:j:c:k: opt;
+BUILD_IN_DOCKER=${BUILD_IN_DOCKER:-FALSE}
+
+# default variables when building release.
+function _default_release_variables {
+    version=""
+    package_one="ON"
+    strip_enable="TRUE"
+    enablesanitizer="OFF"
+    static_sanitizer="OFF"
+    build_type="RelWithDebInfo"
+    build_console="OFF"
+    jobs=$(nproc)
+    enable_compressed_debug_info="OFF"
+    dump_symbols="ON"
+    dump_syms_tool_dir=
+    system_name=
+    enable_breakpad="ON"
+
+}
+
+# change default variables. e.g. build release in docker
+function _extra_release_variables {
+    if [[ $BUILD_IN_DOCKER == TRUE ]]; then
+        package_one="OFF"
+        enable_compressed_debug_info="ON"
+        dump_symbols="OFF"
+    fi 
+}
+
+_default_release_variables
+_extra_release_variables
+
+while getopts v:n:s:d:t:r:p:j:c:k: opt;
 do
     case $opt in
         v)


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
1. there're too many variables when building release package, and when we build nebula in test platform, we should follow these options.
2. just use `package.sh` directly when building release.
