### PR TITLE
added a deprecated marker in common.thrift

### DIFF
--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -95,6 +95,7 @@ enum NullType {
     BAD_DATA = 2,
     BAD_TYPE = 3,
     ERR_OVERFLOW = 4,
+    UNKNOWN_PROP = 5,  // deprecated but not to be deleted
     DIV_BY_ZERO = 6,
     OUT_OF_RANGE = 7,
 } (cpp.enum_strict, cpp.type = "nebula::NullType")


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #4986 
Related to #4907 

#### Description:
Remove a member in an enum may result in generating inconsistent thrift codes and building errors. Not sure what the exact reason is. But keeping the enmu unchanged avoids this risk.

## How do you solve it?

- Add the removed member back (i.e., `UNKNOWN_PROP`) with a deprecated comment marker.
- It serves as a placeholder to avoid size differences of `enum NullType`.
- It will never be sent to clients, as `UNKNOWN_PROP` has been removed in `Value.h`.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
