### PR TITLE
remove job entries when drop space && check space exist when check jo…

### DIFF
--- a/src/meta/processors/job/JobManager.cpp
+++ b/src/meta/processors/job/JobManager.cpp
@@ -66,6 +66,16 @@ JobManager::~JobManager() {
   shutDown();
 }
 
+bool JobManager::spaceExist(GraphSpaceID spaceId) {
+  auto spaceKey = MetaKeyUtils::spaceKey(spaceId);
+  std::string val;
+  auto retCode = kvStore_->get(kDefaultSpaceId, kDefaultPartId, spaceKey, &val);
+  if (retCode == nebula::cpp2::ErrorCode::E_KEY_NOT_FOUND) {
+    return false;
+  }
+  return true;
+}
+
 nebula::cpp2::ErrorCode JobManager::handleRemainingJobs() {
   std::unique_ptr<kvstore::KVIterator> iter;
   auto retCode =

--- a/src/meta/processors/job/JobManager.h
+++ b/src/meta/processors/job/JobManager.h
@@ -305,15 +305,7 @@ class JobManager : public boost::noncopyable, public nebula::cpp::NonMovable {
    *
    * @return
    */
-  bool spaceExist(GraphSpaceID spaceId) {
-    auto spaceKey = MetaKeyUtils::spaceKey(spaceId);
-    std::string val;
-    auto retCode = kvStore_->get(kDefaultSpaceId, kDefaultPartId, spaceKey, &val);
-    if (retCode == nebula::cpp2::ErrorCode::E_KEY_NOT_FOUND) {
-      return false;
-    }
-    return true;
-  }
+  bool spaceExist(GraphSpaceID spaceId);
 
  private:
   using PriorityQueue = folly::PriorityUMPSCQueueSet<std::tuple<JbOp, JobID, GraphSpaceID>, true>;

--- a/src/meta/processors/job/JobManager.h
+++ b/src/meta/processors/job/JobManager.h
@@ -300,6 +300,21 @@ class JobManager : public boost::noncopyable, public nebula::cpp::NonMovable {
    */
   void resetSpaceRunning(GraphSpaceID spaceId);
 
+  /**
+   * @brief check if the space exist
+   *
+   * @return
+   */
+  bool spaceExist(GraphSpaceID spaceId) {
+    auto spaceKey = MetaKeyUtils::spaceKey(spaceId);
+    std::string val;
+    auto retCode = kvStore_->get(kDefaultSpaceId, kDefaultPartId, spaceKey, &val);
+    if (retCode == nebula::cpp2::ErrorCode::E_KEY_NOT_FOUND) {
+      return false;
+    }
+    return true;
+  }
+
  private:
   using PriorityQueue = folly::PriorityUMPSCQueueSet<std::tuple<JbOp, JobID, GraphSpaceID>, true>;
   // Each PriorityQueue contains high and low priority queues.

--- a/src/meta/processors/job/ReportTaskProcessor.cpp
+++ b/src/meta/processors/job/ReportTaskProcessor.cpp
@@ -13,6 +13,8 @@ namespace meta {
 #include "meta/processors/job/JobManager.h"
 
 void ReportTaskProcessor::process(const cpp2::ReportTaskReq& req) {
+  CHECK_SPACE_ID_AND_RETURN(req.get_space_id());
+
   JobManager* jobMgr = JobManager::getInstance();
   auto rc = jobMgr->reportTaskFinish(req);
   if (rc != nebula::cpp2::ErrorCode::SUCCEEDED) {

--- a/src/meta/processors/parts/DropSpaceProcessor.cpp
+++ b/src/meta/processors/parts/DropSpaceProcessor.cpp
@@ -134,7 +134,7 @@ void DropSpaceProcessor::process(const cpp2::DropSpaceReq& req) {
   auto jobRet = doPrefix(jobPrefix);
   if (!nebula::ok(jobRet)) {
     auto retCode = nebula::error(jobRet);
-    LOG(INFO) << "Loading Job Failed" << apache::thrift::util::enumNameSafe(jobRet);
+    LOG(INFO) << "Loading Job Failed" << apache::thrift::util::enumNameSafe(retCode);
     handleErrorCode(retCode);
     onFinished();
     return;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula-ent/issues/1643

#### Description:
When drop the space, the job entries have not been dropped. Then we create backup, it may have some job entries left which are rebuilding jobs. In this case, there is no rebuilding job really, but the backup creation is blocked.

## How do you solve it?
1. drop the job entries when drop spaces.
2. skip the spaces not exist when check rebuilding jobs.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
