### PR TITLE
fix some rocksdb api will fail in PlainTable

### DIFF
--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -568,13 +568,13 @@ void NebulaStore::removePart(GraphSpaceID spaceId, PartitionID partId, bool need
 void NebulaStore::addListenerSpace(GraphSpaceID spaceId, meta::cpp2::ListenerType type) {
   UNUSED(type);
   folly::RWSpinLock::WriteHolder wh(&lock_);
-  // listener don't need engine for now
   if (this->spaceListeners_.find(spaceId) != this->spaceListeners_.end()) {
     LOG(INFO) << "Listener space " << spaceId << " has existed!";
-    return;
+  } else {
+    LOG(INFO) << "Create listener space " << spaceId;
+    this->spaceListeners_[spaceId] = std::make_unique<SpaceListenerInfo>();
   }
-  LOG(INFO) << "Create listener space " << spaceId;
-  this->spaceListeners_[spaceId] = std::make_unique<SpaceListenerInfo>();
+  // Perform extra initialization of given type of listener here
 }
 
 void NebulaStore::removeListenerSpace(GraphSpaceID spaceId, meta::cpp2::ListenerType type) {

--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -97,7 +97,7 @@ RocksEngine::RocksEngine(GraphSpaceID spaceId,
     extractorLen_ = sizeof(PartitionID) + vIdLen;
   } else if (factoryName == rocksdb::TableFactory::kPlainTableName()) {
     // PlainTable only support prefix-based seek, which means if the prefix is not inserted into
-    // rocksdb, we can't read them from "prefix" api anymore. For simplarity, we just set the length
+    // rocksdb, we can't read them from "prefix" api anymore. For simplicity, we just set the length
     // of prefix extractor to the minimum length we used in "prefix" api, which is 4 when we seek by
     // tagPrefix(partId) or edgePrefix(partId).
     isPlainTable_ = true;

--- a/src/kvstore/RocksEngine.cpp
+++ b/src/kvstore/RocksEngine.cpp
@@ -92,7 +92,17 @@ RocksEngine::RocksEngine(GraphSpaceID spaceId,
     CHECK(status.ok()) << status.ToString();
   }
   db_.reset(db);
-  extractorLen_ = sizeof(PartitionID) + vIdLen;
+  std::string factoryName = options.table_factory->Name();
+  if (factoryName == rocksdb::TableFactory::kBlockBasedTableName()) {
+    extractorLen_ = sizeof(PartitionID) + vIdLen;
+  } else if (factoryName == rocksdb::TableFactory::kPlainTableName()) {
+    // PlainTable only support prefix-based seek, which means if the prefix is not inserted into
+    // rocksdb, we can't read them from "prefix" api anymore. For simplarity, we just set the length
+    // of prefix extractor to the minimum length we used in "prefix" api, which is 4 when we seek by
+    // tagPrefix(partId) or edgePrefix(partId).
+    isPlainTable_ = true;
+    extractorLen_ = sizeof(PartitionID);
+  }
   partsNum_ = allParts().size();
   LOG(INFO) << "open rocksdb on " << path;
 
@@ -175,7 +185,11 @@ nebula::cpp2::ErrorCode RocksEngine::range(const std::string& start,
                                            const std::string& end,
                                            std::unique_ptr<KVIterator>* storageIter) {
   rocksdb::ReadOptions options;
-  options.total_order_seek = FLAGS_enable_rocksdb_prefix_filtering;
+  if (!isPlainTable_) {
+    options.total_order_seek = FLAGS_enable_rocksdb_prefix_filtering;
+  } else {
+    options.prefix_same_as_start = true;
+  }
   rocksdb::Iterator* iter = db_->NewIterator(options);
   if (iter) {
     iter->Seek(rocksdb::Slice(start));
@@ -232,8 +246,11 @@ nebula::cpp2::ErrorCode RocksEngine::rangeWithPrefix(const std::string& start,
                                                      const std::string& prefix,
                                                      std::unique_ptr<KVIterator>* storageIter) {
   rocksdb::ReadOptions options;
-  // prefix_same_as_start is false by default
-  options.total_order_seek = FLAGS_enable_rocksdb_prefix_filtering;
+  if (!isPlainTable_) {
+    options.total_order_seek = FLAGS_enable_rocksdb_prefix_filtering;
+  } else {
+    options.prefix_same_as_start = true;
+  }
   rocksdb::Iterator* iter = db_->NewIterator(options);
   if (iter) {
     iter->Seek(rocksdb::Slice(start));

--- a/src/kvstore/RocksEngine.h
+++ b/src/kvstore/RocksEngine.h
@@ -552,6 +552,7 @@ class RocksEngine : public KVEngine {
   std::unique_ptr<rocksdb::BackupEngine> backupDb_{nullptr};
   int32_t partsNum_ = -1;
   size_t extractorLen_;
+  bool isPlainTable_{false};
 };
 
 }  // namespace kvstore

--- a/src/kvstore/RocksEngineConfig.cpp
+++ b/src/kvstore/RocksEngineConfig.cpp
@@ -292,7 +292,6 @@ rocksdb::Status initRocksdbOptions(rocksdb::Options& baseOpts,
     baseOpts.rate_limiter = rate_limiter;
   }
 
-  size_t prefixLength = sizeof(PartitionID) + vidLen;
   if (FLAGS_rocksdb_table_format == "BlockBasedTable") {
     // BlockBasedTableOptions
     std::unordered_map<std::string, std::string> bbtOptsMap;
@@ -330,6 +329,7 @@ rocksdb::Status initRocksdbOptions(rocksdb::Options& baseOpts,
           baseOpts.compaction_style == rocksdb::CompactionStyle::kCompactionStyleLevel;
     }
     if (FLAGS_enable_rocksdb_prefix_filtering) {
+      size_t prefixLength = sizeof(PartitionID) + vidLen;
       baseOpts.prefix_extractor.reset(rocksdb::NewCappedPrefixTransform(prefixLength));
     }
     bbtOpts.whole_key_filtering = FLAGS_enable_rocksdb_whole_key_filtering;
@@ -346,6 +346,11 @@ rocksdb::Status initRocksdbOptions(rocksdb::Options& baseOpts,
     if (!FLAGS_enable_rocksdb_prefix_filtering) {
       return rocksdb::Status::InvalidArgument("PlainTable should use prefix bloom filter");
     }
+    // PlainTable only support prefix-based seek, which means if the prefix is not inserted into
+    // rocksdb, we can't read them from "prefix" api anymore. For simplarity, we just set the length
+    // of prefix extractor to the minimum length we used in "prefix" api, which is 4 when we seek by
+    // tagPrefix(partId) or edgePrefix(partId).
+    size_t prefixLength = sizeof(PartitionID);
     baseOpts.prefix_extractor.reset(rocksdb::NewCappedPrefixTransform(prefixLength));
     baseOpts.table_factory.reset(rocksdb::NewPlainTableFactory());
     baseOpts.create_if_missing = true;

--- a/src/kvstore/RocksEngineConfig.cpp
+++ b/src/kvstore/RocksEngineConfig.cpp
@@ -347,7 +347,7 @@ rocksdb::Status initRocksdbOptions(rocksdb::Options& baseOpts,
       return rocksdb::Status::InvalidArgument("PlainTable should use prefix bloom filter");
     }
     // PlainTable only support prefix-based seek, which means if the prefix is not inserted into
-    // rocksdb, we can't read them from "prefix" api anymore. For simplarity, we just set the length
+    // rocksdb, we can't read them from "prefix" api anymore. For simplicity, we just set the length
     // of prefix extractor to the minimum length we used in "prefix" api, which is 4 when we seek by
     // tagPrefix(partId) or edgePrefix(partId).
     size_t prefixLength = sizeof(PartitionID);


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
Legacy PR from #4254. (Legacy problem has been addressed in this PR)

This problem is found in nebula-ng. Some of our rocksdb api is not well verified in PlainTable, for example, whether the data is in sst will effect the api result. The main problem is that:
1. Since PlainTable only support prefix-based Seek, we need to specify prefix_same_as_start not only in prefix, but also range and rangeWithPrefix.
2. And the length of prefix_extractor need to be modified. Because within PlainTable, if the prefix bloom filter is not inserted, you can't be read by prefix any more. So to make sure every data could be read, we use the minimum length we use in prefix, which is 4.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
