### PR TITLE
forbid insert vertex when vertex_key flag is off

### DIFF
--- a/src/graph/service/GraphFlags.cpp
+++ b/src/graph/service/GraphFlags.cpp
@@ -103,3 +103,5 @@ DEFINE_uint32(
     gc_worker_size,
     0,
     "Background garbage clean workers, default number is 0 which means using hardware core size.");
+
+DEFINE_bool(graph_use_vertex_key, false, "whether allow insert or query the vertex key");

--- a/src/graph/service/GraphFlags.h
+++ b/src/graph/service/GraphFlags.h
@@ -65,4 +65,7 @@ DECLARE_int32(max_job_size);
 
 DECLARE_bool(enable_async_gc);
 DECLARE_uint32(gc_worker_size);
+
+DECLARE_bool(graph_use_vertex_key);
+
 #endif  // GRAPH_GRAPHFLAGS_H_

--- a/src/graph/validator/MutateValidator.cpp
+++ b/src/graph/validator/MutateValidator.cpp
@@ -46,6 +46,9 @@ Status InsertVerticesValidator::check() {
   }
 
   auto tagItems = sentence->tagItems();
+  if (!FLAGS_graph_use_vertex_key && tagItems.empty()) {
+    return Status::SemanticError("Insert vertex is forbidden, please speicify the tag");
+  }
 
   schemas_.reserve(tagItems.size());
 

--- a/src/storage/query/GetPropProcessor.cpp
+++ b/src/storage/query/GetPropProcessor.cpp
@@ -208,7 +208,7 @@ StoragePlan<VertexID> GetPropProcessor::buildTagPlan(RuntimeContext* context,
     plan.addNode(std::move(tag));
   }
   auto output = std::make_unique<GetTagPropNode>(
-      context, tags, result, filter_ == nullptr ? nullptr : filter_->clone(), limit_);
+      context, tags, result, filter_ == nullptr ? nullptr : filter_->clone(), limit_, &tagContext_);
   for (auto* tag : tags) {
     output->addDependency(tag);
   }

--- a/tests/tck/features/delete/DeleteTag.IntVid.feature
+++ b/tests/tck/features/delete/DeleteTag.IntVid.feature
@@ -161,7 +161,6 @@ Feature: Delete int vid of tag
       | id |
     Then drop the used space
 
-  @wtf
   Scenario: delete int vid multiple vertex one tag
     Given an empty graph
     And load "nba_int_vid" csv data to a new space

--- a/tests/tck/features/insert/insertVertexOnly.feature
+++ b/tests/tck/features/insert/insertVertexOnly.feature
@@ -19,6 +19,10 @@ Feature: insert vertex without tag
     When executing query and retrying it on failure every 6 seconds for 3 times:
       """
       INSERT VERTEX VALUES 1:(),2:(),3:();
+      """
+    Then a SemanticError should be raised at runtime: Insert vertex is forbidden, please speicify the tag
+    When executing query:
+      """
       INSERT EDGE e() VALUES 1->2:(),2->3:();
       """
     Then the execution should be successful

--- a/tests/tck/features/ttl/TTL.feature
+++ b/tests/tck/features/ttl/TTL.feature
@@ -394,21 +394,18 @@ Feature: TTLTest
       """
     Then the result should be, in any order, with relax comparison:
       | node  |
-      | ("1") |
     When executing query:
       """
       FETCH PROP ON person "1" YIELD person.id as id
       """
     Then the result should be, in any order:
       | id    |
-      | EMPTY |
     When executing query:
       """
       FETCH PROP ON * "1" YIELD person.id, career.id
       """
     Then the result should be, in any order:
       | person.id | career.id |
-      | EMPTY     | EMPTY     |
     When executing query:
       """
       FETCH PROP ON person "2" YIELD person.id
@@ -492,5 +489,4 @@ Feature: TTLTest
       """
     Then the result should be, in any order:
       | age   |
-      | EMPTY |
     And drop the used space

--- a/tests/tck/features/ttl/TTL.feature
+++ b/tests/tck/features/ttl/TTL.feature
@@ -393,13 +393,13 @@ Feature: TTLTest
       FETCH PROP ON person "1" YIELD vertex as node;
       """
     Then the result should be, in any order, with relax comparison:
-      | node  |
+      | node |
     When executing query:
       """
       FETCH PROP ON person "1" YIELD person.id as id
       """
     Then the result should be, in any order:
-      | id    |
+      | id |
     When executing query:
       """
       FETCH PROP ON * "1" YIELD person.id, career.id
@@ -488,5 +488,5 @@ Feature: TTLTest
       FETCH PROP ON person "1" YIELD person.age as age;
       """
     Then the result should be, in any order:
-      | age   |
+      | age |
     And drop the used space


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
As title, when vertex_key is not used, we forbid it. Otherwise, it will report succeeded, but no data is inserted.

Fix https://github.com/vesoft-inc/nebula-ent/issues/1420, it seems we can't simply prefix scan, we need to check if any tag is valid indeed. And valid means: tag schema exists and no ttl expired.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
