### PR TITLE
unify time format in show job

### DIFF
--- a/src/graph/executor/admin/SubmitJobExecutor.cpp
+++ b/src/graph/executor/admin/SubmitJobExecutor.cpp
@@ -131,8 +131,8 @@ nebula::DataSet SubmitJobExecutor::buildShowResultData(
     v.emplace_back(Row({jd.get_job_id(),
                         apache::thrift::util::enumNameSafe(meta::cpp2::JobType::DATA_BALANCE),
                         apache::thrift::util::enumNameSafe(jd.get_status()),
-                        convertJobTimestampToDateTime(jd.get_start_time()).toString(),
-                        convertJobTimestampToDateTime(jd.get_stop_time()).toString(),
+                        convertJobTimestampToDateTime(jd.get_start_time()),
+                        convertJobTimestampToDateTime(jd.get_stop_time()),
                         apache::thrift::util::enumNameSafe(jd.get_code())}));
     for (size_t i = index; i < paras.size() - 1; i++) {
       meta::cpp2::BalanceTask tsk;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

https://github.com/vesoft-inc/nebula-ent/issues/1553

#### Description:

As you can see, time show in this table is not in the same format, since a toString() method,  I unify them to version without toString, so that it can look the same.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
