### PR TITLE
fix_shortest_path_crash

### DIFF
--- a/src/graph/executor/algo/BatchShortestPath.cpp
+++ b/src/graph/executor/algo/BatchShortestPath.cpp
@@ -135,7 +135,7 @@ folly::Future<Status> BatchShortestPath::getNeighbors(size_t rowNum, size_t step
                      nullptr)
       .via(qctx_->rctx()->runner())
       .thenValue([this, rowNum, reverse, stepNum, getNbrTime](auto&& resp) {
-        addStats(resp, stats_, stepNum, getNbrTime.elapsedInUSec(), reverse);
+        addStats(resp, stepNum, getNbrTime.elapsedInUSec(), reverse);
         return buildPath(rowNum, std::move(resp), reverse);
       });
 }

--- a/src/graph/executor/algo/ShortestPathBase.h
+++ b/src/graph/executor/algo/ShortestPathBase.h
@@ -43,15 +43,9 @@ class ShortestPathBase {
 
   Status handleErrorCode(nebula::cpp2::ErrorCode code, PartitionID partId) const;
 
-  void addStats(RpcResponse& resp,
-                std::unordered_map<std::string, std::string>* stats,
-                size_t stepNum,
-                int64_t timeInUSec,
-                bool reverse) const;
+  void addStats(RpcResponse& resp, size_t stepNum, int64_t timeInUSec, bool reverse) const;
 
-  void addStats(PropRpcResponse& resp,
-                std::unordered_map<std::string, std::string>* stats,
-                int64_t timeInUSec) const;
+  void addStats(PropRpcResponse& resp, int64_t timeInUSec) const;
 
   template <typename Resp>
   StatusOr<Result::State> handleCompleteness(const storage::StorageRpcResponse<Resp>& rpcResp,
@@ -86,6 +80,7 @@ class ShortestPathBase {
   std::unordered_map<std::string, std::string>* stats_{nullptr};
   size_t maxStep_;
   bool singleShortest_{true};
+  folly::SpinLock statsLock_;
 
   std::vector<DataSet> resultDs_;
   std::vector<DataSet> leftVids_;

--- a/src/graph/executor/algo/SingleShortestPath.cpp
+++ b/src/graph/executor/algo/SingleShortestPath.cpp
@@ -108,7 +108,7 @@ folly::Future<Status> SingleShortestPath::getNeighbors(size_t rowNum,
                      nullptr)
       .via(qctx_->rctx()->runner())
       .thenValue([this, rowNum, stepNum, getNbrTime, reverse](auto&& resp) {
-        addStats(resp, stats_, stepNum, getNbrTime.elapsedInUSec(), reverse);
+        addStats(resp, stepNum, getNbrTime.elapsedInUSec(), reverse);
         return buildPath(rowNum, std::move(resp), reverse);
       });
 }
@@ -264,6 +264,9 @@ folly::Future<bool> SingleShortestPath::buildEvenPath(size_t rowNum,
       return false;
     }
     for (auto& meetVertex : vertices) {
+      if (!meetVertex.isVertex()) {
+        continue;
+      }
       auto meetVid = meetVertex.getVertex().vid;
       auto leftPaths = createLeftPath(rowNum, meetVid);
       auto rightPaths = createRightPath(rowNum, meetVid, false);


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:

Graph crash when running tck manually 
![image](https://user-images.githubusercontent.com/84560950/175452978-736ffd5c-464b-4c8a-8ae1-d7ff913028f5.png)
Can't be reproduced consistently.
Tck is run with 16 concurrent threads.

## How do you solve it?

 shared variables are locked before use in multi-threading environment


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
