### PR TITLE
Fix 1212

### DIFF
--- a/src/graph/visitor/FoldConstantExprVisitor.cpp
+++ b/src/graph/visitor/FoldConstantExprVisitor.cpp
@@ -349,7 +349,7 @@ void FoldConstantExprVisitor::visitBinaryExpr(BinaryExpression *expr) {
 
 Expression *FoldConstantExprVisitor::fold(Expression *expr) {
   // Container expression should remain the same type after being folded
-  if (expr->isContainerExpr()) {
+  if (expr->isContainerExpr() || !status_.ok()) {
     return expr;
   }
 

--- a/tests/tck/features/expression/NotIn.feature
+++ b/tests/tck/features/expression/NotIn.feature
@@ -51,6 +51,27 @@ Feature: Not In Expression
       | r     |
       | false |
 
+  Scenario: Match Not In Set
+    Given a graph with space named "nba"
+    When executing query:
+      """
+      match p0 =  (n0)<-[e0:`like`|`teammate`|`teammate`]->(n1)
+      where id(n0) == "Suns"
+      and  not (e0.like.likeness in  [e0.teammate.end_year, ( e0.teammate.start_year ) ] )
+      or  not (( "" ) not ends with ( ""  +  ""  +  "" ))
+      and ("" not in ( ""  +  ""  +  ""  +  "" ))
+      or (e0.teammate.start_year > ( e0.teammate.end_year ))
+      and (( ( ( e0.like.likeness ) ) ) / e0.teammate.start_year >
+      e0.teammate.start_year)
+      or (e0.like.likeness*e0.teammate.start_year%e0.teammate.end_year+
+      ( ( e0.teammate.start_year ) ) > e0.teammate.end_year)
+      or (( ( ( ( e0.teammate.end_year ) ) ) ) in  [9.8978784E7 ] )
+      return e0.like.likeness, e0.teammate.start_year, e0.teammate.start_year,
+      e0.teammate.end_year, e0.teammate.end_year
+      limit 91
+      """
+    Then a SemanticError should be raised at runtime: Type error `("" NOT IN "")'
+
   Scenario: Using NOT IN list in GO
     Given a graph with space named "nba"
     When executing query:


### PR DESCRIPTION
…due to found syantax errors.

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula-ent/issues/1212

#### Description:
When some expression has a wrong syntax, it is merged with others and fed into further evaluation, hitting a LOG(FATAL).

## How do you solve it?
Stop further folding expressions and return in FoldConstantExprVisitor::fold(), if status_ is already set to an error state.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A
- [X] tck 

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Fixing a crash bug caused by evaluating an expression with wrong a syntax.
