### PR TITLE
Add meta offline detect

### DIFF
--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -216,6 +216,14 @@ class Host final : public std::enable_shared_from_this<Host> {
    */
   void setResponse(const cpp2::AppendLogResponse& resp);
 
+  void setLastHeartbeatTime(int64_t time) {
+    lastHeartbeatTime_ = time;
+  }
+
+  int64_t getLastHeartbeatTime() const {
+    return lastHeartbeatTime_;
+  }
+
   /**
    * @brief If there are more logs to send, build the append log request
    *
@@ -262,6 +270,9 @@ class Host final : public std::enable_shared_from_this<Host> {
 
   // CommittedLogId of follower
   LogID followerCommittedLogId_{0};
+
+  // last HB response time from the peer
+  int64_t lastHeartbeatTime_{0};
 };
 
 }  // namespace raftex

--- a/src/kvstore/raftex/RaftPart.h
+++ b/src/kvstore/raftex/RaftPart.h
@@ -377,6 +377,8 @@ class RaftPart : public std::enable_shared_from_this<RaftPart> {
    */
   std::vector<HostAddr> peers() const;
 
+  bool checkAlive(const HostAddr& host);
+
   /**
    * @brief All listeners address
    *


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

issue from ent version https://github.com/vesoft-inc/nebula-ent/issues/1153

#### Description:

Metad status is not checked now and hardcoded in show meta hosts.

## How do you solve it?

When leader of space0 part0 receive heartbeat response, record the last time. Check it when show command is called.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
