### PR TITLE
fix update config

### DIFF
--- a/src/common/meta/GflagsManager.cpp
+++ b/src/common/meta/GflagsManager.cpp
@@ -196,11 +196,14 @@ std::string GflagsManager::ValueToGflagString(const Value& val) {
       std::transform(kvs.begin(), kvs.end(), values.begin(), [](const auto& iter) -> std::string {
         std::stringstream out;
         out << "\"" << iter.first << "\""
-            << ":"
-            << "\"" << iter.second << "\"";
+            << ":";
+        if (iter.second.isStr() || iter.second.isBool()) {
+          out << iter.second;
+        } else {
+          out << "\"" << iter.second << "\"";
+        }
         return out.str();
       });
-
       std::stringstream os;
       os << "{" << folly::join(",", values) << "}";
       return os.str();

--- a/tests/admin/test_configs.py
+++ b/tests/admin/test_configs.py
@@ -120,7 +120,7 @@ class TestConfigs(NebulaTestSuite):
         resp = self.client.execute('''
                                    UPDATE CONFIGS storage:rocksdb_column_family_options={
                                    max_bytes_for_level_base="268435456",
-                                   write_buffer_size="67108864",
+                                   write_buffer_size="33554432",
                                    max_write_buffer_number="4"}
                                    ''')
         self.check_resp_succeeded(resp)


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?

`UPDATE CONFIGS` statement will lead to storage crash when update rocksdb configs.

#### Issue(s) number: 

#### Description:

In the test `test_configs`,  we will try to modify the value of `storage:rocksdb_column_family_options`. And we save the value as an `Expression` after parser. In this case, it's a `Map`.

Then, `gflags` only accepts string type value. We transfer the `Value::Map` to `map<std::string,std::string>`. But we add extra quotes. For example, `a:1` while be transferred to `"a":"1"`, but `b:"x"` will be transferred to `"b":""x""`, which is error format for json.

But I still don't know why this problem is not triggered in our CI.

A preliminary guess is that the update of config will wait for the metaClient to pull regularly. The interval between two modifications is too short, so the metaClient does not find this modification.
```
        if (it == metaConfigMap_.end() ||
            metaConfigMap[key].get_value() != it->second.get_value()) {
          updateGflagsValue(entry.second);               // not invoke
          metaConfigMap_[key] = entry.second;
        }
````

## How do you solve it?

I modified the value written in restore, so that the 'test_configs' case will not report an error, but the subsequent case will fail when creating a space. It can only be regarded as a temporary solution.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
