### PR TITLE
Fixed crash on dropping fulltext index

### DIFF
--- a/src/graph/executor/admin/SpaceExecutor.cpp
+++ b/src/graph/executor/admin/SpaceExecutor.cpp
@@ -140,7 +140,7 @@ folly::Future<Status> DropSpaceExecutor::execute() {
             return Status::OK();
           }
           for (const auto &ftindex : ftIndexes) {
-            auto ftRet = FTIndexUtils::dropTSIndex(std::move(tsRet).value(), ftindex);
+            auto ftRet = FTIndexUtils::dropTSIndex(tsRet.value(), ftindex);
             if (!ftRet.ok()) {
               LOG(WARNING) << "Drop fulltext index `" << ftindex << "' failed: " << ftRet.status();
             }
@@ -195,7 +195,7 @@ folly::Future<Status> ClearSpaceExecutor::execute() {
             return Status::OK();
           }
           for (const auto &ftindex : ftIndexes) {
-            auto ftRet = FTIndexUtils::clearTSIndex(std::move(tsRet).value(), ftindex);
+            auto ftRet = FTIndexUtils::clearTSIndex(tsRet.value(), ftindex);
             if (!ftRet.ok()) {
               LOG(WARNING) << "Clear fulltext index `" << ftindex << "' failed: " << ftRet.status();
             }


### PR DESCRIPTION
Invoking `std::move(StatusOr<T>).value()` will STEAL the value from `StatusOr` into a temporary object, which will be destroyed shortly. 