### PR TITLE
GetDstBySrc

### DIFF
--- a/src/common/datatypes/List.h
+++ b/src/common/datatypes/List.h
@@ -38,6 +38,13 @@ struct List {
     values.emplace_back(std::forward<T>(v));
   }
 
+  void append(List&& other) {
+    values.reserve(size() + other.size());
+    values.insert(values.end(),
+                  std::make_move_iterator(other.values.begin()),
+                  std::make_move_iterator(other.values.end()));
+  }
+
   void clear() {
     values.clear();
   }

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -235,6 +235,20 @@ struct GetNeighborsResponse {
  * End of GetNeighbors section
  */
 
+struct GetDstBySrcRequest {
+    1: common.GraphSpaceID                      space_id,
+    // list of srcId in each part
+    2: map<common.PartitionID, list<common.Value>>
+        (cpp.template = "std::unordered_map")   parts,
+    3: list<common.EdgeType>                    edge_types,
+    4: optional RequestCommon                   common,
+}
+
+struct GetDstBySrcResponse {
+    1: required ResponseCommon                  result,
+    2: optional list<common.Value>              dsts,
+}
+
 
 //
 // Response for data modification requests
@@ -661,7 +675,8 @@ struct KVRemoveRequest {
 }
 
 service GraphStorageService {
-    GetNeighborsResponse getNeighbors(1: GetNeighborsRequest req)
+    GetNeighborsResponse getNeighbors(1: GetNeighborsRequest req);
+    GetDstBySrcResponse getDstBySrc(1: GetDstBySrcRequest req);
 
     // Get vertex or edge properties
     GetPropResponse getProps(1: GetPropRequest req);

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -246,7 +246,8 @@ struct GetDstBySrcRequest {
 
 struct GetDstBySrcResponse {
     1: required ResponseCommon                  result,
-    2: optional list<common.Value>              dsts,
+    // Only one dst column, each row is a dst
+    2: optional common.DataSet                  dsts,
 }
 
 

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -40,6 +40,7 @@ nebula_add_library(
     mutate/UpdateVertexProcessor.cpp
     mutate/UpdateEdgeProcessor.cpp
     query/GetNeighborsProcessor.cpp
+    query/GetDstBySrcProcessor.cpp
     query/GetPropProcessor.cpp
     query/ScanVertexProcessor.cpp
     query/ScanEdgeProcessor.cpp

--- a/src/storage/GraphStorageServiceHandler.cpp
+++ b/src/storage/GraphStorageServiceHandler.cpp
@@ -16,6 +16,7 @@
 #include "storage/mutate/DeleteVerticesProcessor.h"
 #include "storage/mutate/UpdateEdgeProcessor.h"
 #include "storage/mutate/UpdateVertexProcessor.h"
+#include "storage/query/GetDstBySrcProcessor.h"
 #include "storage/query/GetNeighborsProcessor.h"
 #include "storage/query/GetPropProcessor.h"
 #include "storage/query/ScanEdgeProcessor.h"
@@ -57,6 +58,7 @@ GraphStorageServiceHandler::GraphStorageServiceHandler(StorageEnv* env) : env_(e
   kUpdateVertexCounters.init("update_vertex");
   kUpdateEdgeCounters.init("update_edge");
   kGetNeighborsCounters.init("get_neighbors");
+  kGetDstBySrcCounters.init("get_dst_by_src");
   kGetPropCounters.init("get_prop");
   kLookupCounters.init("lookup");
   kScanVertexCounters.init("scan_vertex");
@@ -121,6 +123,12 @@ folly::Future<cpp2::GetNeighborsResponse> GraphStorageServiceHandler::future_get
     const cpp2::GetNeighborsRequest& req) {
   auto* processor =
       GetNeighborsProcessor::instance(env_, &kGetNeighborsCounters, readerPool_.get());
+  RETURN_FUTURE(processor);
+}
+
+folly::Future<cpp2::GetDstBySrcResponse> GraphStorageServiceHandler::future_getDstBySrc(
+    const cpp2::GetDstBySrcRequest& req) {
+  auto* processor = GetDstBySrcProcessor::instance(env_, &kGetDstBySrcCounters, readerPool_.get());
   RETURN_FUTURE(processor);
 }
 

--- a/src/storage/GraphStorageServiceHandler.h
+++ b/src/storage/GraphStorageServiceHandler.h
@@ -45,6 +45,9 @@ class GraphStorageServiceHandler final : public cpp2::GraphStorageServiceSvIf {
   folly::Future<cpp2::GetNeighborsResponse> future_getNeighbors(
       const cpp2::GetNeighborsRequest& req) override;
 
+  folly::Future<cpp2::GetDstBySrcResponse> future_getDstBySrc(
+      const cpp2::GetDstBySrcRequest& req) override;
+
   folly::Future<cpp2::GetPropResponse> future_getProps(const cpp2::GetPropRequest& req) override;
 
   folly::Future<cpp2::LookupIndexResp> future_lookupIndex(

--- a/src/storage/exec/GetDstBySrcNode.h
+++ b/src/storage/exec/GetDstBySrcNode.h
@@ -18,7 +18,7 @@ class GetDstBySrcNode : public QueryNode<VertexID> {
   GetDstBySrcNode(RuntimeContext* context,
                   const std::vector<SingleEdgeNode*>& edgeNodes,
                   EdgeContext* edgeContext,
-                  nebula::List* result)
+                  nebula::DataSet* result)
       : context_(context), edgeNodes_(edgeNodes), edgeContext_(edgeContext), result_(result) {
     name_ = "GetDstBySrcNode";
   }
@@ -55,12 +55,14 @@ class GetDstBySrcNode : public QueryNode<VertexID> {
       auto props = context_->props_;
       DCHECK_EQ(props->size(), 1);
 
+      nebula::List list;
       // collect props need to return
       if (!QueryUtils::collectEdgeProps(
-               key, context_->vIdLen(), context_->isIntId(), reader, props, *result_)
+               key, context_->vIdLen(), context_->isIntId(), reader, props, list)
                .ok()) {
         return nebula::cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND;
       }
+      result_->rows.emplace_back(std::move(list));
     }
     return nebula::cpp2::ErrorCode::SUCCEEDED;
   }
@@ -83,7 +85,7 @@ class GetDstBySrcNode : public QueryNode<VertexID> {
   RuntimeContext* context_;
   std::vector<SingleEdgeNode*> edgeNodes_;
   EdgeContext* edgeContext_;
-  nebula::List* result_;
+  nebula::DataSet* result_;
   std::unique_ptr<MultiEdgeIterator> iter_;
 };
 

--- a/src/storage/exec/GetDstBySrcNode.h
+++ b/src/storage/exec/GetDstBySrcNode.h
@@ -1,0 +1,93 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+#ifndef STORAGE_EXEC_GETDSTBYSRCNODE_H_
+#define STORAGE_EXEC_GETDSTBYSRCNODE_H_
+
+#include "common/base/Base.h"
+
+namespace nebula {
+namespace storage {
+
+class GetDstBySrcNode : public QueryNode<VertexID> {
+ public:
+  using RelNode::doExecute;
+
+  GetDstBySrcNode(RuntimeContext* context,
+                  const std::vector<SingleEdgeNode*>& edgeNodes,
+                  EdgeContext* edgeContext,
+                  nebula::List* result)
+      : context_(context), edgeNodes_(edgeNodes), edgeContext_(edgeContext), result_(result) {
+    name_ = "GetDstBySrcNode";
+  }
+
+  // need to override doExecute because the return format of GetNeighborsNode and
+  // GetDstBySrcNode are different
+  nebula::cpp2::ErrorCode doExecute(PartitionID partId, const VertexID& vId) override {
+    auto ret = RelNode::doExecute(partId, vId);
+    if (ret != nebula::cpp2::ErrorCode::SUCCEEDED) {
+      return ret;
+    }
+
+    std::vector<SingleEdgeIterator*> iters;
+    for (auto* edgeNode : edgeNodes_) {
+      iters.emplace_back(edgeNode->iter());
+    }
+    iter_.reset(new MultiEdgeIterator(std::move(iters)));
+    if (iter_->valid()) {
+      setCurrentEdgeInfo(iter_->edgeType());
+    }
+    return iterateEdges();
+  }
+
+ private:
+  nebula::cpp2::ErrorCode iterateEdges() {
+    for (; iter_->valid(); iter_->next()) {
+      EdgeType type = iter_->edgeType();
+      if (type != context_->edgeType_) {
+        // update info when edgeType changes while iterating over different edge types
+        setCurrentEdgeInfo(type);
+      }
+      auto key = iter_->key();
+      auto reader = iter_->reader();
+      auto props = context_->props_;
+      DCHECK_EQ(props->size(), 1);
+
+      // collect props need to return
+      if (!QueryUtils::collectEdgeProps(
+               key, context_->vIdLen(), context_->isIntId(), reader, props, *result_)
+               .ok()) {
+        return nebula::cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND;
+      }
+    }
+    return nebula::cpp2::ErrorCode::SUCCEEDED;
+  }
+
+  void setCurrentEdgeInfo(EdgeType type) {
+    auto idxIter = edgeContext_->indexMap_.find(type);
+    CHECK(idxIter != edgeContext_->indexMap_.end());
+    auto schemaIter = edgeContext_->schemas_.find(std::abs(type));
+    CHECK(schemaIter != edgeContext_->schemas_.end());
+    CHECK(!schemaIter->second.empty());
+
+    context_->edgeSchema_ = schemaIter->second.back().get();
+    auto idx = idxIter->second;
+    context_->edgeType_ = type;
+    context_->edgeName_ = edgeNodes_[iter_->getIdx()]->getEdgeName();
+    context_->props_ = &(edgeContext_->propContexts_[idx].second);
+  }
+
+ private:
+  RuntimeContext* context_;
+  std::vector<SingleEdgeNode*> edgeNodes_;
+  EdgeContext* edgeContext_;
+  nebula::List* result_;
+  std::unique_ptr<MultiEdgeIterator> iter_;
+};
+
+}  // namespace storage
+}  // namespace nebula
+
+#endif  // STORAGE_EXEC_GETDSTBYSRCNODE_H_

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -148,6 +148,7 @@ class GetNeighborsSampleNode : public GetNeighborsNode {
                          int64_t limit)
       : GetNeighborsNode(context, hashJoinNode, upstream, edgeContext, resultDataSet, limit) {
     sampler_ = std::make_unique<nebula::algorithm::ReservoirSampling<Sample>>(limit);
+    name_ = "GetNeighborsSampleNode";
   }
 
  private:

--- a/src/storage/exec/HashJoinNode.h
+++ b/src/storage/exec/HashJoinNode.h
@@ -57,9 +57,6 @@ class HashJoinNode : public IterateNode<VertexID> {
 
     // add result of each tag node to tagResult
     for (auto* tagNode : tagNodes_) {
-      if (context_->isPlanKilled()) {
-        return nebula::cpp2::ErrorCode::E_PLAN_IS_KILLED;
-      }
       ret = tagNode->collectTagPropsIfValid(
           [&result](const std::vector<PropContext>*) -> nebula::cpp2::ErrorCode {
             result.values.emplace_back(Value());
@@ -93,9 +90,6 @@ class HashJoinNode : public IterateNode<VertexID> {
 
     std::vector<SingleEdgeIterator*> iters;
     for (auto* edgeNode : edgeNodes_) {
-      if (context_->isPlanKilled()) {
-        return nebula::cpp2::ErrorCode::E_PLAN_IS_KILLED;
-      }
       iters.emplace_back(edgeNode->iter());
     }
     iter_.reset(new MultiEdgeIterator(std::move(iters)));

--- a/src/storage/exec/MultiTagNode.h
+++ b/src/storage/exec/MultiTagNode.h
@@ -48,9 +48,6 @@ class MultiTagNode : public IterateNode<VertexID> {
 
     // add result of each tag node to tagResult
     for (auto* tagNode : tagNodes_) {
-      if (context_->isPlanKilled()) {
-        return nebula::cpp2::ErrorCode::E_PLAN_IS_KILLED;
-      }
       ret = tagNode->collectTagPropsIfValid(
           [&result](const std::vector<PropContext>*) -> nebula::cpp2::ErrorCode {
             result.values.emplace_back(Value());

--- a/src/storage/query/GetDstBySrcProcessor.cpp
+++ b/src/storage/query/GetDstBySrcProcessor.cpp
@@ -208,10 +208,15 @@ nebula::cpp2::ErrorCode GetDstBySrcProcessor::buildEdgeContext(
 }
 
 void GetDstBySrcProcessor::onProcessFinished() {
-  std::sort(result_.values.begin(), result_.values.end());
-  result_.values.erase(std::unique(result_.values.begin(), result_.values.end()),
-                       result_.values.end());
-  resp_.dsts_ref() = std::move(result_.values);
+  std::unordered_set<const Value*> unique;
+  for (const auto& val : result_.values) {
+    unique.emplace(&val);
+  }
+  std::vector<Value> deduped;
+  for (const auto& val : unique) {
+    deduped.emplace_back(*val);
+  }
+  resp_.dsts_ref() = std::move(deduped);
 }
 
 }  // namespace storage

--- a/src/storage/query/GetDstBySrcProcessor.cpp
+++ b/src/storage/query/GetDstBySrcProcessor.cpp
@@ -1,0 +1,218 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+#include "storage/query/GetDstBySrcProcessor.h"
+
+#include "storage/exec/EdgeNode.h"
+#include "storage/exec/GetDstBySrcNode.h"
+
+namespace nebula {
+namespace storage {
+
+ProcessorCounters kGetDstBySrcCounters;
+
+void GetDstBySrcProcessor::process(const cpp2::GetDstBySrcRequest& req) {
+  if (executor_ != nullptr) {
+    executor_->add([req, this]() { this->doProcess(req); });
+  } else {
+    doProcess(req);
+  }
+}
+
+void GetDstBySrcProcessor::doProcess(const cpp2::GetDstBySrcRequest& req) {
+  spaceId_ = req.get_space_id();
+  auto retCode = getSpaceVidLen(spaceId_);
+  if (retCode != nebula::cpp2::ErrorCode::SUCCEEDED) {
+    for (auto& p : req.get_parts()) {
+      pushResultCode(retCode, p.first);
+    }
+    onFinished();
+    return;
+  }
+  this->planContext_ = std::make_unique<PlanContext>(
+      this->env_, spaceId_, this->spaceVidLen_, this->isIntId_, req.common_ref());
+
+  // check edgetypes exists
+  retCode = checkAndBuildContexts(req);
+  if (retCode != nebula::cpp2::ErrorCode::SUCCEEDED) {
+    for (auto& p : req.get_parts()) {
+      pushResultCode(retCode, p.first);
+    }
+    onFinished();
+    return;
+  }
+
+  if (!FLAGS_query_concurrently) {
+    runInSingleThread(req);
+  } else {
+    runInMultipleThread(req);
+  }
+}
+
+void GetDstBySrcProcessor::runInSingleThread(const cpp2::GetDstBySrcRequest& req) {
+  contexts_.emplace_back(RuntimeContext(planContext_.get()));
+  auto plan = buildPlan(&contexts_.front(), &result_);
+  std::unordered_set<PartitionID> failedParts;
+  for (const auto& partEntry : req.get_parts()) {
+    auto partId = partEntry.first;
+    for (const auto& src : partEntry.second) {
+      auto vId = src.getStr();
+
+      if (!NebulaKeyUtils::isValidVidLen(spaceVidLen_, vId)) {
+        LOG(INFO) << "Space " << spaceId_ << ", vertex length invalid, "
+                  << " space vid len: " << spaceVidLen_ << ",  vid is " << vId;
+        pushResultCode(nebula::cpp2::ErrorCode::E_INVALID_VID, partId);
+        onFinished();
+        return;
+      }
+
+      // the first column of each row would be the vertex id
+      auto ret = plan.go(partId, vId);
+      if (ret != nebula::cpp2::ErrorCode::SUCCEEDED) {
+        if (failedParts.find(partId) == failedParts.end()) {
+          failedParts.emplace(partId);
+          handleErrorCode(ret, spaceId_, partId);
+        }
+      }
+    }
+  }
+  onProcessFinished();
+  onFinished();
+}
+
+void GetDstBySrcProcessor::runInMultipleThread(const cpp2::GetDstBySrcRequest& req) {
+  for (size_t i = 0; i < req.get_parts().size(); i++) {
+    partResults_.emplace_back(nebula::List());
+    contexts_.emplace_back(RuntimeContext(planContext_.get()));
+  }
+  size_t i = 0;
+  std::vector<folly::Future<std::pair<nebula::cpp2::ErrorCode, PartitionID>>> futures;
+  for (const auto& [partId, srcIds] : req.get_parts()) {
+    futures.emplace_back(runInExecutor(&contexts_[i], &partResults_[i], partId, srcIds));
+    i++;
+  }
+
+  folly::collectAll(futures).via(executor_).thenTry([this](auto&& t) mutable {
+    CHECK(!t.hasException());
+    const auto& tries = t.value();
+    for (size_t j = 0; j < tries.size(); j++) {
+      CHECK(!tries[j].hasException());
+      const auto& [code, partId] = tries[j].value();
+      if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
+        handleErrorCode(code, spaceId_, partId);
+      } else {
+        result_.append(std::move(partResults_[j]));
+      }
+    }
+    this->onProcessFinished();
+    this->onFinished();
+  });
+}
+
+folly::Future<std::pair<nebula::cpp2::ErrorCode, PartitionID>> GetDstBySrcProcessor::runInExecutor(
+    RuntimeContext* context,
+    nebula::List* result,
+    PartitionID partId,
+    const std::vector<Value>& srcIds) {
+  return folly::via(executor_, [this, context, result, partId, input = std::move(srcIds)]() {
+    auto plan = buildPlan(context, result);
+    for (const auto& src : input) {
+      auto vId = src.getStr();
+
+      if (!NebulaKeyUtils::isValidVidLen(spaceVidLen_, vId)) {
+        LOG(INFO) << "Space " << spaceId_ << ", vertex length invalid, "
+                  << " space vid len: " << spaceVidLen_ << ",  vid is " << vId;
+        return std::make_pair(nebula::cpp2::ErrorCode::E_INVALID_VID, partId);
+      }
+
+      // the first column of each row would be the vertex id
+      auto ret = plan.go(partId, vId);
+      if (ret != nebula::cpp2::ErrorCode::SUCCEEDED) {
+        return std::make_pair(ret, partId);
+      }
+    }
+    return std::make_pair(nebula::cpp2::ErrorCode::SUCCEEDED, partId);
+  });
+}
+
+StoragePlan<VertexID> GetDstBySrcProcessor::buildPlan(RuntimeContext* context,
+                                                      nebula::List* result) {
+  /*
+    The StoragePlan looks like this:
+        +------------------+
+        |  GetDstBySrcNode |
+        +--------+---------+
+                 |
+        +--------+---------+
+        |     EdgeNodes    |
+        +--------+---------+
+  */
+  StoragePlan<VertexID> plan;
+  std::vector<SingleEdgeNode*> edges;
+  for (const auto& ec : edgeContext_.propContexts_) {
+    auto edge = std::make_unique<SingleEdgeNode>(context, &edgeContext_, ec.first, &ec.second);
+    edges.emplace_back(edge.get());
+    plan.addNode(std::move(edge));
+  }
+
+  auto output = std::make_unique<GetDstBySrcNode>(context, edges, &edgeContext_, result);
+  for (auto* edge : edges) {
+    output->addDependency(edge);
+  }
+  plan.addNode(std::move(output));
+  return plan;
+}
+
+nebula::cpp2::ErrorCode GetDstBySrcProcessor::checkAndBuildContexts(
+    const cpp2::GetDstBySrcRequest& req) {
+  auto code = getSpaceEdgeSchema();
+  if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
+    return code;
+  }
+  code = buildEdgeContext(req);
+  if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
+    return code;
+  }
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
+}
+
+nebula::cpp2::ErrorCode GetDstBySrcProcessor::buildEdgeContext(
+    const cpp2::GetDstBySrcRequest& req) {
+  // Offset is not used in this processor, just set to a dummy value
+  static constexpr size_t kDstOffsetInRespDataSet = 0;
+  edgeContext_.offset_ = kDstOffsetInRespDataSet;
+  const auto& edgeTypes = req.get_edge_types();
+  for (const auto& edgeType : edgeTypes) {
+    auto iter = edgeContext_.schemas_.find(std::abs(edgeType));
+    if (iter == edgeContext_.schemas_.end()) {
+      VLOG(1) << "Can't find spaceId " << spaceId_ << " edgeType " << edgeType;
+      return nebula::cpp2::ErrorCode::E_EDGE_NOT_FOUND;
+    }
+    CHECK(!iter->second.empty());
+    auto edgeName = this->env_->schemaMan_->toEdgeName(spaceId_, std::abs(edgeType));
+    if (!edgeName.ok()) {
+      VLOG(1) << "Can't find spaceId " << spaceId_ << " edgeType " << edgeType;
+      return nebula::cpp2::ErrorCode::E_EDGE_NOT_FOUND;
+    }
+    std::vector<PropContext> ctxs;
+    // Only need to return dst of the edge
+    addReturnPropContext(ctxs, kDst, nullptr);
+    edgeContext_.propContexts_.emplace_back(edgeType, std::move(ctxs));
+    edgeContext_.indexMap_.emplace(edgeType, kDstOffsetInRespDataSet);
+    edgeContext_.edgeNames_.emplace(edgeType, std::move(edgeName).value());
+  }
+  buildEdgeTTLInfo();
+  return nebula::cpp2::ErrorCode::SUCCEEDED;
+}
+
+void GetDstBySrcProcessor::onProcessFinished() {
+  std::sort(result_.values.begin(), result_.values.end());
+  result_.values.erase(std::unique(result_.values.begin(), result_.values.end()),
+                       result_.values.end());
+  resp_.dsts_ref() = std::move(result_.values);
+}
+
+}  // namespace storage
+}  // namespace nebula

--- a/src/storage/query/GetDstBySrcProcessor.h
+++ b/src/storage/query/GetDstBySrcProcessor.h
@@ -1,0 +1,68 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+#ifndef STORAGE_QUERY_GETDSTBYSRCPROCESSOR_H_
+#define STORAGE_QUERY_GETDSTBYSRCPROCESSOR_H_
+
+#include "common/base/Base.h"
+#include "storage/BaseProcessor.h"
+#include "storage/exec/StoragePlan.h"
+
+namespace nebula {
+namespace storage {
+
+extern ProcessorCounters kGetDstBySrcCounters;
+
+class GetDstBySrcProcessor
+    : public QueryBaseProcessor<cpp2::GetDstBySrcRequest, cpp2::GetDstBySrcResponse> {
+ public:
+  static GetDstBySrcProcessor* instance(StorageEnv* env,
+                                        const ProcessorCounters* counters = &kGetDstBySrcCounters,
+                                        folly::Executor* executor = nullptr) {
+    return new GetDstBySrcProcessor(env, counters, executor);
+  }
+
+  void process(const cpp2::GetDstBySrcRequest& req) override;
+
+ protected:
+  GetDstBySrcProcessor(StorageEnv* env,
+                       const ProcessorCounters* counters,
+                       folly::Executor* executor)
+      : QueryBaseProcessor<cpp2::GetDstBySrcRequest, cpp2::GetDstBySrcResponse>(
+            env, counters, executor) {}
+
+  void onProcessFinished() override;
+
+  nebula::cpp2::ErrorCode checkAndBuildContexts(const cpp2::GetDstBySrcRequest& req) override;
+
+ private:
+  void doProcess(const cpp2::GetDstBySrcRequest& req);
+
+  nebula::cpp2::ErrorCode buildEdgeContext(const cpp2::GetDstBySrcRequest& req);
+
+  void runInSingleThread(const cpp2::GetDstBySrcRequest& req);
+
+  void runInMultipleThread(const cpp2::GetDstBySrcRequest& req);
+
+  folly::Future<std::pair<nebula::cpp2::ErrorCode, PartitionID>> runInExecutor(
+      RuntimeContext* context,
+      nebula::List* result,
+      PartitionID partId,
+      const std::vector<Value>& srcIds);
+
+  StoragePlan<VertexID> buildPlan(RuntimeContext* context, nebula::List* result);
+
+ private:
+  std::vector<RuntimeContext> contexts_;
+  // The response of GetDstBySrcProcessor is different from other processor derive from
+  // QeuryBaseProcessor, so we need to use define here
+  nebula::List result_;
+  // The process result of each part if run concurrently, then merge into result_ at last
+  std::vector<nebula::List> partResults_;
+};
+
+}  // namespace storage
+}  // namespace nebula
+#endif  // STORAGE_QUERY_GETDSTBYSRCPROCESSOR_H_

--- a/src/storage/query/GetDstBySrcProcessor.h
+++ b/src/storage/query/GetDstBySrcProcessor.h
@@ -48,19 +48,16 @@ class GetDstBySrcProcessor
 
   folly::Future<std::pair<nebula::cpp2::ErrorCode, PartitionID>> runInExecutor(
       RuntimeContext* context,
-      nebula::List* result,
+      nebula::DataSet* result,
       PartitionID partId,
       const std::vector<Value>& srcIds);
 
-  StoragePlan<VertexID> buildPlan(RuntimeContext* context, nebula::List* result);
+  StoragePlan<VertexID> buildPlan(RuntimeContext* context, nebula::DataSet* result);
 
  private:
   std::vector<RuntimeContext> contexts_;
-  // The response of GetDstBySrcProcessor is different from other processor derive from
-  // QeuryBaseProcessor, so we need to use define here
-  nebula::List result_;
-  // The process result of each part if run concurrently, then merge into result_ at last
-  std::vector<nebula::List> partResults_;
+  // The process result of each part if run concurrently, then merge into resultDataSet_ at last
+  std::vector<nebula::DataSet> partResults_;
 };
 
 }  // namespace storage

--- a/src/storage/test/CMakeLists.txt
+++ b/src/storage/test/CMakeLists.txt
@@ -309,7 +309,6 @@ nebula_add_test(
         gtest
 )
 
-
 nebula_add_executable(
     NAME
         get_neighbors_bm
@@ -332,6 +331,21 @@ nebula_add_executable(
         scan_edge_prop_bm
     SOURCES
         ScanEdgePropBenchmark.cpp
+    OBJECTS
+        ${storage_test_deps}
+    LIBRARIES
+        ${ROCKSDB_LIBRARIES}
+        ${THRIFT_LIBRARIES}
+        ${PROXYGEN_LIBRARIES}
+        wangle
+        gtest
+)
+
+nebula_add_test(
+    NAME
+        get_dst_by_src_test
+    SOURCES
+        GetDstBySrcTest.cpp
     OBJECTS
         ${storage_test_deps}
     LIBRARIES

--- a/src/storage/test/GetDstBySrcTest.cpp
+++ b/src/storage/test/GetDstBySrcTest.cpp
@@ -56,10 +56,16 @@ class GetDstBySrcTest : public ::testing::Test {
     return req;
   }
 
-  void checkResponse(std::vector<Value>& actual, std::vector<VertexID>& expect) {
-    std::vector<Value> expected(expect.begin(), expect.end());
-    std::sort(actual.begin(), actual.end());
-    std::sort(expected.begin(), expected.end());
+  void checkResponse(nebula::DataSet& actual, std::vector<VertexID>& dsts) {
+    // sort to make sure the return order are same
+    std::sort(actual.rows.begin(), actual.rows.end());
+    nebula::DataSet expected({"_dst"});
+    for (const auto& dst : dsts) {
+      List list;
+      list.emplace_back(dst);
+      expected.emplace_back(std::move(list));
+    }
+    std::sort(expected.rows.begin(), expected.rows.end());
     EXPECT_EQ(actual, expected);
   }
 

--- a/src/storage/test/GetDstBySrcTest.cpp
+++ b/src/storage/test/GetDstBySrcTest.cpp
@@ -1,0 +1,243 @@
+/* Copyright (c) 2022 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "common/base/Base.h"
+#include "common/fs/TempDir.h"
+#include "storage/query/GetDstBySrcProcessor.h"
+#include "storage/test/QueryTestUtils.h"
+
+namespace nebula {
+namespace storage {
+
+class GetDstBySrcTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    fs::TempDir rootPath("/tmp/GetDstBySrcTest.XXXXXX");
+    cluster_.reset(new mock::MockCluster());
+    cluster_->initStorageKV(rootPath.path());
+    env_ = cluster_->storageEnv_.get();
+    totalParts_ = cluster_->getTotalParts();
+    threadPool_ = std::make_shared<folly::IOThreadPoolExecutor>(4);
+    ASSERT_EQ(true, QueryTestUtils::mockEdgeData(env_, totalParts_));
+  }
+
+  void TearDown() override {}
+
+ protected:
+  void verify(const std::vector<VertexID>& vertices,
+              const std::vector<EdgeType>& edges,
+              std::vector<VertexID>& expect) {
+    auto req = buildRequest(vertices, edges);
+    auto* processor = GetDstBySrcProcessor::instance(env_, nullptr, threadPool_.get());
+    auto fut = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(fut).get();
+    ASSERT_EQ(0, (*resp.result_ref()).failed_parts.size());
+    checkResponse(*resp.dsts_ref(), expect);
+  }
+
+ private:
+  cpp2::GetDstBySrcRequest buildRequest(const std::vector<VertexID>& vertices,
+                                        const std::vector<EdgeType>& edges) {
+    std::hash<std::string> hash;
+    cpp2::GetDstBySrcRequest req;
+    req.space_id_ref() = 1;
+    for (const auto& vertex : vertices) {
+      PartitionID partId = (hash(vertex) % totalParts_) + 1;
+      (*req.parts_ref())[partId].emplace_back(vertex);
+    }
+    for (const auto& edge : edges) {
+      req.edge_types_ref()->emplace_back(edge);
+    }
+    return req;
+  }
+
+  void checkResponse(std::vector<Value>& actual, std::vector<VertexID>& expect) {
+    std::vector<Value> expected(expect.begin(), expect.end());
+    std::sort(actual.begin(), actual.end());
+    std::sort(expected.begin(), expected.end());
+    EXPECT_EQ(actual, expected);
+  }
+
+ private:
+  std::unique_ptr<mock::MockCluster> cluster_;
+  StorageEnv* env_;
+  int32_t totalParts_;
+  std::shared_ptr<folly::IOThreadPoolExecutor> threadPool_;
+};
+
+TEST_F(GetDstBySrcTest, BasicTest) {
+  EdgeType serve = 101;
+  EdgeType teammate = 102;
+
+  {
+    LOG(INFO) << "OneSrcOneOutEdgeType";
+    std::vector<VertexID> vertices{"Tim Duncan"};
+    std::vector<EdgeType> edges{serve};
+    std::vector<VertexID> expect{"Spurs"};
+    verify(vertices, edges, expect);
+  }
+  {
+    LOG(INFO) << "OneSrcOneInEdgeType";
+    std::vector<VertexID> vertices{"Rockets"};
+    std::vector<EdgeType> edges{-serve};
+    std::vector<VertexID> expect{"Tracy McGrady",
+                                 "Russell Westbrook",
+                                 "James Harden",
+                                 "Chris Paul",
+                                 "Carmelo Anthony",
+                                 "Yao Ming",
+                                 "Dwight Howard"};
+    verify(vertices, edges, expect);
+  }
+  {
+    LOG(INFO) << "OneSrcMultipleOutEdgeType";
+    std::vector<VertexID> vertices = {"Tim Duncan"};
+    std::vector<EdgeType> edges{serve, teammate};
+    std::vector<VertexID> expect{"Spurs", "Tony Parker", "Manu Ginobili"};
+    verify(vertices, edges, expect);
+  }
+  {
+    LOG(INFO) << "OneSrcInOutEdgeType";
+    std::vector<VertexID> vertices = {"Tim Duncan"};
+    std::vector<EdgeType> edges{serve, -teammate};
+    std::vector<VertexID> expect{"Spurs", "Tony Parker", "Manu Ginobili"};
+    verify(vertices, edges, expect);
+  }
+  {
+    LOG(INFO) << "OneSrcInOutEdgeType";
+    std::vector<VertexID> vertices = {"Tim Duncan"};
+    std::vector<EdgeType> edges{serve, teammate, -teammate};
+    std::vector<VertexID> expect{"Spurs", "Tony Parker", "Manu Ginobili"};
+    verify(vertices, edges, expect);
+  }
+  {
+    LOG(INFO) << "MultipleSrcOneOutEdgeType";
+    std::vector<VertexID> vertices = {"Tim Duncan", "Manu Ginobili"};
+    std::vector<EdgeType> edges{serve};
+    // The output has been deduped, so only one Spurs
+    std::vector<VertexID> expect{"Spurs"};
+    verify(vertices, edges, expect);
+  }
+  {
+    LOG(INFO) << "MultipleSrcMultipleOutEdgeType";
+    std::vector<VertexID> vertices = {"Tim Duncan", "Tony Parker", "Manu Ginobili", "Kobe Bryant"};
+    std::vector<EdgeType> edges{serve, teammate};
+    std::vector<VertexID> expect{"Spurs",
+                                 "Lakers",
+                                 "Hornets",
+                                 "Tim Duncan",
+                                 "Tony Parker",
+                                 "Manu Ginobili",
+                                 "Shaquille O'Neal"};
+    verify(vertices, edges, expect);
+  }
+  {
+    LOG(INFO) << "MultipleSrcInOutEdgeType";
+    std::vector<VertexID> vertices = {"Tim Duncan", "Rockets"};
+    std::vector<EdgeType> edges{serve, -serve, teammate, -teammate};
+    std::vector<VertexID> expect{"Spurs",
+                                 "Tony Parker",
+                                 "Manu Ginobili",
+                                 "Tracy McGrady",
+                                 "Russell Westbrook",
+                                 "James Harden",
+                                 "Chris Paul",
+                                 "Carmelo Anthony",
+                                 "Yao Ming",
+                                 "Dwight Howard"};
+    verify(vertices, edges, expect);
+  }
+}
+
+class GetDstBySrcConcurrentTest : public GetDstBySrcTest {
+ public:
+  void SetUp() override {
+    FLAGS_query_concurrently = true;
+    GetDstBySrcTest::SetUp();
+  }
+
+  void TearDown() override {
+    FLAGS_query_concurrently = false;
+  }
+};
+
+TEST_F(GetDstBySrcConcurrentTest, ConcurrentTest) {
+  EdgeType serve = 101;
+  {
+    std::vector<VertexID> vertices = {"Spurs", "Rockets"};
+    std::vector<EdgeType> edges{-serve};
+    // clang-format off
+    std::vector<VertexID> expect{
+        "Aron Baynes", "Boris Diaw", "Cory Joseph", "Danny Green", "David West",
+        "Dejounte Murray", "Jonathon Simmons", "Kyle Anderson", "LaMarcus Aldridge",
+        "Manu Ginobili", "Marco Belinelli", "Pau Gasol", "Rudy Gay", "Tiago Splitter",
+        "Tim Duncan", "Tony Parker", "Tracy McGrady", "Russell Westbrook", "James Harden",
+        "Chris Paul", "Carmelo Anthony", "Yao Ming", "Dwight Howard"};
+    // clang-format on
+    verify(vertices, edges, expect);
+  }
+}
+
+class GetDstBySrcTTLTest : public GetDstBySrcTest {
+ public:
+  void SetUp() override {
+    FLAGS_mock_ttl_col = true;
+    GetDstBySrcTest::SetUp();
+  }
+
+  void TearDown() override {
+    FLAGS_mock_ttl_col = false;
+  }
+};
+
+TEST_F(GetDstBySrcTTLTest, TTLTest) {
+  EdgeType serve = 101;
+  LOG(INFO) << "Read data when data valid";
+  {
+    std::vector<VertexID> vertices{"Tim Duncan"};
+    std::vector<EdgeType> edges{serve};
+    std::vector<VertexID> expect{"Spurs"};
+    verify(vertices, edges, expect);
+  }
+  {
+    std::vector<VertexID> vertices{"Rockets"};
+    std::vector<EdgeType> edges{-serve};
+    std::vector<VertexID> expect{"Tracy McGrady",
+                                 "Russell Westbrook",
+                                 "James Harden",
+                                 "Chris Paul",
+                                 "Carmelo Anthony",
+                                 "Yao Ming",
+                                 "Dwight Howard"};
+    verify(vertices, edges, expect);
+  }
+  sleep(FLAGS_mock_ttl_duration + 1);
+  LOG(INFO) << "Read data when data expired";
+  {
+    std::vector<VertexID> vertices{"Tim Duncan"};
+    std::vector<EdgeType> edges{serve};
+    std::vector<VertexID> expect{};
+    verify(vertices, edges, expect);
+  }
+  {
+    std::vector<VertexID> vertices{"Rockets"};
+    std::vector<EdgeType> edges{-serve};
+    std::vector<VertexID> expect{};
+    verify(vertices, edges, expect);
+  }
+}
+
+}  // namespace storage
+}  // namespace nebula
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, true);
+  google::SetStderrLogging(google::INFO);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [X] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Subtask of #4525

#### Description:
Add a new rpc interface called GetDstBySrc, the difference between it and GetNeighbors is that it **only** return dst of the edge in each row (even the srcId is not returned), see the interface in storage.thrift for details. And the dst has been deduped before returned to graphd to minimize memory cost.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
