### PR TITLE
fix subgraph crash

### DIFF
--- a/src/graph/context/Iterator.cpp
+++ b/src/graph/context/Iterator.cpp
@@ -114,9 +114,12 @@ Status GetNeighborsIter::processList(std::shared_ptr<Value> value) {
     if (UNLIKELY(!val.isDataSet())) {
       return Status::Error("There is a value in list which is not a data set.");
     }
-    auto status = makeDataSetIndex(val.getDataSet());
-    NG_RETURN_IF_ERROR(status);
-    dsIndices_.emplace_back(std::move(status).value());
+    const auto& dataSet = val.getDataSet();
+    if (dataSet.rowSize() != 0) {
+      auto status = makeDataSetIndex(dataSet);
+      NG_RETURN_IF_ERROR(status);
+      dsIndices_.emplace_back(std::move(status).value());
+    }
   }
   return Status::OK();
 }

--- a/src/graph/context/test/IteratorTest.cpp
+++ b/src/graph/context/test/IteratorTest.cpp
@@ -581,7 +581,7 @@ TEST(IteratorTest, TestHead) {
     auto val = std::make_shared<Value>(std::move(datasets));
     GetNeighborsIter iter(nullptr);
     auto status = iter.processList(val);
-    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.ok());
   }
   {
     // no _stats
@@ -592,7 +592,7 @@ TEST(IteratorTest, TestHead) {
     auto val = std::make_shared<Value>(std::move(datasets));
     GetNeighborsIter iter(nullptr);
     auto status = iter.processList(val);
-    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.ok());
   }
   {
     // no _expr
@@ -603,7 +603,7 @@ TEST(IteratorTest, TestHead) {
     auto val = std::make_shared<Value>(std::move(datasets));
     GetNeighborsIter iter(nullptr);
     auto status = iter.processList(val);
-    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.ok());
   }
   {
     // no +/- before edge name
@@ -615,7 +615,7 @@ TEST(IteratorTest, TestHead) {
     auto val = std::make_shared<Value>(std::move(datasets));
     GetNeighborsIter iter(nullptr);
     auto status = iter.processList(val);
-    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.ok());
   }
   // no prop
   {
@@ -645,7 +645,7 @@ TEST(IteratorTest, TestHead) {
     auto val = std::make_shared<Value>(std::move(datasets));
     GetNeighborsIter iter(nullptr);
     auto status = iter.processList(val);
-    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.ok());
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula/issues/4694

#### Description:

In a distributed environment, getNeighbor may return multiple datasets, and due to filter conditions, not every dataset has data

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
