### PR TITLE
fix no print to console

### DIFF
--- a/src/common/fs/FileUtils.cpp
+++ b/src/common/fs/FileUtils.cpp
@@ -158,12 +158,9 @@ FileType FileUtils::fileType(const char* path) {
   struct stat st;
   if (lstat(path, &st)) {
     if (errno == ENOENT) {
-      VLOG(3) << "The path \"" << path << "\" does not exist";
       return FileType::NOTEXIST;
     } else {
-      // Failed o get file stat
-      VLOG(3) << "Failed to get information about \"" << path << "\" (" << errno
-              << "): " << strerror(errno);
+      // Failed to get file stat
       return FileType::UNKNOWN;
     }
   }

--- a/src/daemons/MetaDaemon.cpp
+++ b/src/daemons/MetaDaemon.cpp
@@ -79,10 +79,6 @@ int main(int argc, char* argv[]) {
   if (FLAGS_enable_ssl || FLAGS_enable_meta_ssl) {
     folly::ssl::init();
   }
-  if (FLAGS_data_path.empty()) {
-    LOG(ERROR) << "Meta Data Path should not empty";
-    return EXIT_FAILURE;
-  }
 
   // Setup logging
   status = setupLogging(argv[0]);
@@ -104,6 +100,11 @@ int main(int argc, char* argv[]) {
     return EXIT_FAILURE;
   }
 #endif
+
+  if (FLAGS_data_path.empty()) {
+    LOG(ERROR) << "Meta Data Path should not empty";
+    return EXIT_FAILURE;
+  }
 
   // Init stats
   nebula::initMetaStats();


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
fix the enterprise version problem(close https://github.com/vesoft-inc/nebula-ent/issues/1813 ), the community version also exists, just submit it in the community version:

1 Before the `FLAGS_log_dir` directory is generated, you can use `LOG(ERROR)` to print errors to standard output, but you cannot use `vlog` to print log information. The reasons are as follows:

Calling `vlog` before creating the `FLAGS_log_dir` directory will cause the following error message:
```
Could not create logging file: No such file or directory
COULD NOT CREATE A LOGGINGFILE 20221205-164038.3542522!
```
This information is not what we want to output.


Calling `LOG(ERROR)` before creating the `FLAGS_log_dir` directory will cause an error message similar to the following:
```
WARNING: Logging before InitGoogleLogging() is written to STDERR
E20221205 17:31:35.309763 3455851 StorageDaemon.cpp:71] pids_listener/nebula-storaged.pid: Success
```
Here, because there is no `FLAGS_log_dir` directory, it is reasonable to print the error to the standard err.

2 `vlog` Information in `FileUtils::fileType` is redundant and meaningless, so remove them.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
