### PR TITLE
Avoid full scan of match when there is an Relational In predicate

### DIFF
--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -4,8 +4,11 @@
 
 #include "graph/util/ExpressionUtils.h"
 
+#include "ExpressionUtils.h"
 #include "common/base/ObjectPool.h"
 #include "common/expression/ArithmeticExpression.h"
+#include "common/expression/ConstantExpression.h"
+#include "common/expression/ContainerExpression.h"
 #include "common/expression/Expression.h"
 #include "common/expression/PropertyExpression.h"
 #include "common/function/AggFunctionManager.h"
@@ -172,6 +175,50 @@ Expression *ExpressionUtils::rewriteParameter(const Expression *expr, QueryConte
     DCHECK_EQ(e->kind(), Expression::Kind::kVar);
     auto &v = const_cast<Expression *>(e)->eval(graph::QueryExpressionContext(qctx->ectx())());
     return ConstantExpression::make(qctx->objPool(), v);
+  };
+
+  return graph::RewriteVisitor::transform(expr, matcher, rewriter);
+}
+
+Expression *ExpressionUtils::rewriteInnerInExpr(const Expression *expr) {
+  auto matcher = [](const Expression *e) -> bool {
+    if (e->kind() != Expression::Kind::kRelIn) {
+      return false;
+    }
+    auto rhs = static_cast<const RelationalExpression *>(e)->right();
+    if (rhs->kind() != Expression::Kind::kList && rhs->kind() != Expression::Kind::kSet) {
+      return false;
+    }
+    auto items = static_cast<const ContainerExpression *>(rhs)->getKeys();
+    for (const auto *item : items) {
+      if (!ExpressionUtils::isEvaluableExpr(item)) {
+        return false;
+      }
+    }
+    return true;
+  };
+  auto rewriter = [](const Expression *e) -> Expression * {
+    DCHECK_EQ(e->kind(), Expression::Kind::kRelIn);
+    const auto re = static_cast<const RelationalExpression *>(e);
+    auto lhs = re->left();
+    auto rhs = re->right();
+    DCHECK(rhs->kind() == Expression::Kind::kList || rhs->kind() == Expression::Kind::kSet);
+    auto ce = static_cast<const ContainerExpression *>(rhs);
+    auto pool = e->getObjPool();
+    auto *rewrittenExpr = LogicalExpression::makeOr(pool);
+    // Pointer to a single-level expression
+    Expression *singleExpr = nullptr;
+    auto items = ce->getKeys();
+    for (auto i = 0u; i < items.size(); ++i) {
+      auto *ee = RelationalExpression::makeEQ(pool, lhs->clone(), items[i]->clone());
+      rewrittenExpr->addOperand(ee);
+      if (i == 0) {
+        singleExpr = ee;
+      } else {
+        singleExpr = nullptr;
+      }
+    }
+    return singleExpr ? singleExpr : rewrittenExpr;
   };
 
   return graph::RewriteVisitor::transform(expr, matcher, rewriter);
@@ -344,10 +391,10 @@ std::vector<Expression *> ExpressionUtils::getContainerExprOperands(const Expres
   std::vector<Expression *> containerOperands;
   switch (containerExpr->kind()) {
     case Expression::Kind::kList:
-      containerOperands = static_cast<ListExpression *>(containerExpr)->get();
+      containerOperands = static_cast<ListExpression *>(containerExpr)->getKeys();
       break;
     case Expression::Kind::kSet: {
-      containerOperands = static_cast<SetExpression *>(containerExpr)->get();
+      containerOperands = static_cast<SetExpression *>(containerExpr)->getKeys();
       break;
     }
     case Expression::Kind::kMap: {

--- a/src/graph/util/ExpressionUtils.h
+++ b/src/graph/util/ExpressionUtils.h
@@ -83,6 +83,9 @@ class ExpressionUtils {
   // Rewrites ParameterExpression to ConstantExpression
   static Expression* rewriteParameter(const Expression* expr, QueryContext* qctx);
 
+  // Rewrite RelInExpr with only one operand in expression tree
+  static Expression* rewriteInnerInExpr(const Expression* expr);
+
   // Rewrites relational expression, gather all evaluable expressions in the left operands and move
   // them to the right
   static Expression* rewriteRelExpr(const Expression* expr);

--- a/src/graph/validator/MatchValidator.cpp
+++ b/src/graph/validator/MatchValidator.cpp
@@ -303,7 +303,8 @@ Status MatchValidator::buildEdgeInfo(const MatchPath *path,
 // Rewrite expression to fit semantic, check type and check used aliases.
 Status MatchValidator::validateFilter(const Expression *filter,
                                       WhereClauseContext &whereClauseCtx) {
-  auto transformRes = ExpressionUtils::filterTransform(filter);
+  auto *newFilter = graph::ExpressionUtils::rewriteInnerInExpr(filter);
+  auto transformRes = ExpressionUtils::filterTransform(newFilter);
   NG_RETURN_IF_ERROR(transformRes);
   // rewrite Attribute to LabelTagProperty
   whereClauseCtx.filter = ExpressionUtils::rewriteAttr2LabelTagProp(

--- a/tests/tck/features/match/IndexSelecting.feature
+++ b/tests/tck/features/match/IndexSelecting.feature
@@ -59,6 +59,35 @@ Feature: Index selecting for match statement
       | 0  | Start          |              |                                                     |
     When profiling query:
       """
+      MATCH (v:player) WHERE v.player.name in ["Yao Ming"] RETURN v.player.name AS name
+      """
+    Then the result should be, in any order, with relax comparison:
+      | name       |
+      | "Yao Ming" |
+    And the execution plan should be:
+      | id | name           | dependencies | operator info                                       |
+      | 6  | Project        | 2            |                                                     |
+      | 2  | Filter         | 5            |                                                     |
+      | 2  | AppendVertices | 5            |                                                     |
+      | 5  | IndexScan      | 0            | {"indexCtx": {"columnHints":{"scanType":"PREFIX"}}} |
+      | 0  | Start          |              |                                                     |
+    When profiling query:
+      """
+      MATCH (v:player) WHERE v.player.name in ["Yao Ming", "Tim Duncan"] RETURN v.player.name AS name
+      """
+    Then the result should be, in any order, with relax comparison:
+      | name         |
+      | "Tim Duncan" |
+      | "Yao Ming"   |
+    And the execution plan should be:
+      | id | name           | dependencies | operator info                                       |
+      | 6  | Project        | 2            |                                                     |
+      | 2  | Filter         | 5            |                                                     |
+      | 2  | AppendVertices | 5            |                                                     |
+      | 5  | IndexScan      | 0            | {"indexCtx": {"columnHints":{"scanType":"PREFIX"}}} |
+      | 0  | Start          |              |                                                     |
+    When profiling query:
+      """
       MATCH (v:player) WHERE v.player.name == "Tim Duncan" and v.player.name < "Zom" RETURN v.player.name AS name
       """
     Then the result should be, in any order, with relax comparison:

--- a/tests/tck/features/match/SeekById.feature
+++ b/tests/tck/features/match/SeekById.feature
@@ -226,7 +226,6 @@ Feature: Match seek by id
       | "Rajon Rondo"      | "Lakers"    |
       | "LeBron James"     | "Lakers"    |
 
-  @czp
   Scenario: can't refer
     When executing query:
       """

--- a/tests/tck/features/match/SeekById.feature
+++ b/tests/tck/features/match/SeekById.feature
@@ -226,6 +226,7 @@ Feature: Match seek by id
       | "Rajon Rondo"      | "Lakers"    |
       | "LeBron James"     | "Lakers"    |
 
+  @czp
   Scenario: can't refer
     When executing query:
       """


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula/issues/4708

#### Description:


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [x] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [x] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
