### PR TITLE
Could report error even if there is no task

### DIFF
--- a/src/meta/processors/job/BalanceJobExecutor.cpp
+++ b/src/meta/processors/job/BalanceJobExecutor.cpp
@@ -19,8 +19,8 @@ BalanceJobExecutor::BalanceJobExecutor(GraphSpaceID space,
                                        const std::vector<std::string>& paras)
     : MetaJobExecutor(space, jobId, kvstore, adminClient, paras) {}
 
-bool BalanceJobExecutor::check() {
-  return true;
+nebula::cpp2::ErrorCode BalanceJobExecutor::check() {
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
 nebula::cpp2::ErrorCode BalanceJobExecutor::prepare() {
@@ -67,8 +67,7 @@ nebula::cpp2::ErrorCode BalanceJobExecutor::recovery() {
     plan_.reset(nullptr);
     return recRet;
   }
-  plan_->saveInStore();
-  return nebula::cpp2::ErrorCode::SUCCEEDED;
+  return plan_->saveInStore();
 }
 
 nebula::cpp2::ErrorCode BalanceJobExecutor::finish(bool) {

--- a/src/meta/processors/job/BalanceJobExecutor.h
+++ b/src/meta/processors/job/BalanceJobExecutor.h
@@ -98,7 +98,7 @@ class BalanceJobExecutor : public MetaJobExecutor {
    *
    * @return
    */
-  bool check() override;
+  nebula::cpp2::ErrorCode check() override;
 
   /**
    * @brief See implementation in child class

--- a/src/meta/processors/job/DownloadJobExecutor.cpp
+++ b/src/meta/processors/job/DownloadJobExecutor.cpp
@@ -21,16 +21,16 @@ DownloadJobExecutor::DownloadJobExecutor(GraphSpaceID space,
   helper_ = std::make_unique<nebula::hdfs::HdfsCommandHelper>();
 }
 
-bool DownloadJobExecutor::check() {
+nebula::cpp2::ErrorCode DownloadJobExecutor::check() {
   if (paras_.size() != 1) {
-    return false;
+    return nebula::cpp2::ErrorCode::E_INVALID_JOB;
   }
 
   auto& url = paras_[0];
   std::string hdfsPrefix = "hdfs://";
   if (url.find(hdfsPrefix) != 0) {
     LOG(ERROR) << "URL should start with " << hdfsPrefix;
-    return false;
+    return nebula::cpp2::ErrorCode::E_INVALID_JOB;
   }
 
   auto u = url.substr(hdfsPrefix.size(), url.size());
@@ -44,20 +44,20 @@ bool DownloadJobExecutor::check() {
         port_ = folly::to<int32_t>(tokens[1].toString().substr(0, position).c_str());
       } catch (const std::exception& ex) {
         LOG(ERROR) << "URL's port parse failed: " << url;
-        return false;
+        return nebula::cpp2::ErrorCode::E_INVALID_JOB;
       }
       path_ =
           std::make_unique<std::string>(tokens[1].toString().substr(position, tokens[1].size()));
     } else {
       LOG(ERROR) << "URL Parse Failed: " << url;
-      return false;
+      return nebula::cpp2::ErrorCode::E_INVALID_JOB;
     }
   } else {
     LOG(ERROR) << "URL Parse Failed: " << url;
-    return false;
+    return nebula::cpp2::ErrorCode::E_INVALID_JOB;
   }
 
-  return true;
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
 nebula::cpp2::ErrorCode DownloadJobExecutor::prepare() {

--- a/src/meta/processors/job/DownloadJobExecutor.h
+++ b/src/meta/processors/job/DownloadJobExecutor.h
@@ -26,7 +26,7 @@ class DownloadJobExecutor : public SimpleConcurrentJobExecutor {
                       AdminClient* adminClient,
                       const std::vector<std::string>& params);
 
-  bool check() override;
+  nebula::cpp2::ErrorCode check() override;
 
   nebula::cpp2::ErrorCode prepare() override;
 

--- a/src/meta/processors/job/IngestJobExecutor.cpp
+++ b/src/meta/processors/job/IngestJobExecutor.cpp
@@ -18,8 +18,9 @@ IngestJobExecutor::IngestJobExecutor(GraphSpaceID space,
                                      const std::vector<std::string>& paras)
     : SimpleConcurrentJobExecutor(space, jobId, kvstore, adminClient, paras) {}
 
-bool IngestJobExecutor::check() {
-  return paras_.empty();
+nebula::cpp2::ErrorCode IngestJobExecutor::check() {
+  return paras_.empty() ? nebula::cpp2::ErrorCode::SUCCEEDED
+                        : nebula::cpp2::ErrorCode::E_INVALID_JOB;
 }
 
 nebula::cpp2::ErrorCode IngestJobExecutor::prepare() {
@@ -36,7 +37,7 @@ folly::Future<Status> IngestJobExecutor::executeInternal(HostAddr&& address,
                 taskId_++,
                 space_,
                 std::move(address),
-                taskParameters_,
+                {},
                 std::move(parts))
       .then([pro = std::move(pro)](auto&& t) mutable {
         CHECK(!t.hasException());

--- a/src/meta/processors/job/IngestJobExecutor.h
+++ b/src/meta/processors/job/IngestJobExecutor.h
@@ -23,15 +23,12 @@ class IngestJobExecutor : public SimpleConcurrentJobExecutor {
                     AdminClient* adminClient,
                     const std::vector<std::string>& params);
 
-  bool check() override;
+  nebula::cpp2::ErrorCode check() override;
 
   nebula::cpp2::ErrorCode prepare() override;
 
   folly::Future<Status> executeInternal(HostAddr&& address,
                                         std::vector<PartitionID>&& parts) override;
-
- private:
-  std::vector<std::string> taskParameters_;
 };
 
 }  // namespace meta

--- a/src/meta/processors/job/JobExecutor.h
+++ b/src/meta/processors/job/JobExecutor.h
@@ -27,7 +27,7 @@ class JobExecutor {
    *
    * @return
    */
-  virtual bool check() = 0;
+  virtual nebula::cpp2::ErrorCode check() = 0;
 
   /**
    * @brief Prepare the Job info from the arguments.

--- a/src/meta/processors/job/JobManager.h
+++ b/src/meta/processors/job/JobManager.h
@@ -162,10 +162,16 @@ class JobManager : public boost::noncopyable, public nebula::cpp::NonMovable {
    *
    * @param spaceId
    * @param jobId
-   * @param jobStatus
+   * @param jobStatus Will be one of the FINISHED, FAILED or STOPPED.
+   * @param jobErrorCode Will be specified when the job failed before any tasks executed, e.g. when
+   * check or prepare.
    * @return cpp2::ErrorCode if error when write to kv store
    */
-  nebula::cpp2::ErrorCode jobFinished(GraphSpaceID spaceId, JobID jobId, cpp2::JobStatus jobStatus);
+  nebula::cpp2::ErrorCode jobFinished(GraphSpaceID spaceId,
+                                      JobID jobId,
+                                      cpp2::JobStatus jobStatus,
+                                      std::optional<nebula::cpp2::ErrorCode> jobErrorCode =
+                                          std::optional<nebula::cpp2::ErrorCode>());
 
   /**
    * @brief Report task finished.
@@ -228,9 +234,9 @@ class JobManager : public boost::noncopyable, public nebula::cpp::NonMovable {
    *
    * @param jobDesc
    * @param op
-   * @return true if all task dispatched, else false.
+   * @return error code
    */
-  bool runJobInternal(const JobDescription& jobDesc, JbOp op);
+  nebula::cpp2::ErrorCode runJobInternal(const JobDescription& jobDesc, JbOp op);
 
   ErrorOr<nebula::cpp2::ErrorCode, GraphSpaceID> getSpaceId(const std::string& name);
 

--- a/src/meta/processors/job/MetaJobExecutor.cpp
+++ b/src/meta/processors/job/MetaJobExecutor.cpp
@@ -12,8 +12,8 @@ DECLARE_uint32(expired_time_factor);
 
 namespace nebula {
 namespace meta {
-bool MetaJobExecutor::check() {
-  return true;
+nebula::cpp2::ErrorCode MetaJobExecutor::check() {
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
 // Prepare the Job info from the arguments.

--- a/src/meta/processors/job/MetaJobExecutor.h
+++ b/src/meta/processors/job/MetaJobExecutor.h
@@ -35,7 +35,7 @@ class MetaJobExecutor : public JobExecutor {
    *
    * @return
    */
-  bool check() override;
+  nebula::cpp2::ErrorCode check() override;
 
   /**
    * @brief Prepare the Job info from the arguments.

--- a/src/meta/processors/job/SimpleConcurrentJobExecutor.cpp
+++ b/src/meta/processors/job/SimpleConcurrentJobExecutor.cpp
@@ -18,8 +18,9 @@ SimpleConcurrentJobExecutor::SimpleConcurrentJobExecutor(GraphSpaceID space,
                                                          const std::vector<std::string>& paras)
     : StorageJobExecutor(space, jobId, kvstore, adminClient, paras) {}
 
-bool SimpleConcurrentJobExecutor::check() {
-  return paras_.empty();
+nebula::cpp2::ErrorCode SimpleConcurrentJobExecutor::check() {
+  return paras_.empty() ? nebula::cpp2::ErrorCode::SUCCEEDED
+                        : nebula::cpp2::ErrorCode::E_INVALID_JOB;
 }
 
 nebula::cpp2::ErrorCode SimpleConcurrentJobExecutor::prepare() {

--- a/src/meta/processors/job/SimpleConcurrentJobExecutor.h
+++ b/src/meta/processors/job/SimpleConcurrentJobExecutor.h
@@ -20,7 +20,7 @@ class SimpleConcurrentJobExecutor : public StorageJobExecutor {
                               AdminClient* adminClient,
                               const std::vector<std::string>& params);
 
-  bool check() override;
+  nebula::cpp2::ErrorCode check() override;
 
   nebula::cpp2::ErrorCode prepare() override;
 

--- a/src/meta/processors/job/StatsJobExecutor.cpp
+++ b/src/meta/processors/job/StatsJobExecutor.cpp
@@ -12,8 +12,9 @@
 namespace nebula {
 namespace meta {
 
-bool StatsJobExecutor::check() {
-  return paras_.empty();
+nebula::cpp2::ErrorCode StatsJobExecutor::check() {
+  return paras_.empty() ? nebula::cpp2::ErrorCode::SUCCEEDED
+                        : nebula::cpp2::ErrorCode::E_INVALID_JOB;
 }
 
 nebula::cpp2::ErrorCode StatsJobExecutor::save(const std::string& key, const std::string& val) {

--- a/src/meta/processors/job/StatsJobExecutor.h
+++ b/src/meta/processors/job/StatsJobExecutor.h
@@ -24,7 +24,7 @@ class StatsJobExecutor : public StorageJobExecutor {
     toHost_ = TargetHosts::LEADER;
   }
 
-  bool check() override;
+  nebula::cpp2::ErrorCode check() override;
 
   nebula::cpp2::ErrorCode prepare() override;
 

--- a/src/meta/processors/job/StorageJobExecutor.h
+++ b/src/meta/processors/job/StorageJobExecutor.h
@@ -38,8 +38,8 @@ class StorageJobExecutor : public JobExecutor {
    *
    * @return
    */
-  bool check() override {
-    return true;
+  nebula::cpp2::ErrorCode check() override {
+    return nebula::cpp2::ErrorCode::SUCCEEDED;
   }
 
   /**

--- a/src/meta/test/GetStatsTest.cpp
+++ b/src/meta/test/GetStatsTest.cpp
@@ -187,7 +187,7 @@ TEST_F(GetStatsTest, StatsJob) {
   // Update stats data to finished or failed status in finish function of
   // runJobInternal.
   auto result = jobMgr->runJobInternal(statsJob, JobManager::JbOp::ADD);
-  ASSERT_TRUE(result);
+  ASSERT_EQ(result, nebula::cpp2::ErrorCode::SUCCEEDED);
   // JobManager does not set the job finished status in RunJobInternal function.
   // But set stats data.
   statsJob.setStatus(cpp2::JobStatus::FINISHED);
@@ -351,7 +351,7 @@ TEST_F(GetStatsTest, StatsJob) {
   copyData(kv_.get(), 0, 0, statsKey2, tempKey2);
   jobMgr->jobFinished(spaceId, statsJob2.getJobId(), cpp2::JobStatus::FINISHED);
 
-  ASSERT_TRUE(result2);
+  ASSERT_EQ(result2, nebula::cpp2::ErrorCode::SUCCEEDED);
   // JobManager does not set the job finished status in RunJobInternal function.
   // But set stats data.
   statsJob2.setStatus(cpp2::JobStatus::FINISHED);

--- a/src/meta/test/JobManagerTest.cpp
+++ b/src/meta/test/JobManagerTest.cpp
@@ -120,7 +120,7 @@ TEST_F(JobManagerTest, AddRebuildTagIndexJob) {
   auto rc = jobMgr->addJob(jobDesc, adminClient_.get());
   ASSERT_EQ(rc, nebula::cpp2::ErrorCode::SUCCEEDED);
   auto result = jobMgr->runJobInternal(jobDesc, JobManager::JbOp::ADD);
-  ASSERT_TRUE(result);
+  ASSERT_EQ(result, nebula::cpp2::ErrorCode::SUCCEEDED);
 }
 
 TEST_F(JobManagerTest, AddRebuildEdgeIndexJob) {
@@ -135,7 +135,7 @@ TEST_F(JobManagerTest, AddRebuildEdgeIndexJob) {
   auto rc = jobMgr->addJob(jobDesc, adminClient_.get());
   ASSERT_EQ(rc, nebula::cpp2::ErrorCode::SUCCEEDED);
   auto result = jobMgr->runJobInternal(jobDesc, JobManager::JbOp::ADD);
-  ASSERT_TRUE(result);
+  ASSERT_EQ(result, nebula::cpp2::ErrorCode::SUCCEEDED);
 }
 
 TEST_F(JobManagerTest, DownloadJob) {
@@ -157,7 +157,7 @@ TEST_F(JobManagerTest, DownloadJob) {
       space, job.getJobId(), kv.get(), &adminClient, job.getParas());
   executor->helper_ = std::make_unique<meta::MockHdfsOKHelper>();
 
-  ASSERT_TRUE(executor->check());
+  ASSERT_EQ(executor->check(), nebula::cpp2::ErrorCode::SUCCEEDED);
   auto code = executor->prepare();
   ASSERT_EQ(code, nebula::cpp2::ErrorCode::SUCCEEDED);
   code = executor->execute();
@@ -181,7 +181,7 @@ TEST_F(JobManagerTest, IngestJob) {
   auto executor = std::make_unique<IngestJobExecutor>(
       space, job.getJobId(), kv.get(), &adminClient, job.getParas());
 
-  ASSERT_TRUE(executor->check());
+  ASSERT_EQ(executor->check(), nebula::cpp2::ErrorCode::SUCCEEDED);
   auto code = executor->prepare();
   ASSERT_EQ(code, nebula::cpp2::ErrorCode::SUCCEEDED);
   code = executor->execute();
@@ -199,7 +199,7 @@ TEST_F(JobManagerTest, StatsJob) {
   auto rc = jobMgr->addJob(jobDesc, adminClient_.get());
   ASSERT_EQ(rc, nebula::cpp2::ErrorCode::SUCCEEDED);
   auto result = jobMgr->runJobInternal(jobDesc, JobManager::JbOp::ADD);
-  ASSERT_TRUE(result);
+  ASSERT_EQ(result, nebula::cpp2::ErrorCode::SUCCEEDED);
   // Function runJobInternal does not set the finished status of the job
   jobDesc.setStatus(cpp2::JobStatus::FINISHED);
   auto jobKey = MetaKeyUtils::jobKey(jobDesc.getSpace(), jobDesc.getJobId());


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
Follow up of #4442, if a job failed before generating job, the job error code will be SUCCEEDED, but status is FAILED, which is weird. For example, download from an illegal address, the error code is not consistent.

Before this PR:
![image](https://user-images.githubusercontent.com/13706157/179735227-296a0135-55c2-4bb3-a04b-68d98cbca5f3.png)

After this PR:
![image](https://user-images.githubusercontent.com/13706157/179735695-61db905c-ee74-4178-9e85-0f6bf78d4fe2.png)


## How do you solve it?
Use the error code when in JobExecutor::check/prepare.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
