### PR TITLE
modify subgraph loop condition

### DIFF
--- a/src/graph/planner/ngql/SubgraphPlanner.cpp
+++ b/src/graph/planner/ngql/SubgraphPlanner.cpp
@@ -71,12 +71,16 @@ StatusOr<SubPlan> SubgraphPlanner::nSteps(SubPlan& startVidPlan, const std::stri
   auto resultVar = qctx->vctx()->anonVarGen()->getVar();
   auto loopSteps = qctx->vctx()->anonVarGen()->getVar();
   subgraphCtx_->loopSteps = loopSteps;
-  auto* subgraph = Subgraph::make(qctx, gn, resultVar, loopSteps, steps.steps() + 1);
+
+  auto* subgraph = Subgraph::make(qctx, gn, resultVar, loopSteps, steps.steps());
   subgraph->setOutputVar(input);
   subgraph->setBiDirectEdgeTypes(subgraphCtx_->biDirectEdgeTypes);
   subgraph->setColNames({nebula::kVid});
-
-  auto* condition = loopCondition(steps.steps() + 1, gn->outputVar());
+  uint32_t maxSteps = steps.steps();
+  if (subgraphCtx_->getEdgeProp || subgraphCtx_->withProp) {
+    ++maxSteps;
+  }
+  auto* condition = loopCondition(maxSteps, gn->outputVar());
   auto* loop = Loop::make(qctx, startVidPlan.root, subgraph, condition);
 
   auto* dc = DataCollect::make(qctx, DataCollect::DCKind::kSubgraph);

--- a/src/graph/planner/ngql/SubgraphPlanner.cpp
+++ b/src/graph/planner/ngql/SubgraphPlanner.cpp
@@ -71,8 +71,7 @@ StatusOr<SubPlan> SubgraphPlanner::nSteps(SubPlan& startVidPlan, const std::stri
   auto resultVar = qctx->vctx()->anonVarGen()->getVar();
   auto loopSteps = qctx->vctx()->anonVarGen()->getVar();
   subgraphCtx_->loopSteps = loopSteps;
-
-  auto* subgraph = Subgraph::make(qctx, gn, resultVar, loopSteps, steps.steps());
+  auto* subgraph = Subgraph::make(qctx, gn, resultVar, loopSteps, steps.steps() + 1);
   subgraph->setOutputVar(input);
   subgraph->setBiDirectEdgeTypes(subgraphCtx_->biDirectEdgeTypes);
   subgraph->setColNames({nebula::kVid});


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

The last step of the subgraph is to get all the edges between the visited vetices, if only the output vertices, do not need to take the last step

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
