### PR TITLE
Refactor setOutputVar() to enforce the assignment of colNames explicitly.

### DIFF
--- a/src/graph/executor/test/DedupTest.cpp
+++ b/src/graph/executor/test/DedupTest.cpp
@@ -26,7 +26,7 @@ class DedupTest : public QueryTestBase {
     auto yieldSentence = getYieldSentence(sentence, qctx_.get());                       \
     auto* dedupNode = Dedup::make(qctx_.get(), nullptr);                                \
     dedupNode->setInputVar(inputName);                                                  \
-    dedupNode->setOutputVar(outputName);                                                \
+    dedupNode->setOutputVar(outputName, expected.colNames);                             \
     auto dedupExec = std::make_unique<DedupExecutor>(dedupNode, qctx_.get());           \
     if (!expected.colNames.empty()) {                                                   \
       EXPECT_TRUE(dedupExec->execute().get().ok());                                     \

--- a/src/graph/executor/test/FilterTest.cpp
+++ b/src/graph/executor/test/FilterTest.cpp
@@ -33,7 +33,7 @@ class FilterTest : public QueryTestBase {
     whereSentence->setFilter(ExpressionUtils::rewriteLabelAttr2EdgeProp(whereSentence->filter())); \
     auto* filterNode = Filter::make(qctx_.get(), nullptr, yieldSentence->where()->filter());       \
     filterNode->setInputVar(inputName);                                                            \
-    filterNode->setOutputVar(outputName);                                                          \
+    filterNode->setOutputVar(outputName, expected.colNames);                                       \
     auto filterExec = std::make_unique<FilterExecutor>(filterNode, qctx_.get());                   \
     EXPECT_TRUE(filterExec->execute().get().ok());                                                 \
     auto& filterResult = qctx_->ectx()->getResult(filterNode->outputVar());                        \

--- a/src/graph/executor/test/JoinTest.cpp
+++ b/src/graph/executor/test/JoinTest.cpp
@@ -237,11 +237,9 @@ TEST_F(JoinTest, HashInnerJoin) {
   std::vector<Expression*> probeKeys = {probe1, probe2};
 
   auto lhs = Project::make(qctx_.get(), nullptr, nullptr);
-  lhs->setOutputVar("var4");
-  lhs->setColNames({"v1", "e1", "v2", "v3"});
+  lhs->setOutputVar("var4", {"v1", "e1", "v2", "v3"});
   auto rhs = Project::make(qctx_.get(), nullptr, nullptr);
-  rhs->setOutputVar("var5");
-  rhs->setColNames({"v2", "e2", "v3"});
+  rhs->setOutputVar("var5", {"v2", "e2", "v3"});
 
   auto* join =
       HashInnerJoin::make(qctx_.get(), lhs, rhs, std::move(hashKeys), std::move(probeKeys));
@@ -417,11 +415,9 @@ TEST_F(JoinTest, HashLeftJoin) {
   std::vector<Expression*> probeKeys = {probe1, probe2};
 
   auto lhs = Project::make(qctx_.get(), nullptr, nullptr);
-  lhs->setOutputVar("var5");
-  lhs->setColNames({"v2", "e2", "v3"});
+  lhs->setOutputVar("var5", {"v2", "e2", "v3"});
   auto rhs = Project::make(qctx_.get(), nullptr, nullptr);
-  rhs->setOutputVar("var4");
-  rhs->setColNames({"v1", "e1", "v2", "v3"});
+  rhs->setOutputVar("var4", {"v1", "e1", "v2", "v3"});
 
   auto* join = HashLeftJoin::make(qctx_.get(), lhs, rhs, std::move(hashKeys), std::move(probeKeys));
 

--- a/src/graph/executor/test/LimitTest.cpp
+++ b/src/graph/executor/test/LimitTest.cpp
@@ -23,7 +23,7 @@ class LimitTest : public QueryTestBase {};
     auto start = StartNode::make(qctx_.get());                                              \
     auto* limitNode = Limit::make(qctx_.get(), start, offset, count);                       \
     limitNode->setInputVar("input_sequential");                                             \
-    limitNode->setOutputVar(outputName);                                                    \
+    limitNode->setOutputVar(outputName, expected.colNames);                                 \
     auto limitExec = Executor::create(limitNode, qctx_.get());                              \
     EXPECT_TRUE(limitExec->execute().get().ok());                                           \
     auto& limitResult = qctx_->ectx()->getResult(limitNode->outputVar());                   \

--- a/src/graph/executor/test/SampleTest.cpp
+++ b/src/graph/executor/test/SampleTest.cpp
@@ -23,7 +23,7 @@ class SampleTest : public QueryTestBase {};
     auto start = StartNode::make(qctx_.get());                                              \
     auto* sampleNode = Sample::make(qctx_.get(), start, count);                             \
     sampleNode->setInputVar("input_sequential");                                            \
-    sampleNode->setOutputVar(outputName);                                                   \
+    sampleNode->setOutputVar(outputName, {});                                               \
     auto sampleExec = Executor::create(sampleNode, qctx_.get());                            \
     EXPECT_TRUE(sampleExec->execute().get().ok());                                          \
     auto& sampleResult = qctx_->ectx()->getResult(sampleNode->outputVar());                 \
@@ -59,7 +59,7 @@ TEST_F(SampleTest, SequentialOutRange2) {
     auto start = StartNode::make(qctx_.get());                                             \
     auto* sampleNode = Sample::make(qctx_.get(), start, count);                            \
     sampleNode->setInputVar("input_neighbor");                                             \
-    sampleNode->setOutputVar(outputName);                                                  \
+    sampleNode->setOutputVar(outputName, {});                                              \
     auto sampleExec = Executor::create(sampleNode, qctx_.get());                           \
     EXPECT_TRUE(sampleExec->execute().get().ok());                                         \
     auto& sampleResult = qctx_->ectx()->getResult(sampleNode->outputVar());                \

--- a/src/graph/executor/test/SortTest.cpp
+++ b/src/graph/executor/test/SortTest.cpp
@@ -23,7 +23,7 @@ class SortTest : public QueryTestBase {};
     auto start = StartNode::make(qctx_.get());                                        \
     auto* sortNode = Sort::make(qctx_.get(), start, factors);                         \
     sortNode->setInputVar(input_name);                                                \
-    sortNode->setOutputVar(outputName);                                               \
+    sortNode->setOutputVar(outputName, expected.colNames);                            \
     auto sortExec = Executor::create(sortNode, qctx_.get());                          \
     EXPECT_TRUE(sortExec->execute().get().ok());                                      \
     auto& sortResult = qctx_->ectx()->getResult(sortNode->outputVar());               \

--- a/src/graph/executor/test/TopNTest.cpp
+++ b/src/graph/executor/test/TopNTest.cpp
@@ -23,7 +23,7 @@ class TopNTest : public QueryTestBase {};
     auto start = StartNode::make(qctx_.get());                                             \
     auto* topnNode = TopN::make(qctx_.get(), start, factors, offset, count);               \
     topnNode->setInputVar(input_name);                                                     \
-    topnNode->setOutputVar(outputName);                                                    \
+    topnNode->setOutputVar(outputName, expected.colNames);                                 \
     auto topnExec = Executor::create(topnNode, qctx_.get());                               \
     EXPECT_TRUE(topnExec->execute().get().ok());                                           \
     auto& topnResult = qctx_->ectx()->getResult(topnNode->outputVar());                    \

--- a/src/graph/optimizer/rule/CollapseProjectRule.cpp
+++ b/src/graph/optimizer/rule/CollapseProjectRule.cpp
@@ -110,7 +110,7 @@ StatusOr<OptRule::TransformResult> CollapseProjectRule::transform(
 
   // 4. rebuild OptGroupNode
   newProj->setInputVar(projBelow->inputVar());
-  newProj->setOutputVar(projAbove->outputVar());
+  newProj->setOutputVar(projAbove->outputVar(), projAbove->colNames());
   auto* newGroupNode = OptGroupNode::create(octx, newProj, projGroup);
   newGroupNode->setDeps(groupNodeBelow->dependencies());
 

--- a/src/graph/optimizer/rule/CombineFilterRule.cpp
+++ b/src/graph/optimizer/rule/CombineFilterRule.cpp
@@ -51,7 +51,7 @@ StatusOr<OptRule::TransformResult> CombineFilterRule::transform(
     auto* conditionCombine =
         LogicalExpression::makeAnd(pool, conditionAbove->clone(), conditionBelow->clone());
     newFilter->setCondition(conditionCombine);
-    newFilter->setOutputVar(filterAbove->outputVar());
+    newFilter->setOutputVar(filterAbove->outputVar(), filterAbove->colNames());
     auto* newGroupNode = OptGroupNode::create(octx, newFilter, filterGroup);
     newGroupNode->setDeps(groupNode->dependencies());
     result.newGroupNodes.emplace_back(newGroupNode);

--- a/src/graph/optimizer/rule/EliminateAppendVerticesRule.cpp
+++ b/src/graph/optimizer/rule/EliminateAppendVerticesRule.cpp
@@ -65,7 +65,7 @@ StatusOr<OptRule::TransformResult> EliminateAppendVerticesRule::transform(
   const auto appendVertices = static_cast<const AppendVertices*>(appendVerticesGroupNode->node());
 
   auto newProj = static_cast<Project*>(project->clone());
-  newProj->setOutputVar(project->outputVar());
+  newProj->setOutputVar(project->outputVar(), project->colNames());
   newProj->setInputVar(appendVertices->inputVar());
   auto newProjGroupNode = OptGroupNode::create(octx, newProj, projectGroupNode->group());
   newProjGroupNode->setDeps(appendVerticesGroupNode->dependencies());

--- a/src/graph/optimizer/rule/EliminateRowCollectRule.cpp
+++ b/src/graph/optimizer/rule/EliminateRowCollectRule.cpp
@@ -52,7 +52,7 @@ StatusOr<OptRule::TransformResult> EliminateRowCollectRule::transform(
   const auto proj = static_cast<const Project*>(projGroupNode->node());
 
   auto newProj = static_cast<Project*>(proj->clone());
-  newProj->setOutputVar(dataCollect->outputVar());
+  newProj->setOutputVar(dataCollect->outputVar(), dataCollect->colNames());
   auto newProjGroupNode = OptGroupNode::create(octx, newProj, dataCollectGroupNode->group());
 
   for (auto dep : projGroupNode->dependencies()) {

--- a/src/graph/optimizer/rule/GeoPredicateIndexScanBaseRule.cpp
+++ b/src/graph/optimizer/rule/GeoPredicateIndexScanBaseRule.cpp
@@ -133,7 +133,7 @@ StatusOr<TransformResult> GeoPredicateIndexScanBaseRule::transform(
   scanNode->setIndexQueryContext(std::move(idxCtxs));
   // TODO(jie): geo predicate's calculation is a little heavy,
   // which is not suitable to push down to the storage
-  scanNode->setOutputVar(filter->outputVar());
+  scanNode->setOutputVar(filter->outputVar(), filter->colNames());
   scanNode->setColNames(filter->colNames());
   auto filterGroup = matched.node->group();
   auto optScanNode = OptGroupNode::create(ctx, scanNode, filterGroup);

--- a/src/graph/optimizer/rule/GetEdgesTransformAppendVerticesLimitRule.cpp
+++ b/src/graph/optimizer/rule/GetEdgesTransformAppendVerticesLimitRule.cpp
@@ -77,7 +77,7 @@ StatusOr<OptRule::TransformResult> GetEdgesTransformAppendVerticesLimitRule::tra
 
   auto newProject = project->clone();
   auto newProjectGroupNode = OptGroupNode::create(ctx, newProject, projectGroupNode->group());
-  newProject->setOutputVar(project->outputVar());
+  newProject->setOutputVar(project->outputVar(), project->colNames());
 
   auto limitGroupNode = matched.dependencies.front().node;
   auto limit = static_cast<const Limit *>(limitGroupNode->node());

--- a/src/graph/optimizer/rule/GetEdgesTransformRule.cpp
+++ b/src/graph/optimizer/rule/GetEdgesTransformRule.cpp
@@ -72,7 +72,7 @@ StatusOr<OptRule::TransformResult> GetEdgesTransformRule::transform(
   auto project = static_cast<const Project *>(projectGroupNode->node());
 
   auto newProject = project->clone();
-  newProject->setOutputVar(project->outputVar());
+  newProject->setOutputVar(project->outputVar(), project->colNames());
   auto newProjectGroupNode = OptGroupNode::create(ctx, newProject, projectGroupNode->group());
 
   auto limitGroupNode = matched.dependencies.front().node;

--- a/src/graph/optimizer/rule/IndexFullScanBaseRule.cpp
+++ b/src/graph/optimizer/rule/IndexFullScanBaseRule.cpp
@@ -67,7 +67,7 @@ StatusOr<TransformResult> IndexFullScanBaseRule::transform(OptContext* ctx,
 
   auto scanNode = this->scan(ctx, scan);
   OptimizerUtils::copyIndexScanData(scan, scanNode, ctx->qctx());
-  scanNode->setOutputVar(scan->outputVar());
+  scanNode->setOutputVar(scan->outputVar(), scan->colNames());
   scanNode->setColNames(scan->colNames());
   scanNode->setIndexQueryContext(std::move(idxCtxs));
   auto filterGroup = matched.node->group();

--- a/src/graph/optimizer/rule/IndexScanRule.cpp
+++ b/src/graph/optimizer/rule/IndexScanRule.cpp
@@ -81,7 +81,7 @@ StatusOr<OptRule::TransformResult> IndexScanRule::transform(OptContext* ctx,
   const auto* oldIN = groupNode->node();
   DCHECK_EQ(oldIN->kind(), graph::PlanNode::Kind::kIndexScan);
   auto* newIN = static_cast<IndexScan*>(oldIN->clone());
-  newIN->setOutputVar(oldIN->outputVar());
+  newIN->setOutputVar(oldIN->outputVar(), oldIN->colNames());
   newIN->setIndexQueryContext(std::move(iqctx));
   auto newGroupNode = OptGroupNode::create(ctx, newIN, groupNode->group());
   if (groupNode->dependencies().size() != 1) {

--- a/src/graph/optimizer/rule/MergeGetNbrsAndDedupRule.cpp
+++ b/src/graph/optimizer/rule/MergeGetNbrsAndDedupRule.cpp
@@ -44,7 +44,7 @@ StatusOr<OptRule::TransformResult> MergeGetNbrsAndDedupRule::transform(
     newGN->setDedup();
   }
   newGN->setInputVar(dedup->inputVar());
-  newGN->setOutputVar(gn->outputVar());
+  newGN->setOutputVar(gn->outputVar(), gn->colNames());
   auto newOptGV = OptGroupNode::create(octx, newGN, optGN->group());
   for (auto dep : optDedup->dependencies()) {
     newOptGV->dependsOn(dep);

--- a/src/graph/optimizer/rule/MergeGetNbrsAndProjectRule.cpp
+++ b/src/graph/optimizer/rule/MergeGetNbrsAndProjectRule.cpp
@@ -66,7 +66,7 @@ StatusOr<OptRule::TransformResult> MergeGetNbrsAndProjectRule::transform(
   auto srcExpr = column->expr()->clone();
   newGN->setSrc(srcExpr);
   newGN->setInputVar(project->inputVar());
-  newGN->setOutputVar(gn->outputVar());
+  newGN->setOutputVar(gn->outputVar(), gn->colNames());
   auto newOptGV = OptGroupNode::create(ctx, newGN, optGN->group());
   for (auto dep : optProj->dependencies()) {
     newOptGV->dependsOn(dep);

--- a/src/graph/optimizer/rule/MergeGetVerticesAndDedupRule.cpp
+++ b/src/graph/optimizer/rule/MergeGetVerticesAndDedupRule.cpp
@@ -43,7 +43,7 @@ StatusOr<OptRule::TransformResult> MergeGetVerticesAndDedupRule::transform(
     newGV->setDedup();
   }
   newGV->setInputVar(dedup->inputVar());
-  newGV->setOutputVar(gv->outputVar());
+  newGV->setOutputVar(gv->outputVar(), gv->colNames());
   auto newOptGV = OptGroupNode::create(ctx, newGV, optGV->group());
   for (auto dep : optDedup->dependencies()) {
     newOptGV->dependsOn(dep);

--- a/src/graph/optimizer/rule/MergeGetVerticesAndProjectRule.cpp
+++ b/src/graph/optimizer/rule/MergeGetVerticesAndProjectRule.cpp
@@ -65,7 +65,7 @@ StatusOr<OptRule::TransformResult> MergeGetVerticesAndProjectRule::transform(
   auto srcExpr = column->expr()->clone();
   newGV->setSrc(srcExpr);
   newGV->setInputVar(project->inputVar());
-  newGV->setOutputVar(gv->outputVar());
+  newGV->setOutputVar(gv->outputVar(), gv->colNames());
   auto newOptGV = OptGroupNode::create(ctx, newGV, optGV->group());
   for (auto dep : optProj->dependencies()) {
     newOptGV->dependsOn(dep);

--- a/src/graph/optimizer/rule/OptimizeEdgeIndexScanByFilterRule.cpp
+++ b/src/graph/optimizer/rule/OptimizeEdgeIndexScanByFilterRule.cpp
@@ -135,7 +135,7 @@ StatusOr<TransformResult> OptimizeEdgeIndexScanByFilterRule::transform(
   std::vector<IndexQueryContext> idxCtxs = {ictx};
   auto scanNode = makeEdgeIndexScan(ctx->qctx(), scan, isPrefixScan);
   scanNode->setIndexQueryContext(std::move(idxCtxs));
-  scanNode->setOutputVar(filter->outputVar());
+  scanNode->setOutputVar(filter->outputVar(), filter->colNames());
   scanNode->setColNames(filter->colNames());
   auto filterGroup = matched.node->group();
   auto optScanNode = OptGroupNode::create(ctx, scanNode, filterGroup);

--- a/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
+++ b/src/graph/optimizer/rule/OptimizeTagIndexScanByFilterRule.cpp
@@ -169,7 +169,7 @@ StatusOr<TransformResult> OptimizeTagIndexScanByFilterRule::transform(
   std::vector<IndexQueryContext> idxCtxs = {ictx};
   auto scanNode = makeTagIndexScan(ctx->qctx(), scan, isPrefixScan);
   scanNode->setIndexQueryContext(std::move(idxCtxs));
-  scanNode->setOutputVar(filter->outputVar());
+  scanNode->setOutputVar(filter->outputVar(), filter->colNames());
   scanNode->setColNames(filter->colNames());
   auto filterGroup = matched.node->group();
   auto optScanNode = OptGroupNode::create(ctx, scanNode, filterGroup);

--- a/src/graph/optimizer/rule/PushEFilterDownRule.cpp
+++ b/src/graph/optimizer/rule/PushEFilterDownRule.cpp
@@ -66,7 +66,7 @@ StatusOr<OptRule::TransformResult> PushEFilterDownRule::transform(
 
   auto remainedExpr = std::move(visitor).remainedExpr();
   auto newTraverse = traverse->clone();
-  newTraverse->setOutputVar(traverse->outputVar());
+  newTraverse->setOutputVar(traverse->outputVar(), traverse->colNames());
   newTraverse->setEdgeFilter(remainedExpr);
   if (newTraverse->filter() != nullptr) {
     newTraverse->setFilter(

--- a/src/graph/optimizer/rule/PushFilterDownAggregateRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownAggregateRule.cpp
@@ -91,7 +91,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownAggregateRule::transform(
 
   // Exchange planNode
   // newAggNode shall inherit the output of the oldFilterNode
-  newAggNode->setOutputVar(oldFilterNode->outputVar());
+  newAggNode->setOutputVar(oldFilterNode->outputVar(), oldFilterNode->colNames());
   // as the new agg node now inherits the output var ptr from a filter node, the action of
   // which alters its own colNames, its colNames need to be explicitly preserved.
   newAggNode->setColNames(oldAggNode->colNames());
@@ -100,7 +100,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownAggregateRule::transform(
   DCHECK_EQ(oldAggNode->outputVar(), oldFilterNode->inputVar());
   // newAggNode shall inherit oldFilterNode's inputs
   newAggNode->setInputVar(oldFilterNode->inputVar());
-  newFilterNode->setOutputVar(newAggNode->inputVar());
+  newFilterNode->setOutputVar(newAggNode->inputVar(), newAggNode->colNames());
 
   // Push down filter's optGroup and embed newAggGroupNode into old filter's
   // Group

--- a/src/graph/optimizer/rule/PushFilterDownGetNbrsRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownGetNbrsRule.cpp
@@ -66,7 +66,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownGetNbrsRule::transform(
   PlanNode *newFilter = nullptr;
   if (remainedExpr != nullptr) {
     newFilter = Filter::make(qctx, nullptr, remainedExpr);
-    newFilter->setOutputVar(filter->outputVar());
+    newFilter->setOutputVar(filter->outputVar(), filter->colNames());
     newFilterGroupNode = OptGroupNode::create(ctx, newFilter, filterGroupNode->group());
   }
 
@@ -89,7 +89,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownGetNbrsRule::transform(
   } else {
     // Filter(A)<-GetNeighbors(C) => GetNeighbors(A&&C)
     newGnGroupNode = OptGroupNode::create(ctx, newGN, filterGroupNode->group());
-    newGN->setOutputVar(filter->outputVar());
+    newGN->setOutputVar(filter->outputVar(), filter->colNames());
   }
 
   for (auto dep : gnGroupNode->dependencies()) {

--- a/src/graph/optimizer/rule/PushFilterDownInnerJoinRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownInnerJoinRule.cpp
@@ -105,7 +105,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownInnerJoinRule::transform(
   result.eraseAll = true;
   if (filterUnpicked) {
     auto* newAboveFilterNode = graph::Filter::make(octx->qctx(), newInnerJoinNode);
-    newAboveFilterNode->setOutputVar(oldFilterNode->outputVar());
+    newAboveFilterNode->setOutputVar(oldFilterNode->outputVar(), oldFilterNode->colNames());
     newAboveFilterNode->setCondition(filterUnpicked);
     auto newAboveFilterGroupNode =
         OptGroupNode::create(octx, newAboveFilterNode, filterGroupNode->group());
@@ -116,7 +116,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownInnerJoinRule::transform(
     newInnerJoinGroupNode->setDeps({newFilterGroup});
     result.newGroupNodes.emplace_back(newAboveFilterGroupNode);
   } else {
-    newInnerJoinNode->setOutputVar(oldFilterNode->outputVar());
+    newInnerJoinNode->setOutputVar(oldFilterNode->outputVar(), oldFilterNode->colNames());
     newInnerJoinNode->setColNames(oldInnerJoinNode->colNames());
     auto newInnerJoinGroupNode =
         OptGroupNode::create(octx, newInnerJoinNode, filterGroupNode->group());

--- a/src/graph/optimizer/rule/PushFilterDownLeftJoinRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownLeftJoinRule.cpp
@@ -105,7 +105,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownLeftJoinRule::transform(
   result.eraseAll = true;
   if (filterUnpicked) {
     auto* newAboveFilterNode = graph::Filter::make(octx->qctx(), newLeftJoinNode);
-    newAboveFilterNode->setOutputVar(oldFilterNode->outputVar());
+    newAboveFilterNode->setOutputVar(oldFilterNode->outputVar(), oldFilterNode->colNames());
     newAboveFilterNode->setCondition(filterUnpicked);
     auto newAboveFilterGroupNode =
         OptGroupNode::create(octx, newAboveFilterNode, filterGroupNode->group());
@@ -116,7 +116,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownLeftJoinRule::transform(
     newLeftJoinGroupNode->setDeps({newFilterGroup});
     result.newGroupNodes.emplace_back(newAboveFilterGroupNode);
   } else {
-    newLeftJoinNode->setOutputVar(oldFilterNode->outputVar());
+    newLeftJoinNode->setOutputVar(oldFilterNode->outputVar(), oldFilterNode->colNames());
     newLeftJoinNode->setColNames(oldLeftJoinNode->colNames());
     auto newLeftJoinGroupNode =
         OptGroupNode::create(octx, newLeftJoinNode, filterGroupNode->group());

--- a/src/graph/optimizer/rule/PushFilterDownNodeRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownNodeRule.cpp
@@ -66,7 +66,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownNodeRule::transform(
   auto remainedExpr = std::move(visitor).remainedExpr();
   auto *explore = static_cast<const Explore *>(node);
   auto *newExplore = static_cast<Explore *>(node->clone());
-  newExplore->setOutputVar(explore->outputVar());
+  newExplore->setOutputVar(explore->outputVar(), explore->colNames());
   auto newExploreGroupNode = OptGroupNode::create(ctx, newExplore, groupNode->group());
   if (explore->filter() != nullptr) {
     vFilter = LogicalExpression::makeAnd(pool, vFilter, newExplore->filter());

--- a/src/graph/optimizer/rule/PushFilterDownProjectRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownProjectRule.cpp
@@ -124,7 +124,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownProjectRule::transform(
   if (filterUnpicked) {
     // produce new Filter node above
     auto* newAboveFilterNode = graph::Filter::make(octx->qctx(), newProjNode, filterUnpicked);
-    newAboveFilterNode->setOutputVar(oldFilterNode->outputVar());
+    newAboveFilterNode->setOutputVar(oldFilterNode->outputVar(), oldFilterNode->colNames());
     auto newAboveFilterGroupNode =
         OptGroupNode::create(octx, newAboveFilterNode, filterGroupNode->group());
 
@@ -138,7 +138,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownProjectRule::transform(
   } else {
     // newProjNode shall inherit the output from oldFilterNode
     // which is the output of the opt group
-    newProjNode->setOutputVar(oldFilterNode->outputVar());
+    newProjNode->setOutputVar(oldFilterNode->outputVar(), oldFilterNode->colNames());
     // newProjNode's col names, on the hand, should inherit those of the oldProjNode
     // since they are the same project.
     newProjNode->setColNames(oldProjNode->outputVarPtr()->colNames);

--- a/src/graph/optimizer/rule/PushFilterDownScanVerticesRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownScanVerticesRule.cpp
@@ -56,7 +56,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownScanVerticesRule::transform(
   PlanNode *newFilter = nullptr;
   if (remainedExpr != nullptr) {
     newFilter = Filter::make(qctx, nullptr, remainedExpr);
-    newFilter->setOutputVar(filter->outputVar());
+    newFilter->setOutputVar(filter->outputVar(), filter->colNames());
     newFilter->setInputVar(filter->inputVar());
     newFilterGroupNode = OptGroupNode::create(ctx, newFilter, filterGroupNode->group());
   }
@@ -81,7 +81,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownScanVerticesRule::transform(
   } else {
     // Filter(A)<-ScanVertices(C) => ScanVertices(A&&C)
     newSvGroupNode = OptGroupNode::create(ctx, newSV, filterGroupNode->group());
-    newSV->setOutputVar(filter->outputVar());
+    newSV->setOutputVar(filter->outputVar(), filter->colNames());
   }
 
   for (auto dep : svGroupNode->dependencies()) {

--- a/src/graph/optimizer/rule/PushLimitDownGetNeighborsRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownGetNeighborsRule.cpp
@@ -50,7 +50,7 @@ StatusOr<OptRule::TransformResult> PushLimitDownGetNeighborsRule::transform(
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
-  newLimit->setOutputVar(limit->outputVar());
+  newLimit->setOutputVar(limit->outputVar(), limit->colNames());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newGn = static_cast<GetNeighbors *>(gn->clone());

--- a/src/graph/optimizer/rule/PushLimitDownIndexScanRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownIndexScanRule.cpp
@@ -58,7 +58,7 @@ StatusOr<OptRule::TransformResult> PushLimitDownIndexScanRule::transform(
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
-  newLimit->setOutputVar(limit->outputVar());
+  newLimit->setOutputVar(limit->outputVar(), limit->colNames());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newIndexScan = static_cast<IndexScan *>(indexScan->clone());

--- a/src/graph/optimizer/rule/PushLimitDownProjectRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownProjectRule.cpp
@@ -51,7 +51,7 @@ StatusOr<OptRule::TransformResult> PushLimitDownProjectRule::transform(
   auto newLimitGroupNode = newLimitGroup->makeGroupNode(newLimit);
 
   auto newProj = static_cast<Project *>(proj->clone());
-  newProj->setOutputVar(limit->outputVar());
+  newProj->setOutputVar(limit->outputVar(), limit->colNames());
   newProj->setInputVar(newLimit->outputVar());
   auto newProjGroupNode = OptGroupNode::create(octx, newProj, limitGroupNode->group());
 

--- a/src/graph/optimizer/rule/PushLimitDownScanAppendVerticesRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownScanAppendVerticesRule.cpp
@@ -73,7 +73,7 @@ StatusOr<OptRule::TransformResult> PushLimitDownScanAppendVerticesRule::transfor
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
-  newLimit->setOutputVar(limit->outputVar());
+  newLimit->setOutputVar(limit->outputVar(), limit->colNames());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newAppendVertices = static_cast<AppendVertices *>(appendVertices->clone());

--- a/src/graph/optimizer/rule/PushLimitDownScanEdgesAppendVerticesRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownScanEdgesAppendVerticesRule.cpp
@@ -77,7 +77,7 @@ StatusOr<OptRule::TransformResult> PushLimitDownScanEdgesAppendVerticesRule::tra
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
-  newLimit->setOutputVar(limit->outputVar());
+  newLimit->setOutputVar(limit->outputVar(), limit->colNames());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newAppendVertices = static_cast<AppendVertices *>(appendVertices->clone());

--- a/src/graph/optimizer/rule/PushLimitDownScanEdgesRule.cpp
+++ b/src/graph/optimizer/rule/PushLimitDownScanEdgesRule.cpp
@@ -49,7 +49,7 @@ StatusOr<OptRule::TransformResult> PushLimitDownScanEdgesRule::transform(
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
-  newLimit->setOutputVar(limit->outputVar());
+  newLimit->setOutputVar(limit->outputVar(), limit->colNames());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newSe = static_cast<ScanEdges *>(se->clone());

--- a/src/graph/optimizer/rule/PushStepLimitDownGetNeighborsRule.cpp
+++ b/src/graph/optimizer/rule/PushStepLimitDownGetNeighborsRule.cpp
@@ -51,7 +51,7 @@ StatusOr<OptRule::TransformResult> PushStepLimitDownGetNeighborsRule::transform(
   }
 
   auto newLimit = static_cast<Limit *>(limit->clone());
-  newLimit->setOutputVar(limit->outputVar());
+  newLimit->setOutputVar(limit->outputVar(), limit->colNames());
   auto newLimitGroupNode = OptGroupNode::create(octx, newLimit, limitGroupNode->group());
 
   auto newGn = static_cast<GetNeighbors *>(gn->clone());

--- a/src/graph/optimizer/rule/PushStepSampleDownGetNeighborsRule.cpp
+++ b/src/graph/optimizer/rule/PushStepSampleDownGetNeighborsRule.cpp
@@ -49,7 +49,7 @@ StatusOr<OptRule::TransformResult> PushStepSampleDownGetNeighborsRule::transform
   }
 
   auto newSample = static_cast<Sample *>(sample->clone());
-  newSample->setOutputVar(sample->outputVar());
+  newSample->setOutputVar(sample->outputVar(), sample->colNames());
   auto newSampleGroupNode = OptGroupNode::create(octx, newSample, sampleGroupNode->group());
 
   auto newGn = static_cast<GetNeighbors *>(gn->clone());

--- a/src/graph/optimizer/rule/PushTopNDownIndexScanRule.cpp
+++ b/src/graph/optimizer/rule/PushTopNDownIndexScanRule.cpp
@@ -92,7 +92,7 @@ StatusOr<OptRule::TransformResult> PushTopNDownIndexScanRule::transform(
   }
 
   auto newTopN = static_cast<TopN *>(topN->clone());
-  newTopN->setOutputVar(topN->outputVar());
+  newTopN->setOutputVar(topN->outputVar(), topN->colNames());
   auto newtopNGroupNode = OptGroupNode::create(octx, newTopN, topNGroupNode->group());
 
   auto newProject = static_cast<Project *>(project->clone());

--- a/src/graph/optimizer/rule/PushVFilterDownScanVerticesRule.cpp
+++ b/src/graph/optimizer/rule/PushVFilterDownScanVerticesRule.cpp
@@ -95,7 +95,7 @@ StatusOr<OptRule::TransformResult> PushVFilterDownScanVerticesRule::transform(
     newAppendVertices->setVertexFilter(remainedExpr);
   }
   OptGroupNode *newAppendVerticesGroupNode = nullptr;
-  newAppendVertices->setOutputVar(appendVertices->outputVar());
+  newAppendVertices->setOutputVar(appendVertices->outputVar(), appendVertices->colNames());
   newAppendVerticesGroupNode =
       OptGroupNode::create(ctx, newAppendVertices, appendVerticesGroupNode->group());
 

--- a/src/graph/optimizer/rule/RemoveNoopProjectRule.cpp
+++ b/src/graph/optimizer/rule/RemoveNoopProjectRule.cpp
@@ -84,7 +84,7 @@ StatusOr<OptRule::TransformResult> RemoveNoopProjectRule::transform(
   DCHECK_EQ(oldProjNode->kind(), PlanNode::Kind::kProject);
   const auto* depGroupNode = matched.dependencies.front().node;
   auto* newNode = depGroupNode->node()->clone();
-  newNode->setOutputVar(oldProjNode->outputVar());
+  newNode->setOutputVar(oldProjNode->outputVar(), oldProjNode->colNames());
   auto* newGroupNode = OptGroupNode::create(octx, newNode, projGroup);
   newGroupNode->setDeps(depGroupNode->dependencies());
   TransformResult result;

--- a/src/graph/optimizer/rule/RemoveProjectDedupBeforeGetDstBySrcRule.cpp
+++ b/src/graph/optimizer/rule/RemoveProjectDedupBeforeGetDstBySrcRule.cpp
@@ -44,7 +44,7 @@ StatusOr<OptRule::TransformResult> RemoveProjectDedupBeforeGetDstBySrcRule::tran
   auto* newGetDstBySrc = static_cast<graph::GetDstBySrc*>(getDstBySrc->clone());
   // Replace `$-._vid` with `COLUMN[0]`
   newGetDstBySrc->setSrc(ColumnExpression::make(getDstBySrc->src()->getObjPool(), 0));
-  newGetDstBySrc->setOutputVar(getDstBySrc->outputVar());
+  newGetDstBySrc->setOutputVar(getDstBySrc->outputVar(), getDstBySrc->colNames());
   newGetDstBySrc->setInputVar(project->inputVar());
   newGetDstBySrc->setColNames(newGetDstBySrc->colNames());
 

--- a/src/graph/optimizer/rule/TopNRule.cpp
+++ b/src/graph/optimizer/rule/TopNRule.cpp
@@ -46,7 +46,7 @@ StatusOr<OptRule::TransformResult> TopNRule::transform(OptContext *ctx,
 
   auto qctx = ctx->qctx();
   auto topn = TopN::make(qctx, nullptr, sort->factors(), limit->offset(), limit->count(qctx));
-  topn->setOutputVar(limit->outputVar());
+  topn->setOutputVar(limit->outputVar(), limit->colNames());
   topn->setInputVar(sort->inputVar());
   topn->setColNames(sort->colNames());
   auto topnNode = OptGroupNode::create(ctx, topn, limitGroupNode->group());

--- a/src/graph/optimizer/rule/UnionAllIndexScanBaseRule.cpp
+++ b/src/graph/optimizer/rule/UnionAllIndexScanBaseRule.cpp
@@ -185,7 +185,7 @@ StatusOr<TransformResult> UnionAllIndexScanBaseRule::transform(OptContext* ctx,
   auto scanNode = IndexScan::make(qctx, nullptr);
   OptimizerUtils::copyIndexScanData(scan, scanNode, qctx);
   scanNode->setIndexQueryContext(std::move(idxCtxs));
-  scanNode->setOutputVar(filter->outputVar());
+  scanNode->setOutputVar(filter->outputVar(), filter->colNames());
   scanNode->setColNames(filter->colNames());
   auto filterGroup = matched.node->group();
   auto optScanNode = OptGroupNode::create(ctx, scanNode, filterGroup);

--- a/src/graph/planner/match/VertexIdSeek.cpp
+++ b/src/graph/planner/match/VertexIdSeek.cpp
@@ -78,8 +78,7 @@ StatusOr<SubPlan> VertexIdSeek::transformNode(NodeContext *nodeCtx) {
   std::string inputVar = listToAnnoVarVid(qctx, nodeCtx->ids);
 
   auto *passThrough = PassThroughNode::make(qctx, nullptr);
-  passThrough->setOutputVar(inputVar);
-  passThrough->setColNames({kVid});
+  passThrough->setOutputVar(inputVar, {kVid});
 
   auto *dedup = Dedup::make(qctx, passThrough);
   dedup->setColNames({kVid});

--- a/src/graph/planner/ngql/GoPlanner.cpp
+++ b/src/graph/planner/ngql/GoPlanner.cpp
@@ -191,7 +191,7 @@ PlanNode* GoPlanner::trackStartVid(PlanNode* left, PlanNode* right) {
 
   auto* project = Project::make(qctx, join, columns);
   auto* dedup = Dedup::make(qctx, project);
-  dedup->setOutputVar(left->outputVar());
+  dedup->setOutputVar(left->outputVar(), left->colNames());
 
   return dedup;
 }
@@ -486,8 +486,7 @@ SubPlan GoPlanner::nStepsPlan(SubPlan& startVidPlan) {
     gd->setInputVar(goCtx_->vidsVar);
     gd->setColNames({goCtx_->dstIdColName});
     auto* dedup = Dedup::make(qctx, gd);
-    dedup->setOutputVar(goCtx_->vidsVar);
-    dedup->setColNames(gd->colNames());
+    dedup->setOutputVar(goCtx_->vidsVar, gd->colNames());
     getDst = dedup;
 
     loopBody = getDst;
@@ -544,8 +543,7 @@ SubPlan GoPlanner::mToNStepsPlan(SubPlan& startVidPlan) {
     // The outputVar of `Dedup` is the same as the inputVar of `GetDstBySrc`.
     // So the output of `Dedup` of current iteration feeds into the input of `GetDstBySrc` of next
     // iteration.
-    dedup->setOutputVar(goCtx_->vidsVar);
-    dedup->setColNames(gd->colNames());
+    dedup->setOutputVar(goCtx_->vidsVar, gd->colNames());
     getDst = dedup;
     loopBody = getDst;
 

--- a/src/graph/planner/ngql/PathPlanner.cpp
+++ b/src/graph/planner/ngql/PathPlanner.cpp
@@ -190,8 +190,7 @@ SubPlan PathPlanner::loopDepPlan() {
     columns->addColumn(column);
     auto* project = Project::make(qctx, subPlan.root, columns);
     project->setInputVar(pathCtx_->fromVidsVar);
-    project->setOutputVar(pathCtx_->fromVidsVar);
-    project->setColNames({nebula::kVid});
+    project->setOutputVar(pathCtx_->fromVidsVar, {nebula::kVid});
     subPlan.root = project;
   }
   subPlan.tail = subPlan.tail == nullptr ? subPlan.root : subPlan.tail;
@@ -201,8 +200,7 @@ SubPlan PathPlanner::loopDepPlan() {
     columns->addColumn(column);
     auto* project = Project::make(qctx, subPlan.root, columns);
     project->setInputVar(pathCtx_->toVidsVar);
-    project->setOutputVar(pathCtx_->toVidsVar);
-    project->setColNames({nebula::kVid});
+    project->setOutputVar(pathCtx_->toVidsVar, {nebula::kVid});
     subPlan.root = project;
   }
   return subPlan;

--- a/src/graph/planner/plan/PlanNode.cpp
+++ b/src/graph/planner/plan/PlanNode.cpp
@@ -334,11 +334,16 @@ void PlanNode::calcCost() {
   VLOG(1) << "unimplemented cost calculation.";
 }
 
-void PlanNode::setOutputVar(const std::string& var) {
+void PlanNode::setOutputVar(const std::string& var, const std::vector<std::string>& colNames) {
   auto* outputVarPtr = qctx_->symTable()->getVar(var);
   DCHECK(outputVarPtr != nullptr);
   auto oldVar = outputVar_->name;
   outputVar_ = outputVarPtr;
+  if (colNames.empty() && !outputVar_->colNames.empty()) {
+    setColNames(outputVar_->colNames);
+  } else {
+    setColNames(colNames);
+  }
   qctx_->symTable()->updateWrittenBy(oldVar, var, this);
 }
 

--- a/src/graph/planner/plan/PlanNode.h
+++ b/src/graph/planner/plan/PlanNode.h
@@ -221,7 +221,7 @@ class PlanNode {
     return numDeps() == 2U;
   }
 
-  void setOutputVar(const std::string& var);
+  void setOutputVar(const std::string& var, const std::vector<std::string>& colNames);
 
   const std::string& outputVar() const {
     return outputVarPtr()->name;

--- a/src/graph/util/PlannerUtil.cpp
+++ b/src/graph/util/PlannerUtil.cpp
@@ -72,7 +72,7 @@ PlanNode* PlannerUtil::extractDstFromGN(QueryContext* qctx,
   auto* project = Project::make(qctx, gn, columns);
 
   auto* dedup = Dedup::make(qctx, project);
-  dedup->setOutputVar(output);
+  dedup->setOutputVar(output, {kVid});
   return dedup;
 }
 

--- a/src/graph/validator/AssignmentValidator.cpp
+++ b/src/graph/validator/AssignmentValidator.cpp
@@ -28,7 +28,7 @@ Status AssignmentValidator::toPlan() {
   for (const auto &outputCol : validator_->outputCols()) {
     var->colNames.emplace_back(outputCol.name);
   }
-  root_->setOutputVar(var_);
+  root_->setOutputVar(var_, var->colNames);
   tail_ = validator_->tail();
   return Status::OK();
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #4919 
Close #4881 

#### Description:

There is a risk that `colNames` are borrowed from a outputVar by mistake.

## How do you solve it?

Change the method's input parameters to require `colNames` explicitly.

Changing 

```
  lhs->setOutputVar("var5");
  lhs->setColNames({"v2", "e2", "v3"});
```

to

`lhs->setOutputVar("var5", {"v2", "e2", "v3"});
`

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
