### PR TITLE
fix wrong expr evaluation on bool-type property in with

### DIFF
--- a/src/common/expression/AttributeExpression.cpp
+++ b/src/common/expression/AttributeExpression.cpp
@@ -51,7 +51,7 @@ const Value &AttributeExpression::eval(ExpressionContext &ctx) {
       }
       auto iter = lvalue.getEdge().props.find(rvalue.getStr());
       if (iter == lvalue.getEdge().props.end()) {
-        return Value::kNullUnknownProp;
+        return Value::kNullValue;
       }
       return iter->second;
     }

--- a/tests/tck/features/expression/Attribute.feature
+++ b/tests/tck/features/expression/Attribute.feature
@@ -90,9 +90,9 @@ Feature: Attribute
       MATCH (v)-[e:like]->() WHERE id(v) == 'Tim Duncan' RETURN e.Likeness
       """
     Then the result should be, in any order:
-      | e.Likeness   |
-      | UNKNOWN_PROP |
-      | UNKNOWN_PROP |
+      | e.Likeness |
+      | NULL       |
+      | NULL       |
 
   Scenario: Not exists attribute
     When executing query:
@@ -136,8 +136,8 @@ Feature: Attribute
       """
     Then the result should be, in any order:
       | e.not_exists_attr |
-      | UNKNOWN_PROP      |
-      | UNKNOWN_PROP      |
+      | NULL              |
+      | NULL              |
 
   Scenario: Invalid type
     When executing query:

--- a/tests/tck/features/match/With.feature
+++ b/tests/tck/features/match/With.feature
@@ -320,3 +320,57 @@ Feature: With clause
       RETURN a
       """
     Then a SemanticError should be raised at runtime:  Alias `b` not defined
+
+  Scenario: condition on nonexist prop
+    Given an empty graph
+    And having executed:
+      """
+      CREATE SPACE IF NOT EXISTS `nebula_huskie` (partition_num = 32, replica_factor = 1, charset = utf8, collate = utf8_bin, vid_type = INT64, atomic_edge = false);
+      """
+    And having executed:
+      """
+      USE `nebula_huskie`
+      """
+    And having executed:
+      """
+      CREATE EDGE IF NOT EXISTS `EDGE_0` (`edgeProp_0_0` bool NULL, `edgeProp_0_1` bool NULL, `edgeProp_0_2` float NULL,
+      `edgeProp_0_3` string NULL, `edgeProp_0_4` float NULL)
+      ttl_duration = 0, ttl_col = ""
+      """
+    And having executed:
+      """
+      CREATE EDGE IF NOT EXISTS `EDGE_1` (`edgeProp_1_0` bool NULL) ttl_duration = 0, ttl_col = ""
+      """
+    And having executed:
+      """
+      CREATE TAG IF NOT EXISTS `Label_0` (`labelProp_0_0` float NULL, `labelProp_0_1` string NULL, `labelProp_0_2` bool NULL, `labelProp_0_3` string NULL) ttl_duration = 0, ttl_col = ""
+      """
+    And wait 3 seconds
+    And having executed:
+      """
+      insert vertex Label_0(labelProp_0_0, labelProp_0_1, labelProp_0_2, labelProp_0_3) values 100:(0.5402889847755432,"Rajon Rondo",true,"Shaquile O'Neal");
+      insert vertex Label_0(labelProp_0_0, labelProp_0_1, labelProp_0_2, labelProp_0_3) values 101:(0.5402889847755432,"Rajon Rondo",true,"Shaquile O'Neal");
+      insert edge EDGE_0 values 100->101:(true, false, 0.9068049788475037, "Yao Ming", 0.906804);
+      insert edge EDGE_1 values 100->101:(true);
+      """
+    When executing query:
+      """
+      Match p = (v)-[e]->(t) where id(v) in [100] and e.edgeProp_1_0 == true with e as e, t as t where e.edgeProp_1_0 == true return e;
+      """
+    Then the result should be, in any order:
+      | e                                          |
+      | [:EDGE_1 100->101 @0 {edgeProp_1_0: true}] |
+    When executing query:
+      """
+      match p = (v)-[e]->(t) where id(v) in [100] and e.edgeProp_0_0 == true with e as e, t as t where e.edgeProp_0_0 == true return e.edgeProp_0_0;
+      """
+    Then the result should be, in any order:
+      | e.edgeProp_0_0 |
+      | true           |
+    When executing query:
+      """
+      match p = (v)-[e]->(t) where id(v) in [100] and e.edgeProp_0_0 == true with e as e, t as t where e.edgeProp_0_0 == true return e.edgeProp_1_0;
+      """
+    Then the result should be, in any order:
+      | e.edgeProp_1_0 |
+      | NULL           |

--- a/tests/tck/features/optimizer/PrunePropertiesRule.feature
+++ b/tests/tck/features/optimizer/PrunePropertiesRule.feature
@@ -845,10 +845,10 @@ Feature: Prune Properties rule
       match (src_v)-[e:like|serve]->(dst_v)-[e2]-(dst_v2) where  id(src_v)=="Rajon Rondo" return properties(e).degree1,properties(e).degree1,e2.a,dst_v.p.name,dst_v.player.sex1,properties(src_v).name2 limit 5;
       """
     Then the result should be, in order, with relax comparison:
-      | properties(e).degree1 | properties(e).degree1 | e2.a         | dst_v.p.name | dst_v.player.sex1 | properties(src_v).name2 |
-      | UNKNOWN_PROP          | UNKNOWN_PROP          | UNKNOWN_PROP | NULL         | NULL              | UNKNOWN_PROP            |
-      | UNKNOWN_PROP          | UNKNOWN_PROP          | UNKNOWN_PROP | NULL         | NULL              | UNKNOWN_PROP            |
-      | UNKNOWN_PROP          | UNKNOWN_PROP          | UNKNOWN_PROP | NULL         | NULL              | UNKNOWN_PROP            |
-      | UNKNOWN_PROP          | UNKNOWN_PROP          | UNKNOWN_PROP | NULL         | NULL              | UNKNOWN_PROP            |
-      | UNKNOWN_PROP          | UNKNOWN_PROP          | UNKNOWN_PROP | NULL         | NULL              | UNKNOWN_PROP            |
+      | properties(e).degree1 | properties(e).degree1 | e2.a | dst_v.p.name | dst_v.player.sex1 | properties(src_v).name2 |
+      | UNKNOWN_PROP          | UNKNOWN_PROP          | NULL | NULL         | NULL              | UNKNOWN_PROP            |
+      | UNKNOWN_PROP          | UNKNOWN_PROP          | NULL | NULL         | NULL              | UNKNOWN_PROP            |
+      | UNKNOWN_PROP          | UNKNOWN_PROP          | NULL | NULL         | NULL              | UNKNOWN_PROP            |
+      | UNKNOWN_PROP          | UNKNOWN_PROP          | NULL | NULL         | NULL              | UNKNOWN_PROP            |
+      | UNKNOWN_PROP          | UNKNOWN_PROP          | NULL | NULL         | NULL              | UNKNOWN_PROP            |
     Then drop the used space


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

Close https://github.com/vesoft-inc/nebula-ent/issues/1574

#### Description:

An `e.non-exist-prop == true` expr is rewritten to `e.non-exist-prop` without checking whether `e.non-exist-prop` exists. This is fine by itself.

And, while the filter operator evaluates the `e.non-exist-prop` condition, it finds it to be of the `Value::kNullUnknownProp` type. This causes unexpected error messages that terminte the query.

After discussion, we've decided that `e.non-exist-prop == true` shall return a plain null value.

## How do you solve it?

`e.non-exist-prop == true` returns plain null.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

It may be the case that all nulls of the unkown_prop type shall be changed to plain ones. But I want to keep the impact of a bug fix to its minimal level. So I only made this change for edges, excluding tags' properties. This may cause inconsistent nulls in the results, which I think is probabaly a minor issue.


## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] TCK

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
