### PR TITLE
Skip redudant self-reflective edges in GetNeighborsNode

### DIFF
--- a/src/graph/executor/query/TraverseExecutor.h
+++ b/src/graph/executor/query/TraverseExecutor.h
@@ -14,7 +14,11 @@
 // invoke the getNeighbors interface, according to the number of times specified by the user,
 // and assemble the result into paths
 //
-//  The definition of path is : array of vertex and edges
+//  Path is an array of vertex and edges physically.
+//  Its definition is a trail, in which all edges are distinct. It's different to a walk
+//  which allows duplicated vertices and edges, and a path where all vertices and edges
+//  are distinct.
+//
 //  Eg a->b->c. path is [Vertex(a), [Edge(a->b), Vertex(b), Edge(b->c), Vertex(c)]]
 //  the purpose is to extract the path by pathBuildExpression
 // `resDs_` : keep result dataSet

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -116,6 +116,9 @@ class GetNeighborsNode : public QueryNode<VertexID> {
         return nebula::cpp2::ErrorCode::SUCCEEDED;
       }
       auto key = upstream_->key();
+      if (isDuplicatedSelfReflectiveEdge(key)) {
+        continue;
+      }
       auto reader = upstream_->reader();
       auto props = context_->props_;
       auto columnIdx = context_->columnIdx_;
@@ -138,6 +141,24 @@ class GetNeighborsNode : public QueryNode<VertexID> {
     return nebula::cpp2::ErrorCode::SUCCEEDED;
   }
 
+  bool isDuplicatedSelfReflectiveEdge(const folly::StringPiece& key) {
+    std::string srcID = NebulaKeyUtils::getSrcId(context_->vIdLen(), key).str();
+    std::string dstID = NebulaKeyUtils::getDstId(context_->vIdLen(), key).str();
+    if (srcID.compare(dstID) == 0) {
+      // self-reflective edge
+      std::string rank = std::to_string(NebulaKeyUtils::getRank(context_->vIdLen(), key));
+      auto edgeType = NebulaKeyUtils::getEdgeType(context_->vIdLen(), key);
+      edgeType = edgeType > 0 ? edgeType : -edgeType;
+      std::string type = std::to_string(edgeType);
+      std::string localKey = type + rank + srcID;
+      if (!visitedSelfReflectiveEdges_.insert(localKey).second) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  std::unordered_set<std::string> visitedSelfReflectiveEdges_;
   RuntimeContext* context_;
   IterateNode<VertexID>* hashJoinNode_;
   IterateNode<VertexID>* upstream_;

--- a/src/storage/exec/GetNeighborsNode.h
+++ b/src/storage/exec/GetNeighborsNode.h
@@ -142,15 +142,15 @@ class GetNeighborsNode : public QueryNode<VertexID> {
   }
 
   bool isDuplicatedSelfReflectiveEdge(const folly::StringPiece& key) {
-    std::string srcID = NebulaKeyUtils::getSrcId(context_->vIdLen(), key).str();
-    std::string dstID = NebulaKeyUtils::getDstId(context_->vIdLen(), key).str();
-    if (srcID.compare(dstID) == 0) {
+    folly::StringPiece srcID = NebulaKeyUtils::getSrcId(context_->vIdLen(), key);
+    folly::StringPiece dstID = NebulaKeyUtils::getDstId(context_->vIdLen(), key);
+    if (srcID == dstID) {
       // self-reflective edge
       std::string rank = std::to_string(NebulaKeyUtils::getRank(context_->vIdLen(), key));
       auto edgeType = NebulaKeyUtils::getEdgeType(context_->vIdLen(), key);
       edgeType = edgeType > 0 ? edgeType : -edgeType;
       std::string type = std::to_string(edgeType);
-      std::string localKey = type + rank + srcID;
+      std::string localKey = type + rank + srcID.str();
       if (!visitedSelfReflectiveEdges_.insert(localKey).second) {
         return true;
       }

--- a/tests/tck/features/match/SelfReflectiveEdges.feature
+++ b/tests/tck/features/match/SelfReflectiveEdges.feature
@@ -15,7 +15,7 @@ Feature: Matches on self-reflective edges
       """
     When executing query:
       """
-      MATCH x =  (n0)-[e1]->(n1)-[e2]-(n0) WHERE id(n0) == "Hades" and id(n1) == "Hades" return e1, e2
+      MATCH x = (n0)-[e1]->(n1)-[e2]-(n0) WHERE id(n0) == "Hades" and id(n1) == "Hades" return e1, e2
       """
     Then the result should be, in any order:
       | e1                                                                 | e2                                                                 |
@@ -23,9 +23,18 @@ Feature: Matches on self-reflective edges
       | [:like "Hades"->"Hades" @0 {likeness: 3000}]                       | [:teammate "Hades"->"Hades" @0 {end_year: 3000, start_year: 3000}] |
     When executing query:
       """
-      MATCH x =  (n0)-[e1]->(n1)-[e2]-(n0) WHERE id(n0) == "Hades" and id(n1) == "Hades" return e1, e2
+      MATCH x = (n0)-[e1]->(n1)-[e2]-(n0) WHERE id(n0) == "Hades" and id(n1) == "Hades" return e1, e2
       """
     Then the result should be, in any order:
       | e1                                                                 | e2                                                                 |
       | [:teammate "Hades"->"Hades" @0 {end_year: 3000, start_year: 3000}] | [:like "Hades"->"Hades" @0 {likeness: 3000}]                       |
       | [:like "Hades"->"Hades" @0 {likeness: 3000}]                       | [:teammate "Hades"->"Hades" @0 {end_year: 3000, start_year: 3000}] |
+    When executing query:
+      """
+      DELETE EDGE serve "Hades"->"Underworld";
+      DELETE EDGE teammate "Hades"->"Hades";
+      DELETE EDGE like "Hades"->"Hades";
+      DELETE VERTEX "Underworld";
+      DELETE VERTEX "Hades";
+      """
+    Then the execution should be successful

--- a/tests/tck/features/match/SelfReflectiveEdges.feature
+++ b/tests/tck/features/match/SelfReflectiveEdges.feature
@@ -23,7 +23,7 @@ Feature: Matches on self-reflective edges
       | [:like "Hades"->"Hades" @0 {likeness: 3000}]                       | [:teammate "Hades"->"Hades" @0 {end_year: 3000, start_year: 3000}] |
     When executing query:
       """
-      MATCH x = (n0)-[e1]->(n1)-[e2]-(n0) WHERE id(n0) == "Hades" and id(n1) == "Hades" return e1, e2
+      MATCH x = (n0)-[e1]->(n1)<-[e2]-(n0) WHERE id(n0) == "Hades" and id(n1) == "Hades" return e1, e2
       """
     Then the result should be, in any order:
       | e1                                                                 | e2                                                                 |

--- a/tests/tck/features/match/SelfReflectiveEdges.feature
+++ b/tests/tck/features/match/SelfReflectiveEdges.feature
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+Feature: Matches on self-reflective edges
+
+  Scenario: no duplicated self reflective edges
+    Given a graph with space named "nba"
+    And having executed:
+      """
+      insert vertex player (name, age) values "Hades":("Hades", 99999);
+      insert vertex team (name) values "Underworld":("Underworld");
+      insert edge like (likeness) values "Hades"->"Hades":(3000);
+      insert edge teammate (start_year, end_year) values "Hades"->"Hades":(3000, 3000);
+      insert edge serve (start_year, end_year) values "Hades"->"Underworld":(0, 99999);
+      """
+    When executing query:
+      """
+      MATCH x =  (n0)-[e1]->(n1)-[e2]-(n0) WHERE id(n0) == "Hades" and id(n1) == "Hades" return e1, e2
+      """
+    Then the result should be, in any order:
+      | e1                                                                 | e2                                                                 |
+      | [:teammate "Hades"->"Hades" @0 {end_year: 3000, start_year: 3000}] | [:like "Hades"->"Hades" @0 {likeness: 3000}]                       |
+      | [:like "Hades"->"Hades" @0 {likeness: 3000}]                       | [:teammate "Hades"->"Hades" @0 {end_year: 3000, start_year: 3000}] |
+    When executing query:
+      """
+      MATCH x =  (n0)-[e1]->(n1)-[e2]-(n0) WHERE id(n0) == "Hades" and id(n1) == "Hades" return e1, e2
+      """
+    Then the result should be, in any order:
+      | e1                                                                 | e2                                                                 |
+      | [:teammate "Hades"->"Hades" @0 {end_year: 3000, start_year: 3000}] | [:like "Hades"->"Hades" @0 {likeness: 3000}]                       |
+      | [:like "Hades"->"Hades" @0 {likeness: 3000}]                       | [:teammate "Hades"->"Hades" @0 {end_year: 3000, start_year: 3000}] |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #4929 

#### Description:
Duplicated results in matches.

Reason:

- Self-reflective edges like `(v0)-[e]->(v0)` are stored as two different versions in the storage: the outbound one and the inbound one.
- When fetching edges of both directions in the GetNeighborsNode, these two physical versions are treated as two distinct edges, although they are the same edge.
- Such redudant edges returned from the storage cause the query engine's traverse operator to process redudant edges, resulting in extra overhead and wrong results.

## How do you solve it?
In the GetNeighborsNode, if an edge fetched from the storage has identical srcID and dstID, check whether it has been visited previously. If so, skip it.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] TCK
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
