### PR TITLE
add vertex filter for GetNeighbors

### DIFF
--- a/src/clients/storage/StorageClient.cpp
+++ b/src/clients/storage/StorageClient.cpp
@@ -51,7 +51,8 @@ StorageRpcRespFuture<cpp2::GetNeighborsResponse> StorageClient::getNeighbors(
     bool random,
     const std::vector<cpp2::OrderBy>& orderBy,
     int64_t limit,
-    const Expression* filter) {
+    const Expression* filter,
+    const Expression* vertexFilter) {
   auto cbStatus = getIdFromValue(param.space);
   if (!cbStatus.ok()) {
     return folly::makeFuture<StorageRpcResponse<cpp2::GetNeighborsResponse>>(
@@ -96,6 +97,9 @@ StorageRpcRespFuture<cpp2::GetNeighborsResponse> StorageClient::getNeighbors(
     spec.limit_ref() = limit;
     if (filter != nullptr) {
       spec.filter_ref() = filter->encode();
+    }
+    if (vertexFilter != nullptr) {
+      spec.vertex_filter_ref() = vertexFilter->encode();
     }
     req.traverse_spec_ref() = std::move(spec);
   }

--- a/src/clients/storage/StorageClient.cpp
+++ b/src/clients/storage/StorageClient.cpp
@@ -52,7 +52,7 @@ StorageRpcRespFuture<cpp2::GetNeighborsResponse> StorageClient::getNeighbors(
     const std::vector<cpp2::OrderBy>& orderBy,
     int64_t limit,
     const Expression* filter,
-    const Expression* vertexFilter) {
+    const Expression* tagFilter) {
   auto cbStatus = getIdFromValue(param.space);
   if (!cbStatus.ok()) {
     return folly::makeFuture<StorageRpcResponse<cpp2::GetNeighborsResponse>>(
@@ -98,8 +98,8 @@ StorageRpcRespFuture<cpp2::GetNeighborsResponse> StorageClient::getNeighbors(
     if (filter != nullptr) {
       spec.filter_ref() = filter->encode();
     }
-    if (vertexFilter != nullptr) {
-      spec.vertex_filter_ref() = vertexFilter->encode();
+    if (tagFilter != nullptr) {
+      spec.tag_filter_ref() = tagFilter->encode();
     }
     req.traverse_spec_ref() = std::move(spec);
   }

--- a/src/clients/storage/StorageClient.h
+++ b/src/clients/storage/StorageClient.h
@@ -79,7 +79,7 @@ class StorageClient
       const std::vector<cpp2::OrderBy>& orderBy = std::vector<cpp2::OrderBy>(),
       int64_t limit = std::numeric_limits<int64_t>::max(),
       const Expression* filter = nullptr,
-      const Expression* vertexFilter = nullptr);
+      const Expression* tagFilter = nullptr);
 
   StorageRpcRespFuture<cpp2::GetDstBySrcResponse> getDstBySrc(
       const CommonRequestParam& param,

--- a/src/clients/storage/StorageClient.h
+++ b/src/clients/storage/StorageClient.h
@@ -78,7 +78,8 @@ class StorageClient
       bool random = false,
       const std::vector<cpp2::OrderBy>& orderBy = std::vector<cpp2::OrderBy>(),
       int64_t limit = std::numeric_limits<int64_t>::max(),
-      const Expression* filter = nullptr);
+      const Expression* filter = nullptr,
+      const Expression* vertexFilter = nullptr);
 
   StorageRpcRespFuture<cpp2::GetDstBySrcResponse> getDstBySrc(
       const CommonRequestParam& param,

--- a/src/graph/executor/algo/BatchShortestPath.cpp
+++ b/src/graph/executor/algo/BatchShortestPath.cpp
@@ -133,6 +133,7 @@ folly::Future<Status> BatchShortestPath::getNeighbors(size_t rowNum, size_t step
                      false,
                      {},
                      -1,
+                     nullptr,
                      nullptr)
       .via(qctx_->rctx()->runner())
       .thenValue([this, rowNum, reverse, stepNum, getNbrTime](auto&& resp) {

--- a/src/graph/executor/algo/SingleShortestPath.cpp
+++ b/src/graph/executor/algo/SingleShortestPath.cpp
@@ -104,6 +104,7 @@ folly::Future<Status> SingleShortestPath::getNeighbors(size_t rowNum,
                      false,
                      {},
                      -1,
+                     nullptr,
                      nullptr)
       .via(qctx_->rctx()->runner())
       .thenValue([this, rowNum, stepNum, getNbrTime, reverse](auto&& resp) {

--- a/src/graph/executor/query/GetNeighborsExecutor.cpp
+++ b/src/graph/executor/query/GetNeighborsExecutor.cpp
@@ -53,7 +53,8 @@ folly::Future<Status> GetNeighborsExecutor::execute() {
                      gn_->random(),
                      gn_->orderBy(),
                      gn_->limit(qec),
-                     gn_->filter())
+                     gn_->filter(),
+                     nullptr)
       .via(runner())
       .ensure([this, getNbrTime]() {
         SCOPED_TIMER(&execTime_);

--- a/src/graph/executor/query/TraverseExecutor.cpp
+++ b/src/graph/executor/query/TraverseExecutor.cpp
@@ -94,7 +94,8 @@ folly::Future<Status> TraverseExecutor::getNeighbors() {
                      finalStep ? traverse_->random() : false,
                      finalStep ? traverse_->orderBy() : std::vector<storage::cpp2::OrderBy>(),
                      finalStep ? traverse_->limit(qctx()) : -1,
-                     selectFilter())
+                     selectFilter(),
+                     nullptr)
       .via(runner())
       .thenValue([this, getNbrTime](StorageRpcResponse<GetNeighborsResponse>&& resp) mutable {
         SCOPED_TIMER(&execTime_);

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -158,8 +158,8 @@ struct TraverseSpec {
     10: optional i64                            limit,
     // If provided, only the rows satisfied the given expression will be returned
     11: optional binary                         filter,
-    // only contain filter expression for vertex, vertex_filter is a subset of filter
-    12: optional binary                         vertex_filter,
+    // only contain filter expression for tag, tag_filter is a subset of filter
+    12: optional binary                         tag_filter,
 }
 
 

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -158,7 +158,7 @@ struct TraverseSpec {
     10: optional i64                            limit,
     // If provided, only the rows satisfied the given expression will be returned
     11: optional binary                         filter,
-    // only contain filter expression for vertex
+    // only contain filter expression for vertex, vertex_filter is a subset of filter
     12: optional binary                         vertex_filter,
 }
 

--- a/src/interface/storage.thrift
+++ b/src/interface/storage.thrift
@@ -158,6 +158,8 @@ struct TraverseSpec {
     10: optional i64                            limit,
     // If provided, only the rows satisfied the given expression will be returned
     11: optional binary                         filter,
+    // only contain filter expression for vertex
+    12: optional binary                         vertex_filter,
 }
 
 

--- a/src/storage/CommonUtils.h
+++ b/src/storage/CommonUtils.h
@@ -134,6 +134,7 @@ enum class ResultStatus {
   NORMAL = 0,
   ILLEGAL_DATA = -1,
   FILTER_OUT = -2,
+  TAG_FILTER_OUT = -3,
 };
 
 struct PropContext;

--- a/src/storage/exec/FilterNode.h
+++ b/src/storage/exec/FilterNode.h
@@ -39,8 +39,13 @@ class FilterNode : public IterateNode<T> {
   FilterNode(RuntimeContext* context,
              IterateNode<T>* upstream,
              StorageExpressionContext* expCtx = nullptr,
-             Expression* exp = nullptr)
-      : IterateNode<T>(upstream), context_(context), expCtx_(expCtx), filterExp_(exp) {
+             Expression* exp = nullptr,
+             Expression* tagFilterExp = nullptr)
+      : IterateNode<T>(upstream),
+        context_(context),
+        expCtx_(expCtx),
+        filterExp_(exp),
+        tagFilterExp_(tagFilterExp) {
     IterateNode<T>::name_ = "FilterNode";
   }
 
@@ -70,10 +75,6 @@ class FilterNode : public IterateNode<T> {
     mode_ = mode;
   }
 
-  void setVertexFilter(Expression* vertexFilter) {
-    vertexFilterExp_ = vertexFilter;
-  }
-
  private:
   bool check() override {
     if (filterExp_ == nullptr) {
@@ -99,8 +100,8 @@ class FilterNode : public IterateNode<T> {
   // return true when the value iter points to a value which can filter
   bool checkTagAndEdge() {
     expCtx_->reset(this->reader(), this->key().str());
-    if (vertexFilterExp_ != nullptr) {
-      auto res = vertexFilterExp_->eval(*expCtx_);
+    if (tagFilterExp_ != nullptr) {
+      auto res = tagFilterExp_->eval(*expCtx_);
       if (!res.isBool() || !res.getBool()) {
         context_->resultStat_ = ResultStatus::TAG_FILTER_OUT;
         return false;
@@ -117,7 +118,7 @@ class FilterNode : public IterateNode<T> {
   RuntimeContext* context_;
   StorageExpressionContext* expCtx_;
   Expression* filterExp_{nullptr};
-  Expression* vertexFilterExp_{nullptr};
+  Expression* tagFilterExp_{nullptr};
   FilterMode mode_{FilterMode::TAG_AND_EDGE};
   int32_t callCheck{0};
 };

--- a/src/storage/exec/FilterNode.h
+++ b/src/storage/exec/FilterNode.h
@@ -55,7 +55,9 @@ class FilterNode : public IterateNode<T> {
         break;
       }
       if (this->valid() && !check()) {
-        context_->resultStat_ = ResultStatus::FILTER_OUT;
+        if (context_->resultStat_ != ResultStatus::TAG_FILTER_OUT) {
+          context_->resultStat_ = ResultStatus::FILTER_OUT;
+        }
         this->next();
         continue;
       }
@@ -114,8 +116,8 @@ class FilterNode : public IterateNode<T> {
  private:
   RuntimeContext* context_;
   StorageExpressionContext* expCtx_;
-  Expression* filterExp_;
-  Expression* vertexFilterExp_;
+  Expression* filterExp_{nullptr};
+  Expression* vertexFilterExp_{nullptr};
   FilterMode mode_{FilterMode::TAG_AND_EDGE};
   int32_t callCheck{0};
 };

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -51,6 +51,8 @@ class GetNeighborsNode : public QueryNode<VertexID> {
     }
 
     if (context_->resultStat_ == ResultStatus::TAG_FILTER_OUT) {
+      // if the filter condition of the tag is not satisfied
+      // do not return the data for this vertex and corresponding edge
       return nebula::cpp2::ErrorCode::SUCCEEDED;
     }
 

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -50,6 +50,10 @@ class GetNeighborsNode : public QueryNode<VertexID> {
       return nebula::cpp2::ErrorCode::E_INVALID_DATA;
     }
 
+    if (context_->resultStat_ == ResultStatus::TAG_FILTER_OUT) {
+      return nebula::cpp2::ErrorCode::SUCCEEDED;
+    }
+
     std::vector<Value> row;
     // vertexId is the first column
     if (context_->isIntId()) {

--- a/src/storage/query/GetNeighborsProcessor.cpp
+++ b/src/storage/query/GetNeighborsProcessor.cpp
@@ -261,7 +261,10 @@ StoragePlan<VertexID> GetNeighborsProcessor::buildPlan(RuntimeContext* context,
     filter->addDependency(upstream);
     upstream = filter.get();
     if (edges.empty()) {
-      filter.get()->setFilterMode(FilterMode::TAG_ONLY);
+      filter->setFilterMode(FilterMode::TAG_ONLY);
+    }
+    if (vertexFilter_) {
+      filter->setVertexFilter(vertexFilter_->clone());
     }
     plan.addNode(std::move(filter));
   }
@@ -313,13 +316,16 @@ nebula::cpp2::ErrorCode GetNeighborsProcessor::checkAndBuildContexts(
   if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
     return code;
   }
-  code = buildFilter(req, [](const cpp2::GetNeighborsRequest& r) -> const std::string* {
-    if (r.get_traverse_spec().filter_ref().has_value()) {
-      return r.get_traverse_spec().get_filter();
-    } else {
-      return nullptr;
-    }
-  });
+  code =
+      buildFilter(req, [](const cpp2::GetNeighborsRequest& r, bool isVertex) -> const std::string* {
+        if (isVertex) {
+          return r.get_traverse_spec().vertex_filter_ref().has_value()
+                     ? r.get_traverse_spec().get_vertex_filter()
+                     : nullptr;
+        }
+        return r.get_traverse_spec().filter_ref().has_value() ? r.get_traverse_spec().get_filter()
+                                                              : nullptr;
+      });
   if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
     return code;
   }

--- a/src/storage/query/GetPropProcessor.cpp
+++ b/src/storage/query/GetPropProcessor.cpp
@@ -272,8 +272,8 @@ nebula::cpp2::ErrorCode GetPropProcessor::checkAndBuildContexts(const cpp2::GetP
       return code;
     }
   }
-  code = buildFilter(req, [](const cpp2::GetPropRequest& r, bool isVertex) -> const std::string* {
-    UNUSED(isVertex);
+  code = buildFilter(req, [](const cpp2::GetPropRequest& r, bool onlyTag) -> const std::string* {
+    UNUSED(onlyTag);
     if (r.filter_ref().has_value()) {
       return r.get_filter();
     } else {

--- a/src/storage/query/GetPropProcessor.cpp
+++ b/src/storage/query/GetPropProcessor.cpp
@@ -272,7 +272,8 @@ nebula::cpp2::ErrorCode GetPropProcessor::checkAndBuildContexts(const cpp2::GetP
       return code;
     }
   }
-  code = buildFilter(req, [](const cpp2::GetPropRequest& r) -> const std::string* {
+  code = buildFilter(req, [](const cpp2::GetPropRequest& r, bool isVertex) -> const std::string* {
+    UNUSED(isVertex);
     if (r.filter_ref().has_value()) {
       return r.get_filter();
     } else {

--- a/src/storage/query/QueryBaseProcessor-inl.h
+++ b/src/storage/query/QueryBaseProcessor-inl.h
@@ -138,7 +138,7 @@ nebula::cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::buildYields(const REQ& re
 
 template <typename REQ, typename RESP>
 nebula::cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::buildFilter(
-    const REQ& req, std::function<const std::string*(const REQ& req, bool isVertex)>&& getFilter) {
+    const REQ& req, std::function<const std::string*(const REQ& req, bool onlyTag)>&& getFilter) {
   const auto* filterStr = getFilter(req, false);
   if (filterStr == nullptr) {
     return nebula::cpp2::ErrorCode::SUCCEEDED;
@@ -152,10 +152,10 @@ nebula::cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::buildFilter(
     if (filter_ == nullptr) {
       return nebula::cpp2::ErrorCode::E_INVALID_FILTER;
     }
-    const auto* vertexFilterStr = getFilter(req, true);
-    if (vertexFilterStr != nullptr && !vertexFilterStr->empty()) {
-      vertexFilter_ = Expression::decode(pool, *vertexFilterStr);
-      if (vertexFilter_ == nullptr) {
+    const auto* tagFilterStr = getFilter(req, true);
+    if (tagFilterStr != nullptr && !tagFilterStr->empty()) {
+      tagFilter_ = Expression::decode(pool, *tagFilterStr);
+      if (tagFilter_ == nullptr) {
         return nebula::cpp2::ErrorCode::E_INVALID_FILTER;
       }
     }

--- a/src/storage/query/QueryBaseProcessor-inl.h
+++ b/src/storage/query/QueryBaseProcessor-inl.h
@@ -138,8 +138,8 @@ nebula::cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::buildYields(const REQ& re
 
 template <typename REQ, typename RESP>
 nebula::cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::buildFilter(
-    const REQ& req, std::function<const std::string*(const REQ& req)>&& getFilter) {
-  const auto* filterStr = getFilter(req);
+    const REQ& req, std::function<const std::string*(const REQ& req, bool isVertex)>&& getFilter) {
+  const auto* filterStr = getFilter(req, false);
   if (filterStr == nullptr) {
     return nebula::cpp2::ErrorCode::SUCCEEDED;
   }
@@ -151,6 +151,13 @@ nebula::cpp2::ErrorCode QueryBaseProcessor<REQ, RESP>::buildFilter(
     filter_ = Expression::decode(pool, *filterStr);
     if (filter_ == nullptr) {
       return nebula::cpp2::ErrorCode::E_INVALID_FILTER;
+    }
+    const auto* vertexFilterStr = getFilter(req, true);
+    if (vertexFilterStr != nullptr && !vertexFilterStr->empty()) {
+      vertexFilter_ = Expression::decode(pool, *vertexFilterStr);
+      if (vertexFilter_ == nullptr) {
+        return nebula::cpp2::ErrorCode::E_INVALID_FILTER;
+      }
     }
     return checkExp(filter_, false, true, false, true);
   }

--- a/src/storage/query/QueryBaseProcessor.h
+++ b/src/storage/query/QueryBaseProcessor.h
@@ -169,7 +169,7 @@ class QueryBaseProcessor : public BaseProcessor<RESP> {
   nebula::cpp2::ErrorCode handleEdgeProps(std::vector<cpp2::EdgeProp>& edgeProps);
 
   nebula::cpp2::ErrorCode buildFilter(
-      const REQ& req, std::function<const std::string*(const REQ& req)>&& getFilter);
+      const REQ& req, std::function<const std::string*(const REQ& req, bool isVertex)>&& getFilter);
   nebula::cpp2::ErrorCode buildYields(const REQ& req);
 
   // build ttl info map
@@ -207,6 +207,7 @@ class QueryBaseProcessor : public BaseProcessor<RESP> {
   TagContext tagContext_;
   EdgeContext edgeContext_;
   Expression* filter_{nullptr};
+  Expression* vertexFilter_{nullptr};
 
   // Collect prop in value expression in upsert set clause
   std::unordered_set<std::string> valueProps_;

--- a/src/storage/query/QueryBaseProcessor.h
+++ b/src/storage/query/QueryBaseProcessor.h
@@ -169,7 +169,7 @@ class QueryBaseProcessor : public BaseProcessor<RESP> {
   nebula::cpp2::ErrorCode handleEdgeProps(std::vector<cpp2::EdgeProp>& edgeProps);
 
   nebula::cpp2::ErrorCode buildFilter(
-      const REQ& req, std::function<const std::string*(const REQ& req, bool isVertex)>&& getFilter);
+      const REQ& req, std::function<const std::string*(const REQ& req, bool onlyTag)>&& getFilter);
   nebula::cpp2::ErrorCode buildYields(const REQ& req);
 
   // build ttl info map
@@ -207,7 +207,7 @@ class QueryBaseProcessor : public BaseProcessor<RESP> {
   TagContext tagContext_;
   EdgeContext edgeContext_;
   Expression* filter_{nullptr};
-  Expression* vertexFilter_{nullptr};
+  Expression* tagFilter_{nullptr};
 
   // Collect prop in value expression in upsert set clause
   std::unordered_set<std::string> valueProps_;

--- a/src/storage/query/ScanEdgeProcessor.cpp
+++ b/src/storage/query/ScanEdgeProcessor.cpp
@@ -65,7 +65,8 @@ nebula::cpp2::ErrorCode ScanEdgeProcessor::checkAndBuildContexts(const cpp2::Sca
   std::vector<cpp2::EdgeProp> returnProps = *req.return_columns_ref();
   ret = handleEdgeProps(returnProps);
   buildEdgeColName(returnProps);
-  ret = buildFilter(req, [](const cpp2::ScanEdgeRequest& r) -> const std::string* {
+  ret = buildFilter(req, [](const cpp2::ScanEdgeRequest& r, bool isVertex) -> const std::string* {
+    UNUSED(isVertex);
     if (r.filter_ref().has_value()) {
       return r.get_filter();
     } else {

--- a/src/storage/query/ScanEdgeProcessor.cpp
+++ b/src/storage/query/ScanEdgeProcessor.cpp
@@ -65,8 +65,8 @@ nebula::cpp2::ErrorCode ScanEdgeProcessor::checkAndBuildContexts(const cpp2::Sca
   std::vector<cpp2::EdgeProp> returnProps = *req.return_columns_ref();
   ret = handleEdgeProps(returnProps);
   buildEdgeColName(returnProps);
-  ret = buildFilter(req, [](const cpp2::ScanEdgeRequest& r, bool isVertex) -> const std::string* {
-    UNUSED(isVertex);
+  ret = buildFilter(req, [](const cpp2::ScanEdgeRequest& r, bool onlyTag) -> const std::string* {
+    UNUSED(onlyTag);
     if (r.filter_ref().has_value()) {
       return r.get_filter();
     } else {

--- a/src/storage/query/ScanVertexProcessor.cpp
+++ b/src/storage/query/ScanVertexProcessor.cpp
@@ -68,8 +68,8 @@ nebula::cpp2::ErrorCode ScanVertexProcessor::checkAndBuildContexts(
   std::vector<cpp2::VertexProp> returnProps = *req.return_columns_ref();
   ret = handleVertexProps(returnProps);
   buildTagColName(returnProps);
-  ret = buildFilter(req, [](const cpp2::ScanVertexRequest& r, bool isVertex) -> const std::string* {
-    UNUSED(isVertex);
+  ret = buildFilter(req, [](const cpp2::ScanVertexRequest& r, bool onlyTag) -> const std::string* {
+    UNUSED(onlyTag);
     if (r.filter_ref().has_value()) {
       return r.get_filter();
     } else {

--- a/src/storage/query/ScanVertexProcessor.cpp
+++ b/src/storage/query/ScanVertexProcessor.cpp
@@ -68,7 +68,8 @@ nebula::cpp2::ErrorCode ScanVertexProcessor::checkAndBuildContexts(
   std::vector<cpp2::VertexProp> returnProps = *req.return_columns_ref();
   ret = handleVertexProps(returnProps);
   buildTagColName(returnProps);
-  ret = buildFilter(req, [](const cpp2::ScanVertexRequest& r) -> const std::string* {
+  ret = buildFilter(req, [](const cpp2::ScanVertexRequest& r, bool isVertex) -> const std::string* {
+    UNUSED(isVertex);
     if (r.filter_ref().has_value()) {
       return r.get_filter();
     } else {

--- a/src/storage/test/GetNeighborsTest.cpp
+++ b/src/storage/test/GetNeighborsTest.cpp
@@ -1788,6 +1788,36 @@ TEST(GetNeighborsTest, FilterTest) {
     ASSERT_EQ(expected, *resp.vertices_ref());
   }
   {
+    LOG(INFO) << "Filter apply to vertices";
+    std::vector<VertexID> vertices = {"Tim Duncan"};
+    std::vector<EdgeType> over = {serve};
+    std::vector<std::pair<TagID, std::vector<std::string>>> tags;
+    std::vector<std::pair<EdgeType, std::vector<std::string>>> edges;
+    tags.emplace_back(player, std::vector<std::string>{"name", "age"});
+    edges.emplace_back(serve, std::vector<std::string>{"teamName", "startYear", "endYear"});
+    auto req = QueryTestUtils::buildRequest(totalParts, vertices, over, tags, edges);
+    // where $^.player.age > 50
+    const auto& exp = *RelationalExpression::makeGT(
+        pool,
+        SourcePropertyExpression::make(pool, folly::to<std::string>(player), "age"),
+        ConstantExpression::make(pool, Value(50)));
+    (*req.traverse_spec_ref()).filter_ref() = Expression::encode(exp);
+    (*req.traverse_spec_ref()).vertex_filter_ref() = Expression::encode(exp);
+
+    auto* processor = GetNeighborsProcessor::instance(env, nullptr, threadPool.get());
+    auto fut = processor->getFuture();
+    processor->process(req);
+    auto resp = std::move(fut).get();
+
+    ASSERT_EQ(0, (*resp.result_ref()).failed_parts.size());
+    // vId, stat, player, serve, expr
+    nebula::DataSet expected;
+    expected.colNames = {
+        kVid, "_stats", "_tag:1:name:age", "_edge:+101:teamName:startYear:endYear", "_expr"};
+    ASSERT_EQ(expected.colNames, (*resp.vertices_ref()).colNames);
+    ASSERT_EQ(0, (*resp.vertices_ref()).rows.size());
+  }
+  {
     LOG(INFO) << "Filter apply to multi vertices";
     std::vector<VertexID> vertices = {
         "Tracy McGrady", "Tim Duncan", "Tony Parker", "Manu Ginobili"};

--- a/src/storage/test/GetNeighborsTest.cpp
+++ b/src/storage/test/GetNeighborsTest.cpp
@@ -1802,7 +1802,7 @@ TEST(GetNeighborsTest, FilterTest) {
         SourcePropertyExpression::make(pool, folly::to<std::string>(player), "age"),
         ConstantExpression::make(pool, Value(50)));
     (*req.traverse_spec_ref()).filter_ref() = Expression::encode(exp);
-    (*req.traverse_spec_ref()).vertex_filter_ref() = Expression::encode(exp);
+    (*req.traverse_spec_ref()).tag_filter_ref() = Expression::encode(exp);
 
     auto* processor = GetNeighborsProcessor::instance(env, nullptr, threadPool.get());
     auto fut = processor->getFuture();
@@ -1832,7 +1832,7 @@ TEST(GetNeighborsTest, FilterTest) {
         SourcePropertyExpression::make(pool, folly::to<std::string>(player), "age"),
         ConstantExpression::make(pool, Value(40)));
     (*req.traverse_spec_ref()).filter_ref() = Expression::encode(exp);
-    (*req.traverse_spec_ref()).vertex_filter_ref() = Expression::encode(exp);
+    (*req.traverse_spec_ref()).tag_filter_ref() = Expression::encode(exp);
 
     auto* processor = GetNeighborsProcessor::instance(env, nullptr, threadPool.get());
     auto fut = processor->getFuture();


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula/issues/4649

#### Description:

Add vertexFilter to getNeighbor interface, when the filter condition of the  vertex is not satisfied, do not return the data for this vertex and corresponding edge 
 


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
