### PR TITLE
fix learner's wal is not empty in rare cases

### DIFF
--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -401,6 +401,15 @@ const char* RaftPart::roleStr(Role role) const {
 void RaftPart::start(std::vector<HostAddr>&& peers, bool asLearner) {
   std::lock_guard<std::mutex> g(raftLock_);
 
+  // There are some rare cases that the part start as learner, but wal is not empty. For example,
+  // the node is dead, and one partition is removed from raft group (majority still alive). However,
+  // the part is added back to raft group again as learner. So the wal may be not empty, what is
+  // worse, there could be case that commitLogId is 0, but wal's lastLogId is not 0, which is
+  // obviously not expected
+  if (asLearner) {
+    wal_->reset();
+  }
+
   lastLogId_ = wal_->lastLogId();
   lastLogTerm_ = wal_->lastLogTerm();
   term_ = lastLogTerm_;

--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -631,6 +631,7 @@ bool FileBasedWal::reset() {
     unlink(absFn.c_str());
   }
   lastLogId_ = firstLogId_ = 0;
+  lastLogTerm_ = 0;
   return true;
 }
 


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 



#### Description:
See the comments in code, below is an example, previously if the part start as learner, all id is 0. But after 20220530-2344, things go wrong.

![image](https://user-images.githubusercontent.com/13706157/171091133-da89e7c0-9187-4f57-b277-d49bdd972442.png)


## How do you solve it?
Clean wal is start as learner


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
