### PR TITLE
fix validateHostOrIp fail when one device has more than one ip

### DIFF
--- a/src/common/network/NetworkUtils.h
+++ b/src/common/network/NetworkUtils.h
@@ -25,7 +25,7 @@ class NetworkUtils final {
   // List out all Ipv4 addresses, including the loopback one.
   static StatusOr<std::vector<std::string>> listIPv4s();
   // List out all network devices and its corresponding Ipv4 address.
-  static StatusOr<std::unordered_map<std::string, std::string>> listDeviceAndIPv4s();
+  static StatusOr<std::vector<std::pair<std::string, std::string>>> listDeviceAndIPv4s();
 
   // Get the local dynamic port range [low, high], only works for IPv4
   static bool getDynamicPortRange(uint16_t& low, uint16_t& high);

--- a/src/common/network/test/NetworkUtilsTest.cpp
+++ b/src/common/network/test/NetworkUtilsTest.cpp
@@ -56,7 +56,10 @@ TEST(NetworkUtils, listDeviceAndIPv4s) {
   auto result = NetworkUtils::listDeviceAndIPv4s();
   ASSERT_TRUE(result.ok()) << result.status();
   ASSERT_FALSE(result.value().empty());
-  ASSERT_NE(result.value().end(), result.value().find("lo"));
+  ASSERT_NE(result.value().end(),
+            std::find_if(result.value().begin(), result.value().end(), [](const auto& deviceAndIp) {
+              return deviceAndIp.first == "lo";
+            }));
 }
 
 TEST(NetworkUtils, getDynamicPortRange) {


### PR DESCRIPTION


## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula/issues/3333

#### Description:
When one network device has more than one ip, will failed to started up, because `validateHostOrIp` will failed, see the issue for more information.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [X] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
