### PR TITLE
Fix ColumnExpression encode and decode are not matched

### DIFF
--- a/src/common/expression/ColumnExpression.cpp
+++ b/src/common/expression/ColumnExpression.cpp
@@ -38,7 +38,7 @@ void ColumnExpression::writeTo(Encoder &encoder) const {
 }
 
 void ColumnExpression::resetFrom(Decoder &decoder) {
-  index_ = decoder.readValue().getInt();
+  index_ = decoder.readSize();
 }
 
 }  // namespace nebula

--- a/src/common/expression/test/ColumnExpressionTest.cpp
+++ b/src/common/expression/test/ColumnExpressionTest.cpp
@@ -53,6 +53,25 @@ TEST_F(ExpressionTest, ColumnExpression) {
     auto eval = Expression::eval(expr, gExpCtxt);
     EXPECT_EQ(eval, 1);
   }
+  // test encode and decode
+  {
+    auto originExpr = ColumnExpression::make(&pool, 0);
+    auto str = Expression::encode(*originExpr);
+    auto decodeExpr = Expression::decode(&pool, str);
+    EXPECT_EQ(*decodeExpr, *originExpr);
+  }
+  {
+    auto originExpr = ColumnExpression::make(&pool, -1);
+    auto str = Expression::encode(*originExpr);
+    auto decodeExpr = Expression::decode(&pool, str);
+    EXPECT_EQ(*decodeExpr, *originExpr);
+  }
+  {
+    auto originExpr = ColumnExpression::make(&pool, 1);
+    auto str = Expression::encode(*originExpr);
+    auto decodeExpr = Expression::decode(&pool, str);
+    EXPECT_EQ(*decodeExpr, *originExpr);
+  }
 }
 
 }  // namespace nebula


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

[#4412](https://github.com/vesoft-inc/nebula/issues/4412)

#### Description:

## How do you solve it?

Let ColumnExpression writeTo encoder via `Value` instead of `size_t`

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
