### PR TITLE
Fix the format of explain of input variables of Join.

### DIFF
--- a/src/graph/planner/plan/Query.cpp
+++ b/src/graph/planner/plan/Query.cpp
@@ -605,8 +605,12 @@ void DataCollect::cloneMembers(const DataCollect& l) {
 std::unique_ptr<PlanNodeDescription> Join::explain() const {
   auto desc = SingleDependencyNode::explain();
   folly::dynamic inputVar = folly::dynamic::object();
-  inputVar.insert("leftVar", folly::toJson(util::toJson(leftVar_)));
-  inputVar.insert("rightVar", folly::toJson(util::toJson(rightVar_)));
+  folly::dynamic leftVar = folly::dynamic::object();
+  leftVar.insert(leftVar_.first, leftVar_.second);
+  inputVar.insert("leftVar", std::move(leftVar));
+  folly::dynamic rightVar = folly::dynamic::object();
+  rightVar.insert(rightVar_.first, rightVar_.second);
+  inputVar.insert("rightVar", std::move(rightVar));
   addDescription("inputVar", folly::toJson(inputVar), desc.get());
   addDescription("hashKeys", folly::toJson(util::toJson(hashKeys_)), desc.get());
   addDescription("probeKeys", folly::toJson(util::toJson(probeKeys_)), desc.get());


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
Fix the issue that the result of dot format explanation of `Join` is malformed for GraphViz online tool, which caused by twice json converting.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
