### PR TITLE
Fix web service crash(issue:#4398)

### DIFF
--- a/src/webservice/SetFlagsHandler.cpp
+++ b/src/webservice/SetFlagsHandler.cpp
@@ -39,10 +39,15 @@ void SetFlagsHandler::onBody(std::unique_ptr<folly::IOBuf> body) noexcept {
 void SetFlagsHandler::onEOM() noexcept {
   folly::dynamic flags;
   try {
-    std::string body = body_->moveToFbString().toStdString();
-    flags = folly::parseJson(body);
-    if (flags.empty()) {
+    if (!body_) {
+      LOG(ERROR) << "Got an empty body";
       err_ = HttpCode::E_UNPROCESSABLE;
+    } else {
+      std::string body = body_->moveToFbString().toStdString();
+      flags = folly::parseJson(body);
+      if (flags.empty()) {
+        err_ = HttpCode::E_UNPROCESSABLE;
+      }
     }
   } catch (const std::exception &e) {
     LOG(ERROR) << "Fail to update flags: " << e.what();


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug

## What problem(s) does this PR solve?
#### Issue(s) number: #4398 

#### Description:

* when we use flags put interface, but we does not specify the body.
* The service will be crashed.
For example:
curl -X PUT xxx.xxx.xxx.xxxx:19559/flags


## How do you solve it?

Checking for body_, if we got nullptr, Ignore this request.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] N/A

Affects:
- [ ] N/A 


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug of service when we use put flags interface, but we does not specify body.
