### PR TITLE
lookup with dedup

### DIFF
--- a/src/graph/planner/ngql/LookupPlanner.cpp
+++ b/src/graph/planner/ngql/LookupPlanner.cpp
@@ -58,8 +58,11 @@ StatusOr<SubPlan> LookupPlanner::transform(AstContext* astCtx) {
   if (lookupCtx->filter) {
     plan.root = Filter::make(qctx, plan.root, lookupCtx->filter);
   }
-
   plan.root = Project::make(qctx, plan.root, lookupCtx->yieldExpr);
+  if (lookupCtx->dedup) {
+    plan.root = Dedup::make(qctx, plan.root);
+  }
+
   return plan;
 }
 

--- a/tests/tck/features/lookup/LookUp.feature
+++ b/tests/tck/features/lookup/LookUp.feature
@@ -939,6 +939,35 @@ Feature: LookUpTest_Vid_String
       | '121' |
     When executing query:
       """
+      LOOKUP ON player where player.age < 100 YIELD player.age as age
+      """
+    Then the result should be, in any order:
+      | age |
+      | 42  |
+      | 36  |
+      | 33  |
+      | 35  |
+      | 28  |
+      | 21  |
+      | 21  |
+      | 60  |
+      | 20  |
+    When executing query:
+      """
+      LOOKUP ON player where player.age < 100 YIELD distinct player.age as age
+      """
+    Then the result should be, in any order:
+      | age |
+      | 42  |
+      | 36  |
+      | 33  |
+      | 35  |
+      | 28  |
+      | 21  |
+      | 60  |
+      | 20  |
+    When executing query:
+      """
       LOOKUP ON player where player.name == "Useless" YIELD id(vertex) as id
       """
     Then the result should be, in any order:

--- a/tests/tck/features/lookup/LookUp.feature
+++ b/tests/tck/features/lookup/LookUp.feature
@@ -950,7 +950,6 @@ Feature: LookUpTest_Vid_String
       | 28  |
       | 21  |
       | 21  |
-      | 60  |
       | 20  |
     When executing query:
       """
@@ -964,7 +963,6 @@ Feature: LookUpTest_Vid_String
       | 35  |
       | 28  |
       | 21  |
-      | 60  |
       | 20  |
     When executing query:
       """


### PR DESCRIPTION
## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: #4602

#### Description:
yield distinct not return a distinct result set in LOOKUP

## How do you solve it?
Add `Dedup` plan node in LookupPlanner.

```
(root@nebula) [nba]> lookup on player where player.age>40 yield keys(vertex) as p;
+-----------------+
| p               |
+-----------------+
| ["age", "name"] |
| ["age", "name"] |
| ["age", "name"] |
| ["age", "name"] |
| ["age", "name"] |
| ["age", "name"] |
| ["age", "name"] |
| ["age", "name"] |
+-----------------+
Got 8 rows (time spent 7735/8484 us)

Fri, 16 Sep 2022 11:12:03 CST

(root@nebula) [nba]> lookup on player where player.age>40 yield distinct keys(vertex) as p;
+-----------------+
| p               |
+-----------------+
| ["age", "name"] |
+-----------------+
Got 1 rows (time spent 7447/8064 us)

Fri, 16 Sep 2022 11:12:15 CST
```

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
