### PR TITLE
fix PrunProperties tck random order

### DIFF
--- a/tests/tck/features/optimizer/PrunePropertiesRule.feature
+++ b/tests/tck/features/optimizer/PrunePropertiesRule.feature
@@ -858,7 +858,7 @@ Feature: Prune Properties rule
       """
       MATCH (v:player)-[e:like]->(t) WHERE v.player.name=='Tim Duncan'  RETURN v.player.name, v.x.y, v.player.age
       """
-    Then the result should be, in order, with relax comparison:
+    Then the result should be, in any order, with relax comparison:
       | v.player.name | v.x.y    | v.player.age |
       | "Tim Duncan"  | __NULL__ | 42           |
       | "Tim Duncan"  | __NULL__ | 42           |
@@ -866,7 +866,7 @@ Feature: Prune Properties rule
       """
       MATCH (v:player)-[:like]->(t) WHERE v.player.name=="Tim Duncan" RETURN v.player.name, properties(v), t
       """
-    Then the result should be, in order, with relax comparison:
+    Then the result should be, in any order, with relax comparison:
       | v.player.name | properties(v)                                           | t                                                         |
       | "Tim Duncan"  | {age: 42, name: "Tim Duncan", speciality: "psychology"} | ("Tony Parker" :player{age: 36, name: "Tony Parker"})     |
       | "Tim Duncan"  | {age: 42, name: "Tim Duncan", speciality: "psychology"} | ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"}) |
@@ -874,7 +874,7 @@ Feature: Prune Properties rule
       """
       MATCH (v:player)-[:like]->(t) WHERE v.player.name=="Tim Duncan" RETURN v.player.name, t.errortag.name, properties(v), t
       """
-    Then the result should be, in order, with relax comparison:
+    Then the result should be, in any order, with relax comparison:
       | v.player.name | t.errortag.name | properties(v)                                           | t                                                         |
       | "Tim Duncan"  | __NULL__        | {age: 42, name: "Tim Duncan", speciality: "psychology"} | ("Tony Parker" :player{age: 36, name: "Tony Parker"})     |
       | "Tim Duncan"  | __NULL__        | {age: 42, name: "Tim Duncan", speciality: "psychology"} | ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"}) |


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

As title https://github.com/vesoft-inc/nebula/pull/4949 introduced tck case 's result is not ordered, fix with any order


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
