### PR TITLE
Fix wrong output when using pattern expression as the filter in MATCH

### DIFF
--- a/src/common/expression/UnaryExpression.h
+++ b/src/common/expression/UnaryExpression.h
@@ -87,7 +87,7 @@ class UnaryExpression final : public Expression {
   void resetFrom(Decoder& decoder) override;
 
  private:
-  Expression* operand_;
+  Expression* operand_{nullptr};
   Value result_;
 };
 

--- a/tests/tck/features/match/PathExpr.feature
+++ b/tests/tck/features/match/PathExpr.feature
@@ -150,6 +150,13 @@ Feature: Basic match
       | ("Aron Baynes" :player{age: 32, name: "Aron Baynes"})         |
       | ("Tiago Splitter" :player{age: 34, name: "Tiago Splitter"})   |
       | ("Boris Diaw" :player{age: 36, name: "Boris Diaw"})           |
+    When executing query:
+      """
+      MATCH p = (v:player{name:"Tim Duncan"})-[e]->(t) WHERE NOT (v)-[]->(t:player) RETURN t
+      """
+    Then the result should be, in any order:
+      | t                              |
+      | ("Spurs" :team{name: "Spurs"}) |
 
   Scenario: In With
     When executing query:


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula/issues/4760

#### Description:
The `roolUp` executor produces wrong results.

After fix:
```
(root@nebula) [nba]> match p = (v:player{name:"Tim Duncan"})-[e]->(t) where not (v)-[]->(t:player) return t
+--------------------------------+
| t                              |
+--------------------------------+
| ("Spurs" :team{name: "Spurs"}) |
+--------------------------------+
Got 1 rows (time spent 22.629ms/23.301331ms)
```

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [x] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
