### PR TITLE
Repair some problems in query_concurrently mode

### DIFF
--- a/src/storage/exec/IndexSelectionNode.cpp
+++ b/src/storage/exec/IndexSelectionNode.cpp
@@ -6,12 +6,12 @@
 namespace nebula {
 namespace storage {
 IndexSelectionNode::IndexSelectionNode(const IndexSelectionNode& node)
-    : IndexNode(node), expr_(node.expr_), colPos_(node.colPos_) {
+    : IndexNode(node), expr_(node.expr_->clone()), colPos_(node.colPos_) {
   ctx_ = std::make_unique<IndexExprContext>(colPos_);
 }
 
 IndexSelectionNode::IndexSelectionNode(RuntimeContext* context, Expression* expr)
-    : IndexNode(context, "IndexSelectionNode"), expr_(expr) {}
+    : IndexNode(context, "IndexSelectionNode"), expr_(expr->clone()) {}
 nebula::cpp2::ErrorCode IndexSelectionNode::init(InitContext& ctx) {
   DCHECK_EQ(children_.size(), 1);
   SelectionExprVisitor vis;

--- a/src/storage/exec/IndexTopNNode.h
+++ b/src/storage/exec/IndexTopNNode.h
@@ -88,7 +88,7 @@ class IndexTopNNode : public IndexLimitNode {
   nebula::cpp2::ErrorCode doExecute(PartitionID partId) override;
   Result doNext() override;
   void topN();
-  const std::vector<cpp2::OrderBy>* orderBy_;
+  const std::vector<cpp2::OrderBy> orderBy_;
   std::deque<Result> results_;
   bool finished_{false};
   std::vector<std::string> requiredColumns_;

--- a/src/storage/index/LookupProcessor.cpp
+++ b/src/storage/index/LookupProcessor.cpp
@@ -430,6 +430,7 @@ std::vector<std::unique_ptr<IndexNode>> LookupProcessor::reproducePlan(IndexNode
   return ret;
 }
 void LookupProcessor::profilePlan(IndexNode* root) {
+  std::unique_lock<std::mutex> lck(BaseProcessor<cpp2::LookupIndexResp>::profileMut_);
   std::queue<IndexNode*> q;
   q.push(root);
   while (!q.empty()) {


### PR DESCRIPTION
1. Null pointer exception in IndexTopNNode

2. The expression in IndexSelectionNode is incorrectly shared

3. The IndexTopNNode is incorrectly constructed, resulting in incorrect data

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
