### PR TITLE
Fix optional of multi-match

### DIFF
--- a/src/graph/planner/match/MatchPlanner.cpp
+++ b/src/graph/planner/match/MatchPlanner.cpp
@@ -83,11 +83,19 @@ Status MatchPlanner::connectMatchPlan(SubPlan& queryPlan, MatchClauseContext* ma
   }
   if (!intersectedAliases.empty()) {
     if (matchCtx->isOptional) {
+      // connect LeftJoin match filter
+      if (matchCtx->where != nullptr) {
+        auto wherePlanStatus =
+            std::make_unique<WhereClausePlanner>()->transform(matchCtx->where.get());
+        NG_RETURN_IF_ERROR(wherePlanStatus);
+        auto wherePlan = std::move(wherePlanStatus).value();
+        matchPlan = SegmentsConnector::addInput(wherePlan, matchPlan, true);
+      }
       queryPlan =
-          SegmentsConnector::leftJoin(matchCtx->qctx, matchPlan, queryPlan, intersectedAliases);
+          SegmentsConnector::leftJoin(matchCtx->qctx, queryPlan, matchPlan, intersectedAliases);
     } else {
       queryPlan =
-          SegmentsConnector::innerJoin(matchCtx->qctx, matchPlan, queryPlan, intersectedAliases);
+          SegmentsConnector::innerJoin(matchCtx->qctx, queryPlan, matchPlan, intersectedAliases);
     }
   } else {
     queryPlan.root = BiCartesianProduct::make(matchCtx->qctx, queryPlan.root, matchPlan.root);
@@ -103,7 +111,7 @@ Status MatchPlanner::genQueryPartPlan(QueryContext* qctx,
   for (auto& match : queryPart.matchs) {
     connectMatchPlan(queryPlan, match.get());
     // connect match filter
-    if (match->where != nullptr) {
+    if (match->where != nullptr && !match->isOptional) {
       auto wherePlanStatus = std::make_unique<WhereClausePlanner>()->transform(match->where.get());
       NG_RETURN_IF_ERROR(wherePlanStatus);
       auto wherePlan = std::move(wherePlanStatus).value();

--- a/tests/tck/features/match/MultiLineMultiQueryParts.feature
+++ b/tests/tck/features/match/MultiLineMultiQueryParts.feature
@@ -207,7 +207,7 @@ Feature: Multi Line Multi Query Parts
       """
     Then the result should be, in any order:
       | count |
-      | 2    |
+      | 2     |
     When executing query:
       """
       MATCH (v:player) WHERE v.player.age > 40 and v.player.age<46
@@ -216,7 +216,7 @@ Feature: Multi Line Multi Query Parts
       """
     Then the result should be, in any order:
       | count |
-      | 6    |
+      | 6     |
     When executing query:
       """
       OPTIONAL MATCH (v:player) WHERE v.player.age > 40 and v.player.age<46
@@ -225,7 +225,7 @@ Feature: Multi Line Multi Query Parts
       """
     Then the result should be, in any order:
       | count |
-      | 6   |
+      | 6     |
     When executing query:
       """
       OPTIONAL MATCH (v:player) WHERE v.player.age>43
@@ -234,7 +234,7 @@ Feature: Multi Line Multi Query Parts
       """
     Then the result should be, in any order:
       | count |
-      | 2    |
+      | 2     |
     When executing query:
       """
       MATCH (v:player) WHERE v.player.age>43
@@ -243,7 +243,7 @@ Feature: Multi Line Multi Query Parts
       """
     Then the result should be, in any order:
       | count |
-      | 4    |
+      | 4     |
     When executing query:
       """
       OPTIONAL MATCH (v:player) WHERE v.player.age>43
@@ -252,7 +252,7 @@ Feature: Multi Line Multi Query Parts
       """
     Then the result should be, in any order:
       | count |
-      | 4    |
+      | 4     |
 
   Scenario: Multi Line Multi Query Parts
     When executing query:

--- a/tests/tck/features/match/MultiLineMultiQueryParts.feature
+++ b/tests/tck/features/match/MultiLineMultiQueryParts.feature
@@ -29,7 +29,6 @@ Feature: Multi Line Multi Query Parts
       | "Tim Duncan" | "Boris Diaw"  | "Tim Duncan" |
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n), (n)-[]-(l) WHERE id(n)=="Tim Duncan"
       RETURN m.player.name AS n1, n.player.name AS n2, l.player.name AS n3 ORDER BY n1, n2, n3 LIMIT 10
       """
@@ -47,7 +46,6 @@ Feature: Multi Line Multi Query Parts
       | "Aron Baynes" | "Tim Duncan" | "Manu Ginobili"     |
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n), (n)-[]-(l), (l)-[]-(h) WHERE id(m)=="Tim Duncan"
       RETURN m.player.name AS n1, n.player.name AS n2, l.team.name AS n3, h.player.name AS n4
       ORDER BY n1, n2, n3, n4 LIMIT 10
@@ -68,7 +66,6 @@ Feature: Multi Line Multi Query Parts
   Scenario: Multi Line Multi Match
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n) WHERE id(m)=="Tim Duncan"
       MATCH (n)-[]-(l)
       RETURN m.player.name AS n1, n.player.name AS n2,
@@ -89,7 +86,6 @@ Feature: Multi Line Multi Query Parts
       | "Tim Duncan" | "Boris Diaw"  | "Tim Duncan" |
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n),(n) WHERE id(m)=="Tim Duncan" and id(n)=="Tony Parker"
       MATCH (n)-[]-(l) where n.player.age<m.player.age
       RETURN count(*) AS count
@@ -99,7 +95,6 @@ Feature: Multi Line Multi Query Parts
       | 64    |
     When executing query:
       """
-      USE nba;
       MATCH (v:player) WHERE v.player.age>43
       MATCH (n:player) WHERE v.player.age>40 and n.player.age>v.player.age
       RETURN count(*) AS count
@@ -109,7 +104,6 @@ Feature: Multi Line Multi Query Parts
       | 5     |
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n) WHERE id(m)=="Tim Duncan"
       MATCH (n)-[]-(l), (l)-[]-(h)
       RETURN m.player.name AS n1, n.player.name AS n2, l.team.name AS n3, h.player.name AS n4
@@ -129,7 +123,6 @@ Feature: Multi Line Multi Query Parts
       | "Tim Duncan" | "Aron Baynes" | "Spurs"   | "Boris Diaw"      |
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n) WHERE id(m)=="Tim Duncan"
       MATCH (n)-[]-(l)
       MATCH (l)-[]-(h)
@@ -150,7 +143,6 @@ Feature: Multi Line Multi Query Parts
       | "Tim Duncan" | "Aron Baynes" | "Spurs"   | "Boris Diaw"      |
     When executing query:
       """
-      USE nba;
       MATCH (v:player{name:"Tony Parker"})
       WITH v AS a
       MATCH p=(o:player{name:"Tim Duncan"})-[]->(a)
@@ -164,7 +156,6 @@ Feature: Multi Line Multi Query Parts
   Scenario: Multi Line Optional Match
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n) WHERE id(m)=="Tim Duncan"
       OPTIONAL MATCH (n)<-[:serve]-(l)
       RETURN m.player.name AS n1, n.player.name AS n2, l AS n3 ORDER BY n1, n2, n3 LIMIT 10
@@ -183,7 +174,6 @@ Feature: Multi Line Multi Query Parts
       | "Tim Duncan" | "Manu Ginobili"     | NULL |
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n),(n) WHERE id(m)=="Tim Duncan" and id(n)=="Tony Parker"
       OPTIONAL MATCH (n)-[]-(l) where n.player.age < m.player.age
       RETURN count(*) AS count
@@ -193,7 +183,6 @@ Feature: Multi Line Multi Query Parts
       | 64    |
     When executing query:
       """
-      USE nba;
       OPTIONAL match (v:player) WHERE v.player.age > 41
       MATCH (v:player) WHERE v.player.age>40
       RETURN count(*) AS count
@@ -203,7 +192,6 @@ Feature: Multi Line Multi Query Parts
       | 7     |
     When executing query:
       """
-      USE nba;
       OPTIONAL match (v:player) WHERE v.player.age>43
       MATCH (n:player) WHERE n.player.age>40
       RETURN count(*) AS count
@@ -211,11 +199,64 @@ Feature: Multi Line Multi Query Parts
     Then the result should be, in order:
       | count |
       | 32    |
+    When executing query:
+      """
+      OPTIONAL MATCH (v:player) WHERE v.player.age > 40 and v.player.age<46
+      MATCH (v:player) WHERE v.player.age>43
+      RETURN count(*) AS count
+      """
+    Then the result should be, in any order:
+      | count |
+      | 2    |
+    When executing query:
+      """
+      MATCH (v:player) WHERE v.player.age > 40 and v.player.age<46
+      OPTIONAL MATCH (v:player) WHERE v.player.age>43
+      RETURN count(*) AS count
+      """
+    Then the result should be, in any order:
+      | count |
+      | 6    |
+    When executing query:
+      """
+      OPTIONAL MATCH (v:player) WHERE v.player.age > 40 and v.player.age<46
+      OPTIONAL MATCH (v:player) WHERE v.player.age>43
+      RETURN count(*) AS count
+      """
+    Then the result should be, in any order:
+      | count |
+      | 6   |
+    When executing query:
+      """
+      OPTIONAL MATCH (v:player) WHERE v.player.age>43
+      MATCH (v:player) WHERE v.player.age > 40 and v.player.age<46
+      RETURN count(*) AS count
+      """
+    Then the result should be, in any order:
+      | count |
+      | 2    |
+    When executing query:
+      """
+      MATCH (v:player) WHERE v.player.age>43
+      OPTIONAL MATCH (v:player) WHERE v.player.age > 40 and v.player.age<46
+      RETURN count(*) AS count
+      """
+    Then the result should be, in any order:
+      | count |
+      | 4    |
+    When executing query:
+      """
+      OPTIONAL MATCH (v:player) WHERE v.player.age>43
+      OPTIONAL MATCH (v:player) WHERE v.player.age > 40 and v.player.age<46
+      RETURN count(*) AS count
+      """
+    Then the result should be, in any order:
+      | count |
+      | 4    |
 
   Scenario: Multi Line Multi Query Parts
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n) WHERE id(m)=="Tim Duncan"
       WITH n, n.player.name AS n1 ORDER BY n1 LIMIT 10
       MATCH (n)-[]-(l)
@@ -237,7 +278,6 @@ Feature: Multi Line Multi Query Parts
       | "Boris Diaw"  | "Tim Duncan" |
     When executing query:
       """
-      USE nba;
       MATCH (m:player{name:"Tim Duncan"})-[:like]-(n)--()
       WITH  m,count(*) AS lcount
       MATCH (m)--(n)
@@ -248,7 +288,6 @@ Feature: Multi Line Multi Query Parts
       | 19     | 110    |
     When executing query:
       """
-      USE nba;
       MATCH (m:player{name:"Tim Duncan"})-[:like]-(n)--()
       WITH  m,n
       MATCH (m)--(n)
@@ -259,7 +298,6 @@ Feature: Multi Line Multi Query Parts
       | 270    |
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n) WHERE id(m)=="Tim Duncan"
       OPTIONAL MATCH (n)-->(v) WHERE v.player.age < m.player.age
       RETURN count(*) AS count
@@ -269,7 +307,6 @@ Feature: Multi Line Multi Query Parts
       | 45    |
     When executing query:
       """
-      USE nba;
       MATCH (a:player{age:42}) WITH a
       MATCH (b:player{age:40}) WHERE b.player.age<a.player.age
       UNWIND [1,2,3] as l
@@ -280,7 +317,6 @@ Feature: Multi Line Multi Query Parts
       | 12    |
     When executing query:
       """
-      USE nba;
       MATCH (a:player{age:42}) WITH a
       MATCH (b:player{age:40}) WITH a,b WHERE b.player.age<a.player.age
       UNWIND [1,2,3] as l
@@ -291,7 +327,6 @@ Feature: Multi Line Multi Query Parts
       | 12    |
     When executing query:
       """
-      USE nba;
       OPTIONAL match (v:player) WHERE v.player.age>43 WITH v
       MATCH (v:player) WHERE v.player.age>40  WITH v
       RETURN count(*) AS count
@@ -301,7 +336,6 @@ Feature: Multi Line Multi Query Parts
       | 4     |
     When executing query:
       """
-      USE nba;
       OPTIONAL match (v:player) WHERE v.player.age>43 WITH v
       MATCH (n:player) WHERE n.player.age>40  WITH v, n
       RETURN count(*) AS count
@@ -311,7 +345,6 @@ Feature: Multi Line Multi Query Parts
       | 32    |
     When executing query:
       """
-      USE nba;
       MATCH (a:player{age:42}) WITH a
       MATCH (b:player{age:40}) WHERE b.player.age<a.player.age
       UNWIND [1,2,3] AS l WITH a,b,l WHERE b.player.age+1 < a.player.age
@@ -324,7 +357,6 @@ Feature: Multi Line Multi Query Parts
   Scenario: Multi Line Some Erros
     When executing query:
       """
-      USE nba;
       MATCH (m)-[]-(n) WHERE id(m)=="Tim Duncan"
       WITH n, n.player.name AS n1 ORDER BY n1 LIMIT 10
       RETURN m


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula/issues/4154

#### Description:


## How do you solve it?
The calculation of `Filter` before and after `InnerJoin/Cartesian` are equivalent *if the Filter can be delay*.

The calculation of `Filter` before and after `LeftJoin` are not equivalent, bcz `LeftJoin` always keep the left table rows.
So the correct solution is to introduce all visible variables via `Argument` and computes the `Filter` before `LeftJoin`.

This pr currently only fixes the case where `Filter` not referencing variables outside the definitions in the current match pattern.

## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
