### PR TITLE
Remove the pruning of Expression::Kind::kVarProperty in agg.

### DIFF
--- a/src/graph/visitor/PropertyTrackerVisitor.cpp
+++ b/src/graph/visitor/PropertyTrackerVisitor.cpp
@@ -317,8 +317,7 @@ void PropertyTrackerVisitor::visit(AggregateExpression *expr) {
   std::transform(funName.begin(), funName.end(), funName.begin(), ::tolower);
   if (funName == "count") {
     auto kind = expr->arg()->kind();
-    if (kind == Expression::Kind::kConstant || kind == Expression::Kind::kInputProperty ||
-        kind == Expression::Kind::kVarProperty) {
+    if (kind == Expression::Kind::kConstant) {
       return;
     }
   }

--- a/tests/tck/features/optimizer/PrunePropertiesRule.feature
+++ b/tests/tck/features/optimizer/PrunePropertiesRule.feature
@@ -422,14 +422,14 @@ Feature: Prune Properties rule
       | count(v2) |
       | 24        |
     And the execution plan should be:
-      | id | name           | dependencies | operator info                                                                                                                 |
-      | 7  | Aggregate      | 6            |                                                                                                                               |
-      | 6  | Project        | 5            |                                                                                                                               |
-      | 5  | AppendVertices | 4            | {  "props": "[{\"props\":[\"_tag\"],\"tagId\":8}, {\"props\":[\"_tag\"],\"tagId\":9}, {\"props\":[\"_tag\"],\"tagId\":10}]" } |
-      | 4  | Traverse       | 2            | {"vertexProps": "", "edgeProps": "[{\"type\": 3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                            |
-      | 2  | Dedup          | 1            |                                                                                                                               |
-      | 1  | PassThrough    | 3            |                                                                                                                               |
-      | 3  | Start          |              |                                                                                                                               |
+      | id | name           | dependencies | operator info                                                                                                                                                                 |
+      | 7  | Aggregate      | 6            |                                                                                                                                                                               |
+      | 6  | Project        | 5            |                                                                                                                                                                               |
+      | 5  | AppendVertices | 4            | {  "props": "[{\"tagId\":8,\"props\":[\"name\",\"speciality\",\"_tag\"]},{\"props\":[\"_tag\",\"name\",\"age\"],\"tagId\":9},{\"tagId\":10,\"props\":[\"name\",\"_tag\"]}]" } |
+      | 4  | Traverse       | 2            | {"vertexProps": "", "edgeProps": "[{\"type\": 3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                                                                            |
+      | 2  | Dedup          | 1            |                                                                                                                                                                               |
+      | 1  | PassThrough    | 3            |                                                                                                                                                                               |
+      | 3  | Start          |              |                                                                                                                                                                               |
     When profiling query:
       """
       MATCH p = (v1)-[e:like*1..5]->(v2)
@@ -533,27 +533,27 @@ Feature: Prune Properties rule
       | "Spurs"     | 11          |
       | "Hornets"   | 3           |
     And the execution plan should be:
-      | id | name           | dependencies | operator info                                                                                                                                                   |
-      | 21 | Aggregate      | 20           |                                                                                                                                                                 |
-      | 20 | Aggregate      | 19           |                                                                                                                                                                 |
-      | 19 | HashLeftJoin   | 10, 25       |                                                                                                                                                                 |
-      | 10 | Aggregate      | 23           |                                                                                                                                                                 |
-      | 23 | Project        | 22           |                                                                                                                                                                 |
-      | 22 | Filter         | 29           |                                                                                                                                                                 |
-      | 29 | AppendVertices | 28           | {  "props": "[{\"props\":[\"name\", \"_tag\"],\"tagId\":10}]" }                                                                                                 |
-      | 28 | Traverse       | 27           | {"vertexProps": "[{\"props\":[\"age\"],\"tagId\":9}]", "edgeProps": "[{\"type\": 4, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                           |
-      | 27 | Traverse       | 26           | {"vertexProps": "", "edgeProps": "[{\"type\": -5, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                                                             |
-      | 26 | Traverse       | 2            | {"vertexProps": "", "edgeProps": "[{\"type\": -3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}, {\"type\": 3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  } |
-      | 2  | Dedup          | 1            |                                                                                                                                                                 |
-      | 1  | PassThrough    | 3            |                                                                                                                                                                 |
-      | 3  | Start          |              |                                                                                                                                                                 |
-      | 25 | Project        | 24           |                                                                                                                                                                 |
-      | 24 | Filter         | 16           |                                                                                                                                                                 |
-      | 16 | AppendVertices | 15           | {  "props": "[{\"props\":[\"name\", \"_tag\"],\"tagId\":10}]" }                                                                                                 |
-      | 15 | Traverse       | 14           | {"vertexProps": "[{\"props\":[\"age\"],\"tagId\":9}]", "edgeProps": "[{\"type\": 4, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                           |
-      | 14 | Traverse       | 13           | {"vertexProps": "", "edgeProps": "[{\"type\": -3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                                                             |
-      | 13 | Traverse       | 11           | {"vertexProps": "", "edgeProps": "[{\"type\": -3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}, {\"type\": 3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  } |
-      | 11 | Argument       |              |                                                                                                                                                                 |
+      | id | name           | dependencies | operator info                                                                                                                                                                                                                                            |
+      | 21 | Aggregate      | 20           |                                                                                                                                                                                                                                                          |
+      | 20 | Aggregate      | 19           |                                                                                                                                                                                                                                                          |
+      | 19 | HashLeftJoin   | 10, 25       |                                                                                                                                                                                                                                                          |
+      | 10 | Aggregate      | 23           |                                                                                                                                                                                                                                                          |
+      | 23 | Project        | 22           |                                                                                                                                                                                                                                                          |
+      | 22 | Filter         | 29           |                                                                                                                                                                                                                                                          |
+      | 29 | AppendVertices | 28           | {  "props": "[{\"props\":[\"name\", \"_tag\"],\"tagId\":10}]" }                                                                                                                                                                                          |
+      | 28 | Traverse       | 27           | {"vertexProps": "[{\"tagId\":8,\"props\":[\"name\",\"speciality\",\"_tag\"]},{\"tagId\":9,\"props\":[\"name\",\"age\",\"_tag\"]},{\"props\":[\"name\",\"_tag\"],\"tagId\":10}]", "edgeProps": "[{\"type\":4,\"props\":[\"_dst\",\"_type\",\"_rank\"]}]"} |
+      | 27 | Traverse       | 26           | {"vertexProps": "", "edgeProps": "[{\"type\": -5, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                                                                                                                                                      |
+      | 26 | Traverse       | 2            | {"vertexProps": "", "edgeProps": "[{\"type\": -3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}, {\"type\": 3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                                                                                          |
+      | 2  | Dedup          | 1            |                                                                                                                                                                                                                                                          |
+      | 1  | PassThrough    | 3            |                                                                                                                                                                                                                                                          |
+      | 3  | Start          |              |                                                                                                                                                                                                                                                          |
+      | 25 | Project        | 24           |                                                                                                                                                                                                                                                          |
+      | 24 | Filter         | 16           |                                                                                                                                                                                                                                                          |
+      | 16 | AppendVertices | 15           | {  "props": "[{\"props\":[\"name\", \"_tag\"],\"tagId\":10}]" }                                                                                                                                                                                          |
+      | 15 | Traverse       | 14           | {"vertexProps": "[{\"tagId\":8,\"props\":[\"name\",\"speciality\",\"_tag\"]},{\"tagId\":9,\"props\":[\"name\",\"age\",\"_tag\"]},{\"props\":[\"name\",\"_tag\"],\"tagId\":10}]", "edgeProps": "[{\"type\":4,\"props\":[\"_dst\",\"_type\",\"_rank\"]}]"} |
+      | 14 | Traverse       | 13           | {"vertexProps": "", "edgeProps": "[{\"type\": -3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                                                                                                                                                      |
+      | 13 | Traverse       | 11           | {"vertexProps": "", "edgeProps": "[{\"type\": -3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}, {\"type\": 3, \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                                                                                          |
+      | 11 | Argument       |              |                                                                                                                                                                                                                                                          |
 
   @distonly
   Scenario: test properties:

--- a/tests/tck/features/optimizer/PrunePropertiesRule.feature
+++ b/tests/tck/features/optimizer/PrunePropertiesRule.feature
@@ -888,3 +888,59 @@ Feature: Prune Properties rule
     Then the result should be, in any order:
       | count(a) |
       | 5        |
+    When executing query:
+      """
+      match (v0:player)-[e0]->(v1) where id(v0) == "Tim Duncan" unwind e0.start_year as a return sum(a)
+      """
+    Then the result should be, in any order:
+      | sum(a) |
+      | 10025  |
+    When executing query:
+      """
+      match (v0:player)-[e0]->(v1) where id(v0) == "Tim Duncan" unwind e0.start_year as a return max(a)
+      """
+    Then the result should be, in any order:
+      | max(a) |
+      | 2015   |
+    When executing query:
+      """
+      match (v0:player)-[e0]->(v1) where id(v0) == "Tim Duncan" unwind e0.start_year as a return min(a)
+      """
+    Then the result should be, in any order:
+      | min(a) |
+      | 1997   |
+    When executing query:
+      """
+      match (v0:player)-[e0]->(v1) where id(v0) == "Tim Duncan" unwind e0.start_year as a return avg(a)
+      """
+    Then the result should be, in any order:
+      | avg(a) |
+      | 2005.0 |
+    When executing query:
+      """
+      match (v0:player)-[e0]->(v1) where id(v0) == "Tim Duncan" unwind e0.start_year as a return std(a)
+      """
+    Then the result should be, in any order:
+      | std(a)            |
+      | 6.542170893518461 |
+    When executing query:
+      """
+      match (v0:player)-[e0]->(v1) where id(v0) == "Tim Duncan" unwind e0.start_year as a return std(a)
+      """
+    Then the result should be, in any order:
+      | std(a)            |
+      | 6.542170893518461 |
+    When executing query:
+      """
+      match (v0:player)-[e0]->(v1) where id(v0) == "Tim Duncan" unwind e0.start_year as a return bit_or(a)
+      """
+    Then the result should be, in any order:
+      | bit_or(a) |
+      | 2015      |
+    When executing query:
+      """
+      match (v0:player)-[e0]->(v1) where id(v0) == "Tim Duncan" unwind e0.start_year as a return bit_and(a)
+      """
+    Then the result should be, in any order:
+      | bit_and(a) |
+      | 1984       |

--- a/tests/tck/features/optimizer/PrunePropertiesRule.feature
+++ b/tests/tck/features/optimizer/PrunePropertiesRule.feature
@@ -878,3 +878,13 @@ Feature: Prune Properties rule
       | v.player.name | t.errortag.name | properties(v)                                           | t                                                         |
       | "Tim Duncan"  | __NULL__        | {age: 42, name: "Tim Duncan", speciality: "psychology"} | ("Tony Parker" :player{age: 36, name: "Tony Parker"})     |
       | "Tim Duncan"  | __NULL__        | {age: 42, name: "Tim Duncan", speciality: "psychology"} | ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"}) |
+
+  Scenario: no pruning on agg after unwind
+    Given a graph with space named "nba"
+    When executing query:
+      """
+      match (v0:player)-[e0]->(v1) where id(v0) == "Tim Duncan" unwind e0.start_year as a return count(a)
+      """
+    Then the result should be, in any order:
+      | count(a) |
+      | 5        |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #4974 

#### Description:
`match (v0:player)-[e0]->(v1) where id(v0) == "Tim Duncan" unwind e0.start_year as a return count(a)
`

$a was pruned in this query, causing the unwind operator to produce NULL dataset, which in the end leads to wrong counting results.

## How do you solve it?

Disable the pruning of `Expression::Kind::kVarProperty` and `Expression::Kind::kInputProperty` in PropertyTrackerVisitor.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] TCK

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
