### PR TITLE
fixed `show hosts`

### DIFF
--- a/src/graph/executor/admin/ShowHostsExecutor.cpp
+++ b/src/graph/executor/admin/ShowHostsExecutor.cpp
@@ -38,7 +38,7 @@ folly::Future<Status> ShowHostsExecutor::showHosts() {
     for (const auto &host : hostVec) {
       nebula::Row r({host.get_hostAddr().host,
                      host.get_hostAddr().port,
-                     FLAGS_ws_http_port,
+                     19779,  // FIXME: update real http port.
                      apache::thrift::util::enumNameSafe(host.get_status())});
       int64_t leaderCount = 0;
       for (const auto &spaceEntry : host.get_leader_parts()) {


### PR DESCRIPTION
## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula-ent/issues/1290

#### Description:


## How do you solve it?
Change to default http port for storage now. And fixed later.

```
(root@nebula) [(none)]> show hosts;
+-----------------+------+-----------+----------+--------------+---------------------+------------------------+---------+
| Host            | Port | HTTP port | Status   | Leader count | Leader distribution | Partition distribution | Version |
+-----------------+------+-----------+----------+--------------+---------------------+------------------------+---------+
| "192.168.8.212" | 1779 | 19779     | "ONLINE" | 102          | "nba:100, space3:2" | "nba:100, space3:2"    | ""      |
+-----------------+------+-----------+----------+--------------+---------------------+------------------------+---------+
Got 1 rows (time spent 2637/3544 us)
```



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [x] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:


