### PR TITLE
could not add a host that is not a storage

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -965,6 +965,8 @@ Status MetaClient::handleResponse(const RESP& resp) {
       return Status::Error("There are still space on the host");
     case nebula::cpp2::ErrorCode::E_RELATED_FULLTEXT_INDEX_EXISTS:
       return Status::Error("Related fulltext index exists, please drop it first");
+    case nebula::cpp2::ErrorCode::E_HOST_CAN_NOT_BE_ADDED:
+      return Status::Error("Could not add a host, which is not a storage and not expired either");
     default:
       return Status::Error("Unknown error!");
   }

--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -374,6 +374,7 @@ enum ErrorCode {
     E_NO_VALID_HOST                   = -2026,  // Lack of valid hosts
     E_CORRUPTED_BALANCE_PLAN          = -2027,  // A data balancing plan that has been corrupted
     E_NO_INVALID_BALANCE_PLAN         = -2028,  // No invalid balance plan
+    E_HOST_CAN_NOT_BE_ADDED           = -2029,  // the host can not be added for it's not a storage host
 
 
     // Authentication Failure


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
start nebula graph with address 192.168.8.134:9669
add hosts 192.168.8.134:9669
create space
expected:
only store data in storage

actual:
partitions are wrong.
![image](https://user-images.githubusercontent.com/38217397/206383029-11c116cd-ca3f-47e7-af0e-fdbdce718932.png)


## How do you solve it?
when add a host, check if the host is storage, if not, it can't be added


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
