### PR TITLE
allow check god user read from follower

### DIFF
--- a/src/daemons/MetaDaemonInit.cpp
+++ b/src/daemons/MetaDaemonInit.cpp
@@ -181,8 +181,9 @@ nebula::cpp2::ErrorCode initGodUser(nebula::kvstore::KVStore* kvstore,
       LOG(ERROR) << "Part leader get failed";
       return nebula::error(ret);
     }
+    bool isLeader = nebula::value(ret) == localhost;
     LOG(INFO) << "Check root user";  // follower need to wait reading all ok, too.
-    auto checkRet = nebula::meta::RootUserMan::isGodExists(kvstore);
+    auto checkRet = nebula::meta::RootUserMan::isGodExists(kvstore, isLeader);
     if (!nebula::ok(checkRet)) {
       auto retCode = nebula::error(checkRet);
       if (retCode == nebula::cpp2::ErrorCode::E_LEADER_CHANGED) {
@@ -193,7 +194,7 @@ nebula::cpp2::ErrorCode initGodUser(nebula::kvstore::KVStore* kvstore,
       LOG(ERROR) << "Parser God Role error:" << apache::thrift::util::enumNameSafe(retCode);
       return nebula::error(checkRet);
     }
-    if (nebula::value(ret) == localhost) {
+    if (isLeader) {
       auto existGod = nebula::value(checkRet);
       if (!existGod) {
         auto initGod = nebula::meta::RootUserMan::initRootUser(kvstore);

--- a/src/meta/RootUserMan.h
+++ b/src/meta/RootUserMan.h
@@ -21,10 +21,10 @@ namespace meta {
  * */
 class RootUserMan {
  public:
-  static ErrorOr<nebula::cpp2::ErrorCode, bool> isGodExists(kvstore::KVStore* kv) {
+  static ErrorOr<nebula::cpp2::ErrorCode, bool> isGodExists(kvstore::KVStore* kv, bool fromLeader) {
     auto rolePrefix = MetaKeyUtils::roleSpacePrefix(kDefaultSpaceId);
     std::unique_ptr<kvstore::KVIterator> iter;
-    auto code = kv->prefix(kDefaultSpaceId, kDefaultPartId, rolePrefix, &iter, false);
+    auto code = kv->prefix(kDefaultSpaceId, kDefaultPartId, rolePrefix, &iter, !fromLeader);
     if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
       return code;
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

https://github.com/vesoft-inc/nebula-ent/issues/1319#event-7444097789

#### Description:

`can ready from follower` flag not set so that follower alway get a LEADER_CHANGED error when read from kv.


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
