### PR TITLE
Report errors in the executor when an unwind operator is applied on a…

### DIFF
--- a/src/graph/executor/query/UnwindExecutor.cpp
+++ b/src/graph/executor/query/UnwindExecutor.cpp
@@ -23,6 +23,12 @@ folly::Future<Status> UnwindExecutor::execute() {
   ds.colNames = unwind->colNames();
   for (; iter->valid(); iter->next()) {
     const Value &list = unwindExpr->eval(ctx(iter.get()));
+    if (!list.isList()) {
+      std::stringstream ss;
+      ss << "Unwind on types other than list for " << unwindExpr->toString()
+         << ". This is not supported.";
+      return Status::Error(ss.str());
+    }
     std::vector<Value> vals = extractList(list);
     for (auto &v : vals) {
       Row row;


### PR DESCRIPTION
… non-list data type.

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #5051 

#### Description:
Multiple bugs have been reported while executing unwind on a non-list data type, which is not the original target for unwind. Unwind is designed to flat lists, not other types. And, these bugs run deep into the codes. Better delay their fixes, report errors in such cases and fix them later, if needed.

## How do you solve it?
Report errors if an unwind is applied on non-list types. This effectively disables unwind for non-list types.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:

I've checked that this PR does not affect the doc. In the doc, all queries are executing unwind on lists. https://docs.nebula-graph.com.cn/3.3.0/3.ngql-guide/8.clauses-and-options/unwind/

## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
