### PR TITLE
fix deadlock

### DIFF
--- a/src/meta/processors/job/LeaderBalanceJobExecutor.cpp
+++ b/src/meta/processors/job/LeaderBalanceJobExecutor.cpp
@@ -44,7 +44,7 @@ ErrorOr<nebula::cpp2::ErrorCode, bool> LeaderBalanceJobExecutor::getHostParts(Gr
                                                                               bool dependentOnZone,
                                                                               HostParts& hostParts,
                                                                               int32_t& totalParts) {
-  folly::SharedMutex::ReadHolder holder(LockUtils::lock());
+  // has been locked ouside
   const auto& prefix = MetaKeyUtils::partPrefix(spaceId);
   std::unique_ptr<kvstore::KVIterator> iter;
   auto retCode = kvstore_->prefix(kDefaultSpaceId, kDefaultPartId, prefix, &iter);


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

There are two read lock in LeaderBalanceJobExecutor.cpp in same thread (grab the first one then another, first not released). Once a write lock happens between two read lock, deadlock would happen.

> btw, std::shared_lock won't happen, will dig more later

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [X] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [X] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
