### PR TITLE
[DO NOT MERGE] Reset space info of the session after drop a space

### DIFF
--- a/src/graph/service/QueryInstance.cpp
+++ b/src/graph/service/QueryInstance.cpp
@@ -136,7 +136,7 @@ void QueryInstance::onFinish() {
 void QueryInstance::onError(Status status) {
   LOG(ERROR) << status;
   auto *rctx = qctx()->rctx();
-  auto &spaceName = rctx->session()->space().name;
+  std::string spaceName = rctx->session()->space().name;
   switch (status.code()) {
     case Status::Code::kOk:
       rctx->resp().errorCode = ErrorCode::SUCCEEDED;
@@ -171,7 +171,12 @@ void QueryInstance::onError(Status status) {
     case Status::Code::kNoSuchFile:
     case Status::Code::kNotSupported:
     case Status::Code::kPartNotFound:
-    case Status::Code::kSpaceNotFound:
+    case Status::Code::kSpaceNotFound: {
+      // Detach the space info from the session
+      rctx->session()->setSpace(SpaceInfo());
+      spaceName = rctx->session()->spaceName();
+      [[fallthrough]];
+    }
     case Status::Code::kGroupNotFound:
     case Status::Code::kZoneNotFound:
     case Status::Code::kTagNotFound:

--- a/src/storage/GraphStorageServiceHandler.h
+++ b/src/storage/GraphStorageServiceHandler.h
@@ -21,7 +21,7 @@ class StorageEnv;
 class GraphStorageServiceHandler final : public cpp2::GraphStorageServiceSvIf {
  public:
   explicit GraphStorageServiceHandler(StorageEnv* env);
-  // Vertice section
+  // Vertices section
   folly::Future<cpp2::ExecResponse> future_addVertices(
       const cpp2::AddVerticesRequest& req) override;
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -104,7 +104,7 @@ sess: currdir
 jobs: currdir
 	$(test_without_skip) tck/steps/test_jobs.py
 
-test: sess
+test:
 	$(test_j) --dist=loadfile -k "not tck" $(TEST_DIR)
 
 slow-query: currdir

--- a/tests/admin/test_space.py
+++ b/tests/admin/test_space.py
@@ -230,23 +230,23 @@ class TestSpace(NebulaTestSuite):
         resp = self.client.execute('DROP SPACE space_int_vid')
         self.check_resp_succeeded(resp)
 
-    # def test_reset_space_after_drop_space(self):
-    #     resp = self.client.execute('CREATE SPACE space_int_vid (partition_num=1, '
-    #                         'replica_factor=1, charset=utf8, collate=utf8_bin, '
-    #                         'vid_type = int64)')
-    #     self.check_resp_succeeded(resp)
+    def test_reset_space_after_drop_space(self):
+        resp = self.client.execute('CREATE SPACE space_int_vid (partition_num=1, '
+                            'replica_factor=1, charset=utf8, collate=utf8_bin, '
+                            'vid_type = int64)')
+        self.check_resp_succeeded(resp)
 
-    #     # session 1 use space
-    #     resp = self.client.execute('USE space_int_vid')
-    #     self.check_resp_succeeded(resp)
+        # session 1 use space
+        resp = self.client.execute('USE space_int_vid')
+        self.check_resp_succeeded(resp)
 
-    #     # session 2 drop space
-    #     newSession = self.spawn_nebula_client("user", "password")
-    #     resp = newSession.execute('DROP space space_int_vid')
-    #     self.check_resp_succeeded(resp)
+        # session 2 drop space
+        newSession = self.spawn_nebula_client("user", "password")
+        resp = newSession.execute('DROP space space_int_vid')
+        self.check_resp_succeeded(resp)
 
-    #     # session 1 create tag, expect to fail
-    #     resp = self.client.execute('CREATE TAG tag1 (col1 int)')
-    #     self.check_resp_failed(resp)
-    #     # the space name of the session bonding to should be reset
-    #     assert(resp.space_name() == '')
+        # session 1 create tag, expect to fail
+        resp = self.client.execute('CREATE TAG tag1 (col1 int)')
+        self.check_resp_failed(resp)
+        # the space name of the session bonding to should be reset
+        assert(resp.space_name() == '')

--- a/tests/admin/test_space.py
+++ b/tests/admin/test_space.py
@@ -4,6 +4,7 @@
 #
 # This source code is licensed under Apache 2.0 License.
 
+import logging
 import time
 
 from tests.common.nebula_test_suite import NebulaTestSuite, T_EMPTY
@@ -235,18 +236,22 @@ class TestSpace(NebulaTestSuite):
                             'replica_factor=1, charset=utf8, collate=utf8_bin, '
                             'vid_type = int64)')
         self.check_resp_succeeded(resp)
+        time.sleep(self.delay)
 
         # session 1 use space
         resp = self.client.execute('USE space_int_vid')
         self.check_resp_succeeded(resp)
 
         # session 2 drop space
-        newSession = self.spawn_nebula_client("user", "password")
+        newSession = self.spawn_nebula_client("root", "nebula")
         resp = newSession.execute('DROP space space_int_vid')
         self.check_resp_succeeded(resp)
+        time.sleep(self.delay)
 
         # session 1 create tag, expect to fail
         resp = self.client.execute('CREATE TAG tag1 (col1 int)')
         self.check_resp_failed(resp)
         # the space name of the session bonding to should be reset
+        
+        logging.info(resp.space_name())
         assert(resp.space_name() == '')

--- a/tests/admin/test_space.py
+++ b/tests/admin/test_space.py
@@ -229,3 +229,24 @@ class TestSpace(NebulaTestSuite):
         # clean up
         resp = self.client.execute('DROP SPACE space_int_vid')
         self.check_resp_succeeded(resp)
+
+    # def test_reset_space_after_drop_space(self):
+    #     resp = self.client.execute('CREATE SPACE space_int_vid (partition_num=1, '
+    #                         'replica_factor=1, charset=utf8, collate=utf8_bin, '
+    #                         'vid_type = int64)')
+    #     self.check_resp_succeeded(resp)
+
+    #     # session 1 use space
+    #     resp = self.client.execute('USE space_int_vid')
+    #     self.check_resp_succeeded(resp)
+
+    #     # session 2 drop space
+    #     newSession = self.spawn_nebula_client("user", "password")
+    #     resp = newSession.execute('DROP space space_int_vid')
+    #     self.check_resp_succeeded(resp)
+
+    #     # session 1 create tag, expect to fail
+    #     resp = self.client.execute('CREATE TAG tag1 (col1 int)')
+    #     self.check_resp_failed(resp)
+    #     # the space name of the session bonding to should be reset
+    #     assert(resp.space_name() == '')

--- a/tests/common/nebula_test_suite.py
+++ b/tests/common/nebula_test_suite.py
@@ -40,7 +40,7 @@ T_NULL_UNKNOWN_DIV_BY_ZERO = CommonTtypes.Value()
 T_NULL_UNKNOWN_DIV_BY_ZERO.set_nVal(CommonTtypes.NullType.DIV_BY_ZERO)
 
 
-@pytest.mark.usefixtures("workarround_for_class")
+@pytest.mark.usefixtures("workaround_for_class")
 class NebulaTestSuite(object):
     @classmethod
     def set_delay(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -234,7 +234,7 @@ def load_student_data():
 
 # TODO(yee): Delete this when we migrate all test cases
 @pytest.fixture(scope="class")
-def workarround_for_class(
+def workaround_for_class(
     request, pytestconfig, conn_pool, session, load_nba_data, load_student_data
 ):
     if request.cls is None:


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula/issues/4818

#### Description:
![image](https://user-images.githubusercontent.com/18348405/201652266-cbc920f1-f783-4c2e-af47-6532579a8c5a.png)


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:
Seems some further discussion on this issue is needed:

Should we reset the space to `null` after the space bond to the session is dropped? 
```
// session 1
create space space-1; use space-1;
// session 2
drop space space-1;
// session 1
create tag t1(); This query should cause an error says SPACE_NOT_FOUND, and we should reset the session space
```
What if the user uses a nonexistent space in a query? Should we reset it as well?
```
// session 1
create space space-1; use space-1;
use nonexistent_space; // This query should cause an error says SPACE_NOT_FOUND, but should we reset the session to NONE?
```


## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
