### PR TITLE
add bash -c for folly::subprocess

### DIFF
--- a/src/common/hdfs/HdfsCommandHelper.cpp
+++ b/src/common/hdfs/HdfsCommandHelper.cpp
@@ -20,7 +20,7 @@ Status HdfsCommandHelper::ls(const std::string& hdfsHost,
       "hdfs dfs -ls hdfs://%s:%d%s", hdfsHost.c_str(), hdfsPort, hdfsPath.c_str());
   LOG(INFO) << "Running HDFS Command: " << command;
   try {
-    folly::Subprocess proc(std::vector<std::string>({command}));
+    folly::Subprocess proc(std::vector<std::string>({"/bin/bash", "-c", command}));
     auto result = proc.wait();
     if (!result.exited()) {
       return Status::Error("Failed to ls hdfs");
@@ -43,7 +43,7 @@ Status HdfsCommandHelper::copyToLocal(const std::string& hdfsHost,
                                      localPath.c_str());
   LOG(INFO) << "Running HDFS Command: " << command;
   try {
-    folly::Subprocess proc(std::vector<std::string>({command}));
+    folly::Subprocess proc(std::vector<std::string>({"/bin/bash", "-c", command}));
     auto result = proc.wait();
     if (!result.exited()) {
       return Status::Error("Failed to download from hdfs");


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

folly::subprocess won't execute cmd now because "no such file" and if you add whole path , thers's some system environment like `JAVA_HOME` won't work.

So I specify bash to run cmd for now.

Also there's some problem with system ENV. if you use `sudo `, then you lose some ENV info.

![1663923466355_5BAE588D-4E0C-49c1-8D1E-E8D8041DC4FE](https://user-images.githubusercontent.com/90179377/191933056-524b19e0-b4e7-4bb4-af71-f8e0d56ea8a7.png)




## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
