### PR TITLE
JobManager related fix

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -918,9 +918,13 @@ Status MetaClient::handleResponse(const RESP& resp) {
       return Status::Error("Stop job failure!");
     case nebula::cpp2::ErrorCode::E_SAVE_JOB_FAILURE:
       return Status::Error("Save job failure!");
-    case nebula::cpp2::ErrorCode::E_JOB_NOT_STOPPABLE:
+    case nebula::cpp2::ErrorCode::E_JOB_ALREADY_FINISH:
       return Status::Error(
           "Finished job or failed job can not be stopped, please start another job instead");
+    case nebula::cpp2::ErrorCode::E_JOB_NOT_STOPPABLE:
+      return Status::Error(
+          "The job type do not support stopping, either wait previous job done or restart the "
+          "cluster to start another job");
     case nebula::cpp2::ErrorCode::E_BALANCER_FAILURE:
       return Status::Error("Balance failure!");
     case nebula::cpp2::ErrorCode::E_NO_INVALID_BALANCE_PLAN:

--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -396,8 +396,10 @@ enum ErrorCode {
     E_TASK_REPORT_OUT_DATE            = -2049,  // Task report failed
     E_JOB_NOT_IN_SPACE                = -2050,  // The current task is not in the graph space
     E_JOB_NEED_RECOVER                = -2051,  // The current task needs to be resumed
-    E_JOB_NOT_STOPPABLE               = -2052,  // Failed or finished job could not be stopped
+    E_JOB_ALREADY_FINISH              = -2052,  // The job status has already been failed or finished
     E_JOB_SUBMITTED                   = -2053,  // Job default status.
+    E_JOB_NOT_STOPPABLE               = -2054,  // The given job do not support stop
+    E_JOB_HAS_NO_TARGET_STORAGE       = -2055,  // The leader distribution has not been reported, so can't send task to storage
     E_INVALID_JOB                     = -2065,  // Invalid task
 
     // Backup Failure

--- a/src/meta/processors/job/StorageJobExecutor.cpp
+++ b/src/meta/processors/job/StorageJobExecutor.cpp
@@ -81,6 +81,12 @@ ErrOrHosts StorageJobExecutor::getLeaderHost(GraphSpaceID space) {
       it->second.emplace_back(partId);
     }
   }
+  // If storage has not report leader distribution to meta and we don't report error here,
+  // JobMananger will think of the job consists of 0 task, and the task will not send to any
+  // storage. And the job will always be RUNNING.
+  if (hosts.empty()) {
+    return nebula::cpp2::ErrorCode::E_JOB_HAS_NO_TARGET_STORAGE;
+  }
   return hosts;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
Two bugs are fixed:
1. Some job do not support stop, e.g. COMPACT/DOWNLOAD/INGEST and so on. Previously in #4460, we have already report error. However, sadly, when we `show job`, the job is marked as STOPPED, which is not expected. It looks like as  below:

![image](https://user-images.githubusercontent.com/13706157/196425506-97530e46-2329-4032-9d7f-4c5d1cd9fba6.png)



After this PR, these unstoppable job will still keep in RUNNING state.
2. Some job need to run in storage leader. There is a corner case that, when we create a new space, before storage report leader distribution to meta, we start a job, e.g. STATS. For now JobManager can't select a storage to run the job, and the task won't be sent to storage for execution. Since no storage ever run it,  the job will always stay in RUNNING.

## How do you solve it?
1. Only save STOPPED when it really stopped
2. If no leader found, report error.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
