### PR TITLE
Better error msg for validity check of geography

### DIFF
--- a/src/common/datatypes/Geography.h
+++ b/src/common/datatypes/Geography.h
@@ -52,7 +52,9 @@ struct Coordinate {
   Coordinate(double lng, double lat) : x(lng), y(lat) {}
 
   void normalize();
-  bool isValid() const;
+  Status isValid() const;
+
+  std::string toString() const;
 
   void clear() {
     x = 0.0;
@@ -87,7 +89,7 @@ struct Point {
   explicit Point(Coordinate&& v) : coord(std::move(v)) {}
 
   void normalize();
-  bool isValid() const;
+  Status isValid() const;
 
   void clear() {
     coord.clear();
@@ -116,7 +118,7 @@ struct LineString {
   }
 
   void normalize();
-  bool isValid() const;
+  Status isValid() const;
 
   void clear() {
     coordList.clear();
@@ -145,7 +147,7 @@ struct Polygon {
   }
 
   void normalize();
-  bool isValid() const;
+  Status isValid() const;
 
   void clear() {
     coordListList.clear();
@@ -193,7 +195,7 @@ struct Geography {
   Polygon& mutablePolygon();
 
   void normalize();
-  bool isValid() const;
+  Status isValid() const;
 
   Point centroid() const;
 

--- a/src/common/function/FunctionManager.cpp
+++ b/src/common/function/FunctionManager.cpp
@@ -2511,7 +2511,8 @@ FunctionManager::FunctionManager() {
       if (!args[0].get().isGeography()) {
         return Value::kNullBadType;
       }
-      return args[0].get().getGeography().isValid();
+      auto status = args[0].get().getGeography().isValid();
+      return status.ok() ? true : false;
     };
   }
   // geo predicates

--- a/src/common/function/FunctionManager.cpp
+++ b/src/common/function/FunctionManager.cpp
@@ -2512,7 +2512,10 @@ FunctionManager::FunctionManager() {
         return Value::kNullBadType;
       }
       auto status = args[0].get().getGeography().isValid();
-      return status.ok() ? true : false;
+      if (!status.ok()) {
+        LOG(ERROR) << "ST_IsValid error: " << status;
+      }
+      return status.ok();
     };
   }
   // geo predicates

--- a/src/common/geo/io/wkb/test/WKBTest.cpp
+++ b/src/common/geo/io/wkb/test/WKBTest.cpp
@@ -41,25 +41,25 @@ TEST_F(WKBTest, TestWKB) {
     Point v(Coordinate(24.7, 36.842));
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(true, v.isValid());
+    EXPECT_EQ(true, v.isValid().ok());
   }
   {
     Point v(Coordinate(-179, 36.842));
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(true, v.isValid());
+    EXPECT_EQ(true, v.isValid().ok());
   }
   {
     Point v(Coordinate(24.7, 36.842));
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(true, v.isValid());
+    EXPECT_EQ(true, v.isValid().ok());
   }
   {
     Point v(Coordinate(298.4, 499.99));
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(false, v.isValid());
+    EXPECT_EQ(false, v.isValid().ok());
   }
   {
     Point v(Coordinate(24.7, 36.842));
@@ -75,32 +75,32 @@ TEST_F(WKBTest, TestWKB) {
         Coordinate(0, 1), Coordinate(1, 2), Coordinate(2, 3), Coordinate(3, 4)});
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(true, v.isValid());
+    EXPECT_EQ(true, v.isValid().ok());
   }
   {
     LineString v(std::vector<Coordinate>{Coordinate(26.4, 78.9), Coordinate(138.725, 91.0)});
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(false, v.isValid());
+    EXPECT_EQ(false, v.isValid().ok());
   }
   {
     LineString v(std::vector<Coordinate>{Coordinate(0, 1), Coordinate(2, 3), Coordinate(0, 1)});
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(true, v.isValid());
+    EXPECT_EQ(true, v.isValid().ok());
   }
   {
     LineString v(std::vector<Coordinate>{Coordinate(0, 1), Coordinate(0, 1)});
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(false, v.isValid());
+    EXPECT_EQ(false, v.isValid().ok());
   }
   // LineString must have at least 2 points
   {
     LineString v(std::vector<Coordinate>{Coordinate(0, 1)});
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(false, v.isValid());
+    EXPECT_EQ(false, v.isValid().ok());
   }
   {
     LineString v(std::vector<Coordinate>{Coordinate(26.4, 78.9), Coordinate(138.725, 91.0)});
@@ -124,7 +124,7 @@ TEST_F(WKBTest, TestWKB) {
         Coordinate(0, 1), Coordinate(1, 2), Coordinate(2, 3), Coordinate(0, 1)}});
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(true, v.isValid());
+    EXPECT_EQ(true, v.isValid().ok());
   }
   {
     Polygon v(std::vector<std::vector<Coordinate>>{
@@ -137,7 +137,7 @@ TEST_F(WKBTest, TestWKB) {
                                 Coordinate(4, 5)}});
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(true, v.isValid());
+    EXPECT_EQ(true, v.isValid().ok());
   }
   // The loop is not closed
   {
@@ -145,7 +145,7 @@ TEST_F(WKBTest, TestWKB) {
         Coordinate(0, 1), Coordinate(1, 2), Coordinate(2, 3), Coordinate(3, 4)}});
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(false, v.isValid());
+    EXPECT_EQ(false, v.isValid().ok());
   }
   // Loop must have at least 4 points
   {
@@ -153,7 +153,7 @@ TEST_F(WKBTest, TestWKB) {
         std::vector<Coordinate>{Coordinate(0, 1), Coordinate(1, 2), Coordinate(0, 1)}});
     auto result = read(v);
     ASSERT_TRUE(result.ok()) << result.status();
-    EXPECT_EQ(false, v.isValid());
+    EXPECT_EQ(false, v.isValid().ok());
   }
   {
     Polygon v(std::vector<std::vector<Coordinate>>{std::vector<Coordinate>{

--- a/src/common/geo/test/GeoFunctionTest.cpp
+++ b/src/common/geo/test/GeoFunctionTest.cpp
@@ -1054,22 +1054,22 @@ TEST(s2CellIdFromPoint, polygon) {
 TEST(isValid, point) {
   {
     auto point = Geography::fromWKT("POINT(1.0 1.0)").value();
-    bool b = point.isValid();
+    bool b = point.isValid().ok();
     EXPECT_EQ(true, b);
   }
   {
     auto point = Geography::fromWKT("POINT(181.0 1.0)").value();
-    bool b = point.isValid();
+    bool b = point.isValid().ok();
     EXPECT_EQ(false, b);
   }
   {
     auto point = Geography::fromWKT("POINT(1.0 91.0)").value();
-    bool b = point.isValid();
+    bool b = point.isValid().ok();
     EXPECT_EQ(false, b);
   }
   {
     auto point = Geography::fromWKT("POINT(-181.0 -91.0)").value();
-    bool b = point.isValid();
+    bool b = point.isValid().ok();
     EXPECT_EQ(false, b);
   }
 }
@@ -1077,32 +1077,32 @@ TEST(isValid, point) {
 TEST(isValid, lineString) {
   {
     auto line = Geography::fromWKT("LINESTRING(1.0 1.0, 2.0 2.0)").value();
-    bool b = line.isValid();
+    bool b = line.isValid().ok();
     EXPECT_EQ(true, b);
   }
   {
     auto line = Geography::fromWKT("LINESTRING(1 1, 2 3, 4 8, -6 3)").value();
-    bool b = line.isValid();
+    bool b = line.isValid().ok();
     EXPECT_EQ(true, b);
   }
   {
     auto line = Geography::fromWKT("LINESTRING(1.0 1.0)").value();
-    bool b = line.isValid();
+    bool b = line.isValid().ok();
     EXPECT_EQ(false, b);
   }
   {
     auto line = Geography::fromWKT("LINESTRING(1.0 1.0, 1.0 1.0)").value();
-    bool b = line.isValid();
+    bool b = line.isValid().ok();
     EXPECT_EQ(false, b);
   }
   {
     auto line = Geography::fromWKT("LINESTRING(1.0 1.0, 181.0 2.0)").value();
-    bool b = line.isValid();
+    bool b = line.isValid().ok();
     EXPECT_EQ(false, b);
   }
   {
     auto line = Geography::fromWKT("LINESTRING(1.0 1.0, 1.0 90.001)").value();
-    bool b = line.isValid();
+    bool b = line.isValid().ok();
     EXPECT_EQ(false, b);
   }
 }
@@ -1110,12 +1110,12 @@ TEST(isValid, lineString) {
 TEST(isValid, polygon) {
   {
     auto polygon = Geography::fromWKT("POLYGON((1.0 1.0, 2.0 2.0, 0.0 2.0, 1.0 1.0))").value();
-    bool b = polygon.isValid();
+    bool b = polygon.isValid().ok();
     EXPECT_EQ(true, b);
   }
   {
     auto polygon = Geography::fromWKT("POLYGON((-20 -20, -20 20, 20 20, 20 -20, -20 -20))").value();
-    bool b = polygon.isValid();
+    bool b = polygon.isValid().ok();
     EXPECT_EQ(true, b);
   }
   {
@@ -1123,7 +1123,7 @@ TEST(isValid, polygon) {
         Geography::fromWKT(
             "POLYGON((-20 -20, -20 20, 20 20, 20 -20, -20 -20), (10 0, 0 10, 0 -10, 10 0))")
             .value();
-    bool b = polygon.isValid();
+    bool b = polygon.isValid().ok();
     EXPECT_EQ(true, b);
   }
   {
@@ -1131,7 +1131,7 @@ TEST(isValid, polygon) {
                        "POLYGON((-20 -20, -20 20, 20 20, 20 -20, -20 -20), (10 0, 0 10, 0 -10, 10 "
                        "0), (-10 0, 0 10, -5 -10, -10 0))")
                        .value();
-    bool b = polygon.isValid();
+    bool b = polygon.isValid().ok();
     EXPECT_EQ(true, b);
   }
   {
@@ -1139,17 +1139,17 @@ TEST(isValid, polygon) {
                        "POLYGON((-20 -20, -20 20, 20 20, 20 -20, -20 -20), (1.0 1.0, 2.0 2.0, 0.0 "
                        "2.0, 1.0 1.0))")
                        .value();
-    bool b = polygon.isValid();
+    bool b = polygon.isValid().ok();
     EXPECT_EQ(true, b);
   }
   {
     auto polygon = Geography::fromWKT("POLYGON((1.0 1.0, 2.0 2.0, 0.0 2.0))").value();
-    bool b = polygon.isValid();
+    bool b = polygon.isValid().ok();
     EXPECT_EQ(false, b);
   }
   {
     auto polygon = Geography::fromWKT("POLYGON((1.0 1.0, 2.0 2.0, 0.0 2.0, 1.2 1.2))").value();
-    bool b = polygon.isValid();
+    bool b = polygon.isValid().ok();
     EXPECT_EQ(false, b);
   }
   // The first loop doesn't contain the second loop
@@ -1159,18 +1159,18 @@ TEST(isValid, polygon) {
   //                      "
   //                      "-20, -20 -20))")
   //                      .value();
-  //   bool b = polygon.isValid();
+  //   bool b = polygon.isValid().ok();
   //   EXPECT_EQ(false, b);  // Expect false, got true
   // }
   {
     auto polygon =
         Geography::fromWKT("POLYGON((1.0 1.0, -180.0001 2.0, 0.0 2.0, 1.0 1.0))").value();
-    bool b = polygon.isValid();
+    bool b = polygon.isValid().ok();
     EXPECT_EQ(false, b);
   }
   {
     auto polygon = Geography::fromWKT("POLYGON((1.0 1.0, 2.0 2.0, 0.0 -90.001, 1.0 1.0))").value();
-    bool b = polygon.isValid();
+    bool b = polygon.isValid().ok();
     EXPECT_EQ(false, b);
   }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
When geography dataum is found to be illegal, print the specific cause of the error to facilitate troubleshooting.
eg.
```
E20220902 03:24:24.550307 350836 FunctionManager.cpp:2440] ST_GeogFromText error: The geography LINESTRING(0 1, 2 3) built from wkt LINESTRING(0 1, 2 3) is invalid, error: FindValidationError, S2 Errorcode: 1, message: Vertex 0 is not unit length
```

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
