### PR TITLE
Enhance the AppendVertices operator to avoid unnecessary rpc overhead

### DIFF
--- a/src/graph/executor/query/AppendVerticesExecutor.cpp
+++ b/src/graph/executor/query/AppendVerticesExecutor.cpp
@@ -27,7 +27,7 @@ StatusOr<DataSet> AppendVerticesExecutor::buildRequestDataSet(const AppendVertic
 folly::Future<Status> AppendVerticesExecutor::appendVertices() {
   SCOPED_TIMER(&execTime_);
   auto *av = asNode<AppendVertices>(node());
-  if (FLAGS_optimize_appendvertices && av != nullptr && av->props() == nullptr) {
+  if (FLAGS_optimize_appendvertices && av != nullptr && av->noNeedFetchProp()) {
     return handleNullProp(av);
   }
 

--- a/src/graph/planner/plan/Query.h
+++ b/src/graph/planner/plan/Query.h
@@ -346,6 +346,25 @@ class GetVertices : public Explore {
     return props_.get();
   }
 
+  bool noNeedFetchProp() const {
+    if (props_.get() == nullptr) {
+      return true;
+    }
+    auto& vprops = *props_;
+    for (const auto& vprop : vprops) {
+      auto& props = vprop.get_props();
+      if (props.size() > 1) {
+        return false;
+      }
+      DCHECK_EQ(props.size(), 1);
+      auto& prop = props.front();
+      if (prop.compare("_tag")) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   const std::vector<Expr>* exprs() const {
     return exprs_.get();
   }

--- a/src/graph/planner/plan/Query.h
+++ b/src/graph/planner/plan/Query.h
@@ -356,6 +356,9 @@ class GetVertices : public Explore {
       if (props.size() > 1) {
         return false;
       }
+      if (props.empty()) {
+        continue;
+      }
       DCHECK_EQ(props.size(), 1);
       auto& prop = props.front();
       if (prop.compare("_tag")) {


### PR DESCRIPTION
Do not make an rpc request if no need to fetch properties.

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
