### PR TITLE
Fix unmatched insertion position in DataSet merge

### DIFF
--- a/src/common/datatypes/DataSet.h
+++ b/src/common/datatypes/DataSet.h
@@ -127,7 +127,7 @@ struct DataSet {
                     std::make_move_iterator(o.colNames.end()));
     for (std::size_t i = 0; i < rowSize(); ++i) {
       rows[i].values.reserve(newColSize);
-      rows[i].values.insert(rows[i].values.begin(),
+      rows[i].values.insert(rows[i].values.end(),
                             std::make_move_iterator(o.rows[i].values.begin()),
                             std::make_move_iterator(o.rows[i].values.end()));
     }

--- a/src/common/datatypes/test/DataSetTest.cpp
+++ b/src/common/datatypes/test/DataSetTest.cpp
@@ -25,6 +25,18 @@ TEST(DataSetTest, Basic) {
     data2.emplace_back(it);
   }
   EXPECT_EQ(data, data2);
+
+  nebula::DataSet data3({"col4", "col5"});
+  data3.emplace_back(nebula::Row({10, 20}));
+  data3.emplace_back(nebula::Row({40, 50}));
+  data3.emplace_back(nebula::Row({70, 80}));
+  data.merge(std::move(data3));
+
+  nebula::DataSet data4({"col1", "col2", "col3", "col4", "col5"});
+  data4.emplace_back(nebula::Row({1, 2, 3, 10, 20}));
+  data4.emplace_back(nebula::Row({4, 5, 6, 40, 50}));
+  data4.emplace_back(nebula::Row({7, 8, 9, 70, 80}));
+  EXPECT_EQ(data, data4);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

4435

#### Description:


## How do you solve it?

Let rowValues insert position keep consistent with colNames.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
