### PR TITLE
fix job manager ut in asan

### DIFF
--- a/src/meta/test/JobManagerTest.cpp
+++ b/src/meta/test/JobManagerTest.cpp
@@ -66,7 +66,7 @@ class JobManagerTest : public ::testing::Test {
           }
           delete p;
         });
-    jobMgr->status_.store(JobManager::JbmgrStatus::NOT_START, std::memory_order_release);
+    jobMgr->status_ = JobManager::JbmgrStatus::NOT_START;
     jobMgr->kvStore_ = kv_.get();
     jobMgr->init(kv_.get());
     return jobMgr;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
fix error in job manager UT in ASAN
```
I20220926 11:01:14.179844 18070 JobManager.cpp:136] JobManager::scheduleThread enter
*** Aborted at 1664161274 (Unix time, try 'date -d @1664161274') ***
*** Signal 11 (SIGSEGV) (0x0) received by PID 15368 (pthread TID 0x7f6b17917700) (linux TID 18070) (code: address not mapped to object), stack trace: ***
/__w/nebula/nebula/build/bin/test/job_manager_test(_ZN5folly10symbolizer17getStackTraceSafeEPmm+0x31)[0x507e771]
/__w/nebula/nebula/build/bin/test/job_manager_test(_ZN5folly10symbolizer21SafeStackTracePrinter15printStackTraceEb+0x26)[0x5075c76]
/__w/nebula/nebula/build/bin/test/job_manager_test[0x5073c07]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x1441f)[0x7f6c01f4c41f]
/__w/nebula/nebula/build/bin/test/job_manager_test(_ZN6nebula4meta16FlushJobExecutor15executeInternalEONS_8HostAddrEOSt6vectorIiSaIiEE+0x300)[0x17cd550]
/__w/nebula/nebula/build/bin/test/job_manager_test(_ZN6nebula4meta18StorageJobExecutor7executeEv+0x15e4)[0x17b4f64]
/__w/nebula/nebula/build/bin/test/job_manager_test(_ZN6nebula4meta10JobManager14runJobInternalERKNS0_14JobDescriptionENS1_4JbOpE+0xd42)[0x1739df2]
/__w/nebula/nebula/build/bin/test/job_manager_test(_ZN6nebula4meta10JobManager14scheduleThreadEv+0x1aed)[0x1730fad]
/__w/nebula/nebula/build/bin/test/job_manager_test[0x5587c0f]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x8608)[0x7f6c01f40608]
/lib/x86_64-linux-gnu/libc.so.6(clone+0x42)[0x7f6c01e5b132]
(safe mode, symbolizer not available)
AddressSanitizer:DEADLYSIGNAL
=================================================================
==15368==ERROR: AddressSanitizer: SEGV on unknown address 0x000000003c08 (pc 0x0000017cd550 bp 0x7f6b1790e730 sp 0x7f6b1790e5c0 T579)
==15368==The signal is caused by a READ memory access.
    #0 0x17cd550 in nebula::meta::FlushJobExecutor::executeInternal(nebula::HostAddr&&, std::vector<int, std::allocator<int> >&&) build/../src/meta/processors/job/FlushJobExecutor.cpp:23:9
    #1 0x17b4f64 in nebula::meta::StorageJobExecutor::execute() build/../src/meta/processors/job/StorageJobExecutor.cpp:186:26
    #2 0x1739df2 in nebula::meta::JobManager::runJobInternal(nebula::meta::JobDescription const&, nebula::meta::JobManager::JbOp) build/../src/meta/processors/job/JobManager.cpp:241:12
    #3 0x1730fad in nebula::meta::JobManager::scheduleThread() build/../src/meta/processors/job/JobManager.cpp:181:5
    #4 0x5587c0f in execute_native_thread_routine (build/bin/test/job_manager_test+0x5587c0f)
    #5 0x7f6c01f40608 in start_thread (/lib/x86_64-linux-gnu/libpthread.so.0+0x8608)
    #6 0x7f6c01e5b132 in clone (/lib/x86_64-linux-gnu/libc.so.6+0x11f132)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV build/../src/meta/processors/job/FlushJobExecutor.cpp:23:9 in nebula::meta::FlushJobExecutor::executeInternal(nebula::HostAddr&&, std::vector<int, std::allocator<int> >&&)
Thread T579 created by T0 here:
    #0 0x12ece62 in pthread_create /usr/src/nebula-package/toolset-build/source/llvm-10.0.0/projects/compiler-rt/lib/asan/asan_interceptors.cpp:214:3
    #1 0x5587cd4 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (build/bin/test/job_manager_test+0x5587cd4)
    #2 0x465a395 in nebula::meta::JobManagerTest::getJobManager() build/../src/meta/test/JobManagerTest.cpp:71:13
    #3 0x4632a5c in nebula::meta::JobManagerTest_RecoverJob_Test::TestBody() build/../src/meta/test/JobManagerTest.cpp:598:76
    #4 0x4f33a10 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (build/bin/test/job_manager_test+0x4f33a10)
    #5 0x4f285d5 in testing::Test::Run() (build/bin/test/job_manager_test+0x4f285d5)
    #6 0x4f2879c in testing::TestInfo::Run() (build/bin/test/job_manager_test+0x4f2879c)
    #7 0x4f288c7 in testing::TestSuite::Run() (build/bin/test/job_manager_test+0x4f288c7)
    #8 0x4f28ebe in testing::internal::UnitTestImpl::RunAllTests() (build/bin/test/job_manager_test+0x4f28ebe)
    #9 0x4f292e7 in testing::UnitTest::Run() (build/bin/test/job_manager_test+0x4f292e7)
    #10 0x4657e99 in RUN_ALL_TESTS() /opt/vesoft/third-party/3.3/include/gtest/gtest.h:2293:73
    #11 0x4657e99 in main build/../src/meta/test/JobManagerTest.cpp:1017:10
    #12 0x7f6c01d60082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082)
```

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
