### PR TITLE
Fix dup alias in MATCH

### DIFF
--- a/src/graph/planner/match/MatchPathPlanner.cpp
+++ b/src/graph/planner/match/MatchPathPlanner.cpp
@@ -307,6 +307,17 @@ Status MatchPathPlanner::leftExpandFromNode(
   appendV->setColNames(genAppendVColNames(subplan.root->colNames(), node, !edgeInfos.empty()));
   subplan.root = appendV;
 
+  auto& lastNode = nodeInfos.front();
+  bool expandInto = nodeAliasesSeenInPattern.find(lastNode.alias) != nodeAliasesSeenInPattern.end();
+  if (expandInto) {
+    auto* startVid = nodeId(qctx->objPool(), lastNode);
+    auto* endVid = nextTraverseStart;
+    auto* filterExpr = RelationalExpression::makeEQ(qctx->objPool(), startVid, endVid);
+    auto* filter = Filter::make(qctx, appendV, filterExpr, false);
+    subplan.root = filter;
+    inputVar = filter->outputVar();
+  }
+
   return Status::OK();
 }
 
@@ -369,6 +380,17 @@ Status MatchPathPlanner::rightExpandFromNode(
   appendV->setTrackPrevPath(!edgeInfos.empty());
   appendV->setColNames(genAppendVColNames(subplan.root->colNames(), node, !edgeInfos.empty()));
   subplan.root = appendV;
+
+  auto& lastNode = nodeInfos.back();
+  bool expandInto = nodeAliasesSeenInPattern.find(lastNode.alias) != nodeAliasesSeenInPattern.end();
+  if (expandInto) {
+    auto* startVid = nodeId(qctx->objPool(), lastNode);
+    auto* endVid = nextTraverseStart;
+    auto* filterExpr = RelationalExpression::makeEQ(qctx->objPool(), startVid, endVid);
+    auto* filter = Filter::make(qctx, appendV, filterExpr, false);
+    subplan.root = filter;
+    inputVar = filter->outputVar();
+  }
 
   return Status::OK();
 }

--- a/src/graph/validator/test/MatchValidatorTest.cpp
+++ b/src/graph/validator/test/MatchValidatorTest.cpp
@@ -535,6 +535,19 @@ TEST_F(MatchValidatorTest, validateAlias) {
         std::string(result.message()),
         "SemanticError: keywords: vertex and edge are not supported in return clause `EDGE AS b'");
   }
+  // Duplicate alias at the end of the pattern
+  {
+    std::string query = "MATCH (v :person{name:\"Tim Duncan\"})-[e]->(v2)-[]->(v2) RETURN e";
+    std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kProject,
+                                            PlanNode::Kind::kProject,
+                                            PlanNode::Kind::kFilter,
+                                            PlanNode::Kind::kAppendVertices,
+                                            PlanNode::Kind::kTraverse,
+                                            PlanNode::Kind::kTraverse,
+                                            PlanNode::Kind::kIndexScan,
+                                            PlanNode::Kind::kStart};
+    EXPECT_TRUE(checkResult(query, expected));
+  }
 }
 
 }  // namespace graph

--- a/src/graph/validator/test/MatchValidatorTest.cpp
+++ b/src/graph/validator/test/MatchValidatorTest.cpp
@@ -541,7 +541,6 @@ TEST_F(MatchValidatorTest, validateAlias) {
     std::vector<PlanNode::Kind> expected = {PlanNode::Kind::kProject,
                                             PlanNode::Kind::kProject,
                                             PlanNode::Kind::kFilter,
-                                            PlanNode::Kind::kAppendVertices,
                                             PlanNode::Kind::kTraverse,
                                             PlanNode::Kind::kTraverse,
                                             PlanNode::Kind::kIndexScan,

--- a/tests/tck/features/bugfix/DupAliasInMatch.feature
+++ b/tests/tck/features/bugfix/DupAliasInMatch.feature
@@ -1,0 +1,45 @@
+# Copyright (c) 2022 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+# Issue link: https://github.com/vesoft-inc/nebula-ent/issues/1605
+Feature: Duplicate alias in MATCH
+
+  Background:
+    Given a graph with space named "nba"
+
+  Scenario: Duplicate node alias
+    # expand from left to right
+    When executing query:
+      """
+      MATCH (n0)-[]->(n1)-[]->(n1) WHERE (id(n0) == "Tim Duncan") RETURN n1
+      """
+    Then the result should be, in any order:
+      | n1 |
+    # expand from right to left
+    When executing query:
+      """
+      MATCH (n1)<-[]-(n1)<-[]-(n0) WHERE (id(n0) == "Tim Duncan") RETURN n1
+      """
+    Then the result should be, in any order:
+      | n1 |
+    When executing query:
+      """
+      MATCH (n0)-[]->(n1)-[]->(n1)-[]->(n1) WHERE (id(n0) == "Tim Duncan") RETURN n1
+      """
+    Then the result should be, in any order:
+      | n1 |
+    When executing query:
+      """
+      MATCH (n0)-[]->(n1)-[]->(n1)-[]->(n1)-[]->(n1) WHERE (id(n0) == "Tim Duncan") RETURN n1
+      """
+    Then the result should be, in any order:
+      | n1 |
+
+  Scenario: Duplicate node alias expand both direction
+    # expand from left to right
+    When executing query:
+      """
+      MATCH (n1)-[]->(n0)-[]->(n1)-[]->(n1)-[]->(n1) WHERE (id(n0) == "Tim Duncan") RETURN n1
+      """
+    Then the result should be, in any order:
+      | n1 |

--- a/tests/tck/features/bugfix/DupAliasInMatch.feature
+++ b/tests/tck/features/bugfix/DupAliasInMatch.feature
@@ -36,7 +36,7 @@ Feature: Duplicate alias in MATCH
       | n1 |
 
   Scenario: Duplicate node alias expand both direction
-    # expand from left to right
+    # expand from middle to both sides
     When executing query:
       """
       MATCH (n1)-[]->(n0)-[]->(n1)-[]->(n1)-[]->(n1) WHERE (id(n0) == "Tim Duncan") RETURN n1


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Fix https://github.com/vesoft-inc/nebula-ent/issues/1605, https://github.com/vesoft-inc/nebula-ent/issues/1727
#### Description:
Emit `addVertises` node if the last node in the pattern is duplicated.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [x] TCK

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
