### PR TITLE
fix lookup crash when has nullable cols

### DIFF
--- a/src/common/meta/NebulaSchemaProvider.h
+++ b/src/common/meta/NebulaSchemaProvider.h
@@ -124,6 +124,10 @@ class NebulaSchemaProvider : public SchemaProviderIf {
 
   StatusOr<std::pair<std::string, int64_t>> getTTLInfo() const;
 
+  bool hasNullableCol() const {
+    return numNullableFields_ != 0;
+  }
+
  protected:
   NebulaSchemaProvider() = default;
 

--- a/src/storage/exec/IndexEdgeScanNode.cpp
+++ b/src/storage/exec/IndexEdgeScanNode.cpp
@@ -11,8 +11,9 @@ IndexEdgeScanNode::IndexEdgeScanNode(const IndexEdgeScanNode& node)
 IndexEdgeScanNode::IndexEdgeScanNode(RuntimeContext* context,
                                      IndexID indexId,
                                      const std::vector<cpp2::IndexColumnHint>& columnHint,
-                                     ::nebula::kvstore::KVStore* kvstore)
-    : IndexScanNode(context, "IndexEdgeScanNode", indexId, columnHint, kvstore) {
+                                     ::nebula::kvstore::KVStore* kvstore,
+                                     bool hasNullableCol)
+    : IndexScanNode(context, "IndexEdgeScanNode", indexId, columnHint, kvstore, hasNullableCol) {
   getIndex = std::function([this](std::shared_ptr<IndexItem>& index) {
     auto env = this->context_->env();
     auto indexMgr = env->indexMan_;

--- a/src/storage/exec/IndexEdgeScanNode.h
+++ b/src/storage/exec/IndexEdgeScanNode.h
@@ -24,7 +24,8 @@ class IndexEdgeScanNode : public IndexScanNode {
   IndexEdgeScanNode(RuntimeContext* context,
                     IndexID indexId,
                     const std::vector<cpp2::IndexColumnHint>& columnHint,
-                    ::nebula::kvstore::KVStore* kvstore);
+                    ::nebula::kvstore::KVStore* kvstore,
+                    bool hasNullableCol);
   ::nebula::cpp2::ErrorCode init(InitContext& ctx) override;
   std::unique_ptr<IndexNode> copy() override;
 

--- a/src/storage/exec/IndexScanNode.cpp
+++ b/src/storage/exec/IndexScanNode.cpp
@@ -358,9 +358,9 @@ IndexScanNode::IndexScanNode(const IndexScanNode& node)
       partId_(node.partId_),
       indexId_(node.indexId_),
       index_(node.index_),
-      indexNullable_(node.indexNullable_),
       columnHints_(node.columnHints_),
       kvstore_(node.kvstore_),
+      indexNullable_(node.indexNullable_),
       requiredColumns_(node.requiredColumns_),
       requiredAndHintColumns_(node.requiredAndHintColumns_),
       ttlProps_(node.ttlProps_),
@@ -498,11 +498,14 @@ void IndexScanNode::decodePropFromIndex(folly::StringPiece key,
   if (colPosMap.empty()) {
     return;
   }
+  // offset is the start posistion of index values
   size_t offset = sizeof(PartitionID) + sizeof(IndexID);
   std::bitset<16> nullableBit;
   int8_t nullableColPosit = 15;
   if (indexNullable_) {
-    auto bitOffset = key.size() - context_->vIdLen() - sizeof(uint16_t);
+    // key has been truncated ouside, it **ONLY** contains partId, indexId, indexValue and
+    // nullableBits. So the last two bytes is the nullableBits
+    auto bitOffset = key.size() - sizeof(uint16_t);
     auto v = *reinterpret_cast<const uint16_t*>(key.data() + bitOffset);
     nullableBit = v;
   }

--- a/src/storage/exec/IndexScanNode.h
+++ b/src/storage/exec/IndexScanNode.h
@@ -60,8 +60,13 @@ class IndexScanNode : public IndexNode {
                 const std::string& name,
                 IndexID indexId,
                 const std::vector<cpp2::IndexColumnHint>& columnHints,
-                ::nebula::kvstore::KVStore* kvstore)
-      : IndexNode(context, name), indexId_(indexId), columnHints_(columnHints), kvstore_(kvstore) {}
+                ::nebula::kvstore::KVStore* kvstore,
+                bool hasNullableCol)
+      : IndexNode(context, name),
+        indexId_(indexId),
+        columnHints_(columnHints),
+        kvstore_(kvstore),
+        indexNullable_(hasNullableCol) {}
   ::nebula::cpp2::ErrorCode init(InitContext& ctx) override;
   std::string identify() override;
 
@@ -139,10 +144,6 @@ class IndexScanNode : public IndexNode {
    * @brief index definition
    */
   std::shared_ptr<nebula::meta::cpp2::IndexItem> index_;
-  /**
-   * @brief if index contain nullable field or not
-   */
-  bool indexNullable_ = false;
   const std::vector<cpp2::IndexColumnHint>& columnHints_;
   /**
    * @see Path
@@ -153,6 +154,10 @@ class IndexScanNode : public IndexNode {
    */
   std::unique_ptr<kvstore::KVIterator> iter_;
   nebula::kvstore::KVStore* kvstore_;
+  /**
+   * @brief if index contain nullable field or not
+   */
+  bool indexNullable_ = false;
   /**
    * @brief row format that `doNext` needs to return
    */

--- a/src/storage/exec/IndexVertexScanNode.cpp
+++ b/src/storage/exec/IndexVertexScanNode.cpp
@@ -16,8 +16,9 @@ IndexVertexScanNode::IndexVertexScanNode(const IndexVertexScanNode& node)
 IndexVertexScanNode::IndexVertexScanNode(RuntimeContext* context,
                                          IndexID indexId,
                                          const std::vector<cpp2::IndexColumnHint>& columnHint,
-                                         ::nebula::kvstore::KVStore* kvstore)
-    : IndexScanNode(context, "IndexVertexScanNode", indexId, columnHint, kvstore) {
+                                         ::nebula::kvstore::KVStore* kvstore,
+                                         bool hasNullableCol)
+    : IndexScanNode(context, "IndexVertexScanNode", indexId, columnHint, kvstore, hasNullableCol) {
   getIndex = std::function([this](std::shared_ptr<IndexItem>& index) {
     auto env = this->context_->env();
     auto indexMgr = env->indexMan_;

--- a/src/storage/exec/IndexVertexScanNode.h
+++ b/src/storage/exec/IndexVertexScanNode.h
@@ -28,7 +28,8 @@ class IndexVertexScanNode final : public IndexScanNode {
   IndexVertexScanNode(RuntimeContext* context,
                       IndexID indexId,
                       const std::vector<cpp2::IndexColumnHint>& columnHint,
-                      ::nebula::kvstore::KVStore* kvstore);
+                      ::nebula::kvstore::KVStore* kvstore,
+                      bool hasNullableCol);
   ::nebula::cpp2::ErrorCode init(InitContext& ctx) override;
   std::unique_ptr<IndexNode> copy() override;
 

--- a/src/storage/index/LookupProcessor.cpp
+++ b/src/storage/index/LookupProcessor.cpp
@@ -116,8 +116,11 @@ ErrorOr<nebula::cpp2::ErrorCode, std::unique_ptr<IndexNode>> LookupProcessor::bu
     const cpp2::LookupIndexRequest& req) {
   std::vector<std::unique_ptr<IndexNode>> nodes;
   for (auto& ctx : req.get_indices().get_contexts()) {
-    auto node = buildOneContext(ctx);
-    nodes.emplace_back(std::move(node));
+    auto scan = buildOneContext(ctx);
+    if (!ok(scan)) {
+      return error(scan);
+    }
+    nodes.emplace_back(std::move(value(scan)));
   }
   for (size_t i = 0; i < nodes.size(); i++) {
     auto projection =
@@ -164,17 +167,42 @@ ErrorOr<nebula::cpp2::ErrorCode, std::unique_ptr<IndexNode>> LookupProcessor::bu
   return std::move(nodes[0]);
 }
 
-std::unique_ptr<IndexNode> LookupProcessor::buildOneContext(const cpp2::IndexQueryContext& ctx) {
+ErrorOr<nebula::cpp2::ErrorCode, std::unique_ptr<IndexNode>> LookupProcessor::buildOneContext(
+    const cpp2::IndexQueryContext& ctx) {
   std::unique_ptr<IndexNode> node;
   DLOG(INFO) << ctx.get_column_hints().size();
   DLOG(INFO) << &ctx.get_column_hints();
   DLOG(INFO) << ::apache::thrift::SimpleJSONSerializer::serialize<std::string>(ctx);
   if (context_->isEdge()) {
-    node = std::make_unique<IndexEdgeScanNode>(
-        context_.get(), ctx.get_index_id(), ctx.get_column_hints(), context_->env()->kvstore_);
+    auto idx = env_->indexMan_->getEdgeIndex(context_->spaceId(), ctx.get_index_id());
+    if (!idx.ok()) {
+      return nebula::cpp2::ErrorCode::E_INDEX_NOT_FOUND;
+    }
+    auto cols = idx.value()->get_fields();
+    bool hasNullableCol =
+        std::any_of(cols.begin(), cols.end(), [](const meta::cpp2::ColumnDef& col) {
+          return col.nullable_ref().value_or(false);
+        });
+    node = std::make_unique<IndexEdgeScanNode>(context_.get(),
+                                               ctx.get_index_id(),
+                                               ctx.get_column_hints(),
+                                               context_->env()->kvstore_,
+                                               hasNullableCol);
   } else {
-    node = std::make_unique<IndexVertexScanNode>(
-        context_.get(), ctx.get_index_id(), ctx.get_column_hints(), context_->env()->kvstore_);
+    auto idx = env_->indexMan_->getTagIndex(context_->spaceId(), ctx.get_index_id());
+    if (!idx.ok()) {
+      return nebula::cpp2::ErrorCode::E_INDEX_NOT_FOUND;
+    }
+    auto cols = idx.value()->get_fields();
+    bool hasNullableCol =
+        std::any_of(cols.begin(), cols.end(), [](const meta::cpp2::ColumnDef& col) {
+          return col.nullable_ref().value_or(false);
+        });
+    node = std::make_unique<IndexVertexScanNode>(context_.get(),
+                                                 ctx.get_index_id(),
+                                                 ctx.get_column_hints(),
+                                                 context_->env()->kvstore_,
+                                                 hasNullableCol);
   }
   if (ctx.filter_ref().is_set() && !ctx.get_filter().empty()) {
     auto expr = Expression::decode(context_->objPool(), *ctx.filter_ref());

--- a/src/storage/index/LookupProcessor.h
+++ b/src/storage/index/LookupProcessor.h
@@ -40,7 +40,8 @@ class LookupProcessor : public BaseProcessor<cpp2::LookupIndexResp> {
   ::nebula::cpp2::ErrorCode prepare(const cpp2::LookupIndexRequest& req);
   ErrorOr<nebula::cpp2::ErrorCode, std::unique_ptr<IndexNode>> buildPlan(
       const cpp2::LookupIndexRequest& req);
-  std::unique_ptr<IndexNode> buildOneContext(const cpp2::IndexQueryContext& ctx);
+  ErrorOr<nebula::cpp2::ErrorCode, std::unique_ptr<IndexNode>> buildOneContext(
+      const cpp2::IndexQueryContext& ctx);
   std::vector<std::unique_ptr<IndexNode>> reproducePlan(IndexNode* root, size_t count);
   ErrorOr<nebula::cpp2::ErrorCode, std::vector<std::pair<std::string, cpp2::StatType>>>
   handleStatProps(const std::vector<cpp2::StatProp>& statProps);

--- a/src/storage/test/IndexTest.cpp
+++ b/src/storage/test/IndexTest.cpp
@@ -238,6 +238,7 @@ TEST_F(IndexScanTest, Base) {
     (i1,2):a
     (i2,3):b
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeTag(rows, 1, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   for (auto& iter : kv) {
@@ -251,8 +252,8 @@ TEST_F(IndexScanTest, Base) {
     };
     IndexID indexId = 2;
     auto context = makeContext(1, 0);
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), indexId, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), indexId, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), indices[0]);
     helper.setTag(scanNode.get(), schema);
@@ -289,8 +290,8 @@ TEST_F(IndexScanTest, Base) {
     };
     IndexID indexId = 3;
     auto context = makeContext(1, 0);
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), indexId, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), indexId, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), indices[1]);
     helper.setTag(scanNode.get(), schema);
@@ -336,6 +337,7 @@ TEST_F(IndexScanTest, Vertex) {
     TAG(t,1)
     (i1,2):a
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeTag(rows, 1, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   std::vector<ColumnHint> columnHints{
@@ -348,8 +350,8 @@ TEST_F(IndexScanTest, Vertex) {
     for (auto& item : kv[1]) {
       kvstore->put(item.first, item.second);
     }
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), indexId, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), indexId, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), indices[0]);
     helper.setTag(scanNode.get(), schema);
@@ -386,8 +388,8 @@ TEST_F(IndexScanTest, Vertex) {
     for (auto& item : kv[0]) {
       kvstore->put(item.first, item.second);
     }
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), indexId, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), indexId, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), indices[0]);
     helper.setTag(scanNode.get(), schema);
@@ -437,6 +439,7 @@ TEST_F(IndexScanTest, Edge) {
     EDGE(e,1)
     (i1,2):b,c
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeEdge(rows, 1, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   std::vector<ColumnHint> columnHints{
@@ -448,8 +451,8 @@ TEST_F(IndexScanTest, Edge) {
     for (auto& item : kv[1]) {
       kvstore->put(item.first, item.second);
     }
-    auto scanNode =
-        std::make_unique<IndexEdgeScanNode>(context.get(), indexId, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexEdgeScanNode>(
+        context.get(), indexId, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), indices[0]);
     helper.setEdge(scanNode.get(), schema);
@@ -485,8 +488,8 @@ TEST_F(IndexScanTest, Edge) {
     for (auto& item : kv[0]) {
       kvstore->put(item.first, item.second);
     }
-    auto scanNode =
-        std::make_unique<IndexEdgeScanNode>(context.get(), indexId, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexEdgeScanNode>(
+        context.get(), indexId, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), indices[0]);
     helper.setEdge(scanNode.get(), schema);
@@ -540,6 +543,7 @@ TEST_F(IndexScanTest, Int) {
     (i2,3):b
     (i3,4):c
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeTag(rows, 1, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   for (auto& iter : kv) {
@@ -552,8 +556,8 @@ TEST_F(IndexScanTest, Int) {
                    const std::vector<Row>& expect,
                    const std::string& case_) {
     auto context = makeContext(1, 0);
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), 0, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), 0, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), index);
     helper.setTag(scanNode.get(), schema);
@@ -753,6 +757,7 @@ float     | float                     | float                   | int
     (i2,3):b
     (i3,4):c
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeEdge(rows, 1, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   for (auto& iter : kv) {
@@ -765,8 +770,8 @@ float     | float                     | float                   | int
                    const std::vector<Row>& expect,
                    const std::string& case_) {
     auto context = makeContext(0, 1);
-    auto scanNode =
-        std::make_unique<IndexEdgeScanNode>(context.get(), 0, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexEdgeScanNode>(
+        context.get(), 0, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), index);
     helper.setEdge(scanNode.get(), schema);
@@ -982,6 +987,7 @@ TEST_F(IndexScanTest, Bool) {
     (i1,2):a
     (i2,3):b
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeTag(rows, 2, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   for (auto& iter : kv) {
@@ -994,8 +1000,8 @@ TEST_F(IndexScanTest, Bool) {
                    const std::vector<Row>& expect,
                    const std::string& case_) {
     auto context = makeContext(1, 0);
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), 0, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), 0, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), index);
     helper.setTag(scanNode.get(), schema);
@@ -1069,6 +1075,7 @@ TEST_F(IndexScanTest, String1) {
     (ib,3): b(10)
     (ic,4): c(10)
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeTag(rows, 1, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   for (size_t i = 0; i < kv.size(); i++) {
@@ -1082,8 +1089,8 @@ TEST_F(IndexScanTest, String1) {
                    const std::vector<Row>& expect,
                    const std::string& case_) {
     auto context = makeContext(1, 0);
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), 0, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), 0, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), index);
     helper.setTag(scanNode.get(), schema);
@@ -1225,6 +1232,7 @@ TEST_F(IndexScanTest, String2) {
     (i2,3):c2(5)
     (i3,4):c3(5)
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeTag(rows, 1, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   for (size_t i = 0; i < kv.size(); i++) {
@@ -1238,8 +1246,8 @@ TEST_F(IndexScanTest, String2) {
                    const std::vector<Row>& expect,
                    const std::string& case_) {
     auto context = makeContext(1, 0);
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), 0, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), 0, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), index);
     helper.setTag(scanNode.get(), schema);
@@ -1355,6 +1363,7 @@ TEST_F(IndexScanTest, String3) {
     (ib,2): b(6)
     (ic,3): c(6)
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeTag(rows, 1, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   for (size_t i = 0; i < kv.size(); i++) {
@@ -1368,8 +1377,8 @@ TEST_F(IndexScanTest, String3) {
                    const std::vector<Row>& expect,
                    const std::string& case_) {
     auto context = makeContext(1, 0);
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), 0, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), 0, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), index);
     helper.setTag(scanNode.get(), schema);
@@ -1476,6 +1485,7 @@ TEST_F(IndexScanTest, String4) {
     (ia,1): a(5)
     (ib,2): b(5)
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeTag(rows, 1, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   for (size_t i = 0; i < kv.size(); i++) {
@@ -1489,8 +1499,8 @@ TEST_F(IndexScanTest, String4) {
                    const std::vector<Row>& expect,
                    const std::string& case_) {
     auto context = makeContext(1, 0);
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), 0, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), 0, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), index);
     helper.setTag(scanNode.get(), schema);
@@ -1602,10 +1612,11 @@ TEST_F(IndexScanTest, Nullable) {
   auto check = [&](std::shared_ptr<IndexItem> index,
                    const std::vector<ColumnHint>& columnHints,
                    const std::vector<Row>& expect,
-                   const std::string& case_) {
+                   const std::string& case_,
+                   bool hasNullableCol) {
     auto context = makeContext(1, 0);
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), 0, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), 0, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), index);
     helper.setTag(scanNode.get(), schema);
@@ -1658,6 +1669,7 @@ TEST_F(IndexScanTest, Nullable) {
       (ib,3):b
       (iba,4):b,a
     )"_index(schema);
+    bool hasNullableCol = schema->hasNullableCol();
     auto kv = encodeTag(rows, 1, schema, indices);
     kvstore = std::make_unique<MockKVStore>();
     for (auto& iter : kv) {
@@ -1665,9 +1677,9 @@ TEST_F(IndexScanTest, Nullable) {
         kvstore->put(item.first, item.second);
       }
     }
-    check(indices[0], hint("a"), {}, "case1.1");
-    check(indices[1], hint("b"), expect(1, 2), "case1.2");
-    check(indices[2], hint("b"), expect(1, 2), "case1.3");
+    check(indices[0], hint("a"), {}, "case1.1", hasNullableCol);
+    check(indices[1], hint("b"), expect(1, 2), "case1.2", hasNullableCol);
+    check(indices[2], hint("b"), expect(1, 2), "case1.3", hasNullableCol);
   }
   /* Case 2: Float */ {
     auto rows = R"(
@@ -1687,6 +1699,7 @@ TEST_F(IndexScanTest, Nullable) {
       (ib,3):b
       (iba,4):b,a
     )"_index(schema);
+    bool hasNullableCol = schema->hasNullableCol();
     auto kv = encodeTag(rows, 1, schema, indices);
     kvstore = std::make_unique<MockKVStore>();
     for (auto& iter : kv) {
@@ -1694,9 +1707,9 @@ TEST_F(IndexScanTest, Nullable) {
         kvstore->put(item.first, item.second);
       }
     }
-    check(indices[0], hint("a"), {}, "case2.1");
-    check(indices[1], hint("b"), expect(0, 2), "case2.2");
-    check(indices[2], hint("b"), expect(0, 2), "case2.3");
+    check(indices[0], hint("a"), {}, "case2.1", hasNullableCol);
+    check(indices[1], hint("b"), expect(0, 2), "case2.2", hasNullableCol);
+    check(indices[2], hint("b"), expect(0, 2), "case2.3", hasNullableCol);
   }
   /* Case 3: String */ {
     auto rows = R"(
@@ -1716,6 +1729,7 @@ TEST_F(IndexScanTest, Nullable) {
       (ib,3):b(3)
       (iba,4):b(3),a(3)
     )"_index(schema);
+    bool hasNullableCol = schema->hasNullableCol();
     auto kv = encodeTag(rows, 1, schema, indices);
     kvstore = std::make_unique<MockKVStore>();
     for (auto& iter : kv) {
@@ -1723,9 +1737,51 @@ TEST_F(IndexScanTest, Nullable) {
         kvstore->put(item.first, item.second);
       }
     }
-    check(indices[0], hint("a"), {}, "case3.1");
-    check(indices[1], hint("b"), expect(0, 3), "case3.2");
-    check(indices[2], hint("b"), expect(0, 3), "case3.3");
+    check(indices[0], hint("a"), {}, "case3.1", hasNullableCol);
+    check(indices[1], hint("b"), expect(0, 3), "case3.2", hasNullableCol);
+    check(indices[2], hint("b"), expect(0, 3), "case3.3", hasNullableCol);
+  }
+  /* Case 4: Bool */ {
+    auto rows = R"(
+      bool  | bool
+      false | <null>
+      true  | <null>
+      true  | true
+      true  | false
+      false | true
+      false | false
+    )"_row;
+    schema = R"(
+      a | bool | | false
+      b | bool | | true
+    )"_schema;
+    auto indices = R"(
+      TAG(t,1)
+      (ia,2):a
+      (ib,3):b
+      (iba,4):b,a
+    )"_index(schema);
+    bool hasNullableCol = schema->hasNullableCol();
+    auto kv = encodeTag(rows, 1, schema, indices);
+    kvstore = std::make_unique<MockKVStore>();
+    for (auto& iter : kv) {
+      for (auto& item : iter) {
+        kvstore->put(item.first, item.second);
+      }
+    }
+    check(indices[0], hint("a"), {}, "case4.1", hasNullableCol);
+    check(indices[1], hint("b"), expect(0, 1), "case4.2", hasNullableCol);
+    check(indices[2], hint("b"), expect(0, 1), "case4.3", hasNullableCol);
+    check(indices[0],
+          std::vector{makeColumnHint("a", Value(true))},
+          expect(1, 2, 3),
+          "case4.4",
+          hasNullableCol);
+    check(indices[1],
+          std::vector{makeColumnHint("b", Value(true))},
+          expect(2, 4),
+          "case4.5",
+          hasNullableCol);
   }
 }
 TEST_F(IndexScanTest, TTL) {
@@ -1772,6 +1828,7 @@ TEST_F(IndexScanTest, Geography) {
     TAG(t,1)
     (i1,2):geo
   )"_index(schema);
+  bool hasNullableCol = schema->hasNullableCol();
   auto kv = encodeTag(rows, 1, schema, indices);
   auto kvstore = std::make_unique<MockKVStore>();
   for (auto& iter : kv) {
@@ -1782,8 +1839,8 @@ TEST_F(IndexScanTest, Geography) {
   auto actual = [&](std::shared_ptr<IndexItem> index,
                     const std::vector<ColumnHint>& columnHints) -> auto {
     auto context = makeContext(1, 0);
-    auto scanNode =
-        std::make_unique<IndexVertexScanNode>(context.get(), 0, columnHints, kvstore.get());
+    auto scanNode = std::make_unique<IndexVertexScanNode>(
+        context.get(), 0, columnHints, kvstore.get(), hasNullableCol);
     IndexScanTestHelper helper;
     helper.setIndex(scanNode.get(), index);
     helper.setTag(scanNode.get(), schema);


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#4230 

#### Description:

The main problem has two parts:
1. The `indexNullable_` in `IndexScanNode` is not initialized correctly.
2. In `IndexScanNode`, the offset of nullable bits is not calculated correctly.


## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:

Check if there is an nullable property when build plan.


## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
Fix storage may crash when lookup index with nullable property.