### PR TITLE
Fix delete vertex or edge, the storage crashed.(issue: #4397)

### DIFF
--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -103,6 +103,14 @@ void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
 
       nebula::cpp2::ErrorCode err = nebula::cpp2::ErrorCode::SUCCEEDED;
       for (const auto& edgeKey : part.second) {
+        if (!NebulaKeyUtils::isValidVidLen(
+                spaceVidLen_, edgeKey.src_ref()->getStr(), edgeKey.dst_ref()->getStr())) {
+          LOG(ERROR) << "Space " << spaceId_ << " vertex length invalid, "
+                     << "space vid len: " << spaceVidLen_ << ", edge srcVid: " << *edgeKey.src_ref()
+                     << " dstVid: " << *edgeKey.dst_ref();
+          err = nebula::cpp2::ErrorCode::E_INVALID_VID;
+          break;
+        }
         auto l = std::make_tuple(spaceId_,
                                  partId,
                                  edgeKey.src_ref()->getStr(),

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -114,6 +114,12 @@ ErrorOr<nebula::cpp2::ErrorCode, std::string> DeleteVerticesProcessor::deleteVer
   target.reserve(vertices.size());
   std::unique_ptr<kvstore::BatchHolder> batchHolder = std::make_unique<kvstore::BatchHolder>();
   for (auto& vertex : vertices) {
+    if (!NebulaKeyUtils::isValidVidLen(spaceVidLen_, vertex.getStr())) {
+      LOG(ERROR) << "Space " << spaceId_ << ", vertex length invalid, "
+                 << " space vid len: " << spaceVidLen_ << ",  vid is " << vertex;
+      auto code = nebula::cpp2::ErrorCode::E_INVALID_VID;
+      return code;
+    }
     batchHolder->remove(NebulaKeyUtils::vertexKey(spaceVidLen_, partId, vertex.getStr()));
     auto prefix = NebulaKeyUtils::tagPrefix(spaceVidLen_, partId, vertex.getStr());
     std::unique_ptr<kvstore::KVIterator> iter;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug

## What problem(s) does this PR solve?
#### Issue(s) number: 4397

#### Description:

* When our space has tag index or edge index.
* When delete vertex or edge, we specify one vid more than our defined
  in space.
* The sotrage will be crashed.

## How do you solve it?

Solution:
1. Add vid valid verfication.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

## Checklist:
Tests:
- [ ] N/A

Affects:
- [ ] N/A


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed storaged crashed, when we delete vertex and edge specify vid more than our defined before in space.
