### PR TITLE
Share memory for vertex and edge value (#1565)

### DIFF
--- a/src/common/datatypes/Edge.h
+++ b/src/common/datatypes/Edge.h
@@ -20,6 +20,7 @@ struct Edge {
   std::string name;
   EdgeRanking ranking;
   std::unordered_map<std::string, Value> props;
+  std::atomic<size_t> refcnt{1};
 
   Edge() {}
   Edge(Edge&& v) noexcept
@@ -44,6 +45,13 @@ struct Edge {
         ranking(std::move(r)),
         props(std::move(p)) {}
 
+  size_t ref() {
+    return ++refcnt;
+  }
+  size_t unref() {
+    return --refcnt;
+  }
+
   void clear();
 
   void __clear() {
@@ -56,6 +64,10 @@ struct Edge {
   folly::dynamic getMetaData() const;
 
   bool operator==(const Edge& rhs) const;
+
+  bool operator!=(const Edge& rhs) const {
+    return !(*this == rhs);
+  }
 
   void format() {
     if (type < 0) {

--- a/src/common/datatypes/Path.h
+++ b/src/common/datatypes/Path.h
@@ -91,7 +91,7 @@ struct Step {
     if (dst != rhs.dst) {
       return dst < rhs.dst;
     }
-    if (type != rhs.dst) {
+    if (type != rhs.type) {
       return type < rhs.type;
     }
     if (ranking != rhs.ranking) {

--- a/src/common/datatypes/Value.h
+++ b/src/common/datatypes/Value.h
@@ -256,10 +256,10 @@ struct Value {
   void setDateTime(DateTime&& v);
   void setVertex(const Vertex& v);
   void setVertex(Vertex&& v);
-  void setVertex(std::unique_ptr<Vertex>&& v);
+  void setVertex(Vertex* v);
   void setEdge(const Edge& v);
   void setEdge(Edge&& v);
-  void setEdge(std::unique_ptr<Edge>&& v);
+  void setEdge(Edge* v);
   void setPath(const Path& v);
   void setPath(Path&& v);
   void setPath(std::unique_ptr<Path>&& v);
@@ -391,8 +391,8 @@ struct Value {
     Date dVal;
     Time tVal;
     DateTime dtVal;
-    std::unique_ptr<Vertex> vVal;
-    std::unique_ptr<Edge> eVal;
+    Vertex* vVal;
+    Edge* eVal;
     std::unique_ptr<Path> pVal;
     std::unique_ptr<List> lVal;
     std::unique_ptr<Map> mVal;
@@ -437,13 +437,11 @@ struct Value {
   void setDT(const DateTime& v);
   void setDT(DateTime&& v);
   // Vertex value
-  void setV(const std::unique_ptr<Vertex>& v);
-  void setV(std::unique_ptr<Vertex>&& v);
+  void setV(Vertex* v);
   void setV(const Vertex& v);
   void setV(Vertex&& v);
   // Edge value
-  void setE(const std::unique_ptr<Edge>& v);
-  void setE(std::unique_ptr<Edge>&& v);
+  void setE(Edge* v);
   void setE(const Edge& v);
   void setE(Edge&& v);
   // Path value

--- a/src/common/datatypes/ValueOps-inl.h
+++ b/src/common/datatypes/ValueOps-inl.h
@@ -368,10 +368,10 @@ void Cpp2Ops<nebula::Value>::read(Protocol* proto, nebula::Value* obj) {
       }
       case 9: {
         if (readState.fieldType == apache::thrift::protocol::T_STRUCT) {
-          obj->setVertex(nebula::Vertex());
-          auto ptr = std::make_unique<nebula::Vertex>();
-          Cpp2Ops<nebula::Vertex>::read(proto, ptr.get());
-          obj->setVertex(std::move(ptr));
+          auto* ptr = new nebula::Vertex();
+          Cpp2Ops<nebula::Vertex>::read(proto, ptr);
+          obj->setVertex(ptr);
+          ptr->unref();
         } else {
           proto->skip(readState.fieldType);
         }
@@ -379,10 +379,10 @@ void Cpp2Ops<nebula::Value>::read(Protocol* proto, nebula::Value* obj) {
       }
       case 10: {
         if (readState.fieldType == apache::thrift::protocol::T_STRUCT) {
-          obj->setEdge(nebula::Edge());
-          auto ptr = std::make_unique<nebula::Edge>();
-          Cpp2Ops<nebula::Edge>::read(proto, ptr.get());
-          obj->setEdge(std::move(ptr));
+          auto* ptr = new nebula::Edge();
+          Cpp2Ops<nebula::Edge>::read(proto, ptr);
+          obj->setEdge(ptr);
+          ptr->unref();
         } else {
           proto->skip(readState.fieldType);
         }

--- a/src/common/datatypes/Vertex.h
+++ b/src/common/datatypes/Vertex.h
@@ -61,11 +61,19 @@ struct Tag {
 struct Vertex {
   Value vid;
   std::vector<Tag> tags;
+  std::atomic<size_t> refcnt{1};
 
   Vertex() = default;
   Vertex(const Vertex& v) : vid(v.vid), tags(v.tags) {}
   Vertex(Vertex&& v) noexcept : vid(std::move(v.vid)), tags(std::move(v.tags)) {}
   Vertex(Value id, std::vector<Tag> t) : vid(std::move(id)), tags(std::move(t)) {}
+
+  size_t ref() {
+    return ++refcnt;
+  }
+  size_t unref() {
+    return --refcnt;
+  }
 
   void clear() {
     vid.clear();
@@ -87,6 +95,10 @@ struct Vertex {
 
   bool operator==(const Vertex& rhs) const {
     return vid == rhs.vid && tags == rhs.tags;
+  }
+
+  bool operator!=(const Vertex& rhs) const {
+    return vid != rhs.vid || tags != rhs.tags;
   }
 
   bool operator<(const Vertex& rhs) const;

--- a/src/graph/context/Iterator.cpp
+++ b/src/graph/context/Iterator.cpp
@@ -439,12 +439,15 @@ const Value& GetNeighborsIter::getEdgeProp(const std::string& edge, const std::s
   return currentEdge_->values[propIndex->second];
 }
 
-Value GetNeighborsIter::getVertex(const std::string& name) const {
+Value GetNeighborsIter::getVertex(const std::string& name) {
   UNUSED(name);
   if (!valid()) {
     return Value::kNullValue;
   }
   auto vidVal = getColumn(0);
+  if (!prevVertex_.empty() && prevVertex_.getVertex().vid == vidVal) {
+    return prevVertex_;
+  }
 
   Vertex vertex;
   vertex.vid = vidVal;
@@ -470,7 +473,8 @@ Value GetNeighborsIter::getVertex(const std::string& name) const {
     }
     vertex.tags.emplace_back(std::move(tag));
   }
-  return Value(std::move(vertex));
+  prevVertex_ = Value(std::move(vertex));
+  return prevVertex_;
 }
 
 std::vector<Value> GetNeighborsIter::vids() {
@@ -735,7 +739,7 @@ StatusOr<std::size_t> SequentialIter::getColumnIndex(const std::string& col) con
   return index->second;
 }
 
-Value SequentialIter::getVertex(const std::string& name) const {
+Value SequentialIter::getVertex(const std::string& name) {
   return getColumn(name);
 }
 
@@ -852,7 +856,7 @@ const Value& PropIter::getProp(const std::string& name, const std::string& prop)
   }
 }
 
-Value PropIter::getVertex(const std::string& name) const {
+Value PropIter::getVertex(const std::string& name) {
   UNUSED(name);
   if (!valid()) {
     return Value::kNullValue;

--- a/src/graph/context/Iterator.h
+++ b/src/graph/context/Iterator.h
@@ -145,7 +145,7 @@ class Iterator {
     return Value::kEmpty;
   }
 
-  virtual Value getVertex(const std::string& name = "") const {
+  virtual Value getVertex(const std::string& name = "") {
     UNUSED(name);
     return Value();
   }
@@ -319,7 +319,7 @@ class GetNeighborsIter final : public Iterator {
 
   const Value& getEdgeProp(const std::string& edge, const std::string& prop) const override;
 
-  Value getVertex(const std::string& name = "") const override;
+  Value getVertex(const std::string& name = "") override;
 
   Value getEdge() const override;
 
@@ -420,6 +420,7 @@ class GetNeighborsIter final : public Iterator {
 
   boost::dynamic_bitset<> bitset_;
   int64_t bitIdx_{-1};
+  Value prevVertex_;
 };
 
 class SequentialIter : public Iterator {
@@ -497,7 +498,7 @@ class SequentialIter : public Iterator {
 
   StatusOr<std::size_t> getColumnIndex(const std::string& col) const override;
 
-  Value getVertex(const std::string& name = "") const override;
+  Value getVertex(const std::string& name = "") override;
 
   Value getEdge() const override;
 
@@ -548,7 +549,7 @@ class PropIter final : public SequentialIter {
 
   StatusOr<std::size_t> getColumnIndex(const std::string& col) const override;
 
-  Value getVertex(const std::string& name = "") const override;
+  Value getVertex(const std::string& name = "") override;
 
   Value getEdge() const override;
 


### PR DESCRIPTION
* shallow copy vertex & edgee

* add delete

* fix error

* delete error code

* optimize getVertex

* fix memory leak

* delete useless code

* address comment

* fix multiple threads double free  pointer problem

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
The type of vertex and edge in value is replaced from raw pointer to unique_ptr in other PR

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
