### PR TITLE
Replace unordered_map with robin hood flat map in join executors

### DIFF
--- a/src/graph/executor/query/GetEdgesExecutor.cpp
+++ b/src/graph/executor/query/GetEdgesExecutor.cpp
@@ -4,6 +4,8 @@
 
 #include "graph/executor/query/GetEdgesExecutor.h"
 
+#include <robin_hood.h>
+
 #include "graph/planner/plan/Query.h"
 #include "graph/util/SchemaUtil.h"
 
@@ -24,7 +26,8 @@ StatusOr<DataSet> GetEdgesExecutor::buildRequestDataSet(const GetEdges *ge) {
 
   nebula::DataSet edges({kSrc, kType, kRank, kDst});
   edges.rows.reserve(valueIter->size());
-  std::unordered_set<std::tuple<Value, Value, Value, Value>> uniqueEdges;
+  using ValueTupleType = std::tuple<Value, Value, Value, Value>;
+  robin_hood::unordered_flat_set<ValueTupleType, std::hash<ValueTupleType>> uniqueEdges;
   uniqueEdges.reserve(valueIter->size());
 
   const auto &space = qctx()->rctx()->session()->space();

--- a/src/graph/executor/query/InnerJoinExecutor.h
+++ b/src/graph/executor/query/InnerJoinExecutor.h
@@ -26,11 +26,11 @@ class InnerJoinExecutor : public JoinExecutor {
 
   DataSet probe(const std::vector<Expression*>& probeKeys,
                 Iterator* probeIter,
-                const std::unordered_map<List, std::vector<const Row*>>& hashTable) const;
+                const RhFlatMap<List, std::vector<const Row*>>& hashTable) const;
 
   DataSet singleKeyProbe(Expression* probeKey,
                          Iterator* probeIter,
-                         const std::unordered_map<Value, std::vector<const Row*>>& hashTable) const;
+                         const RhFlatMap<Value, std::vector<const Row*>>& hashTable) const;
 
   // joinMultiJobs/probe/singleKeyProbe implemented for multi jobs.
   // For now, the InnerJoin implementation only implement the parallel processing on probe side.
@@ -43,7 +43,7 @@ class InnerJoinExecutor : public JoinExecutor {
   folly::Future<Status> singleKeyProbe(Expression* probeKey, Iterator* probeIter);
 
   template <class T>
-  void buildNewRow(const std::unordered_map<T, std::vector<const Row*>>& hashTable,
+  void buildNewRow(const RhFlatMap<T, std::vector<const Row*>>& hashTable,
                    const T& val,
                    Row rRow,
                    DataSet& ds) const;

--- a/src/graph/executor/query/IntersectExecutor.cpp
+++ b/src/graph/executor/query/IntersectExecutor.cpp
@@ -4,6 +4,8 @@
 
 #include "graph/executor/query/IntersectExecutor.h"
 
+#include <robin_hood.h>
+
 #include "graph/planner/plan/Query.h"
 
 namespace nebula {
@@ -17,7 +19,7 @@ folly::Future<Status> IntersectExecutor::execute() {
   auto left = getLeftInputData();
   auto right = getRightInputData();
 
-  std::unordered_set<const Row*> hashSet;
+  robin_hood::unordered_flat_set<const Row*, std::hash<const Row*>> hashSet;
   for (; right.iterRef()->valid(); right.iterRef()->next()) {
     hashSet.insert(right.iterRef()->row());
     // TODO: should test duplicate rows

--- a/src/graph/executor/query/JoinExecutor.cpp
+++ b/src/graph/executor/query/JoinExecutor.cpp
@@ -54,7 +54,7 @@ Status JoinExecutor::checkBiInputDataSets() {
 
 void JoinExecutor::buildHashTable(const std::vector<Expression*>& hashKeys,
                                   Iterator* iter,
-                                  std::unordered_map<List, std::vector<const Row*>>& hashTable) {
+                                  RhFlatMap<List, std::vector<const Row*>>& hashTable) {
   QueryExpressionContext ctx(ectx_);
   for (; iter->valid(); iter->next()) {
     List list;
@@ -69,10 +69,9 @@ void JoinExecutor::buildHashTable(const std::vector<Expression*>& hashKeys,
   }
 }
 
-void JoinExecutor::buildSingleKeyHashTable(
-    Expression* hashKey,
-    Iterator* iter,
-    std::unordered_map<Value, std::vector<const Row*>>& hashTable) {
+void JoinExecutor::buildSingleKeyHashTable(Expression* hashKey,
+                                           Iterator* iter,
+                                           RhFlatMap<Value, std::vector<const Row*>>& hashTable) {
   QueryExpressionContext ctx(ectx_);
   for (; iter->valid(); iter->next()) {
     auto& val = hashKey->eval(ctx(iter));

--- a/src/graph/executor/query/JoinExecutor.h
+++ b/src/graph/executor/query/JoinExecutor.h
@@ -5,10 +5,18 @@
 #ifndef GRAPH_EXECUTOR_QUERY_JOINEXECUTOR_H_
 #define GRAPH_EXECUTOR_QUERY_JOINEXECUTOR_H_
 
+#include <robin_hood.h>
+
 #include "graph/executor/Executor.h"
 
 namespace nebula {
 namespace graph {
+
+template <typename K, typename V>
+using RhFlatMap = robin_hood::unordered_flat_map<K, V, std::hash<K>>;
+
+template <typename K>
+using RhFlatSet = robin_hood::unordered_flat_set<K, std::hash<K>>;
 
 class JoinExecutor : public Executor {
  public:
@@ -22,11 +30,11 @@ class JoinExecutor : public Executor {
 
   void buildHashTable(const std::vector<Expression*>& hashKeys,
                       Iterator* iter,
-                      std::unordered_map<List, std::vector<const Row*>>& hashTable);
+                      RhFlatMap<List, std::vector<const Row*>>& hashTable);
 
   void buildSingleKeyHashTable(Expression* hashKey,
                                Iterator* iter,
-                               std::unordered_map<Value, std::vector<const Row*>>& hashTable);
+                               RhFlatMap<Value, std::vector<const Row*>>& hashTable);
 
   // concat rows
   Row newRow(Row left, Row right) const;
@@ -34,8 +42,8 @@ class JoinExecutor : public Executor {
   std::unique_ptr<Iterator> lhsIter_;
   std::unique_ptr<Iterator> rhsIter_;
   size_t colSize_{0};
-  std::unordered_map<Value, std::vector<const Row*>> hashTable_;
-  std::unordered_map<List, std::vector<const Row*>> listHashTable_;
+  RhFlatMap<Value, std::vector<const Row*>> hashTable_;
+  RhFlatMap<List, std::vector<const Row*>> listHashTable_;
 };
 }  // namespace graph
 }  // namespace nebula

--- a/src/graph/executor/query/LeftJoinExecutor.h
+++ b/src/graph/executor/query/LeftJoinExecutor.h
@@ -27,11 +27,11 @@ class LeftJoinExecutor : public JoinExecutor {
 
   DataSet probe(const std::vector<Expression*>& probeKeys,
                 Iterator* probeIter,
-                const std::unordered_map<List, std::vector<const Row*>>& hashTable) const;
+                const RhFlatMap<List, std::vector<const Row*>>& hashTable) const;
 
   DataSet singleKeyProbe(Expression* probeKey,
                          Iterator* probeIter,
-                         const std::unordered_map<Value, std::vector<const Row*>>& hashTable) const;
+                         const RhFlatMap<Value, std::vector<const Row*>>& hashTable) const;
 
   // joinMultiJobs/probe/singleKeyProbe implemented for multi jobs.
   // For now, the InnerJoin implementation only implement the parallel processing on probe side.
@@ -44,7 +44,7 @@ class LeftJoinExecutor : public JoinExecutor {
   folly::Future<Status> singleKeyProbe(Expression* probeKey, Iterator* probeIter);
 
   template <class T>
-  void buildNewRow(const std::unordered_map<T, std::vector<const Row*>>& hashTable,
+  void buildNewRow(const RhFlatMap<T, std::vector<const Row*>>& hashTable,
                    const T& val,
                    Row lRow,
                    DataSet& ds) const;

--- a/src/graph/executor/query/RollUpApplyExecutor.h
+++ b/src/graph/executor/query/RollUpApplyExecutor.h
@@ -5,10 +5,15 @@
 
 #pragma once
 
+#include <robin_hood.h>
+
 #include "graph/executor/Executor.h"
 
 namespace nebula {
 namespace graph {
+
+template <typename K, typename V>
+using RhFlatMap = robin_hood::unordered_flat_map<K, V, std::hash<K>>;
 
 class RollUpApplyExecutor : public Executor {
  public:
@@ -25,12 +30,12 @@ class RollUpApplyExecutor : public Executor {
   void buildHashTable(const std::vector<Expression*>& compareCols,
                       const InputPropertyExpression* collectCol,
                       Iterator* iter,
-                      std::unordered_map<List, List>& hashTable) const;
+                      RhFlatMap<List, List>& hashTable) const;
 
   void buildSingleKeyHashTable(Expression* compareCol,
                                const InputPropertyExpression* collectCol,
                                Iterator* iter,
-                               std::unordered_map<Value, List>& hashTable) const;
+                               RhFlatMap<Value, List>& hashTable) const;
 
   void buildZeroKeyHashTable(const InputPropertyExpression* collectCol,
                              Iterator* iter,
@@ -40,11 +45,11 @@ class RollUpApplyExecutor : public Executor {
 
   DataSet probeSingleKey(Expression* probeKey,
                          Iterator* probeIter,
-                         const std::unordered_map<Value, List>& hashTable);
+                         const RhFlatMap<Value, List>& hashTable);
 
   DataSet probe(std::vector<Expression*> probeKeys,
                 Iterator* probeIter,
-                const std::unordered_map<List, List>& hashTable);
+                const RhFlatMap<List, List>& hashTable);
 
   folly::Future<Status> rollUpApply();
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
none
#### Description:

Use robin hood flat map to speed up the join execution

## How do you solve it?

replace unordered_map with robin hood flat map

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

none

## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [X] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [X] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
