### PR TITLE
[bugfix] security: fix check grant god when FLAGS_enable_authorize is…

### DIFF
--- a/src/graph/service/PermissionManager.cpp
+++ b/src/graph/service/PermissionManager.cpp
@@ -133,24 +133,25 @@ Status PermissionManager::canWriteRole(ClientSession *session,
                                        meta::cpp2::RoleType targetRole,
                                        GraphSpaceID spaceId,
                                        const std::string &targetUser) {
-  if (!FLAGS_enable_authorize) {
-    return Status::OK();
+  // Some check should be done no matter FLAGS_enable_authorize is true or false
+  // Check 1. Reject any user grant or revoke role to GOD,
+  if (targetRole == meta::cpp2::RoleType::GOD) {
+    return Status::PermissionError("No permission to grant/revoke god user.");
   }
-  // Cloud auth user cannot grant role
+
+  // Check 2. Cloud auth user cannot grant role
   if (FLAGS_auth_type == "cloud") {
     return Status::PermissionError("Cloud authenticate user can't write role.");
+  }
+
+  if (!FLAGS_enable_authorize) {
+    return Status::OK();
   }
   /**
    * Reject grant or revoke to himself.
    */
   if (session->user() == targetUser) {
     return Status::PermissionError("No permission to grant/revoke yourself.");
-  }
-  /*
-   * Reject any user grant or revoke role to GOD
-   */
-  if (targetRole == meta::cpp2::RoleType::GOD) {
-    return Status::PermissionError("No permission to grant/revoke god user.");
   }
   /*
    * God user can be grant or revoke any one.

--- a/tests/tck/cluster/Example.feature
+++ b/tests/tck/cluster/Example.feature
@@ -20,7 +20,7 @@ Feature: Example
       """
       GRANT ROLE god on s1 to user1
       """
-    Then the execution should be successful
+    Then an PermissionError should be raised at runtime: No permission to grant/revoke god user.
 
   Scenario: test with enable authorize
     Given a nebulacluster with 1 graphd and 1 metad and 1 storaged:

--- a/tests/tck/cluster/Example.feature
+++ b/tests/tck/cluster/Example.feature
@@ -39,3 +39,21 @@ Feature: Example
       GRANT ROLE god on s1 to user1
       """
     Then an PermissionError should be raised at runtime: No permission to grant/revoke god user.
+
+  Scenario: test with auth type is cloud
+    Given a nebulacluster with 1 graphd and 1 metad and 1 storaged:
+      """
+      graphd:auth_type=cloud
+      """
+    When executing query:
+      """
+      CREATE USER user1 WITH PASSWORD 'nebula';
+      CREATE SPACE s1(vid_type=int)
+      """
+    And wait 3 seconds
+    Then the execution should be successful
+    When executing query:
+      """
+      GRANT ROLE god on s1 to user1
+      """
+    Then an PermissionError should be raised at runtime: Cloud authenticate user can't write role.


### PR DESCRIPTION
God role should not be granted when enable_authorize is false

2 check was lift up before the FLAGS_enable_authorize check
```
 // Check 1. Reject any user grant or revoke role to GOD,
  if (targetRole == meta::cpp2::RoleType::GOD) {
    return Status::PermissionError("No permission to grant/revoke god user.");
  }

  // Check 2. Cloud auth user cannot grant role
  if (FLAGS_auth_type == "cloud") {
    return Status::PermissionError("Cloud authenticate user can't write role.");
  }

```
Not sure if auth_type cloud should also do this, comment if you know




## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

fix #4684 

#### Description:


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
