### PR TITLE
fix listener can't receive snapshot anymore

### DIFF
--- a/src/kvstore/Listener.cpp
+++ b/src/kvstore/Listener.cpp
@@ -147,6 +147,9 @@ void Listener::doApply() {
   if (isStopped()) {
     return;
   }
+  if (needToCleanupSnapshot()) {
+    cleanupSnapshot();
+  }
   // todo(doodle): only put is handled, all remove is ignored for now
   folly::via(executor_.get(), [this] {
     SCOPE_EXIT {

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -557,6 +557,17 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
    */
   void removePeer(const HostAddr& peer);
 
+  /**
+   * @brief Return whether need to clean snapshot when a node has not received the snapshot for a
+   * period of time
+   */
+  bool needToCleanupSnapshot();
+
+  /**
+   * @brief Convert to follower when snapshot has been outdated
+   */
+  void cleanupSnapshot();
+
  private:
   // A list of <idx, resp>
   // idx  -- the index of the peer
@@ -624,17 +635,6 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
    * @brief Return whether need to trigger leader election
    */
   bool needToStartElection();
-
-  /**
-   * @brief Return whether need to clean snapshot when a node has not received the snapshot for a
-   * period of time
-   */
-  bool needToCleanupSnapshot();
-
-  /**
-   * @brief Convert to follower when snapshot has been outdated
-   */
-  void cleanupSnapshot();
 
   /**
    * @brief The method sends out AskForVote request. Return true if I have been granted majority

--- a/src/kvstore/raftex/SnapshotManager.cpp
+++ b/src/kvstore/raftex/SnapshotManager.cpp
@@ -78,11 +78,10 @@ folly::Future<StatusOr<std::pair<LogID, TermID>>> SnapshotManager::sendSnapshot(
                 }
                 return true;
               } else {
-                VLOG(2) << part->idStr_ << "Sending snapshot failed, we don't retry anymore! "
-                        << "The error code is "
+                VLOG(2) << part->idStr_ << "Sending snapshot failed, the error code is "
                         << apache::thrift::util::enumNameSafe(resp.get_error_code());
-                p.setValue(Status::Error("Send snapshot failed!"));
-                return false;
+                sleep(1);
+                continue;
               }
             } catch (const std::exception& e) {
               VLOG(3) << part->idStr_ << "Send snapshot failed, exception " << e.what()


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

During replication test, I found two problems here:
1. Once listener return FAILED when receiving snapshot, the sender won't retry (we only retry for timeout before). This is a minor issue, because usually, listener won't explicitly return error when receiving snapshot (at least listener should not @panda-sheep you need to check your `SyncListener` implementation)
2. What's worse, listener won't be able to receive snapshot. Because the listener is always in `WAITING_SNAPSHOT` state. So we just reuse the same logic in normal `RaftPart`.

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [X] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
Not related