### PR TITLE
datetime2timestamp and timestamp2datetime

### DIFF
--- a/src/common/function/FunctionManager.cpp
+++ b/src/common/function/FunctionManager.cpp
@@ -220,11 +220,13 @@ std::unordered_map<std::string, std::vector<TypeSignature>> FunctionManager::typ
     {"datetime",
      {TypeSignature({}, Value::Type::DATETIME),
       TypeSignature({Value::Type::STRING}, Value::Type::DATETIME),
-      TypeSignature({Value::Type::MAP}, Value::Type::DATETIME)}},
+      TypeSignature({Value::Type::MAP}, Value::Type::DATETIME),
+      TypeSignature({Value::Type::INT}, Value::Type::DATETIME)}},
     {"timestamp",
      {TypeSignature({}, Value::Type::INT),
       TypeSignature({Value::Type::STRING}, Value::Type::INT),
-      TypeSignature({Value::Type::INT}, Value::Type::INT)}},
+      TypeSignature({Value::Type::INT}, Value::Type::INT),
+      TypeSignature({Value::Type::DATETIME}, Value::Type::INT)}},
     {"tags",
      {
          TypeSignature({Value::Type::VERTEX}, Value::Type::LIST),
@@ -1754,6 +1756,8 @@ FunctionManager::FunctionManager() {
               return Value::kNullBadData;
             }
             return time::TimeUtils::dateTimeToUTC(result.value());
+          } else if (args[0].get().isInt()) {
+            return time::TimeConversion::unixSecondsToDateTime(args[0].get().getInt());
           } else {
             return Value::kNullBadData;
           }

--- a/src/common/function/test/FunctionManagerTest.cpp
+++ b/src/common/function/test/FunctionManagerTest.cpp
@@ -623,6 +623,10 @@ TEST_F(FunctionManagerTest, time) {
                   Value(time::TimeUtils::dateTimeToUTC(DateTime(2020, 9, 15, 20, 9, 15, 0))));
   }
   {
+    TEST_FUNCTION(
+        datetime, {0}, Value(time::TimeUtils::dateTimeToUTC(DateTime(1970, 1, 1, 0, 0, 0, 0))));
+  }
+  {
     TEST_FUNCTION(datetime,
                   {Map({{"year", 2020},
                         {"month", 9},
@@ -835,6 +839,12 @@ TEST_F(FunctionManagerTest, time) {
     TEST_FUNCTION(pi, args_["empty"], M_PI);
     TEST_FUNCTION(radians, args_["radians"], M_PI);
     TEST_FUNCTION(radians, args_["nullvalue"], Value::kNullBadType);
+  }
+  {
+    auto result = FunctionManager::get("datetime", kLiteralTimeParaNumber);
+    ASSERT_TRUE(result.ok());
+    auto datetime = std::move(result).value()(genArgsRef({"2020-10-10T10:00:00"}));
+    TEST_FUNCTION(timestamp, {datetime}, 1602324000);
   }
 }
 

--- a/src/common/time/TimeUtils.cpp
+++ b/src/common/time/TimeUtils.cpp
@@ -161,6 +161,8 @@ StatusOr<Value> TimeUtils::toTimestamp(const Value &val) {
     timestamp = time::TimeConversion::dateTimeToUnixSeconds(dateTime);
   } else if (val.isInt()) {
     timestamp = val.getInt();
+  } else if (val.isDateTime()) {
+    timestamp = time::TimeConversion::dateTimeToUnixSeconds(val.getDateTime());
   } else {
     return Status::Error("Incorrect timestamp type: `%s'", val.toString().c_str());
   }


### PR DESCRIPTION


## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number:  #4418

#### Description:

`timestamp` and `datetime` can be convert each other.
```
(root@nebula) [(none)]> return datetime(timestamp())
+----------------------------+
| datetime(timestamp())      |
+----------------------------+
| 2022-08-16T03:32:27.000000 |
+----------------------------+
Got 1 rows (time spent 1842/2836 us)

(root@nebula) [(none)]> return datetime(timestamp(0))
+----------------------------+
| datetime(timestamp(0))     |
+----------------------------+
| 1970-01-01T00:00:00.000000 |
+----------------------------+
Got 1 rows (time spent 1173/1822 us)

Tue, 16 Aug 2022 11:32:37 CST

(root@nebula) [(none)]> return timestamp(datetime())
+-----------------------+
| timestamp(datetime()) |
+-----------------------+
| 1660620772            |
+-----------------------+
Got 1 rows (time spent 1160/1962 us)

(root@nebula) [(none)]> return timestamp(datetime("2022-08-16"))
+-----------------------------------+
| timestamp(datetime("2022-08-16")) |
+-----------------------------------+
| 1660608000                        |
+-----------------------------------+
Got 1 rows (time spent 1292/1996 us)
```

## How do you solve it?
modified:   src/common/function/FunctionManager.cpp
modified:   src/common/function/test/FunctionManagerTest.cpp
modified:   src/common/time/TimeUtils.cpp

fixed `datetime` and `timestadamp` function.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:

