### PR TITLE
fix folly::stringPrintf when ref empty str

### DIFF
--- a/src/storage/exec/UpdateResultNode.h
+++ b/src/storage/exec/UpdateResultNode.h
@@ -66,8 +66,7 @@ class UpdateResNode : public RelNode<T> {
       auto exp = static_cast<PropertyExpression*>(retExp);
       auto& val = exp->eval(*expCtx_);
       if (exp) {
-        result_->colNames.emplace_back(
-            folly::stringPrintf("%s.%s", exp->sym().c_str(), exp->prop().c_str()));
+        result_->colNames.emplace_back(exp->toString());
       } else {
         VLOG(1) << "Can't get expression name";
         result_->colNames.emplace_back("NULL");

--- a/src/storage/exec/UpdateResultNode.h
+++ b/src/storage/exec/UpdateResultNode.h
@@ -62,8 +62,7 @@ class UpdateResNode : public RelNode<T> {
     std::vector<Value> row;
     row.emplace_back(insert_);
 
-    for (auto& retExp : returnPropsExp_) {
-      auto exp = static_cast<PropertyExpression*>(retExp);
+    for (auto& exp : returnPropsExp_) {
       auto& val = exp->eval(*expCtx_);
       if (exp) {
         result_->colNames.emplace_back(exp->toString());

--- a/src/storage/test/UpdateVertexTest.cpp
+++ b/src/storage/test/UpdateVertexTest.cpp
@@ -167,11 +167,11 @@ TEST(UpdateVertexTest, No_Filter_Test) {
   EXPECT_EQ(0, (*resp.result_ref()).failed_parts.size());
   EXPECT_EQ(6, (*resp.props_ref()).colNames.size());
   EXPECT_EQ("_inserted", (*resp.props_ref()).colNames[0]);
-  EXPECT_EQ("1.name", (*resp.props_ref()).colNames[1]);
-  EXPECT_EQ("1.age", (*resp.props_ref()).colNames[2]);
-  EXPECT_EQ("1.country", (*resp.props_ref()).colNames[3]);
-  EXPECT_EQ(std::string("1.").append(kVid), (*resp.props_ref()).colNames[4]);
-  EXPECT_EQ(std::string("1.").append(kTag), (*resp.props_ref()).colNames[5]);
+  EXPECT_EQ("$^.1.name", (*resp.props_ref()).colNames[1]);
+  EXPECT_EQ("$^.1.age", (*resp.props_ref()).colNames[2]);
+  EXPECT_EQ("$^.1.country", (*resp.props_ref()).colNames[3]);
+  EXPECT_EQ(std::string("$^.1.").append(kVid), (*resp.props_ref()).colNames[4]);
+  EXPECT_EQ(std::string("$^.1.").append(kTag), (*resp.props_ref()).colNames[5]);
 
   EXPECT_EQ(1, (*resp.props_ref()).rows.size());
   EXPECT_EQ(6, (*resp.props_ref()).rows[0].values.size());
@@ -286,11 +286,11 @@ TEST(UpdateVertexTest, Filter_Yield_Test2) {
   // Note: If filtered out, the result is old
   EXPECT_EQ(6, (*resp.props_ref()).colNames.size());
   EXPECT_EQ("_inserted", (*resp.props_ref()).colNames[0]);
-  EXPECT_EQ("1.name", (*resp.props_ref()).colNames[1]);
-  EXPECT_EQ("1.age", (*resp.props_ref()).colNames[2]);
-  EXPECT_EQ("1.country", (*resp.props_ref()).colNames[3]);
-  EXPECT_EQ(std::string("1.").append(kVid), (*resp.props_ref()).colNames[4]);
-  EXPECT_EQ(std::string("1.").append(kTag), (*resp.props_ref()).colNames[5]);
+  EXPECT_EQ("$^.1.name", (*resp.props_ref()).colNames[1]);
+  EXPECT_EQ("$^.1.age", (*resp.props_ref()).colNames[2]);
+  EXPECT_EQ("$^.1.country", (*resp.props_ref()).colNames[3]);
+  EXPECT_EQ(std::string("$^.1.").append(kVid), (*resp.props_ref()).colNames[4]);
+  EXPECT_EQ(std::string("$^.1.").append(kTag), (*resp.props_ref()).colNames[5]);
 
   EXPECT_EQ(1, (*resp.props_ref()).rows.size());
   EXPECT_EQ(6, (*resp.props_ref()).rows[0].values.size());
@@ -390,11 +390,11 @@ TEST(UpdateVertexTest, Insertable_Test) {
   EXPECT_EQ(0, (*resp.result_ref()).failed_parts.size());
   EXPECT_EQ(6, (*resp.props_ref()).colNames.size());
   EXPECT_EQ("_inserted", (*resp.props_ref()).colNames[0]);
-  EXPECT_EQ("1.name", (*resp.props_ref()).colNames[1]);
-  EXPECT_EQ("1.age", (*resp.props_ref()).colNames[2]);
-  EXPECT_EQ("1.country", (*resp.props_ref()).colNames[3]);
-  EXPECT_EQ(std::string("1.").append(kVid), (*resp.props_ref()).colNames[4]);
-  EXPECT_EQ(std::string("1.").append(kTag), (*resp.props_ref()).colNames[5]);
+  EXPECT_EQ("$^.1.name", (*resp.props_ref()).colNames[1]);
+  EXPECT_EQ("$^.1.age", (*resp.props_ref()).colNames[2]);
+  EXPECT_EQ("$^.1.country", (*resp.props_ref()).colNames[3]);
+  EXPECT_EQ(std::string("$^.1.").append(kVid), (*resp.props_ref()).colNames[4]);
+  EXPECT_EQ(std::string("$^.1.").append(kTag), (*resp.props_ref()).colNames[5]);
 
   EXPECT_EQ(1, (*resp.props_ref()).rows.size());
   EXPECT_EQ(6, (*resp.props_ref()).rows[0].values.size());
@@ -689,11 +689,11 @@ TEST(UpdateVertexTest, Insertable_Filter_Value_Test) {
   EXPECT_EQ(0, (*resp.result_ref()).failed_parts.size());
   EXPECT_EQ(6, (*resp.props_ref()).colNames.size());
   EXPECT_EQ("_inserted", (*resp.props_ref()).colNames[0]);
-  EXPECT_EQ("1.name", (*resp.props_ref()).colNames[1]);
-  EXPECT_EQ("1.age", (*resp.props_ref()).colNames[2]);
-  EXPECT_EQ("1.country", (*resp.props_ref()).colNames[3]);
-  EXPECT_EQ(std::string("1.").append(kVid), (*resp.props_ref()).colNames[4]);
-  EXPECT_EQ(std::string("1.").append(kTag), (*resp.props_ref()).colNames[5]);
+  EXPECT_EQ("$^.1.name", (*resp.props_ref()).colNames[1]);
+  EXPECT_EQ("$^.1.age", (*resp.props_ref()).colNames[2]);
+  EXPECT_EQ("$^.1.country", (*resp.props_ref()).colNames[3]);
+  EXPECT_EQ(std::string("$^.1.").append(kVid), (*resp.props_ref()).colNames[4]);
+  EXPECT_EQ(std::string("$^.1.").append(kTag), (*resp.props_ref()).colNames[5]);
 
   EXPECT_EQ(1, (*resp.props_ref()).rows.size());
   EXPECT_EQ(true, (*resp.props_ref()).rows[0].values[0].getBool());
@@ -937,11 +937,11 @@ TEST(UpdateVertexTest, TTL_Insert_No_Exist_Test) {
   EXPECT_EQ(0, (*resp.result_ref()).failed_parts.size());
   EXPECT_EQ(6, (*resp.props_ref()).colNames.size());
   EXPECT_EQ("_inserted", (*resp.props_ref()).colNames[0]);
-  EXPECT_EQ("1.name", (*resp.props_ref()).colNames[1]);
-  EXPECT_EQ("1.age", (*resp.props_ref()).colNames[2]);
-  EXPECT_EQ("1.country", (*resp.props_ref()).colNames[3]);
-  EXPECT_EQ(std::string("1.").append(kVid), (*resp.props_ref()).colNames[4]);
-  EXPECT_EQ(std::string("1.").append(kTag), (*resp.props_ref()).colNames[5]);
+  EXPECT_EQ("$^.1.name", (*resp.props_ref()).colNames[1]);
+  EXPECT_EQ("$^.1.age", (*resp.props_ref()).colNames[2]);
+  EXPECT_EQ("$^.1.country", (*resp.props_ref()).colNames[3]);
+  EXPECT_EQ(std::string("$^.1.").append(kVid), (*resp.props_ref()).colNames[4]);
+  EXPECT_EQ(std::string("$^.1.").append(kTag), (*resp.props_ref()).colNames[5]);
 
   EXPECT_EQ(1, (*resp.props_ref()).rows.size());
   EXPECT_EQ(6, (*resp.props_ref()).rows[0].values.size());
@@ -1056,11 +1056,11 @@ TEST(UpdateVertexTest, TTL_Insert_Test) {
   EXPECT_EQ(0, (*resp.result_ref()).failed_parts.size());
   EXPECT_EQ(6, (*resp.props_ref()).colNames.size());
   EXPECT_EQ("_inserted", (*resp.props_ref()).colNames[0]);
-  EXPECT_EQ("1.name", (*resp.props_ref()).colNames[1]);
-  EXPECT_EQ("1.age", (*resp.props_ref()).colNames[2]);
-  EXPECT_EQ("1.country", (*resp.props_ref()).colNames[3]);
-  EXPECT_EQ(std::string("1.").append(kVid), (*resp.props_ref()).colNames[4]);
-  EXPECT_EQ(std::string("1.").append(kTag), (*resp.props_ref()).colNames[5]);
+  EXPECT_EQ("$^.1.name", (*resp.props_ref()).colNames[1]);
+  EXPECT_EQ("$^.1.age", (*resp.props_ref()).colNames[2]);
+  EXPECT_EQ("$^.1.country", (*resp.props_ref()).colNames[3]);
+  EXPECT_EQ(std::string("$^.1.").append(kVid), (*resp.props_ref()).colNames[4]);
+  EXPECT_EQ(std::string("$^.1.").append(kTag), (*resp.props_ref()).colNames[5]);
 
   EXPECT_EQ(1, (*resp.props_ref()).rows.size());
   EXPECT_EQ(6, (*resp.props_ref()).rows[0].values.size());
@@ -1242,10 +1242,10 @@ TEST(UpdateVertexTest, Insertable_In_Set_Test) {
   EXPECT_EQ(0, (*resp.result_ref()).failed_parts.size());
   EXPECT_EQ(5, (*resp.props_ref()).colNames.size());
   EXPECT_EQ("_inserted", (*resp.props_ref()).colNames[0]);
-  EXPECT_EQ("1.name", (*resp.props_ref()).colNames[1]);
-  EXPECT_EQ("1.age", (*resp.props_ref()).colNames[2]);
-  EXPECT_EQ(std::string("1.").append(kVid), (*resp.props_ref()).colNames[3]);
-  EXPECT_EQ(std::string("1.").append(kTag), (*resp.props_ref()).colNames[4]);
+  EXPECT_EQ("$^.1.name", (*resp.props_ref()).colNames[1]);
+  EXPECT_EQ("$^.1.age", (*resp.props_ref()).colNames[2]);
+  EXPECT_EQ(std::string("$^.1.").append(kVid), (*resp.props_ref()).colNames[3]);
+  EXPECT_EQ(std::string("$^.1.").append(kTag), (*resp.props_ref()).colNames[4]);
 
   EXPECT_EQ(1, (*resp.props_ref()).rows.size());
   EXPECT_EQ(5, (*resp.props_ref()).rows[0].values.size());

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,8 +53,8 @@ And if you want to debug only one test case, you should check the usage of `pyte
 
 ```shell
 # pytest will use keyword 'match' to match the Scenario name. All the Scenario whose name contains
-# the key word will be select. 
-# You can also use '@keyword' to annotate a scenario and using pytest -k 'keyword' to run only the one.
+# the keyword 'match' will be selected. 
+# You can also use '@keyword' to annotate a scenario and using `pytest -k 'keyword'` to run only the one scenario.
 $ pytest -k 'match' -m 'not skip' .
 ```
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -13,6 +13,7 @@ Nebula Test framework depends on python3(>=3.7) and some thirdparty libraries, s
 So you should install all these dependencies before running test cases by:
 
 ```shell
+$ cd tests
 $ make init-all
 ```
 
@@ -51,6 +52,9 @@ $ make RM_DIR=false tck  # default value of RM_DIR is true
 And if you want to debug only one test case, you should check the usage of `pytest` itself by `pytest --help`. For example, run the test cases related to `MATCH`, you can do it like:
 
 ```shell
+# pytest will use keyword 'match' to match the Scenario name. All the Scenario whose name contains
+# the key word will be select. 
+# You can also use '@keyword' to annotate a scenario and using pytest -k 'keyword' to run only the one.
 $ pytest -k 'match' -m 'not skip' .
 ```
 

--- a/tests/tck/features/update/Update.feature
+++ b/tests/tck/features/update/Update.feature
@@ -6,9 +6,9 @@ Feature: Update string vid of vertex and edge
   Background: Prepare space
     Given an empty graph
     And create a space with following options:
-      | partition_num  | 1                |
-      | replica_factor | 1                |
-      | vid_type       | FIXED_STRING(20) |
+      | partition_num  | 1                 |
+      | replica_factor | 1                 |
+      | vid_type       | FIXED_STRING(200) |
     And having executed:
       """
       CREATE TAG IF NOT EXISTS course(name string, credits int);
@@ -731,12 +731,21 @@ Feature: Update string vid of vertex and edge
       """
       UPDATE VERTEX ON course "101"
       SET credits = credits + 1
+      YIELD "101" AS courseId, credits AS Credits
+      """
+    Then the result should be, in any order:
+      | courseId | Credits |
+      | '101'    | 7       |
+    When executing query:
+      """
+      UPDATE VERTEX ON course "101"
+      SET credits = credits + 1
       WHEN name == "Math" AND credits > 2
       YIELD name AS Name, credits AS Credits
       """
     Then the result should be, in any order:
       | Name   | Credits |
-      | 'Math' | 7       |
+      | 'Math' | 8       |
     When executing query:
       """
       UPDATE VERTEX ON course "101"
@@ -746,7 +755,7 @@ Feature: Update string vid of vertex and edge
       """
     Then the result should be, in any order:
       | Name   | Credits |
-      | 'Math' | 7       |
+      | 'Math' | 8       |
     When executing query:
       """
       FETCH PROP ON select "200"->"101"@0 YIELD select.grade, select.year


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula/issues/4926
#### Description:
when the sym_ in PropertyExpression is empty, return reference of string and pass it to folly::stringFormat will crash.

```
(gdb) bt
#0  0x00007f26e967f079 in vfprintf () from /lib64/libc.so.6
#1  0x00007f26e96aa179 in vsnprintf () from /lib64/libc.so.6
#2  0x0000000002c2a2b3 in ?? ()
#3  0x0000000002c2b737 in folly::stringVPrintf[abi:cxx11](char const*, __va_list_tag*) ()
#4  0x0000000002c2b8df in folly::stringPrintf[abi:cxx11](char const*, ...) ()
#5  0x00000000014ce1ca in nebula::storage::UpdateResNode<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::doExecute(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
#6  0x00000000014bd030 in nebula::storage::RelNode<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::execute(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
#7  0x00000000014bcd86 in nebula::storage::RelNode<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::doExecute(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
#8  0x00000000014bd030 in nebula::storage::RelNode<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::execute(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) ()
#9  0x00000000014bbfb0 in nebula::storage::UpdateVertexProcessor::doProcess(nebula::storage::cpp2::UpdateVertexRequest const&) ()
#10 0x00000000028b3a27 in virtual thunk to apache::thrift::concurrency::FunctionRunner::run() ()
#11 0x0000000002a0ea38 in apache::thrift::concurrency::ThreadManager::Impl::Worker::run() ()
#12 0x0000000002a10b3e in apache::thrift::concurrency::PthreadThread::threadMain(void*) ()
#13 0x00007f26e9a07ea5 in start_thread () from /lib64/libpthread.so.0
#14 0x00007f26e9730b0d in clone () from /lib64/libc.so.6
```


## How do you solve it?

just use `exp->toString()`, in which will test empty, and then copy.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
