### PR TITLE
check god role exist when meta init

### DIFF
--- a/src/daemons/MetaDaemon.cpp
+++ b/src/daemons/MetaDaemon.cpp
@@ -176,7 +176,7 @@ int main(int argc, char* argv[]) {
     }
     if (nebula::value(ret) == localhost) {
       LOG(INFO) << "Check and init root user";
-      if (!nebula::meta::RootUserMan::isUserExists(gKVStore.get())) {
+      if (!nebula::meta::RootUserMan::isGodExists(gKVStore.get())) {
         if (!nebula::meta::RootUserMan::initRootUser(gKVStore.get())) {
           LOG(ERROR) << "Init root user failed";
           return EXIT_FAILURE;

--- a/src/daemons/MetaDaemon.cpp
+++ b/src/daemons/MetaDaemon.cpp
@@ -176,11 +176,16 @@ int main(int argc, char* argv[]) {
     }
     if (nebula::value(ret) == localhost) {
       LOG(INFO) << "Check and init root user";
-      if (!nebula::meta::RootUserMan::isGodExists(gKVStore.get())) {
-        if (!nebula::meta::RootUserMan::initRootUser(gKVStore.get())) {
-          LOG(ERROR) << "Init root user failed";
-          return EXIT_FAILURE;
-        }
+      auto checkRet = nebula::meta::RootUserMan::isGodExists(gKVStore.get());
+      if (!nebula::ok(checkRet)) {
+        auto retCode = nebula::error(checkRet);
+        LOG(ERROR) << "Parser God Role error:" << apache::thrift::util::enumNameSafe(retCode);
+        return EXIT_FAILURE;
+      }
+      auto existGod = nebula::value(checkRet);
+      if (!existGod && !nebula::meta::RootUserMan::initRootUser(gKVStore.get())) {
+        LOG(ERROR) << "Init root user failed";
+        return EXIT_FAILURE;
       }
     }
   }

--- a/src/daemons/StandAloneDaemon.cpp
+++ b/src/daemons/StandAloneDaemon.cpp
@@ -234,7 +234,7 @@ int main(int argc, char *argv[]) {
       }
       if (nebula::value(ret) == metaLocalhost) {
         LOG(INFO) << "Check and init root user";
-        if (!nebula::meta::RootUserMan::isUserExists(gMetaKVStore.get())) {
+        if (!nebula::meta::RootUserMan::isGodExists(gMetaKVStore.get())) {
           if (!nebula::meta::RootUserMan::initRootUser(gMetaKVStore.get())) {
             LOG(ERROR) << "Init root user failed";
             return;

--- a/src/daemons/StandAloneDaemon.cpp
+++ b/src/daemons/StandAloneDaemon.cpp
@@ -234,11 +234,16 @@ int main(int argc, char *argv[]) {
       }
       if (nebula::value(ret) == metaLocalhost) {
         LOG(INFO) << "Check and init root user";
-        if (!nebula::meta::RootUserMan::isGodExists(gMetaKVStore.get())) {
-          if (!nebula::meta::RootUserMan::initRootUser(gMetaKVStore.get())) {
-            LOG(ERROR) << "Init root user failed";
-            return;
-          }
+        auto checkRet = nebula::meta::RootUserMan::isGodExists(gMetaKVStore.get());
+        if (!nebula::ok(checkRet)) {
+          auto retCode = nebula::error(checkRet);
+          LOG(ERROR) << "Parser God Role error:" << apache::thrift::util::enumNameSafe(retCode);
+          return;
+        }
+        auto existGod = nebula::value(checkRet);
+        if (!existGod && !nebula::meta::RootUserMan::initRootUser(gMetaKVStore.get())) {
+          LOG(ERROR) << "Init root user failed";
+          return;
         }
       }
     }

--- a/src/meta/RootUserMan.h
+++ b/src/meta/RootUserMan.h
@@ -20,6 +20,27 @@ namespace meta {
  * */
 class RootUserMan {
  public:
+  static bool isGodExists(kvstore::KVStore* kv) {
+    auto rolePrefix = MetaKeyUtils::roleSpacePrefix(kDefaultSpaceId);
+    std::unique_ptr<kvstore::KVIterator> iter;
+    auto code = kv->prefix(kDefaultSpaceId, kDefaultPartId, rolePrefix, &iter, false);
+    if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
+      LOG(INFO) << "Prefix God Role Failed";
+      return false;
+    }
+    while (iter->valid()) {
+      auto val = iter->val();
+      auto type = *reinterpret_cast<const meta::cpp2::RoleType*>(val.begin());
+      if (type == meta::cpp2::RoleType::GOD) {
+        LOG(INFO) << "God user exists";
+        return true;
+      }
+      iter->next();
+    }
+    LOG(INFO) << "God user is not exists";
+    return false;
+  }
+
   static bool isUserExists(kvstore::KVStore* kv) {
     auto userKey = MetaKeyUtils::userKey("root");
     std::string val;

--- a/src/meta/RootUserMan.h
+++ b/src/meta/RootUserMan.h
@@ -20,13 +20,12 @@ namespace meta {
  * */
 class RootUserMan {
  public:
-  static bool isGodExists(kvstore::KVStore* kv) {
+  static ErrorOr<nebula::cpp2::ErrorCode, bool> isGodExists(kvstore::KVStore* kv) {
     auto rolePrefix = MetaKeyUtils::roleSpacePrefix(kDefaultSpaceId);
     std::unique_ptr<kvstore::KVIterator> iter;
     auto code = kv->prefix(kDefaultSpaceId, kDefaultPartId, rolePrefix, &iter, false);
     if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
-      LOG(INFO) << "Prefix God Role Failed";
-      return false;
+      return code;
     }
     while (iter->valid()) {
       auto val = iter->val();


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula-ent/issues/957

#### Description:
Before:
 it will check whether there is a root account，when meta is restarted

 After:
 it will check whether there is an account with the GOD role， when the meta is restarted

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
