### PR TITLE
download job related fix

### DIFF
--- a/src/common/hdfs/HdfsCommandHelper.cpp
+++ b/src/common/hdfs/HdfsCommandHelper.cpp
@@ -23,6 +23,7 @@ Status HdfsCommandHelper::ls(const std::string& hdfsHost,
     folly::Subprocess proc(std::vector<std::string>({"/bin/bash", "-c", command}));
     auto result = proc.wait();
     if (!result.exited()) {
+      LOG(INFO) << "Failed to ls: " << result.str();
       return Status::Error("Failed to ls hdfs");
     } else if (result.exitStatus() != 0) {
       LOG(INFO) << "Failed to ls: " << result.str();
@@ -49,6 +50,7 @@ Status HdfsCommandHelper::copyToLocal(const std::string& hdfsHost,
     folly::Subprocess proc(std::vector<std::string>({"/bin/bash", "-c", command}));
     auto result = proc.wait();
     if (!result.exited()) {
+      LOG(INFO) << "Failed to download: " << result.str();
       return Status::Error("Failed to download from hdfs");
     } else if (result.exitStatus() != 0) {
       LOG(INFO) << "Failed to download: " << result.str();

--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -438,6 +438,9 @@ int32_t RocksEngine::totalPartsNum() {
 
 nebula::cpp2::ErrorCode RocksEngine::ingest(const std::vector<std::string>& files,
                                             bool verifyFileChecksum) {
+  if (files.empty()) {
+    return nebula::cpp2::ErrorCode::SUCCEEDED;
+  }
   rocksdb::IngestExternalFileOptions options;
   options.move_files = FLAGS_move_files;
   options.verify_file_checksum = verifyFileChecksum;

--- a/src/kvstore/test/RocksEngineTest.cpp
+++ b/src/kvstore/test/RocksEngineTest.cpp
@@ -225,6 +225,8 @@ TEST_P(RocksEngineTest, IngestTest) {
   EXPECT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, engine->get("key_empty", &result));
   EXPECT_EQ("", result);
   EXPECT_EQ(nebula::cpp2::ErrorCode::E_KEY_NOT_FOUND, engine->get("key_not_exist", &result));
+
+  EXPECT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, engine->ingest({}));
 }
 
 TEST_P(RocksEngineTest, BackupRestoreTable) {

--- a/src/storage/admin/DownloadTask.cpp
+++ b/src/storage/admin/DownloadTask.cpp
@@ -50,6 +50,13 @@ nebula::cpp2::ErrorCode DownloadTask::subTask(GraphSpaceID space, PartitionID pa
     }
   }
 
+  auto listResult = helper_->ls(hdfsHost_, hdfsPort_, hdfsPartPath);
+  if (!listResult.ok()) {
+    LOG(INFO) << "Can't found data of space: " << space << ", part: " << part
+              << ", just skip the part";
+    return nebula::cpp2::ErrorCode::SUCCEEDED;
+  }
+
   auto result = helper_->copyToLocal(hdfsHost_, hdfsPort_, hdfsPartPath, localPath);
   return result.ok() ? nebula::cpp2::ErrorCode::SUCCEEDED
                      : nebula::cpp2::ErrorCode::E_TASK_EXECUTION_FAILED;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula-ent/issues/1463
close https://github.com/vesoft-inc/nebula-ent/issues/1464

#### Description:
When exchange generate SST files, some part may do not have data, so there won't exist corresponding part directory. After we change the way to execute hdfs command, this will be an issue. Because there will be an error like `dir not exists`, so when storage really start download, first `ls`, if the directory exists then copy.

And we need to handle ingest no files into rocksdb.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
