### PR TITLE
Fix extract filter.

### DIFF
--- a/src/graph/executor/StorageAccessExecutor.cpp
+++ b/src/graph/executor/StorageAccessExecutor.cpp
@@ -152,7 +152,7 @@ std::string StorageAccessExecutor::getStorageDetail(
     optional_field_ref<const std::map<std::string, int32_t> &> ref) const {
   if (ref.has_value()) {
     auto content = util::join(*ref, [](auto &iter) -> std::string {
-      return folly::sformat("{}:{}(us)", iter.first, iter.second);
+      return folly::sformat("\n  {}:{}(us)", iter.first, iter.second);
     });
     return "{" + content + "}";
   }

--- a/src/graph/visitor/ExtractFilterExprVisitor.cpp
+++ b/src/graph/visitor/ExtractFilterExprVisitor.cpp
@@ -276,6 +276,7 @@ bool ExtractFilterExprVisitor::visitLogicalOr(LogicalExpression *expr) {
         if (canNotPushedIndex != -1 || !canBeSplit) {
           return false;
         }
+        canBePushed_ = true;  // reset when the LogicalAnd can be split
         canNotPushedIndex = i;
         flags = std::move(flag);
       }

--- a/src/graph/visitor/ExtractFilterExprVisitor.cpp
+++ b/src/graph/visitor/ExtractFilterExprVisitor.cpp
@@ -276,13 +276,11 @@ bool ExtractFilterExprVisitor::visitLogicalOr(LogicalExpression *expr) {
         if (canNotPushedIndex != -1 || !canBeSplit) {
           return false;
         }
+        canBePushed_ = true;  // reset when the LogicalAnd can be split
         canNotPushedIndex = i;
         flags = std::move(flag);
       }
     } else {
-      if (!canBePushed_) {
-        return false;
-      }
       operands[i]->accept(this);
       if (!canBePushed_) {
         return false;

--- a/src/graph/visitor/ExtractFilterExprVisitor.cpp
+++ b/src/graph/visitor/ExtractFilterExprVisitor.cpp
@@ -276,11 +276,13 @@ bool ExtractFilterExprVisitor::visitLogicalOr(LogicalExpression *expr) {
         if (canNotPushedIndex != -1 || !canBeSplit) {
           return false;
         }
-        canBePushed_ = true;  // reset when the LogicalAnd can be split
         canNotPushedIndex = i;
         flags = std::move(flag);
       }
     } else {
+      if (!canBePushed_) {
+        return false;
+      }
       operands[i]->accept(this);
       if (!canBePushed_) {
         return false;

--- a/tests/tck/features/bugfix/ExtractFilter.feature
+++ b/tests/tck/features/bugfix/ExtractFilter.feature
@@ -1,0 +1,17 @@
+# Copyright (c) 2022 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+Feature: Test extract filter
+
+  Background:
+    Given a graph with space named "nba"
+
+  Scenario: Extract filter bug
+    When executing query:
+      """
+      MATCH (v:player{name: 'Tim Duncan'})-[:like]->(t) WHERE ( (1 == 1 AND (NOT is_edge(t))) OR (v.player.name == 'Tim Duncan')) RETURN v.player.name
+      """
+    Then the result should be, in any order:
+      | v.player.name |
+      | 'Tim Duncan'  |
+      | 'Tim Duncan'  |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula-ent/issues/1551

#### Description:
It caused by extract filter don't reset ok status when the first logical and expr can be split.


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
