### PR TITLE
[Enhancement] Add opt rule to push down `STARTS WITH` expr

### DIFF
--- a/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
+++ b/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
@@ -116,6 +116,10 @@ StatusOr<TransformResult> OptimizeTagIndexScanByFilterRule::transform(
   if (conditionType == ExprKind::kRelIn) {
     transformedExpr = graph::ExpressionUtils::rewriteInExpr(condition);
     DCHECK(transformedExpr->kind() == ExprKind::kRelEQ);
+  } else if (conditionType == ExprKind::kStartsWith) {
+    // StartsWith expr is converted to a RelAnd expr with a constant value
+    transformedExpr = graph::ExpressionUtils::rewriteStartsWithExpr(condition);
+    DCHECK(transformedExpr->kind() == ExprKind::kLogicalAnd);
   }
 
   // case2: logical AND expr

--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -248,6 +248,8 @@ Expression *ExpressionUtils::rewriteStartsWithExpr(const Expression *expr) {
   // Do not increment the last char of the string if it could cause overflow
   if (*rightBoundary.end() < 127) {
     rightBoundary[rightBoundary.size() - 1] = ++rightBoundary[rightBoundary.size() - 1];
+  } else {  // If the last char is already 127, append a char of minimum value to the string
+    rightBoundary += static_cast<char>(0);
   }
 
   auto resultLeft =

--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -242,13 +242,12 @@ Expression *ExpressionUtils::rewriteStartsWithExpr(const Expression *expr) {
 
   // rhs is a string value
   QueryExpressionContext ctx(nullptr);
-  auto leftBoundary = startsWithExpr->right()->eval(ctx).getStr();
-  auto rightBoundary = leftBoundary;
-  auto lastChar = *(rightBoundary.end() - 1);
+  auto rightBoundary = startsWithExpr->right()->eval(ctx).getStr();
 
+  // Increment the last char of the right boundary to get the range scan boundary
   // Do not increment the last char of the string if it could cause overflow
   if (*rightBoundary.end() < 127) {
-    rightBoundary[rightBoundary.size() - 1] = ++lastChar;
+    rightBoundary[rightBoundary.size() - 1] = ++rightBoundary[rightBoundary.size() - 1];
   }
 
   auto resultLeft =

--- a/src/graph/util/ExpressionUtils.h
+++ b/src/graph/util/ExpressionUtils.h
@@ -91,6 +91,9 @@ class ExpressionUtils {
   // Rewrites IN expression into OR expression or relEQ expression
   static Expression* rewriteInExpr(const Expression* expr);
 
+  // To support range scan for starts with
+  static Expression* rewriteStartsWithExpr(const Expression* expr);
+
   // Rewrite Logical AND expr that contains Logical OR expr to Logical OR expr using distributive
   // law
   // Examples:

--- a/src/graph/util/ExpressionUtils.h
+++ b/src/graph/util/ExpressionUtils.h
@@ -91,7 +91,7 @@ class ExpressionUtils {
   // Rewrites IN expression into OR expression or relEQ expression
   static Expression* rewriteInExpr(const Expression* expr);
 
-  // To support range scan for starts with
+  // Rewrites STARTS WITH to logical AND expression to support range scan
   static Expression* rewriteStartsWithExpr(const Expression* expr);
 
   // Rewrite Logical AND expr that contains Logical OR expr to Logical OR expr using distributive

--- a/tests/tck/features/lookup/TagIndexFullScan.feature
+++ b/tests/tck/features/lookup/TagIndexFullScan.feature
@@ -385,11 +385,10 @@ Feature: Lookup tag index full scan
       | "Timberwolves"  |
       | "Thunders"      |
     And the execution plan should be:
-      | id | name             | dependencies | operator info                                  |
-      | 3  | Project          | 2            |                                                |
-      | 2  | Filter           | 4            | {"condition": "(team.name STARTS WITH \"T\")"} |
-      | 4  | TagIndexFullScan | 0            |                                                |
-      | 0  | Start            |              |                                                |
+      | id | name              | dependencies | operator info |
+      | 3  | Project           | 4            |               |
+      | 4  | TagIndexRangeScan | 0            |               |
+      | 0  | Start             |              |               |
     When executing query:
       """
       LOOKUP ON team WHERE team.name STARTS WITH "ABC" YIELD id(vertex) as id


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
Rewrite `STARTS WITH` to `AND` expr and trigger  `TagIndexRangeScan` if an index is avaliable.

```
(root@nebula) [nba]> EXPLAIN  lookup on player where player.name starts with "Tim" YIELD player.name
Execution succeeded (time spent 1040/1368 us)

Execution Plan (optimize time 514 us)

-----+-------------------+--------------+----------------+--------------------------------
| id | name              | dependencies | profiling data | operator info                 |
-----+-------------------+--------------+----------------+--------------------------------
|  3 | Project           | 4            |                | outputVar: {                  |
|    |                   |              |                |   "colNames": [               |
|    |                   |              |                |     "player.name"             |
|    |                   |              |                |   ],                          |
|    |                   |              |                |   "type": "DATASET",          |
|    |                   |              |                |   "name": "__Project_3"       |
|    |                   |              |                | }                             |
|    |                   |              |                | inputVar: __Filter_2          |
|    |                   |              |                | columns: [                    |
|    |                   |              |                |   "player.name"               |
|    |                   |              |                | ]                             |
-----+-------------------+--------------+----------------+--------------------------------
|  4 | TagIndexRangeScan | 0            |                | outputVar: {                  |
|    |                   |              |                |   "colNames": [               |
|    |                   |              |                |     "_vid",                   |
|    |                   |              |                |     "player.name"             |
|    |                   |              |                |   ],                          |
|    |                   |              |                |   "name": "__Filter_2",       |
|    |                   |              |                |   "type": "DATASET"           |
|    |                   |              |                | }                             |
|    |                   |              |                | inputVar:                     |
|    |                   |              |                | space: 1                      |
|    |                   |              |                | dedup: false                  |
|    |                   |              |                | limit: 9223372036854775807    |
|    |                   |              |                | filter:                       |
|    |                   |              |                | orderBy: []                   |
|    |                   |              |                | schemaId: 2                   |
|    |                   |              |                | isEdge: false                 |
|    |                   |              |                | returnCols: [                 |
|    |                   |              |                |   "_vid",                     |
|    |                   |              |                |   "name"                      |
|    |                   |              |                | ]                             |
|    |                   |              |                | indexCtx: [                   |
|    |                   |              |                |   {                           |
|    |                   |              |                |     "columnHints": [          |
|    |                   |              |                |       {                       |
|    |                   |              |                |         "beginValue": "Tim",  |
|    |                   |              |                |         "includeEnd": false,  |
|    |                   |              |                |         "includeBegin": true, |
|    |                   |              |                |         "endValue": "Tin",    |
|    |                   |              |                |         "column": "name",     |
|    |                   |              |                |         "scanType": "RANGE"   |
|    |                   |              |                |       }                       |
|    |                   |              |                |     ],                        |
|    |                   |              |                |     "index_id": 8,            |
|    |                   |              |                |     "filter": ""              |
|    |                   |              |                |   }                           |
|    |                   |              |                | ]                             |
-----+-------------------+--------------+----------------+--------------------------------
|  0 | Start             |              |                | outputVar: {                  |
|    |                   |              |                |   "colNames": [],             |
|    |                   |              |                |   "name": "__Start_0",        |
|    |                   |              |                |   "type": "DATASET"           |
|    |                   |              |                | }                             |
-----+-------------------+--------------+----------------+--------------------------------

Fri, 15 Jul 2022 21:55:13 CST
```

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [x] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
