### PR TITLE
unify pushed down filter behavior

### DIFF
--- a/src/storage/context/StorageExpressionContext.cpp
+++ b/src/storage/context/StorageExpressionContext.cpp
@@ -18,7 +18,8 @@ Value StorageExpressionContext::readValue(const std::string& propName) const {
     return Value::kNullValue;
   }
 
-  auto ret = QueryUtils::readValue(reader_, propName, schema_);
+  auto field = schema_->field(propName);
+  auto ret = QueryUtils::readValue(reader_, propName, field);
   if (!ret.ok()) {
     return Value::kNullValue;
   }

--- a/src/storage/exec/QueryUtils.h
+++ b/src/storage/exec/QueryUtils.h
@@ -100,25 +100,6 @@ class QueryUtils final {
     return value;
   }
 
-  /**
-   * @brief read prop value, If the RowReader contains this field, read from the rowreader,
-   * otherwise read the default value or null value from the latest schema
-   *
-   * @param reader
-   * @param propName
-   * @param schema
-   * @return StatusOr<nebula::Value>
-   */
-  static StatusOr<nebula::Value> readValue(RowReader* reader,
-                                           const std::string& propName,
-                                           const meta::NebulaSchemaProvider* schema) {
-    auto field = schema->field(propName);
-    if (!field) {
-      return Status::Error(folly::stringPrintf("Fail to read prop %s ", propName.c_str()));
-    }
-    return readValue(reader, propName, field);
-  }
-
   static StatusOr<nebula::Value> readEdgeProp(folly::StringPiece key,
                                               size_t vIdLen,
                                               bool isIntId,

--- a/src/storage/exec/UpdateNode.h
+++ b/src/storage/exec/UpdateNode.h
@@ -353,7 +353,9 @@ class UpdateTagNode : public UpdateNode<VertexID> {
       // read prop value, If the RowReader contains this field,
       // read from the rowreader, otherwise read the default value
       // or null value from the latest schema
-      auto retVal = QueryUtils::readValue(reader_, propName, schema_);
+      auto field = schema_->field(propName);
+      DCHECK_NOTNULL(field);
+      auto retVal = QueryUtils::readValue(reader_, propName, field);
       if (!retVal.ok()) {
         VLOG(1) << "Bad value for tag: " << tagId_ << ", prop " << propName;
         return nebula::cpp2::ErrorCode::E_TAG_PROP_NOT_FOUND;
@@ -705,7 +707,9 @@ class UpdateEdgeNode : public UpdateNode<cpp2::EdgeKey> {
       // Read prop value, If the RowReader contains this field,
       // read from the rowreader, otherwise read the default value
       // or null value from the latest schema
-      auto retVal = QueryUtils::readValue(reader_, propName, schema_);
+      auto field = schema_->field(propName);
+      DCHECK_NOTNULL(field);
+      auto retVal = QueryUtils::readValue(reader_, propName, field);
       if (!retVal.ok()) {
         VLOG(1) << "Bad value for edge: " << edgeType_ << ", prop " << propName;
         return nebula::cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND;

--- a/src/storage/query/QueryBaseProcessor.h
+++ b/src/storage/query/QueryBaseProcessor.h
@@ -182,8 +182,7 @@ class QueryBaseProcessor : public BaseProcessor<RESP> {
   nebula::cpp2::ErrorCode checkExp(const Expression* exp,
                                    bool returned,
                                    bool filtered,
-                                   bool updated = false,
-                                   bool allowNoexistentProp = false);
+                                   bool updated = false);
 
   void addReturnPropContext(std::vector<PropContext>& ctxs,
                             const char* propName,


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula/issues/4565

#### Description:

Follow-up of #4568, the actual problem arises from #4270, if a filter contains an invalid property, it bypass property check because openCypher regard property not existed as null. However, when storage try to read it in `QueryUtils::readValue`, it does not check whether the field exists. (Before #4270, all field must exists)

## How do you solve it?
#4568 has check the filed existence in `QueryUtils::readValue`, just remove the property existence check in `checkExp`, and the redundant `readValue` is removed to unify usage.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
