### PR TITLE
set job default status as submitted until get some result

### DIFF
--- a/src/common/graph/Response.h
+++ b/src/common/graph/Response.h
@@ -108,6 +108,8 @@
   X(E_TASK_REPORT_OUT_DATE, -2049)                                            \
   X(E_JOB_NOT_IN_SPACE, -2050)                                                \
   X(E_JOB_NEED_RECOVER, -2051)                                                \
+  X(E_JOB_NOT_STOPPABLE, -2052)                                               \
+  X(E_JOB_SUBMITTED, -2053)                                                   \
   X(E_INVALID_JOB, -2065)                                                     \
                                                                               \
   /* Backup Failure */                                                        \

--- a/src/graph/executor/admin/SubmitJobExecutor.cpp
+++ b/src/graph/executor/admin/SubmitJobExecutor.cpp
@@ -151,7 +151,7 @@ nebula::DataSet SubmitJobExecutor::buildShowResultData(
                           apache::thrift::util::enumNameSafe(tsk.get_result()),
                           convertJobTimestampToDateTime(std::move(tsk).get_start_time()),
                           convertJobTimestampToDateTime(std::move(tsk).get_stop_time()),
-                          jd.get_code() == nebula::cpp2::ErrorCode::E_UNKNOWN
+                          jd.get_code() == nebula::cpp2::ErrorCode::E_JOB_SUBMITTED
                               ? ""
                               : apache::thrift::util::enumNameSafe(jd.get_code())}));
     }
@@ -197,7 +197,7 @@ nebula::DataSet SubmitJobExecutor::buildShowResultData(
           apache::thrift::util::enumNameSafe(taskDesc.get_status()),
           convertJobTimestampToDateTime(taskDesc.get_start_time()),
           convertJobTimestampToDateTime(taskDesc.get_stop_time()),
-          jd.get_code() == nebula::cpp2::ErrorCode::E_UNKNOWN
+          jd.get_code() == nebula::cpp2::ErrorCode::E_JOB_SUBMITTED
               ? ""
               : apache::thrift::util::enumNameSafe(jd.get_code()),
       }));

--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -397,6 +397,7 @@ enum ErrorCode {
     E_JOB_NOT_IN_SPACE                = -2050,  // The current task is not in the graph space
     E_JOB_NEED_RECOVER                = -2051,  // The current task needs to be resumed
     E_JOB_NOT_STOPPABLE               = -2052,  // Failed or finished job could not be stopped
+    E_JOB_SUBMITTED                   = -2053,  // Job default status.
     E_INVALID_JOB                     = -2065,  // Invalid task
 
     // Backup Failure

--- a/src/meta/processors/job/JobDescription.h
+++ b/src/meta/processors/job/JobDescription.h
@@ -31,7 +31,7 @@ class JobDescription {
                  Status status = Status::QUEUE,
                  int64_t startTime = 0,
                  int64_t stopTime = 0,
-                 nebula::cpp2::ErrorCode errCode = nebula::cpp2::ErrorCode::E_UNKNOWN);
+                 nebula::cpp2::ErrorCode errCode = nebula::cpp2::ErrorCode::E_JOB_SUBMITTED);
 
   /**
    * @brief Return the JobDescription if both key & val is valid
@@ -179,7 +179,7 @@ class JobDescription {
   Status status_;
   int64_t startTime_;
   int64_t stopTime_;
-  nebula::cpp2::ErrorCode errCode_{nebula::cpp2::ErrorCode::E_UNKNOWN};
+  nebula::cpp2::ErrorCode errCode_{nebula::cpp2::ErrorCode::E_JOB_SUBMITTED};
 };
 
 }  // namespace meta

--- a/src/meta/processors/job/TaskDescription.h
+++ b/src/meta/processors/job/TaskDescription.h
@@ -118,7 +118,7 @@ class TaskDescription {
   cpp2::JobStatus status_;
   int64_t startTime_;
   int64_t stopTime_;
-  nebula::cpp2::ErrorCode errCode_{nebula::cpp2::ErrorCode::E_UNKNOWN};
+  nebula::cpp2::ErrorCode errCode_{nebula::cpp2::ErrorCode::E_JOB_SUBMITTED};
 };
 
 }  // namespace meta


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

https://github.com/vesoft-inc/nebula-ent/issues/1295

#### Description:


## How do you solve it?

set default to a new status as E_JOB_SUBMITTED.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
