### PR TITLE
fix when restoring, the machine key is lost

### DIFF
--- a/src/meta/processors/admin/RestoreProcessor.cpp
+++ b/src/meta/processors/admin/RestoreProcessor.cpp
@@ -106,13 +106,18 @@ nebula::cpp2::ErrorCode RestoreProcessor::replaceHostInMachine(
   }
   auto iter = nebula::value(iterRet).get();
 
+  std::vector<std::string> newMachineKeys;
   while (iter->valid()) {
     auto machine = MetaKeyUtils::parseMachineKey(iter->key());
     if (hostMap.find(machine) != hostMap.end()) {
       batch->remove(MetaKeyUtils::machineKey(machine.host, machine.port));
-      batch->put(MetaKeyUtils::machineKey(hostMap[machine].host, hostMap[machine].port), "");
+      auto newMachineKey = MetaKeyUtils::machineKey(hostMap[machine].host, hostMap[machine].port);
+      newMachineKeys.emplace_back(std::move(newMachineKey));
     }
     iter->next();
+  }
+  for (auto& newKey : newMachineKeys) {
+    batch->put(newKey, "");
   }
 
   return retCode;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
fix when restoring, the machine key is lost.
Examples are as follows:

During restore, the mapping relationship of hosts is as follows
```
211 -> 213
212 -> 212
213 -> 211

```
When the restore is over, there are only `211, 212,` two machine keys left, and the `213` machine key is lost.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
