### PR TITLE
fix startup service failed when log directory not exists and enable_breakpad

### DIFF
--- a/src/daemons/MetaDaemon.cpp
+++ b/src/daemons/MetaDaemon.cpp
@@ -68,14 +68,6 @@ int main(int argc, char* argv[]) {
 
   Status status;
 
-#if defined(ENABLE_BREAKPAD)
-  status = setupBreakpad();
-  if (!status.ok()) {
-    LOG(ERROR) << status;
-    return EXIT_FAILURE;
-  }
-#endif
-
   auto pidPath = FLAGS_pid_file;
   status = ProcessUtils::isPidAvailable(pidPath);
   if (!status.ok()) {
@@ -92,18 +84,26 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 
-  if (FLAGS_daemonize) {
-    google::SetStderrLogging(google::FATAL);
-  } else {
-    google::SetStderrLogging(google::INFO);
-  }
-
   // Setup logging
   status = setupLogging(argv[0]);
   if (!status.ok()) {
     LOG(ERROR) << status;
     return EXIT_FAILURE;
   }
+
+  if (FLAGS_daemonize) {
+    google::SetStderrLogging(google::FATAL);
+  } else {
+    google::SetStderrLogging(google::INFO);
+  }
+
+#if defined(ENABLE_BREAKPAD)
+  status = setupBreakpad();
+  if (!status.ok()) {
+    LOG(ERROR) << status;
+    return EXIT_FAILURE;
+  }
+#endif
 
   // Init stats
   nebula::initMetaStats();

--- a/src/daemons/StorageDaemon.cpp
+++ b/src/daemons/StorageDaemon.cpp
@@ -61,14 +61,6 @@ int main(int argc, char *argv[]) {
 
   Status status;
 
-#if defined(ENABLE_BREAKPAD)
-  status = setupBreakpad();
-  if (!status.ok()) {
-    LOG(ERROR) << status;
-    return EXIT_FAILURE;
-  }
-#endif
-
   auto pidPath = FLAGS_pid_file;
   status = ProcessUtils::isPidAvailable(pidPath);
   if (!status.ok()) {
@@ -80,11 +72,6 @@ int main(int argc, char *argv[]) {
   if (FLAGS_enable_ssl || FLAGS_enable_meta_ssl) {
     folly::ssl::init();
   }
-  if (FLAGS_daemonize) {
-    google::SetStderrLogging(google::FATAL);
-  } else {
-    google::SetStderrLogging(google::INFO);
-  }
 
   // Setup logging
   status = setupLogging(argv[0]);
@@ -92,6 +79,20 @@ int main(int argc, char *argv[]) {
     LOG(ERROR) << status;
     return EXIT_FAILURE;
   }
+
+  if (FLAGS_daemonize) {
+    google::SetStderrLogging(google::FATAL);
+  } else {
+    google::SetStderrLogging(google::INFO);
+  }
+
+#if defined(ENABLE_BREAKPAD)
+  status = setupBreakpad();
+  if (!status.ok()) {
+    LOG(ERROR) << status;
+    return EXIT_FAILURE;
+  }
+#endif
 
   // Init stats
   nebula::initStorageStats();


### PR DESCRIPTION
…reakPad

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
In the released installation package, when `ENABLE_BREAKPAD` is enabled, if the `log` directory does not exist, it will fail to start `meta/stroage (storagelistener)`.

Many versions have this problem.

close https://github.com/vesoft-inc/nebula-ent/issues/1257

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
