### PR TITLE
Add tck execution with retry

### DIFF
--- a/tests/tck/conftest.py
+++ b/tests/tck/conftest.py
@@ -405,6 +405,21 @@ def executing_query(query, exec_ctx, request):
     ngql = combine_query(query)
     exec_query(request, ngql, exec_ctx)
 
+@when(parse("executing query and retrying it on failure every {secs:d} seconds for {retryTimes:d} times:\n{query}"))
+def executing_query_with_retry(query, exec_ctx, request, secs, retryTimes):
+    ngql = combine_query(query)
+    exec_query(request, ngql, exec_ctx)
+    res = exec_ctx["result_set"]
+    if not res.is_succeeded():
+      retryCounter = 0
+      while retryCounter < retryTimes:
+        time.sleep(secs)
+        exec_query(request, ngql, exec_ctx)
+        resRetry = exec_ctx["result_set"]
+        if not resRetry.is_succeeded():
+          retryCounter = retryCounter + 1
+        else:
+          break
 
 @when(parse("executing query with user {username} with password {password}:\n{query}"))
 def executing_query(

--- a/tests/tck/features/delete/DeleteVertexWithoutEdge.feature
+++ b/tests/tck/features/delete/DeleteVertexWithoutEdge.feature
@@ -17,7 +17,7 @@ Feature: delete vertex without edge
       CREATE EDGE e();
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 9 times:
       """
       INSERT VERTEX t(id) VALUES 1:(1),2:(2),3:(3);
       INSERT EDGE e() VALUES 1->2:(),1->3:();
@@ -74,7 +74,7 @@ Feature: delete vertex without edge
       CREATE EDGE e();
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX t(id) VALUES 1:(1),2:(2),3:(2);
       INSERT EDGE e() VALUES 1->2:(),1->3:();

--- a/tests/tck/features/geo/GeoBase.feature
+++ b/tests/tck/features/geo/GeoBase.feature
@@ -93,7 +93,7 @@ Feature: Geo base
       """
     Then the execution should be successful
     And wait 3 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX test_1() VALUES "test_101":()
       """
@@ -245,7 +245,7 @@ Feature: Geo base
     Then the execution should be successful
     And wait 3 seconds
     # Show create tag index
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       SHOW CREATE TAG INDEX any_shape_geo_index;
       """
@@ -741,7 +741,7 @@ Feature: Geo base
       """
     Then the execution should be successful
     And wait 3 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       LOOKUP ON any_shape YIELD id(vertex) as id;
       """
@@ -753,7 +753,7 @@ Feature: Geo base
       """
     Then the execution should be successful
     And wait 3 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       LOOKUP ON any_shape_edge YIELD edge as e;
       """

--- a/tests/tck/features/index/Index.feature
+++ b/tests/tck/features/index/Index.feature
@@ -839,7 +839,7 @@ Feature: IndexTest_Vid_String
       CREATE EDGE INDEX name_edge_index ON name_edge(name(10));
       """
     Then the execution should be successful
-    And wait 6 seconds
+    And wait 12 seconds
     When submit a job:
       """
       REBUILD EDGE INDEX;
@@ -1000,7 +1000,7 @@ Feature: IndexTest_Vid_String
       CREATE TAG student(name string, age int);
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX
         student(name, age)
@@ -1021,7 +1021,7 @@ Feature: IndexTest_Vid_String
       """
     Then the execution should be successful
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       CREATE TAG INDEX student_name_teacher ON student(name(10), teacher(10))
       """

--- a/tests/tck/features/insert/insertVertexOnly.feature
+++ b/tests/tck/features/insert/insertVertexOnly.feature
@@ -16,7 +16,7 @@ Feature: insert vertex without tag
       CREATE EDGE e();
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX VALUES 1:(),2:(),3:();
       INSERT EDGE e() VALUES 1->2:(),2->3:();

--- a/tests/tck/features/lookup/LookUp.feature
+++ b/tests/tck/features/lookup/LookUp.feature
@@ -19,7 +19,7 @@ Feature: LookUpTest_Vid_String
       CREATE TAG INDEX t_index_5 ON lookup_tag_2(col4);
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX
         lookup_tag_1(col1, col2, col3)
@@ -55,7 +55,7 @@ Feature: LookUpTest_Vid_String
       CREATE EDGE INDEX e_index_4 ON lookup_edge_2(col3, col4);
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT EDGE
         lookup_edge_1(col1, col2, col3)
@@ -94,7 +94,7 @@ Feature: LookUpTest_Vid_String
       CREATE TAG INDEX t_index_5 ON lookup_tag_2(col4);
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX
         lookup_tag_2(col1, col2, col3, col4)
@@ -244,7 +244,7 @@ Feature: LookUpTest_Vid_String
       CREATE EDGE INDEX e_index_4 ON lookup_edge_2(col3, col4);
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT EDGE
         lookup_edge_2(col1, col2, col3, col4)
@@ -389,7 +389,7 @@ Feature: LookUpTest_Vid_String
       CREATE TAG INDEX t_index_5 ON lookup_tag_2(col4);
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX
         lookup_tag_2(col1, col2, col3, col4)
@@ -518,7 +518,7 @@ Feature: LookUpTest_Vid_String
       CREATE TAG teacher(number int, age int)
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX student(number, age), teacher(number, age)  VALUES "220":(1, 20, 1, 30), "221":(2, 22, 2, 32)
       """
@@ -573,7 +573,7 @@ Feature: LookUpTest_Vid_String
       CREATE TAG INDEX i5 ON t1(c1, c2, c3, c5)
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       LOOKUP ON t1 WHERE t1.c1 == 1 YIELD vertex as node
       """
@@ -651,7 +651,7 @@ Feature: LookUpTest_Vid_String
       CREATE TAG INDEX i5_str ON t1_str(c1, c2, c3(30), c4(30))
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       LOOKUP ON t1_str WHERE t1_str.c1 == 1 YIELD t1_str.c1
       """
@@ -711,7 +711,7 @@ Feature: LookUpTest_Vid_String
       CREATE TAG INDEX i3_with_str ON tag_with_str(c1, c2(30), c3(30))
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX
         tag_with_str(c1, c2, c3)
@@ -781,7 +781,7 @@ Feature: LookUpTest_Vid_String
         identity(BIRTHDAY, NATION(30), BIRTHPLACE_CITY(30))
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX identity(BIRTHDAY, NATION, BIRTHPLACE_CITY) VALUES "1" : (19860413, "汉族", "aaa")
       """
@@ -973,7 +973,7 @@ Feature: LookUpTest_Vid_String
       CREATE TAG player(name string, age int);
       """
     And wait 6 seconds
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX player(name, age) VALUES 'Tim':('Tim', 20);
       """

--- a/tests/tck/features/lookup/LookupTag2.feature
+++ b/tests/tck/features/lookup/LookupTag2.feature
@@ -58,7 +58,7 @@ Feature: Test lookup on tag index 2
     Then drop the used space
 
   Scenario Outline: [tag] scan without hints
-    When executing query:
+    When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       LOOKUP ON
         lookup_tag_1


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
#4611 

#### Description:

Retry tck query executions on failures.

## How do you solve it?

(1) Instead of using `executing query`, we can now write the following in tck cases: `When executing query and retrying it on failure every 6 seconds for 3 times:`

This will retry the query every 6 seconds for 3 times after it fails for the first time, until it either runs successfully or it has been retried for all 3 times.

(2) I have also applied it in some tck cases that has failed previously because of unfinished DDLs or some other similar reasons.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
