### PR TITLE
only create 1 part in tck

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -97,7 +97,7 @@ jobs:
                   -DENABLE_TESTING=on \
                   -GNinja \
                   -B build
-              echo "::set-output name=j::10"
+              echo "::set-output name=j::8"
               ;;
             ubuntu2004)
               # build with Debug type
@@ -109,7 +109,7 @@ jobs:
                   -DENABLE_COVERAGE=on \
                   -GNinja \
                   -B build
-              echo "::set-output name=j::10"
+              echo "::set-output name=j::8"
               ;;
             esac
             ;;
@@ -123,7 +123,7 @@ jobs:
                 -DENABLE_TESTING=on \
                 -GNinja \
                 -B build
-            echo "::set-output name=j::6"
+            echo "::set-output name=j::4"
             ;;
           esac
       - name: Make
@@ -246,7 +246,7 @@ jobs:
                   -DENABLE_STANDALONE_VERSION=on \
                   -GNinja \
                   -B build
-              echo "::set-output name=j::10"
+              echo "::set-output name=j::8"
               ;;
             esac
             ;;

--- a/src/kvstore/test/NebulaStoreTest.cpp
+++ b/src/kvstore/test/NebulaStoreTest.cpp
@@ -23,6 +23,7 @@
 
 DECLARE_uint32(raft_heartbeat_interval_secs);
 DECLARE_bool(auto_remove_invalid_space);
+DECLARE_bool(wal_sync);
 const int32_t kDefaultVidLen = 8;
 using nebula::meta::PartHosts;
 
@@ -38,11 +39,8 @@ void dump(const std::vector<T>& v) {
   VLOG(1) << ss.str();
 }
 
-std::shared_ptr<apache::thrift::concurrency::PriorityThreadManager> getHandlers() {
-  auto handlersPool =
-      apache::thrift::concurrency::PriorityThreadManager::newPriorityThreadManager(1);
-  handlersPool->setNamePrefix("executor");
-  handlersPool->start();
+std::shared_ptr<folly::IOThreadPoolExecutor> getHandlers() {
+  static auto handlersPool = std::make_shared<folly::IOThreadPoolExecutor>(1);
   return handlersPool;
 }
 
@@ -733,6 +731,7 @@ TEST(NebulaStoreTest, CheckpointTest) {
 }
 
 TEST(NebulaStoreTest, ThreeCopiesCheckpointTest) {
+  FLAGS_wal_sync = true;
   fs::TempDir rootPath("/tmp/nebula_store_test.XXXXXX");
   auto initNebulaStore = [](const std::vector<HostAddr>& peers,
                             int32_t index,
@@ -936,6 +935,7 @@ TEST(NebulaStoreTest, ThreeCopiesCheckpointTest) {
       }
     }
   }
+  FLAGS_wal_sync = false;
 }
 
 TEST(NebulaStoreTest, ReadSnapshotTest) {

--- a/src/kvstore/wal/FileBasedWal.cpp
+++ b/src/kvstore/wal/FileBasedWal.cpp
@@ -389,7 +389,7 @@ void FileBasedWal::scanLastWal(WalFileInfoPtr info, LogID firstId) {
     }
 
     if (id != curLogId) {
-      LOG(WARNING) << "LogId is not consistent" << id << " " << curLogId;
+      LOG(WARNING) << "LogId is not consistent " << id << " " << curLogId;
       break;
     }
 

--- a/tests/admin/test_parts.py
+++ b/tests/admin/test_parts.py
@@ -18,7 +18,7 @@ class TestParts(NebulaTestSuite):
 
     @classmethod
     def prepare(self):
-        resp = self.client.execute('CREATE SPACE space_show_parts(partition_num=5, vid_type=FIXED_STRING(8));'
+        resp = self.client.execute('CREATE SPACE space_show_parts(partition_num=1, vid_type=FIXED_STRING(8));'
                                    'USE space_show_parts;')
         self.check_resp_succeeded(resp)
 
@@ -41,17 +41,17 @@ class TestParts(NebulaTestSuite):
              leader_pattern,
              peers_pattern,
              losts_pattern]
-            for i in range(1, 6)
+            for i in range(1, 2)
         ]
         self.check_result(resp, expected_result, is_regex=True)
 
 
         # Specify the part id
-        resp = self.client.execute('SHOW PART 3')
+        resp = self.client.execute('SHOW PART 1')
         self.check_resp_succeeded(resp)
         expected_col_names = ["Partition ID", "Leader", "Peers", "Losts"]
         self.check_column_names(resp, expected_col_names)
-        expected_result = [[re.compile(r'3'),
+        expected_result = [[re.compile(r'1'),
                             leader_pattern,
                             peers_pattern,
                             losts_pattern]]

--- a/tests/admin/test_space.py
+++ b/tests/admin/test_space.py
@@ -31,7 +31,7 @@ class TestSpace(NebulaTestSuite):
         self.check_resp_succeeded(resp)
 
         # create space succeeded
-        resp = self.client.execute('CREATE SPACE default_space(partition_num=9, replica_factor=1, vid_type=FIXED_STRING(8))')
+        resp = self.client.execute('CREATE SPACE default_space(partition_num=1, replica_factor=1, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
 
         # show spaces
@@ -52,7 +52,7 @@ class TestSpace(NebulaTestSuite):
         resp = self.client.execute('SHOW CREATE SPACE default_space')
         self.check_resp_succeeded(resp)
 
-        # create_space_str_result = 'CREATE SPACE `default_space` (partition_num = 9, '\
+        # create_space_str_result = 'CREATE SPACE `default_space` (partition_num = 1, '\
         #                           'replica_factor = 1, '\
         #                           'charset = utf8, '\
         #                           'collate = utf8_bin, '\
@@ -67,7 +67,7 @@ class TestSpace(NebulaTestSuite):
         resp = self.client.execute('DROP SPACE default_space')
         self.check_resp_succeeded(resp)
 
-        create_space_str = 'CREATE SPACE `default_space` (partition_num = 9, '\
+        create_space_str = 'CREATE SPACE `default_space` (partition_num = 1, '\
                            'replica_factor = 1, '\
                            'charset = utf8, '\
                            'collate = utf8_bin, '\
@@ -86,7 +86,7 @@ class TestSpace(NebulaTestSuite):
         self.check_resp_succeeded(resp)
 
     def test_charset_collate(self):
-        resp = self.client.execute('CREATE SPACE space_charset_collate (partition_num=9, '
+        resp = self.client.execute('CREATE SPACE space_charset_collate (partition_num=1, '
                                    'replica_factor=1, charset=utf8, collate=utf8_bin, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
 
@@ -99,7 +99,7 @@ class TestSpace(NebulaTestSuite):
         resp = self.client.execute('DROP SPACE space_charset_collate')
         self.check_resp_succeeded(resp)
 
-        resp = self.client.execute('CREATE SPACE space_charset (partition_num=9, '
+        resp = self.client.execute('CREATE SPACE space_charset (partition_num=1, '
                                    'replica_factor=1, charset=utf8, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
 
@@ -112,7 +112,7 @@ class TestSpace(NebulaTestSuite):
         resp = self.client.execute('DROP SPACE space_charset')
         self.check_resp_succeeded(resp)
 
-        resp = self.client.execute('CREATE SPACE space_collate (partition_num=9, '
+        resp = self.client.execute('CREATE SPACE space_collate (partition_num=1, '
                                    'replica_factor=1, collate=utf8_bin, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
 
@@ -126,17 +126,17 @@ class TestSpace(NebulaTestSuite):
         self.check_resp_succeeded(resp)
 
         # not supported collate
-        resp = self.client.execute('CREATE SPACE space_charset_collate_nomatch (partition_num=9, '
+        resp = self.client.execute('CREATE SPACE space_charset_collate_nomatch (partition_num=1, '
                                    'replica_factor=1, charset = utf8, collate=gbk_bin, vid_type=FIXED_STRING(8))')
         self.check_resp_failed(resp)
 
         # not supported charset
-        resp = self.client.execute('CREATE SPACE space_charset_collate_nomatch (partition_num=9, '
+        resp = self.client.execute('CREATE SPACE space_charset_collate_nomatch (partition_num=1, '
                                    'replica_factor=1, charset = gbk, collate=utf8_bin, vid_type=FIXED_STRING(8))')
         self.check_resp_failed(resp)
 
         # not supported charset
-        resp = self.client.execute('CREATE SPACE space_illegal_charset (partition_num=9, '
+        resp = self.client.execute('CREATE SPACE space_illegal_charset (partition_num=1, '
                                    'replica_factor=1, charset = gbk, vid_type=FIXED_STRING(8))')
         self.check_resp_failed(resp)
 
@@ -145,11 +145,11 @@ class TestSpace(NebulaTestSuite):
                                    'replica_factor=1, collate = gbk_bin, vid_type=FIXED_STRING(8))')
         self.check_resp_failed(resp)
 
-        resp = self.client.execute('CREATE SPACE space_illegal_collate (partition_num=9, '
+        resp = self.client.execute('CREATE SPACE space_illegal_collate (partition_num=1, '
                                    'replica_factor=1, collate = gbk_bin, vid_type=FIXED_STRING(8))')
         self.check_resp_failed(resp)
 
-        resp = self.client.execute('CREATE SPACE space_capital (partition_num=9, '
+        resp = self.client.execute('CREATE SPACE space_capital (partition_num=1, '
                                    'replica_factor=1, charset=UTF8, collate=UTF8_bin, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
 
@@ -201,7 +201,7 @@ class TestSpace(NebulaTestSuite):
         self.search_not_exist(resp, expect_result)
 
     def test_create_space_with_string_vid(self):
-        resp = self.client.execute('CREATE SPACE space_string_vid (partition_num=9, '
+        resp = self.client.execute('CREATE SPACE space_string_vid (partition_num=1, '
                                    'replica_factor=1, charset=utf8, collate=utf8_bin, '
                                    'vid_type = fixed_string(30))')
         self.check_resp_succeeded(resp)
@@ -216,7 +216,7 @@ class TestSpace(NebulaTestSuite):
         self.check_resp_succeeded(resp)
 
     def test_create_space_with_int_vid(self):
-        resp = self.client.execute('CREATE SPACE space_int_vid (partition_num=9, '
+        resp = self.client.execute('CREATE SPACE space_int_vid (partition_num=1, '
                                    'replica_factor=1, charset=utf8, collate=utf8_bin, '
                                    'vid_type = int64)')
         self.check_resp_succeeded(resp)

--- a/tests/common/nebula_service.py
+++ b/tests/common/nebula_service.py
@@ -303,6 +303,8 @@ class NebulaService(object):
 
         # params for meta only
         self.metad_param = copy.copy(_params)
+        self.metad_param["default_parts_num"] = 1
+
         for p in [self.metad_param, self.storaged_param, self.graphd_param]:
             p.update(kwargs)
 
@@ -338,6 +340,7 @@ class NebulaService(object):
         self.graphd_param['add_local_host'] = 'false'
         if self.query_concurrently:
             self.graphd_param['max_job_size'] = '4'
+        self.graphd_param["default_parts_num"] = 1
 
         for p in [self.metad_param, self.storaged_param, self.graphd_param]:
             p.update(kwargs)

--- a/tests/common/types.py
+++ b/tests/common/types.py
@@ -7,7 +7,7 @@ class SpaceDesc:
     def __init__(self,
                  name: str,
                  vid_type: str = "FIXED_STRING(32)",
-                 partition_num: int = 7,
+                 partition_num: int = 1,
                  replica_factor: int = 1,
                  charset: str = "utf8",
                  collate: str = "utf8_bin"):
@@ -26,7 +26,7 @@ class SpaceDesc:
         return SpaceDesc(
             name=obj.get('name', None),
             vid_type=obj.get('vid_type', 'FIXED_STRING(32)'),
-            partition_num=obj.get('partition_num', 7),
+            partition_num=obj.get('partition_num', 1),
             replica_factor=obj.get('replica_factor', 1),
             charset=obj.get('charset', 'utf8'),
             collate=obj.get('collate', 'utf8_bin'),

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -417,7 +417,7 @@ def load_csv_data(
         space_desc = SpaceDesc(
             name=space_name,
             vid_type=space.get('vidType', 'FIXED_STRING(32)'),
-            partition_num=space.get('partitionNum', 7),
+            partition_num=space.get('partitionNum', 1),
             replica_factor=space.get('replicaFactor', 1),
             charset=space.get('charset', 'utf8'),
             collate=space.get('collate', 'utf8_bin'),
@@ -431,7 +431,7 @@ def load_csv_data(
             resp_ok(sess, line.strip(), True)
 
         # wait heartbeat_interval_secs + 1 seconds for schema synchronization
-        time.sleep(2)
+        time.sleep(3)
 
         if config["files"] is not None:
             for fd in config["files"]:

--- a/tests/data/ldbc_v0_3_3/config.yaml
+++ b/tests/data/ldbc_v0_3_3/config.yaml
@@ -1,6 +1,6 @@
 space:
   name: ldbc_v0_3_3
-  partitionNum: 8
+  partitionNum: 1
   replicaFactor: 1
   vidType: FIXED_STRING(32)
   charset: utf8

--- a/tests/data/nba/config.yaml
+++ b/tests/data/nba/config.yaml
@@ -1,6 +1,6 @@
 space:
   name: nba
-  partitionNum: 7
+  partitionNum: 1
   replicaFactor: 1
   vidType: FIXED_STRING(32)
   charset: utf8

--- a/tests/data/nba_int_vid/config.yaml
+++ b/tests/data/nba_int_vid/config.yaml
@@ -1,6 +1,6 @@
 space:
   name: nba_int_vid
-  partitionNum: 7
+  partitionNum: 1
   replicaFactor: 1
   vidType: int
   charset: utf8

--- a/tests/data/student/config.yaml
+++ b/tests/data/student/config.yaml
@@ -1,6 +1,6 @@
 space:
   name: student
-  partitionNum: 7
+  partitionNum: 1
   replicaFactor: 1
   vidType: FIXED_STRING(32)
   charset: utf8

--- a/tests/query/stateless/test_if_exists.py
+++ b/tests/query/stateless/test_if_exists.py
@@ -24,10 +24,10 @@ class TestDropSpaceIfExists(NebulaTestSuite):
         resp = self.execute(cmd)
         self.check_resp_succeeded(resp)
 
-        resp = self.execute('CREATE SPACE shakespaces(partition_num=1024, vid_type=FIXED_STRING(8))')
+        resp = self.execute('CREATE SPACE shakespaces(partition_num=1, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
 
-        resp = self.execute('CREATE SPACE IF NOT EXISTS shakespaces(partition_num=1024, vid_type=FIXED_STRING(8))')
+        resp = self.execute('CREATE SPACE IF NOT EXISTS shakespaces(partition_num=1, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
 
         cmd = 'drop space shakespaces'
@@ -38,7 +38,7 @@ class TestDropSpaceIfExists(NebulaTestSuite):
         resp = self.execute(cmd)
         self.check_resp_succeeded(resp)
 
-        resp = self.execute('CREATE SPACE IF NOT EXISTS shakespaces(partition_num=1024, vid_type=FIXED_STRING(8))')
+        resp = self.execute('CREATE SPACE IF NOT EXISTS shakespaces(partition_num=1, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
 
         time.sleep(self.delay)

--- a/tests/query/stateless/test_keyword.py
+++ b/tests/query/stateless/test_keyword.py
@@ -20,7 +20,7 @@ class TestReservedKeyword(NebulaTestSuite):
     # some reversed keywords are moved to unreversed keywords, and vice versa in #1922
     def test_keywords1(self):
         resp = self.execute(
-            'CREATE SPACE IF NOT EXISTS test(partition_num=1024, vid_type=FIXED_STRING(8))')
+            'CREATE SPACE IF NOT EXISTS test(partition_num=1, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
         time.sleep(self.delay)
 
@@ -301,7 +301,7 @@ class TestReservedKeyword(NebulaTestSuite):
 
     def test_keywords2(self):
         resp = self.execute(
-            'CREATE SPACE IF NOT EXISTS test(partition_num=1024, vid_type=FIXED_STRING(8))')
+            'CREATE SPACE IF NOT EXISTS test(partition_num=1, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
         time.sleep(self.delay)
 
@@ -901,7 +901,7 @@ class TestReservedKeyword(NebulaTestSuite):
 
     def test_keywords3(self):
         resp = self.execute(
-            'CREATE SPACE IF NOT EXISTS test (partition_num=10, vid_type=FIXED_STRING(8))')
+            'CREATE SPACE IF NOT EXISTS test (partition_num=1, vid_type=FIXED_STRING(8))')
         self.check_resp_succeeded(resp)
         time.sleep(self.delay)
 

--- a/tests/tck/conftest.py
+++ b/tests/tck/conftest.py
@@ -224,7 +224,7 @@ def new_space(request, options, exec_ctx):
     name = "EmptyGraph_" + space_generator()
     space_desc = SpaceDesc(
         name=opts.get("name", name),
-        partition_num=int(opts.get("partition_num", 7)),
+        partition_num=int(opts.get("partition_num", 1)),
         replica_factor=int(opts.get("replica_factor", 1)),
         vid_type=opts.get("vid_type", "FIXED_STRING(30)"),
         charset=opts.get("charset", "utf8"),
@@ -241,7 +241,7 @@ def new_space(request, exec_ctx):
     name = "EmptyGraph_" + space_generator()
     space_desc = SpaceDesc(
         name=name,
-        partition_num=9,
+        partition_num=1,
         replica_factor=1,
         vid_type="FIXED_STRING(30)",
         charset="utf8",

--- a/tests/tck/features/admin/Hosts.feature
+++ b/tests/tck/features/admin/Hosts.feature
@@ -41,12 +41,12 @@ Feature: Admin hosts
     Then a SemanticError should be raised at runtime: space vid_type must be specified explicitly
     When executing query:
       """
-      CREATE SPACE space_without_vid_type(partition_num=9, replica_factor=3);
+      CREATE SPACE space_without_vid_type(partition_num=1, replica_factor=3);
       """
     Then a SemanticError should be raised at runtime: space vid_type must be specified explicitly
     When executing query:
       """
-      CREATE SPACE space_without_vid_type(partition_num=9, replica_factor=3) on default_zone;
+      CREATE SPACE space_without_vid_type(partition_num=1, replica_factor=3) on default_zone;
       """
     Then a SemanticError should be raised at runtime: Create space with zone is unsupported
     When executing query:
@@ -56,7 +56,7 @@ Feature: Admin hosts
     Then a SemanticError should be raised at runtime: Create space with zone is unsupported
     When executing query:
       """
-      CREATE SPACE space_specify_vid_type(partition_num=9, replica_factor=1, vid_type=FIXED_STRING(8));
+      CREATE SPACE space_specify_vid_type(partition_num=1, replica_factor=1, vid_type=FIXED_STRING(8));
       DROP SPACE space_specify_vid_type
       """
     Then the execution should be successful

--- a/tests/tck/features/bugfix/CreateDurationAsDefaultValue.feature
+++ b/tests/tck/features/bugfix/CreateDurationAsDefaultValue.feature
@@ -6,7 +6,7 @@ Feature: Create duration as default value
   Scenario: Create duration as default value
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/bugfix/InsertMismatchedTypeDateTime.feature
+++ b/tests/tck/features/bugfix/InsertMismatchedTypeDateTime.feature
@@ -7,7 +7,7 @@ Feature: Datetime insert mismatched type
   Scenario: DateTime insert mismatched type
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/bugfix/LookupIn.feature
+++ b/tests/tck/features/bugfix/LookupIn.feature
@@ -45,7 +45,7 @@ Feature: Lookup_In
   Scenario: lookup in where filter contains a function call
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/bugfix/RoundFloat.feature
+++ b/tests/tck/features/bugfix/RoundFloat.feature
@@ -7,7 +7,7 @@ Feature: Round the float/double when insert them into integer column
   Scenario: Insert float/double into a integer column
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/bugfix/TimeDefaultValue.feature
+++ b/tests/tck/features/bugfix/TimeDefaultValue.feature
@@ -6,7 +6,7 @@ Feature: Datetime default value
   Scenario: DateTime Default Value
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/bugfix/TruncatedStringIndex.feature
+++ b/tests/tck/features/bugfix/TruncatedStringIndex.feature
@@ -6,7 +6,7 @@ Feature: Truncated string index
   Scenario: Truncated string index
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/bugfix/TypoError.feature
+++ b/tests/tck/features/bugfix/TypoError.feature
@@ -7,7 +7,7 @@ Feature: Typo error
   Scenario: Typo error of KW_VALUE
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/bugfix/VidInvalidLength.feature
+++ b/tests/tck/features/bugfix/VidInvalidLength.feature
@@ -6,7 +6,7 @@ Feature: Invalid vid length
   # issue https://github.com/vesoft-inc/nebula/issues/4397
   Scenario: With vertex operate overlength vid with no index
     Given create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(10) |
     When executing query:
@@ -41,7 +41,7 @@ Feature: Invalid vid length
 
   Scenario: With vertex operate overlength vid with index
     Given create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(10) |
     When executing query:
@@ -77,7 +77,7 @@ Feature: Invalid vid length
 
   Scenario: With edge operate overlength vid with no index
     Given create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(10) |
     When executing query:
@@ -114,7 +114,7 @@ Feature: Invalid vid length
 
   Scenario: With edge operate overlength vid with index
     Given create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(10) |
     When executing query:

--- a/tests/tck/features/delete/DeleteEdge.IntVid.feature
+++ b/tests/tck/features/delete/DeleteEdge.IntVid.feature
@@ -6,7 +6,7 @@ Feature: Delete int vid of edge
   Scenario: delete edges
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9   |
+      | partition_num  | 1   |
       | replica_factor | 1   |
       | vid_type       | int |
     And having executed:

--- a/tests/tck/features/delete/DeleteEdge.feature
+++ b/tests/tck/features/delete/DeleteEdge.feature
@@ -6,7 +6,7 @@ Feature: Delete string vid of edge
   Scenario: delete edges
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:

--- a/tests/tck/features/delete/DeleteVertexWithoutEdge.feature
+++ b/tests/tck/features/delete/DeleteVertexWithoutEdge.feature
@@ -6,7 +6,7 @@ Feature: delete vertex without edge
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9     |
+      | partition_num  | 1     |
       | replica_factor | 1     |
       | vid_type       | int64 |
 

--- a/tests/tck/features/geo/GeoBase.feature
+++ b/tests/tck/features/geo/GeoBase.feature
@@ -6,7 +6,7 @@ Feature: Geo base
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/index/Index.IntVid.feature
+++ b/tests/tck/features/index/Index.IntVid.feature
@@ -3,7 +3,7 @@ Feature: IndexTest_Vid_Int
   Scenario: IndexTest IntVid TagIndex
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9        |
+      | partition_num  | 1        |
       | replica_factor | 1        |
       | vid_type       | int64    |
       | charset        | utf8     |
@@ -141,7 +141,7 @@ Feature: IndexTest_Vid_Int
   Scenario: IndexTest IntVid EdgeIndex
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9        |
+      | partition_num  | 1        |
       | replica_factor | 1        |
       | vid_type       | int64    |
       | charset        | utf8     |
@@ -274,7 +274,7 @@ Feature: IndexTest_Vid_Int
   Scenario: IndexTest IntVid TagIndexTTL
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9        |
+      | partition_num  | 1        |
       | replica_factor | 1        |
       | vid_type       | int64    |
       | charset        | utf8     |
@@ -399,7 +399,7 @@ Feature: IndexTest_Vid_Int
   Scenario: IndexTest IntVid EdgeIndexTTL
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9        |
+      | partition_num  | 1        |
       | replica_factor | 1        |
       | vid_type       | int64    |
       | charset        | utf8     |
@@ -513,7 +513,7 @@ Feature: IndexTest_Vid_Int
   Scenario: IndexTest IntVid AlterTag
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9        |
+      | partition_num  | 1        |
       | replica_factor | 1        |
       | vid_type       | int64    |
       | charset        | utf8     |
@@ -568,7 +568,7 @@ Feature: IndexTest_Vid_Int
   Scenario: IndexTest IntVid RebuildTagIndexStatusInfo
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9        |
+      | partition_num  | 1        |
       | replica_factor | 1        |
       | vid_type       | int64    |
       | charset        | utf8     |
@@ -616,7 +616,7 @@ Feature: IndexTest_Vid_Int
   Scenario: IndexTest IntVid RebuildEdgeIndexStatusInfo
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9        |
+      | partition_num  | 1        |
       | replica_factor | 1        |
       | vid_type       | int64    |
       | charset        | utf8     |
@@ -664,7 +664,7 @@ Feature: IndexTest_Vid_Int
   Scenario: IndexTest IntVid AlterSchemaTest
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9        |
+      | partition_num  | 1        |
       | replica_factor | 1        |
       | vid_type       | int64    |
       | charset        | utf8     |

--- a/tests/tck/features/index/Index.feature
+++ b/tests/tck/features/index/Index.feature
@@ -3,7 +3,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest TagIndex
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |
@@ -146,7 +146,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest EdgeIndex
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |
@@ -284,7 +284,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest TagIndexTTL
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |
@@ -409,7 +409,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest EdgeIndexTTL
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |
@@ -523,7 +523,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest AlterTag
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |
@@ -584,7 +584,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest RebuildTagIndexStatusInfo
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |
@@ -632,7 +632,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest RebuildEdgeIndexStatusInfo
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |
@@ -680,7 +680,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest AlterSchemaTest
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |
@@ -957,7 +957,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest existence check
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |
@@ -1000,7 +1000,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest rebuild tag index with old schema version value
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |
@@ -1151,7 +1151,7 @@ Feature: IndexTest_Vid_String
   Scenario: IndexTest NullableIndex
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/index/TagEdgeIndex.feature
+++ b/tests/tck/features/index/TagEdgeIndex.feature
@@ -3,7 +3,7 @@ Feature: tag and edge index tests from pytest
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/insert/BoundCheck.feature
+++ b/tests/tck/features/insert/BoundCheck.feature
@@ -6,7 +6,7 @@ Feature: Bound integer insertion test
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:

--- a/tests/tck/features/insert/Insert.IntVid.feature
+++ b/tests/tck/features/insert/Insert.IntVid.feature
@@ -6,7 +6,7 @@ Feature: Insert int vid of vertex and edge
   Background: Prepare space
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9   |
+      | partition_num  | 1   |
       | replica_factor | 1   |
       | vid_type       | int |
     And having executed:
@@ -506,7 +506,7 @@ Feature: Insert int vid of vertex and edge
   Scenario: int id ignore existed index
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9   |
+      | partition_num  | 1   |
       | replica_factor | 1   |
       | vid_type       | int |
     And having executed:

--- a/tests/tck/features/insert/Insert.feature
+++ b/tests/tck/features/insert/Insert.feature
@@ -6,7 +6,7 @@ Feature: Insert string vid of vertex and edge
   Scenario: insert vertex and edge test
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:
@@ -458,7 +458,7 @@ Feature: Insert string vid of vertex and edge
   Scenario: insert vertex and edge test by the 2.0 new type
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(10) |
     And having executed:
@@ -535,7 +535,7 @@ Feature: Insert string vid of vertex and edge
   Scenario: string id ignore existed index
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(10) |
     And having executed:

--- a/tests/tck/features/insert/InsertEdgeOnDiffParts.feature
+++ b/tests/tck/features/insert/InsertEdgeOnDiffParts.feature
@@ -6,7 +6,7 @@ Feature: Insert vertex and edge with if not exists
   Scenario: insert edge with default value
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:

--- a/tests/tck/features/insert/InsertIfNotExists.feature
+++ b/tests/tck/features/insert/InsertIfNotExists.feature
@@ -6,7 +6,7 @@ Feature: Insert vertex and edge with if not exists
   Scenario: insert vertex and edge if not exists test
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:
@@ -172,7 +172,7 @@ Feature: Insert vertex and edge with if not exists
   Scenario: insert vertex and edge with default propNames
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:
@@ -280,7 +280,7 @@ Feature: Insert vertex and edge with if not exists
   Scenario: vertices index and data consistency check
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:
@@ -408,7 +408,7 @@ Feature: Insert vertex and edge with if not exists
   Scenario: edge index and data consistency check
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:

--- a/tests/tck/features/insert/insertVertexOnly.feature
+++ b/tests/tck/features/insert/insertVertexOnly.feature
@@ -6,7 +6,7 @@ Feature: insert vertex without tag
   Background: Background name
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9     |
+      | partition_num  | 1     |
       | replica_factor | 1     |
       | vid_type       | int64 |
 

--- a/tests/tck/features/lookup/EdgeIndexFullScan.feature
+++ b/tests/tck/features/lookup/EdgeIndexFullScan.feature
@@ -3,7 +3,7 @@ Feature: Lookup edge index full scan
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(15) |
       | charset        | utf8             |

--- a/tests/tck/features/lookup/LookUp.IntVid.feature
+++ b/tests/tck/features/lookup/LookUp.IntVid.feature
@@ -3,7 +3,7 @@ Feature: LookUpTest_Vid_Int
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9        |
+      | partition_num  | 1        |
       | replica_factor | 1        |
       | vid_type       | int64    |
       | charset        | utf8     |

--- a/tests/tck/features/lookup/LookUp.feature
+++ b/tests/tck/features/lookup/LookUp.feature
@@ -3,7 +3,7 @@ Feature: LookUpTest_Vid_String
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(32) |
 

--- a/tests/tck/features/lookup/LookupEdge.feature
+++ b/tests/tck/features/lookup/LookupEdge.feature
@@ -30,7 +30,7 @@ Feature: Test lookup on edge index
   Scenario Outline: [edge] different condition and yield test for string vid
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | fixed_string(16) |
     And having executed:
@@ -79,7 +79,7 @@ Feature: Test lookup on edge index
   Scenario Outline: [edge] different condition and yield test for int vid
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9     |
+      | partition_num  | 1     |
       | replica_factor | 1     |
       | vid_type       | int64 |
     And having executed:

--- a/tests/tck/features/lookup/LookupEdge2.feature
+++ b/tests/tck/features/lookup/LookupEdge2.feature
@@ -7,7 +7,7 @@ Feature: Test lookup on edge index 2
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9          |
+      | partition_num  | 1          |
       | replica_factor | 1          |
       | vid_type       | <vid_type> |
     And having executed:

--- a/tests/tck/features/lookup/LookupTag.feature
+++ b/tests/tck/features/lookup/LookupTag.feature
@@ -29,7 +29,7 @@ Feature: Test lookup on tag index
   Scenario Outline: [tag] different condition and yield test for string vid
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | fixed_string(16) |
     And having executed:
@@ -79,7 +79,7 @@ Feature: Test lookup on tag index
   Scenario Outline: [tag] different condition and yield test for int vid
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9     |
+      | partition_num  | 1     |
       | replica_factor | 1     |
       | vid_type       | int64 |
     And having executed:

--- a/tests/tck/features/lookup/LookupTag2.feature
+++ b/tests/tck/features/lookup/LookupTag2.feature
@@ -7,7 +7,7 @@ Feature: Test lookup on tag index 2
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9          |
+      | partition_num  | 1          |
       | replica_factor | 1          |
       | vid_type       | <vid_type> |
     And having executed:

--- a/tests/tck/features/match/Base.feature
+++ b/tests/tck/features/match/Base.feature
@@ -457,7 +457,7 @@ Feature: Basic match
   Scenario: Match a path in a space which doesn't have edge schema
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:

--- a/tests/tck/features/match/IndexSelecting.feature
+++ b/tests/tck/features/match/IndexSelecting.feature
@@ -6,7 +6,7 @@ Feature: Index selecting for match statement
   Background: Prepare a new space
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/match/SameTagPropname.feature
+++ b/tests/tck/features/match/SameTagPropname.feature
@@ -6,7 +6,7 @@ Feature: Same Tag Propname
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(32) |
 

--- a/tests/tck/features/match/SeekByEdge.feature
+++ b/tests/tck/features/match/SeekByEdge.feature
@@ -1474,7 +1474,7 @@ Feature: Match seek by edge
   Scenario Outline: seek by edge in a single edge type space
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/match/SeekById.intVid.feature
+++ b/tests/tck/features/match/SeekById.intVid.feature
@@ -371,7 +371,7 @@ Feature: Match seek by id
   Scenario: [v2ga bug] Negative start vid
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9        |
+      | partition_num  | 1        |
       | replica_factor | 1        |
       | vid_type       | int64    |
       | charset        | utf8     |

--- a/tests/tck/features/mutate/ClearSpace.feature
+++ b/tests/tck/features/mutate/ClearSpace.feature
@@ -8,7 +8,7 @@ Feature: Clear space test
     Given an empty graph
     And create a space with following options:
       | name           | clear_space      |
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And wait 6 seconds
@@ -38,7 +38,7 @@ Feature: Clear space test
     Given an empty graph
     And create a space with following options:
       | name           | clear_space2     |
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And wait 6 seconds

--- a/tests/tck/features/mutate/InsertDurationType.feature
+++ b/tests/tck/features/mutate/InsertDurationType.feature
@@ -3,7 +3,7 @@ Feature: Insert duration
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
 

--- a/tests/tck/features/mutate/InsertWithTimeType.feature
+++ b/tests/tck/features/mutate/InsertWithTimeType.feature
@@ -3,7 +3,7 @@ Feature: Insert with time-dependent types
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
 

--- a/tests/tck/features/parser/Example.feature
+++ b/tests/tck/features/parser/Example.feature
@@ -46,7 +46,7 @@ Feature: Feature examples
   Scenario: Supported space creation
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(30) |
       | charset        | utf8             |

--- a/tests/tck/features/schema/Comment.feature
+++ b/tests/tck/features/schema/Comment.feature
@@ -15,15 +15,15 @@ Feature: Schema Comment
       SHOW CREATE SPACE <space_name>;
       """
     Then the result should be, in any order:
-      | Space          | Create Space                                                                                                                                                                                                  |
-      | "<space_name>" | /[CREATE SPACE `<space_name>` \(partition_num = 100, replica_factor = 1, charset = utf8, collate = utf8_bin, vid_type = FIXED_STRING\(8\), atomic_edge = false\) ON]+\s(\w*)\s[comment = `<space_comment>`]+/ |
+      | Space          | Create Space                                                                                                                                                                                                |
+      | "<space_name>" | /[CREATE SPACE `<space_name>` \(partition_num = 1, replica_factor = 1, charset = utf8, collate = utf8_bin, vid_type = FIXED_STRING\(8\), atomic_edge = false\) ON]+\s(\w*)\s[comment = `<space_comment>`]+/ |
     When executing query:
       """
       DESC SPACE <space_name>;
       """
     Then the result should be, in any order:
       | ID    | Name           | Partition Number | Replica Factor | Charset | Collate    | Vid Type          | Comment           |
-      | /\d+/ | "<space_name>" | 100              | 1              | "utf8"  | "utf8_bin" | "FIXED_STRING(8)" | "<space_comment>" |
+      | /\d+/ | "<space_name>" | 1                | 1              | "utf8"  | "utf8_bin" | "FIXED_STRING(8)" | "<space_comment>" |
     When executing query:
       """
       DROP SPACE <space_name>;
@@ -47,15 +47,15 @@ Feature: Schema Comment
       SHOW CREATE SPACE test_comment_not_set;
       """
     Then the result should be, in any order:
-      | Space                  | Create Space                                                                                                                                                       |
-      | "test_comment_not_set" | /[CREATE SPACE `test_comment_not_set` \(partition_num = 100, replica_factor = 1, charset = utf8, collate = utf8_bin, vid_type = FIXED_STRING\(8\), \) ON]+\s(\w*)/ |
+      | Space                  | Create Space                                                                                                                                                     |
+      | "test_comment_not_set" | /[CREATE SPACE `test_comment_not_set` \(partition_num = 1, replica_factor = 1, charset = utf8, collate = utf8_bin, vid_type = FIXED_STRING\(8\), \) ON]+\s(\w*)/ |
     When executing query:
       """
       DESC SPACE test_comment_not_set;
       """
     Then the result should be, in any order:
       | ID    | Name                   | Partition Number | Replica Factor | Charset | Collate    | Vid Type          | Comment |
-      | /\d+/ | "test_comment_not_set" | 100              | 1              | "utf8"  | "utf8_bin" | "FIXED_STRING(8)" | EMPTY   |
+      | /\d+/ | "test_comment_not_set" | 1                | 1              | "utf8"  | "utf8_bin" | "FIXED_STRING(8)" | EMPTY   |
     When executing query:
       """
       DROP SPACE test_comment_not_set;
@@ -74,15 +74,15 @@ Feature: Schema Comment
       SHOW CREATE SPACE test_comment_empty;
       """
     Then the result should be, in any order:
-      | Space                | Create Space                                                                                                                                                                      |
-      | "test_comment_empty" | /[CREATE SPACE `test_comment_empty` \(partition_num = 100, replica_factor = 1, charset = utf8, collate = utf8_bin, vid_type = FIXED_STRING\(8\), \) ON]+\s(\w*)\s[comment = '']+/ |
+      | Space                | Create Space                                                                                                                                                                    |
+      | "test_comment_empty" | /[CREATE SPACE `test_comment_empty` \(partition_num = 1, replica_factor = 1, charset = utf8, collate = utf8_bin, vid_type = FIXED_STRING\(8\), \) ON]+\s(\w*)\s[comment = '']+/ |
     When executing query:
       """
       DESC SPACE test_comment_empty;
       """
     Then the result should be, in any order:
       | ID    | Name                 | Partition Number | Replica Factor | Charset | Collate    | Vid Type          | Comment |
-      | /\d+/ | "test_comment_empty" | 100              | 1              | "utf8"  | "utf8_bin" | "FIXED_STRING(8)" | ""      |
+      | /\d+/ | "test_comment_empty" | 1                | 1              | "utf8"  | "utf8_bin" | "FIXED_STRING(8)" | ""      |
     When executing query:
       """
       DROP SPACE test_comment_empty;
@@ -92,7 +92,7 @@ Feature: Schema Comment
   Scenario Outline: schema comment
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     When try to execute query:

--- a/tests/tck/features/schema/CreateSpaceAs.feature
+++ b/tests/tck/features/schema/CreateSpaceAs.feature
@@ -7,7 +7,7 @@ Feature: Create space as another space
     # Space
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     # Schema

--- a/tests/tck/features/schema/Schema.feature
+++ b/tests/tck/features/schema/Schema.feature
@@ -6,7 +6,7 @@ Feature: Insert string vid of vertex and edge
   Scenario: insert vertex and edge test
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     # empty prop
@@ -396,7 +396,7 @@ Feature: Insert string vid of vertex and edge
     # test same tag in different space
     When executing query:
       """
-      CREATE SPACE my_space(partition_num=9, replica_factor=1, vid_type=FIXED_STRING(8));
+      CREATE SPACE my_space(partition_num=1, replica_factor=1, vid_type=FIXED_STRING(8));
       USE my_space;
       CREATE TAG animal(name string, kind string);
       """
@@ -485,7 +485,7 @@ Feature: Insert string vid of vertex and edge
     # test alter tag with default
     When executing query:
       """
-      CREATE SPACE tag_space(partition_num=9, vid_type=FIXED_STRING(8));
+      CREATE SPACE tag_space(partition_num=1, vid_type=FIXED_STRING(8));
       USE tag_space;
       CREATE TAG t(name string DEFAULT "N/A", age int DEFAULT -1);
       """
@@ -854,7 +854,7 @@ Feature: Insert string vid of vertex and edge
   Scenario: Don't allow DOT in schema name
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     When executing query:

--- a/tests/tck/features/subgraph/subgraph.feature
+++ b/tests/tck/features/subgraph/subgraph.feature
@@ -1021,7 +1021,7 @@ Feature: subgraph
   Scenario: Get subgraph in a space which doesn't have edge schema
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:

--- a/tests/tck/features/ttl/TTL.feature
+++ b/tests/tck/features/ttl/TTL.feature
@@ -3,7 +3,7 @@ Feature: TTLTest
   Background:
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(32) |
 

--- a/tests/tck/features/update/Update.IntVid.feature
+++ b/tests/tck/features/update/Update.IntVid.feature
@@ -6,7 +6,7 @@ Feature: Update int vid of vertex and edge
   Scenario: update and upsert test
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9   |
+      | partition_num  | 1   |
       | replica_factor | 1   |
       | vid_type       | int |
     And having executed:

--- a/tests/tck/features/update/Update.feature
+++ b/tests/tck/features/update/Update.feature
@@ -6,7 +6,7 @@ Feature: Update string vid of vertex and edge
   Background: Prepare space
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And having executed:

--- a/tests/tck/features/user/User.feature
+++ b/tests/tck/features/user/User.feature
@@ -281,6 +281,7 @@ Feature: User & privilege Test
       """
     Then the execution should be successful
 
+  @skip
   Scenario: Describe User
     When executing query:
       """

--- a/tests/tck/features/yield/NoSpaceChosen.feature
+++ b/tests/tck/features/yield/NoSpaceChosen.feature
@@ -44,6 +44,7 @@ Feature: Yield
       | ((!(false) OR (false AND false)) XOR false) |
       | true                                        |
 
+  @skip
   Scenario: nested
     When executing query:
       """

--- a/tests/tck/job/Job.feature
+++ b/tests/tck/job/Job.feature
@@ -51,7 +51,7 @@ Feature: Submit job space requirements
 
   Scenario: Not exist job
     Given create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And wait 6 seconds
@@ -68,7 +68,7 @@ Feature: Submit job space requirements
 
   Scenario: Submit and show jobs
     Given create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And wait 6 seconds
@@ -122,7 +122,7 @@ Feature: Submit job space requirements
 
   Scenario: Submit and show jobs in other space
     Given create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     And wait 6 seconds
@@ -160,7 +160,7 @@ Feature: Submit job space requirements
       | /\d+/  | "FLUSH"   | "FINISHED" | /\w+/      | /\w+/     |
       | /\d+/  | "COMPACT" | "FINISHED" | /\w+/      | /\w+/     |
     Given create a space with following options:
-      | partition_num  | 9                |
+      | partition_num  | 1                |
       | replica_factor | 1                |
       | vid_type       | FIXED_STRING(20) |
     When executing query:


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

Backport from https://github.com/vesoft-inc/nebula-ent/pull/1364.  Only create space with 1 part in all tck/pytest cases. (There are even space with 1000 parts before... This will make ent version ci quite unstable, because we need to create RocksDB for each part) Hope ci could handle it now, especially in ent version.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
