### PR TITLE
fix invalid filter in GetProp make storage crashed

### DIFF
--- a/src/storage/exec/QueryUtils.h
+++ b/src/storage/exec/QueryUtils.h
@@ -73,6 +73,9 @@ class QueryUtils final {
 
       if (nullType == NullType::UNKNOWN_PROP) {
         VLOG(1) << "Fail to read prop " << propName;
+        if (!field) {
+          return value;
+        }
         if (field->hasDefault()) {
           DefaultValueContext expCtx;
           ObjectPool pool;


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

https://github.com/vesoft-inc/nebula-ent/issues/1165
#4565 

#### Description:

Invalid filter will make storage crash, this only happens in enterprise version with additional filter push down rule.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
