### PR TITLE
[enhancement] Add indents to storage details when profiling a query

### DIFF
--- a/src/graph/executor/StorageAccessExecutor.cpp
+++ b/src/graph/executor/StorageAccessExecutor.cpp
@@ -5,7 +5,6 @@
 #include "graph/executor/StorageAccessExecutor.h"
 
 #include <folly/Format.h>
-#include <folly/dynamic.h>
 
 #include "graph/context/Iterator.h"
 #include "graph/context/QueryExpressionContext.h"

--- a/src/graph/executor/StorageAccessExecutor.cpp
+++ b/src/graph/executor/StorageAccessExecutor.cpp
@@ -5,6 +5,7 @@
 #include "graph/executor/StorageAccessExecutor.h"
 
 #include <folly/Format.h>
+#include <folly/dynamic.h>
 
 #include "graph/context/Iterator.h"
 #include "graph/context/QueryExpressionContext.h"
@@ -152,7 +153,7 @@ std::string StorageAccessExecutor::getStorageDetail(
     optional_field_ref<const std::map<std::string, int32_t> &> ref) const {
   if (ref.has_value()) {
     auto content = util::join(*ref, [](auto &iter) -> std::string {
-      return folly::sformat("{}:{}(us)", iter.first, iter.second);
+      return folly::sformat("\n  {}:{}(us)", iter.first, iter.second);
     });
     return "{" + content + "}";
   }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula/issues/4794

#### Description:
The storage stats is a single line which is hard to read.

Before:
```
| 14 | IndexScan      | 2            | {                                                                                                                                                                                       | outputVar: {                                            |
|    |                |              | ver: 0, rows: 1, execTime: 0us, totalTime: 2810us                                                                                                                                       |   "colNames": [                                         |
|    |                |              | "127.0.0.1":39735 exec/total: 1585(us)/2431(us)                                                                                                                                         |     "_vid"                                              |
|    |                |              | storage_detail: {{"IndexVertexScanNode(IndexID=16, Path=(name=\"Tim Duncan\", ))":827,"IndexProjectionNode(projectColumn=[_vid])":859,"IndexLimitNode(limit=9223372036854775807)":884}} |   ],                                                    |
|    |                |              | }                                                                                                                                                                                       |   "type": "DATASET",                                    |
|    |                |              |                                                                                                                                                                                         |   "name": "__IndexScan_1"                               |
|    |                |              |                                                                                                                                                                                         | }                                                       |
|    |                |              |                                                                                                                                                                                         | inputVar:                                               |
```
After:
```
| 14 | IndexScan      | 2            | {                                                                      | outputVar: {                                            |
|    |                |              | ver: 0, rows: 1, execTime: 0us, totalTime: 2876us                      |   "colNames": [                                         |
|    |                |              | "127.0.0.1":39735 exec/total: 1727(us)/2648(us)                        |     "_vid"                                              |
|    |                |              | storage_detail: {                                                      |   ],                                                    |
|    |                |              |   IndexLimitNode(limit=9223372036854775807):957(us),                   |   "name": "__IndexScan_1",                              |
|    |                |              |   IndexProjectionNode(projectColumn=[_vid]):927(us),                   |   "type": "DATASET"                                     |
|    |                |              |   IndexVertexScanNode(IndexID=16, Path=(name="Tim Duncan", )):899(us)} | }                                                       |
|    |                |              | }                                                                      | inputVar:                                               |

```
## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
