### PR TITLE
fix ttl not work when ttl column has default value

### DIFF
--- a/src/clients/meta/MetaClient.h
+++ b/src/clients/meta/MetaClient.h
@@ -442,12 +442,16 @@ class MetaClient : public BaseMetaClient {
   StatusOr<std::vector<std::pair<PartitionID, cpp2::ListenerType>>>
   getListenersBySpaceHostFromCache(GraphSpaceID spaceId, const HostAddr& host);
 
+  // Given host, get the all peers info. This function is used for listener to start up related
+  // listener part
   StatusOr<ListenersMap> getListenersByHostFromCache(const HostAddr& host);
 
+  // Get listener address of given (spaceId + partId + type)
   StatusOr<HostAddr> getListenerHostsBySpacePartType(GraphSpaceID spaceId,
                                                      PartitionID partId,
                                                      cpp2::ListenerType type);
 
+  // Get all listener type + address of given (spaceId + partId)
   StatusOr<std::vector<RemoteListenerInfo>> getListenerHostTypeBySpacePartType(GraphSpaceID spaceId,
                                                                                PartitionID partId);
 

--- a/src/storage/CommonUtils.cpp
+++ b/src/storage/CommonUtils.cpp
@@ -16,6 +16,7 @@ bool CommonUtils::checkDataExpiredForTTL(const meta::SchemaProviderIf* schema,
                                          int64_t ttlDuration) {
   auto v = QueryUtils::readValue(reader, ttlCol, schema);
   if (!v.ok()) {
+    VLOG(3) << "failed to read ttl property";
     return false;
   }
   return checkDataExpiredForTTL(schema, v.value(), ttlCol, ttlDuration);

--- a/src/storage/CommonUtils.cpp
+++ b/src/storage/CommonUtils.cpp
@@ -5,6 +5,8 @@
 
 #include "storage/CommonUtils.h"
 
+#include "storage/exec/QueryUtils.h"
+
 namespace nebula {
 namespace storage {
 
@@ -12,8 +14,11 @@ bool CommonUtils::checkDataExpiredForTTL(const meta::SchemaProviderIf* schema,
                                          RowReader* reader,
                                          const std::string& ttlCol,
                                          int64_t ttlDuration) {
-  auto v = reader->getValueByName(ttlCol);
-  return checkDataExpiredForTTL(schema, v, ttlCol, ttlDuration);
+  auto v = QueryUtils::readValue(reader, ttlCol, schema);
+  if (!v.ok()) {
+    return false;
+  }
+  return checkDataExpiredForTTL(schema, v.value(), ttlCol, ttlDuration);
 }
 
 bool CommonUtils::checkDataExpiredForTTL(const meta::SchemaProviderIf* schema,

--- a/src/storage/CommonUtils.h
+++ b/src/storage/CommonUtils.h
@@ -251,6 +251,15 @@ struct RuntimeContext {
 
 class CommonUtils final {
  public:
+  /**
+   * @brief check whether data is expired by comparing ttl property and current time
+   *
+   * @param schema **Latest** schema
+   * @param reader RowReader of current value
+   * @param ttlCol Ttl property name
+   * @param ttlDuration Ttl property duration
+   * @return Whether data is expired
+   */
   static bool checkDataExpiredForTTL(const meta::SchemaProviderIf* schema,
                                      RowReader* reader,
                                      const std::string& ttlCol,

--- a/src/storage/exec/QueryUtils.h
+++ b/src/storage/exec/QueryUtils.h
@@ -9,6 +9,7 @@
 #include "common/base/Base.h"
 #include "common/expression/Expression.h"
 #include "common/utils/DefaultValueContext.h"
+#include "common/utils/NebulaKeyUtils.h"
 #include "storage/CommonUtils.h"
 #include "storage/context/StorageExpressionContext.h"
 #include "storage/query/QueryBaseProcessor.h"
@@ -119,7 +120,7 @@ class QueryUtils final {
    */
   static StatusOr<nebula::Value> readValue(RowReader* reader,
                                            const std::string& propName,
-                                           const meta::NebulaSchemaProvider* schema) {
+                                           const meta::SchemaProviderIf* schema) {
     auto field = schema->field(propName);
     if (!field) {
       return Status::Error(folly::stringPrintf("Fail to read prop %s ", propName.c_str()));

--- a/tests/tck/features/ttl/TTL.feature
+++ b/tests/tck/features/ttl/TTL.feature
@@ -490,3 +490,38 @@ Feature: TTLTest
     Then the result should be, in any order:
       | age |
     And drop the used space
+
+  @wtf
+  Scenario: TTLTest ttl column has default
+    Given having executed:
+      """
+      CREATE TAG t1(name string, age int)
+      """
+    And wait 3 seconds
+    When executing query:
+      """
+      INSERT VERTEX t1(name, age) VALUES "1":("tom", 18)
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      ALTER TAG t1 ADD(n int default 1669726461)
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      ALTER TAG t1 TTL_DURATION = 30, TTL_COL = "n";
+      """
+    Then the execution should be successful
+    And wait 3 seconds
+    When executing query:
+      """
+      INSERT VERTEX t1(name, age) VALUES "2":("jerry", 18)
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      match (v) return v limit 10
+      """
+    Then the result should be, in any order:
+      | v |

--- a/tests/tck/features/ttl/TTL.feature
+++ b/tests/tck/features/ttl/TTL.feature
@@ -491,7 +491,6 @@ Feature: TTLTest
       | age |
     And drop the used space
 
-  @wtf
   Scenario: TTLTest ttl column has default
     Given having executed:
       """


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula/issues/4962

#### Description:
As title, the reason is that we only read the ttl property from RowReader, we need to use latest schema as well for data with older schema version.

## How do you solve it?
`QueryUtils::readValue` already handle this.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:
Add some comments.

## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
