### PR TITLE
fix hdfs download command will always return succeeded sometimes

### DIFF
--- a/src/common/hdfs/HdfsCommandHelper.cpp
+++ b/src/common/hdfs/HdfsCommandHelper.cpp
@@ -24,6 +24,9 @@ Status HdfsCommandHelper::ls(const std::string& hdfsHost,
     auto result = proc.wait();
     if (!result.exited()) {
       return Status::Error("Failed to ls hdfs");
+    } else if (result.exitStatus() != 0) {
+      LOG(INFO) << "Failed to ls: " << result.str();
+      return Status::Error("Failed to ls hdfs, errno: %d", result.exitStatus());
     } else {
       return Status::OK();
     }
@@ -47,6 +50,9 @@ Status HdfsCommandHelper::copyToLocal(const std::string& hdfsHost,
     auto result = proc.wait();
     if (!result.exited()) {
       return Status::Error("Failed to download from hdfs");
+    } else if (result.exitStatus() != 0) {
+      LOG(INFO) << "Failed to download: " << result.str();
+      return Status::Error("Failed to download from hdfs, errno: %d", result.exitStatus());
     } else {
       return Status::OK();
     }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:


## How do you solve it?
check errno from folly::subProcess 


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
