### PR TITLE
Pass aliases from unwind to project.

### DIFF
--- a/src/graph/validator/MatchValidator.cpp
+++ b/src/graph/validator/MatchValidator.cpp
@@ -380,6 +380,12 @@ Status MatchValidator::buildColumnsForAllNamedAliases(const std::vector<QueryPar
       case CypherClauseKind::kUnwind: {
         auto unwindCtx = static_cast<const UnwindClauseContext *>(boundary.get());
         columns->addColumn(makeColumn(unwindCtx->alias), true);
+        for (auto &passAlias : prevQueryPart.aliasesAvailable) {
+          columns->addColumn(makeColumn(passAlias.first), true);
+        }
+        for (auto &passAlias : prevQueryPart.aliasesGenerated) {
+          columns->addColumn(makeColumn(passAlias.first), true);
+        }
         break;
       }
       case CypherClauseKind::kWith: {

--- a/tests/tck/features/match/With.feature
+++ b/tests/tck/features/match/With.feature
@@ -413,3 +413,34 @@ Feature: With clause
       return count (p)
       """
     Then a SemanticError should be raised at runtime:  Alias used but not defined: `p'
+
+  Scenario: with wildcard after unwind before argument
+    When executing query:
+      """
+      match (v:player)--(t:team)
+      where id(v) == "Tim Duncan"
+      unwind [1] as digit
+      with *
+      match (t:team)<--(v1)
+      return v1.player.name
+      """
+    Then the result should be, in any order:
+      | v1.player.name      |
+      | "Cory Joseph"       |
+      | "Kyle Anderson"     |
+      | "Danny Green"       |
+      | "David West"        |
+      | "Jonathon Simmons"  |
+      | "LaMarcus Aldridge" |
+      | "Rudy Gay"          |
+      | "Tony Parker"       |
+      | "Marco Belinelli"   |
+      | "Marco Belinelli"   |
+      | "Tiago Splitter"    |
+      | "Tim Duncan"        |
+      | "Manu Ginobili"     |
+      | "Tracy McGrady"     |
+      | "Boris Diaw"        |
+      | "Aron Baynes"       |
+      | "Paul Gasol"        |
+      | "Dejounte Murray"   |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Fix #5022 

#### Description:
Consider a clause segment like "unwind a as b with *". The project operator generated to implement "with *" shall carry on all aliases from its previous "unwind" clause, consisting of the aliases that the unwind passes on as well as the alises it generated (e.g., the b in this example).

In the current implementation, only the `unwindCtx->alias` (e.g., the b in this example) is added into the project. With only this alias passed, there would be missing columns in the project's output variable, which in turn would prevent the argument operator, if any, to find its needed columns for its input variable.

Argument will NULL input variable crashses the graphd.

Detailed analysis of the crash bug has been posted in the above issue.

## How do you solve it?
Added aliasesAvailable and aliasesGenerated into the project as well, for the project after wind.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] TCK

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
