### PR TITLE
Restrict the max depth of plan tree in optimizer

### DIFF
--- a/src/graph/optimizer/Optimizer.h
+++ b/src/graph/optimizer/Optimizer.h
@@ -49,6 +49,8 @@ class Optimizer final {
 
   static Status rewriteArgumentInputVar(graph::PlanNode *root);
 
+  Status checkPlanDepth(const graph::PlanNode *root) const;
+
   static constexpr int8_t kMaxIterationRound = 5;
 
   std::vector<const RuleSet *> ruleSets_;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Fix https://github.com/vesoft-inc/nebula/issues/4982.
Related https://github.com/vesoft-inc/nebula-ent/issues/1487.
#### Description:

In most cases, we can considier to constrict the depth of the plan tree to avoid stack overflow crash caused by some bad queries.
But for some queries such as `statement1 interest statement2 interest statement3 ...`,
which is a very normal statement, even if there are many statements to intersect,
we may need to consider the multi-way operator in planner to avoid the overflow.
e.g.

The binary intersect operator:
```
    intersect
    /       \
intersect   c 
  /     \
a       b
```

The multi-way intersect operator:

```
    intersect
    /   |    \
   a    b     c
```

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
