### PR TITLE
Job manager related fix

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -918,6 +918,9 @@ Status MetaClient::handleResponse(const RESP& resp) {
       return Status::Error("Stop job failure!");
     case nebula::cpp2::ErrorCode::E_SAVE_JOB_FAILURE:
       return Status::Error("Save job failure!");
+    case nebula::cpp2::ErrorCode::E_JOB_NOT_STOPPABLE:
+      return Status::Error(
+          "Finished job or failed job can not be stopped, please start another job instead");
     case nebula::cpp2::ErrorCode::E_BALANCER_FAILURE:
       return Status::Error("Balance failure!");
     case nebula::cpp2::ErrorCode::E_NO_INVALID_BALANCE_PLAN:

--- a/src/graph/executor/admin/SubmitJobExecutor.cpp
+++ b/src/graph/executor/admin/SubmitJobExecutor.cpp
@@ -124,7 +124,7 @@ nebula::DataSet SubmitJobExecutor::buildShowResultData(
     uint32_t total = paras.size() - index - 1, succeeded = 0, failed = 0, inProgress = 0,
              invalid = 0;
     v.emplace_back(Row({jd.get_job_id(),
-                        apache::thrift::util::enumNameSafe(meta::cpp2::JobType::DATA_BALANCE),
+                        apache::thrift::util::enumNameSafe(meta::cpp2::JobType::ZONE_BALANCE),
                         apache::thrift::util::enumNameSafe(jd.get_status()),
                         convertJobTimestampToDateTime(jd.get_start_time()).toString(),
                         convertJobTimestampToDateTime(jd.get_stop_time()).toString(),

--- a/src/graph/executor/test/JobTest.cpp
+++ b/src/graph/executor/test/JobTest.cpp
@@ -36,7 +36,8 @@ TEST_F(JobTest, JobFinishTime) {
     auto status = submitJobExe->buildResult(meta::cpp2::JobOp::SHOW, std::move(resp));
     EXPECT_TRUE(status.ok());
     auto result = std::move(status).value();
-    EXPECT_EQ(result.rows.size(), 2);
+    // One line for job, one line for the task, one line for the count
+    EXPECT_EQ(result.rows.size(), 3);
     EXPECT_EQ(result.rows[0][3], Value(time::TimeConversion::unixSecondsToDateTime(123)));
     EXPECT_EQ(result.rows[0][4], Value::kEmpty);
     EXPECT_EQ(result.rows[1][3], Value(time::TimeConversion::unixSecondsToDateTime(456)));

--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -389,6 +389,7 @@ enum ErrorCode {
     E_TASK_REPORT_OUT_DATE            = -2049,  // Task report failed
     E_JOB_NOT_IN_SPACE                = -2050,  // The current task is not in the graph space
     E_JOB_NEED_RECOVER                = -2051,  // The current task needs to be resumed
+    E_JOB_NOT_STOPPABLE               = -2052,  // Failed or finished job could not be stopped
     E_INVALID_JOB                     = -2065,  // Invalid task
 
     // Backup Failure

--- a/src/meta/processors/job/DataBalanceJobExecutor.cpp
+++ b/src/meta/processors/job/DataBalanceJobExecutor.cpp
@@ -15,15 +15,15 @@
 namespace nebula {
 namespace meta {
 
-folly::Future<Status> DataBalanceJobExecutor::executeInternal() {
+folly::Future<nebula::cpp2::ErrorCode> DataBalanceJobExecutor::executeInternal() {
   if (plan_ == nullptr) {
     Status status = buildBalancePlan();
     if (status != Status::OK()) {
       if (status == Status::Balanced()) {
         executorOnFinished_(meta::cpp2::JobStatus::FINISHED);
-        return Status::OK();
+        return nebula::cpp2::ErrorCode::SUCCEEDED;
       }
-      return status;
+      return nebula::cpp2::ErrorCode::E_BALANCER_FAILURE;
     }
   }
   plan_->setFinishCallBack([this](meta::cpp2::JobStatus status) {
@@ -35,7 +35,7 @@ folly::Future<Status> DataBalanceJobExecutor::executeInternal() {
     executorOnFinished_(status);
   });
   plan_->invoke();
-  return Status::OK();
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
 Status DataBalanceJobExecutor::buildBalancePlan() {

--- a/src/meta/processors/job/DataBalanceJobExecutor.h
+++ b/src/meta/processors/job/DataBalanceJobExecutor.h
@@ -49,7 +49,7 @@ class DataBalanceJobExecutor : public BalanceJobExecutor {
    *
    * @return
    */
-  folly::Future<Status> executeInternal() override;
+  folly::Future<nebula::cpp2::ErrorCode> executeInternal() override;
 
   /**
    * @brief Build a balance plan, which balance data in each zone

--- a/src/meta/processors/job/JobManager.cpp
+++ b/src/meta/processors/job/JobManager.cpp
@@ -259,7 +259,7 @@ nebula::cpp2::ErrorCode JobManager::jobFinished(
 
   if (!optJobDesc.setStatus(jobStatus)) {
     // job already been set as finished, failed or stopped
-    return nebula::cpp2::ErrorCode::E_SAVE_JOB_FAILURE;
+    return nebula::cpp2::ErrorCode::E_JOB_NOT_STOPPABLE;
   }
 
   // If the job is marked as FAILED, one of the following will be triggered

--- a/src/meta/processors/job/LeaderBalanceJobExecutor.h
+++ b/src/meta/processors/job/LeaderBalanceJobExecutor.h
@@ -42,7 +42,7 @@ class LeaderBalanceJobExecutor : public MetaJobExecutor {
    *
    * @return
    */
-  folly::Future<Status> executeInternal() override;
+  folly::Future<nebula::cpp2::ErrorCode> executeInternal() override;
 
   /**
    * @brief Build a plan to balance leader

--- a/src/meta/processors/job/MetaJobExecutor.cpp
+++ b/src/meta/processors/job/MetaJobExecutor.cpp
@@ -24,14 +24,13 @@ nebula::cpp2::ErrorCode MetaJobExecutor::prepare() {
 // The skeleton to run the job.
 // You should rewrite the executeInternal to trigger the calling.
 nebula::cpp2::ErrorCode MetaJobExecutor::execute() {
-  folly::SemiFuture<Status> future = executeInternal();
-  auto rc = nebula::cpp2::ErrorCode::SUCCEEDED;
+  folly::SemiFuture<nebula::cpp2::ErrorCode> future = executeInternal();
   future.wait();
-  if (!future.value().ok()) {
-    LOG(INFO) << future.value().toString();
-    rc = nebula::cpp2::ErrorCode::E_ADD_JOB_FAILURE;
+  if (!future.hasValue()) {
+    LOG(INFO) << "Exception occur when execute job";
+    return nebula::cpp2::ErrorCode::E_JOB_NOT_FINISHED;
   }
-  return rc;
+  return future.value();
 }
 
 // Stop the job when the user cancel it.
@@ -60,8 +59,8 @@ nebula::cpp2::ErrorCode MetaJobExecutor::saveSpecialTaskStatus(const cpp2::Repor
   return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
-folly::Future<Status> MetaJobExecutor::executeInternal() {
-  return Status::OK();
+folly::Future<nebula::cpp2::ErrorCode> MetaJobExecutor::executeInternal() {
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
 }  // namespace meta

--- a/src/meta/processors/job/MetaJobExecutor.h
+++ b/src/meta/processors/job/MetaJobExecutor.h
@@ -71,7 +71,7 @@ class MetaJobExecutor : public JobExecutor {
   nebula::cpp2::ErrorCode saveSpecialTaskStatus(const cpp2::ReportTaskReq&) override;
 
  protected:
-  virtual folly::Future<Status> executeInternal();
+  virtual folly::Future<nebula::cpp2::ErrorCode> executeInternal();
 
  protected:
   JobID jobId_{INT_MIN};

--- a/src/meta/processors/job/ZoneBalanceJobExecutor.cpp
+++ b/src/meta/processors/job/ZoneBalanceJobExecutor.cpp
@@ -45,20 +45,20 @@ nebula::cpp2::ErrorCode ZoneBalanceJobExecutor::stop() {
   return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
-folly::Future<Status> ZoneBalanceJobExecutor::executeInternal() {
+folly::Future<nebula::cpp2::ErrorCode> ZoneBalanceJobExecutor::executeInternal() {
   if (plan_ == nullptr) {
     Status status = buildBalancePlan();
     if (status != Status::OK()) {
       if (status == Status::Balanced()) {
         executorOnFinished_(meta::cpp2::JobStatus::FINISHED);
-        return Status::OK();
+        return nebula::cpp2::ErrorCode::SUCCEEDED;
       }
-      return status;
+      return nebula::cpp2::ErrorCode::E_BALANCER_FAILURE;
     }
   }
   plan_->setFinishCallBack([this](meta::cpp2::JobStatus status) { executorOnFinished_(status); });
   plan_->invoke();
-  return Status::OK();
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
 }
 
 nebula::cpp2::ErrorCode ZoneBalanceJobExecutor::updateMeta() {

--- a/src/meta/processors/job/ZoneBalanceJobExecutor.h
+++ b/src/meta/processors/job/ZoneBalanceJobExecutor.h
@@ -33,7 +33,7 @@ class ZoneBalanceJobExecutor : public BalanceJobExecutor {
   nebula::cpp2::ErrorCode stop() override;
 
  protected:
-  folly::Future<Status> executeInternal() override;
+  folly::Future<nebula::cpp2::ErrorCode> executeInternal() override;
 
   /**
    * @brief

--- a/src/meta/test/BalancerTest.cpp
+++ b/src/meta/test/BalancerTest.cpp
@@ -779,7 +779,7 @@ TEST(BalanceTest, NormalZoneTest) {
     return nebula::cpp2::ErrorCode::SUCCEEDED;
   });
   auto ret = balancer.executeInternal();
-  EXPECT_EQ(Status::OK(), ret.value());
+  EXPECT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, ret.value());
   balancer.finish();
   balancer.lostZones_ = {"5", "6", "7", "8"};
   baton.reset();
@@ -789,7 +789,7 @@ TEST(BalanceTest, NormalZoneTest) {
   });
   ret = balancer.executeInternal();
   baton.wait();
-  EXPECT_EQ(Status::OK(), ret.value());
+  EXPECT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, ret.value());
   verifyBalanceTask(
       kv, balancer.jobId_, BalanceTaskStatus::END, BalanceTaskResult::SUCCEEDED, partCount, 12);
 }
@@ -811,7 +811,7 @@ TEST(BalanceTest, NormalDataTest) {
   DataBalanceJobExecutor balancer(jd, kv, &client, {});
   balancer.spaceInfo_.loadInfo(space, kv);
   auto ret = balancer.executeInternal();
-  EXPECT_EQ(Status::OK(), ret.value());
+  EXPECT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, ret.value());
   balancer.finish();
   balancer.lostHosts_ = {{"127.0.0.1", 1}, {"127.0.0.1", 8}};
   folly::Baton<true, std::atomic> baton;
@@ -821,7 +821,7 @@ TEST(BalanceTest, NormalDataTest) {
   });
   ret = balancer.executeInternal();
   baton.wait();
-  EXPECT_EQ(Status::OK(), ret.value());
+  EXPECT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, ret.value());
   verifyBalanceTask(
       kv, balancer.jobId_, BalanceTaskStatus::END, BalanceTaskResult::SUCCEEDED, partCount, 6);
 }
@@ -856,7 +856,7 @@ TEST(BalanceTest, RecoveryTest) {
   });
   auto ret = balancer.executeInternal();
   baton.wait();
-  EXPECT_EQ(Status::OK(), ret.value());
+  EXPECT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, ret.value());
   std::unordered_map<HostAddr, int32_t> partCount;
   verifyBalanceTask(kv,
                     balancer.jobId_,
@@ -923,7 +923,7 @@ TEST(BalanceTest, StopPlanTest) {
     return nebula::cpp2::ErrorCode::SUCCEEDED;
   });
   auto ret = balancer.executeInternal();
-  EXPECT_EQ(Status::OK(), ret.value());
+  EXPECT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, ret.value());
   auto stopRet = balancer.stop();
   EXPECT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, stopRet);
   baton.wait();
@@ -1241,7 +1241,7 @@ TEST(BalanceTest, LeaderBalanceTest) {
   LeaderBalanceJobExecutor balancer(
       space, testJobId.fetch_add(1, std::memory_order_relaxed), kv, &client, {});
   auto ret = balancer.executeInternal();
-  ASSERT_EQ(Status::OK(), ret.value());
+  EXPECT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, ret.value());
 }
 
 TEST(BalanceTest, LeaderBalanceWithZoneTest) {

--- a/tests/tck/job/Job.feature
+++ b/tests/tck/job/Job.feature
@@ -113,11 +113,12 @@ Feature: Submit job space requirements
       | Job Id(TaskId) | Command(Dest) | Status     | Start Time | Stop Time | Error Code  |
       | /\d+/          | "STATS"       | "FINISHED" | /\w+/      | /\w+/     | "SUCCEEDED" |
       | /\d+/          | /\w+/         | "FINISHED" | /\w+/      | /\w+/     | "SUCCEEDED" |
+      | /\w+/          | /\w+/         | /\w+/      | /\w+/      | ""        | ""          |
     When executing query, fill replace holders with element index of 0 in job_id:
       """
       STOP JOB {};
       """
-    Then an ExecutionError should be raised at runtime: Save job failure!
+    Then an ExecutionError should be raised at runtime: Finished job or failed job can not be stopped, please start another job instead
 
   Scenario: Submit and show jobs in other space
     Given create a space with following options:


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula/issues/4247
https://github.com/vesoft-inc/nebula/issues/4232 (Part of the issue is addressed in #4444)
https://github.com/vesoft-inc/nebula-ent/issues/1052

#### Description:
1. When stop job a failed/finished job, we will return "E_SAVE_JOB_FAILURE" , which is obscure, return another error code.
2. Balance leader/data's error code is not passed out.  And balance leader has no tasks, which is quite same as #4442

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
