### PR TITLE
fix storage crash

### DIFF
--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -373,7 +373,6 @@ std::vector<std::string> AddEdgesProcessor::indexKeys(
  * ifNotExist_ is false. Only keep the last one when edgeKey is same
  */
 nebula::cpp2::ErrorCode AddEdgesProcessor::deleteDupEdge(std::vector<cpp2::NewEdge>& edges) {
-  auto code = nebula::cpp2::ErrorCode::SUCCEEDED;
   std::unordered_set<std::string> visited;
   visited.reserve(edges.size());
   if (ifNotExists_) {
@@ -387,8 +386,7 @@ nebula::cpp2::ErrorCode AddEdgesProcessor::deleteDupEdge(std::vector<cpp2::NewEd
                    << ", edge srcVid: " << *edgeKeyRef->src_ref()
                    << ", dstVid: " << *edgeKeyRef->dst_ref() << ", ifNotExists_: " << std::boolalpha
                    << ifNotExists_;
-        code = nebula::cpp2::ErrorCode::E_INVALID_VID;
-        break;
+        return nebula::cpp2::ErrorCode::E_INVALID_VID;
       }
       auto key = NebulaKeyUtils::edgeKey(spaceVidLen_,
                                          0,  // it's ok, just distinguish between different edgekey
@@ -413,8 +411,7 @@ nebula::cpp2::ErrorCode AddEdgesProcessor::deleteDupEdge(std::vector<cpp2::NewEd
                    << ", edge srcVid: " << *edgeKeyRef->src_ref()
                    << ", dstVid: " << *edgeKeyRef->dst_ref() << ", ifNotExists_: " << std::boolalpha
                    << ifNotExists_;
-        code = nebula::cpp2::ErrorCode::E_INVALID_VID;
-        break;
+        return nebula::cpp2::ErrorCode::E_INVALID_VID;
       }
       auto key = NebulaKeyUtils::edgeKey(spaceVidLen_,
                                          0,  // it's ok, just distinguish between different edgekey
@@ -429,7 +426,7 @@ nebula::cpp2::ErrorCode AddEdgesProcessor::deleteDupEdge(std::vector<cpp2::NewEd
       }
     }
   }
-  return code;
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
 }  // namespace storage

--- a/src/storage/mutate/AddEdgesProcessor.h
+++ b/src/storage/mutate/AddEdgesProcessor.h
@@ -50,7 +50,7 @@ class AddEdgesProcessor : public BaseProcessor<cpp2::ExecResponse> {
                                      std::shared_ptr<nebula::meta::cpp2::IndexItem> index,
                                      const meta::SchemaProviderIf* latestSchema);
 
-  void deleteDupEdge(std::vector<cpp2::NewEdge>& edges);
+  nebula::cpp2::ErrorCode deleteDupEdge(std::vector<cpp2::NewEdge>& edges);
 
  private:
   GraphSpaceID spaceId_;

--- a/tests/tck/features/insert/Insert.feature
+++ b/tests/tck/features/insert/Insert.feature
@@ -614,4 +614,19 @@ Feature: Insert string vid of vertex and edge
     Then the result should be, in any order:
       | src   | dst   |
       | "300" | "400" |
+    When try to execute query:
+      """
+      INSERT EDGE like(grade) VALUES "3000000000000000000000000000000000000000000000000000000000" -> "400":(888)
+      """
+    Then a ExecutionError should be raised at runtime: Storage Error: The VID must be a 64-bit integer or a string fitting space vertex id length limit.
+    When try to execute query:
+      """
+      INSERT EDGE like(grade) VALUES "300" -> "4000000000000000000000000000000000000000000000000000000000":(888)
+      """
+    Then a ExecutionError should be raised at runtime: Storage Error: The VID must be a 64-bit integer or a string fitting space vertex id length limit.
+    When try to execute query:
+      """
+      INSERT EDGE like(grade) VALUES "300000000000000000000000000000000000000000000000000" -> "4000000000000000000000000000000000000000000000000000000000":(888)
+      """
+    Then a ExecutionError should be raised at runtime: Storage Error: The VID must be a 64-bit integer or a string fitting space vertex id length limit.
     Then drop the used space


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
![image](https://user-images.githubusercontent.com/84560950/172322619-f502657f-791c-4c32-b2c9-03b936181af6.png)

When the edge has an index and insert value exceeding length, insert edge will cause crash.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
