### PR TITLE
Fix expressions that shall be rewritten to LabelTagProperty

### DIFF
--- a/src/common/expression/AttributeExpression.cpp
+++ b/src/common/expression/AttributeExpression.cpp
@@ -40,7 +40,18 @@ const Value &AttributeExpression::eval(ExpressionContext &ctx) {
        * ListComprehensionExpression without making structural changes to the implementation.
        */
       if (left()->kind() != Expression::Kind::kAttribute) {
-        return lvalue;
+        if (right()->kind() == Expression::Kind::kConstant &&
+            rvalue.type() == Value::Type::STRING) {
+          auto rStr = rvalue.getStr();
+          for (auto &tag : lvalue.getVertex().tags) {
+            if (rStr.compare(tag.name) == 0) {
+              return lvalue;
+            }
+          }
+          LOG(ERROR) << "Tag not found for: " << rStr
+                     << "Please check whether the related expression "
+                     << "follows the format of vertex.tag.property.";
+        }
       } else if (left()->kind() == Expression::Kind::kAttribute &&
                  dynamic_cast<AttributeExpression *>(left())->right()->kind() ==
                      Expression::Kind::kConstant) {

--- a/src/common/expression/AttributeExpression.cpp
+++ b/src/common/expression/AttributeExpression.cpp
@@ -67,7 +67,7 @@ const Value &AttributeExpression::eval(ExpressionContext &ctx) {
           }
         }
       }
-      return Value::kNullBadType;
+      return Value::kNullValue;
     }
     case Value::Type::EDGE: {
       DCHECK(!rvalue.getStr().empty());

--- a/src/common/expression/test/ExpressionContextMock.h
+++ b/src/common/expression/test/ExpressionContextMock.h
@@ -24,7 +24,16 @@ class ExpressionContextMock final : public ExpressionContext {
   }
 
   void setInnerVar(const std::string& var, Value val) override {
-    exprValueMap_[var] = std::move(val);
+    if (var == "xxx") {
+      if (vals_.empty()) {
+        vals_.emplace_back(val);
+        indices_[var] = vals_.size() - 1;
+      } else {
+        vals_[indices_[var]] = val;
+      }
+    } else {
+      exprValueMap_[var] = std::move(val);
+    }
   }
 
   const Value& getInnerVar(const std::string& var) const override {
@@ -143,7 +152,7 @@ class ExpressionContextMock final : public ExpressionContext {
 
   void setVar(const std::string& var, Value val) override {
     // used by tests of list comprehesion, predicate or reduce
-    if (var == "n" || var == "p" || var == "totalNum") {
+    if (var == "n" || var == "p" || var == "totalNum" || var == "v") {
       vals_.emplace_back(val);
       indices_[var] = vals_.size() - 1;
     }

--- a/src/common/expression/test/ListComprehensionExpressionTest.cpp
+++ b/src/common/expression/test/ListComprehensionExpressionTest.cpp
@@ -37,7 +37,7 @@ TEST_F(ListComprehensionExpressionTest, ListComprehensionEvaluate) {
     ASSERT_EQ(expected, value.getList());
   }
   {
-    // [n IN nodes(p) | n.age + 5]
+    // [n IN nodes(p) | n.player.age + 5]
     auto v1 = Vertex("101", {Tag("player", {{"name", "joe"}, {"age", 18}})});
     auto v2 = Vertex("102", {Tag("player", {{"name", "amber"}, {"age", 19}})});
     auto v3 = Vertex("103", {Tag("player", {{"name", "shawdan"}, {"age", 20}})});
@@ -46,19 +46,25 @@ TEST_F(ListComprehensionExpressionTest, ListComprehensionEvaluate) {
     path.steps.emplace_back(Step(v2, 1, "like", 0, {}));
     path.steps.emplace_back(Step(v3, 1, "like", 0, {}));
     gExpCtxt.setVar("p", path);
-
+    std::unordered_map<std::string, graph::AliasType> aliasTypeMap = {
+        {"xxx", graph::AliasType::kNode}};
     ArgumentList *argList = ArgumentList::make(&pool);
     argList->addArgument(VariableExpression::make(&pool, "p"));
     auto expr = ListComprehensionExpression::make(
         &pool,
-        "n",
+        "xxx",
         FunctionCallExpression::make(&pool, "nodes", argList),
         nullptr,
         ArithmeticExpression::makeAdd(
             &pool,
-            AttributeExpression::make(&pool,
-                                      VariableExpression::makeInner(&pool, "n"),
-                                      ConstantExpression::make(&pool, "age")),
+            graph::ExpressionUtils::rewriteAttr2LabelTagProp(
+                AttributeExpression::make(
+                    &pool,
+                    LabelAttributeExpression::make(&pool,
+                                                   LabelExpression::make(&pool, "xxx"),
+                                                   ConstantExpression::make(&pool, "player")),
+                    ConstantExpression::make(&pool, "age")),
+                aliasTypeMap),
             ConstantExpression::make(&pool, 5)));
 
     auto value = Expression::eval(expr, gExpCtxt);
@@ -88,6 +94,8 @@ TEST_F(ListComprehensionExpressionTest, ListComprehensionExprToString) {
   {
     ArgumentList *argList = ArgumentList::make(&pool);
     argList->addArgument(LabelExpression::make(&pool, "p"));
+    std::unordered_map<std::string, graph::AliasType> aliasTypeMap = {
+        {"n", graph::AliasType::kNode}};
     auto expr = ListComprehensionExpression::make(
         &pool,
         "n",
@@ -95,10 +103,16 @@ TEST_F(ListComprehensionExpressionTest, ListComprehensionExprToString) {
         nullptr,
         ArithmeticExpression::makeAdd(
             &pool,
-            LabelAttributeExpression::make(
-                &pool, LabelExpression::make(&pool, "n"), ConstantExpression::make(&pool, "age")),
+            graph::ExpressionUtils::rewriteAttr2LabelTagProp(
+                AttributeExpression::make(
+                    &pool,
+                    LabelAttributeExpression::make(&pool,
+                                                   LabelExpression::make(&pool, "n"),
+                                                   ConstantExpression::make(&pool, "player")),
+                    ConstantExpression::make(&pool, "age")),
+                aliasTypeMap),
             ConstantExpression::make(&pool, 10)));
-    ASSERT_EQ("[n IN nodes(p) | (n.age+10)]", expr->toString());
+    ASSERT_EQ("[n IN nodes(p) | (n.player.age+10)]", expr->toString());
   }
   {
     auto listItems = ExpressionList::make(&pool);

--- a/src/common/expression/test/PredicateExpressionTest.cpp
+++ b/src/common/expression/test/PredicateExpressionTest.cpp
@@ -31,7 +31,7 @@ TEST_F(PredicateExpressionTest, PredicateEvaluate) {
     ASSERT_EQ(false, value.getBool());
   }
   {
-    // any(n IN nodes(p) WHERE n.age >= 19)
+    // any(xxx IN nodes(p) WHERE xxx.player.age >= 19)
     auto v1 = Vertex("101", {Tag("player", {{"name", "joe"}, {"age", 18}})});
     auto v2 = Vertex("102", {Tag("player", {{"name", "amber"}, {"age", 19}})});
     auto v3 = Vertex("103", {Tag("player", {{"name", "shawdan"}, {"age", 20}})});
@@ -40,19 +40,25 @@ TEST_F(PredicateExpressionTest, PredicateEvaluate) {
     path.steps.emplace_back(Step(v2, 1, "like", 0, {}));
     path.steps.emplace_back(Step(v3, 1, "like", 0, {}));
     gExpCtxt.setVar("p", path);
-
+    std::unordered_map<std::string, graph::AliasType> aliasTypeMap = {
+        {"xxx", graph::AliasType::kNode}};
     ArgumentList *argList = ArgumentList::make(&pool);
     argList->addArgument(VariableExpression::make(&pool, "p"));
     auto expr = PredicateExpression::make(
         &pool,
         "any",
-        "n",
+        "xxx",
         FunctionCallExpression::make(&pool, "nodes", argList),
         RelationalExpression::makeGE(
             &pool,
-            AttributeExpression::make(&pool,
-                                      VariableExpression::makeInner(&pool, "n"),
-                                      ConstantExpression::make(&pool, "age")),
+            graph::ExpressionUtils::rewriteAttr2LabelTagProp(
+                AttributeExpression::make(
+                    &pool,
+                    LabelAttributeExpression::make(&pool,
+                                                   LabelExpression::make(&pool, "xxx"),
+                                                   ConstantExpression::make(&pool, "player")),
+                    ConstantExpression::make(&pool, "age")),
+                aliasTypeMap),
             ConstantExpression::make(&pool, 19)));
 
     auto value = Expression::eval(expr, gExpCtxt);
@@ -90,19 +96,25 @@ TEST_F(PredicateExpressionTest, PredicateEvaluate) {
     path.steps.emplace_back(Step(v2, 1, "like", 0, {}));
     path.steps.emplace_back(Step(v3, 1, "like", 0, {}));
     gExpCtxt.setVar("p", path);
-
+    std::unordered_map<std::string, graph::AliasType> aliasTypeMap = {
+        {"xxx", graph::AliasType::kNode}};
     ArgumentList *argList = ArgumentList::make(&pool);
     argList->addArgument(VariableExpression::make(&pool, "p"));
     auto expr = PredicateExpression::make(
         &pool,
         "none",
-        "n",
+        "xxx",
         FunctionCallExpression::make(&pool, "nodes", argList),
         RelationalExpression::makeGE(
             &pool,
-            AttributeExpression::make(&pool,
-                                      VariableExpression::makeInner(&pool, "n"),
-                                      ConstantExpression::make(&pool, "age")),
+            graph::ExpressionUtils::rewriteAttr2LabelTagProp(
+                AttributeExpression::make(
+                    &pool,
+                    LabelAttributeExpression::make(&pool,
+                                                   LabelExpression::make(&pool, "xxx"),
+                                                   ConstantExpression::make(&pool, "player")),
+                    ConstantExpression::make(&pool, "age")),
+                aliasTypeMap),
             ConstantExpression::make(&pool, 19)));
 
     auto value = Expression::eval(expr, gExpCtxt);

--- a/src/graph/validator/MatchValidator.cpp
+++ b/src/graph/validator/MatchValidator.cpp
@@ -636,7 +636,8 @@ Status MatchValidator::validateUnwind(const UnwindClause *unwindClause,
     return Status::SemanticError("Expression in UNWIND must be aliased (use AS)");
   }
   unwindCtx.alias = unwindClause->alias();
-  unwindCtx.unwindExpr = unwindClause->expr()->clone();
+  unwindCtx.unwindExpr = ExpressionUtils::rewriteAttr2LabelTagProp(unwindClause->expr()->clone(),
+                                                                   unwindCtx.aliasesAvailable);
   if (ExpressionUtils::hasAny(unwindCtx.unwindExpr, {Expression::Kind::kAggregate})) {
     return Status::SemanticError("Can't use aggregating expressions in unwind clause, `%s'",
                                  unwindCtx.unwindExpr->toString().c_str());

--- a/tests/tck/features/expression/ListComprehension.feature
+++ b/tests/tck/features/expression/ListComprehension.feature
@@ -53,7 +53,8 @@ Feature: ListComprehension
     When executing query:
       """
       MATCH p = (n:player{name:"LeBron James"})<-[:like]-(m)
-      RETURN [n IN nodes(p) WHERE n.name NOT STARTS WITH "LeBron" | n.age + 100] AS r
+      RETURN [n IN nodes(p) WHERE n.player.name
+      NOT STARTS WITH "LeBron" | n.player.age + 100] AS r
       """
     Then the result should be, in any order:
       | r     |
@@ -66,7 +67,7 @@ Feature: ListComprehension
     When executing query:
       """
       MATCH p = (n:player{name:"LeBron James"})-[:like]->(m)
-      RETURN [n IN nodes(p) | n.age + 100] AS r
+      RETURN [n IN nodes(p) | n.player.age + 100] AS r
       """
     Then the result should be, in any order:
       | r          |

--- a/tests/tck/features/expression/Predicate.feature
+++ b/tests/tck/features/expression/Predicate.feature
@@ -185,8 +185,10 @@ Feature: Predicate
     When executing query:
       """
       MATCH p = (n:player{name:"LeBron James"})<-[:like]-(m)
-      RETURN nodes(p)[0].name AS n1, nodes(p)[1].name AS n2,
-      all(n IN nodes(p) WHERE n.name NOT STARTS WITH "D") AS b
+      RETURN
+        nodes(p)[0].player.name AS n1,
+        nodes(p)[1].player.name AS n2,
+        all(n IN nodes(p) WHERE n.player.name NOT STARTS WITH "D") AS b
       """
     Then the result should be, in any order:
       | n1             | n2                | b     |
@@ -199,7 +201,7 @@ Feature: Predicate
     When executing query:
       """
       MATCH p = (n:player{name:"LeBron James"})-[:like]->(m)
-      RETURN single(n IN nodes(p) WHERE n.age > 40) AS b
+      RETURN single(n IN nodes(p) WHERE n.player.age > 40) AS b
       """
     Then the result should be, in any order:
       | b    |

--- a/tests/tck/features/expression/Reduce.feature
+++ b/tests/tck/features/expression/Reduce.feature
@@ -40,9 +40,9 @@ Feature: Reduce
       """
       MATCH p = (n:player{name:"LeBron James"})<-[:like]-(m)
       RETURN
-        nodes(p)[0].age AS age1,
-        nodes(p)[1].age AS age2,
-        reduce(totalAge = 100, n IN nodes(p) | totalAge + n.age) AS r
+        nodes(p)[0].player.age AS age1,
+        nodes(p)[1].player.age AS age2,
+        reduce(totalAge = 100, n IN nodes(p) | totalAge + n.player.age) AS r
       """
     Then the result should be, in any order:
       | age1 | age2 | r   |
@@ -55,9 +55,9 @@ Feature: Reduce
     When executing query:
       """
       MATCH p = (n:player{name:"LeBron James"})-[:like]->(m)
-      RETURN nodes(p)[0].age AS age1,
-             nodes(p)[1].age AS age2,
-             reduce(x = 10, n IN nodes(p) | n.age - x) AS x
+      RETURN nodes(p)[0].player.age AS age1,
+             nodes(p)[1].player.age AS age2,
+             reduce(x = 10, n IN nodes(p) | n.player.age - x) AS x
       """
     Then the result should be, in any order:
       | age1 | age2 | x  |

--- a/tests/tck/features/match/Unwind.feature
+++ b/tests/tck/features/match/Unwind.feature
@@ -154,3 +154,36 @@ Feature: Unwind clause
       RETURN  num
       """
     Then a SemanticError should be raised at runtime: Can't use aggregating expressions in unwind clause, `count(b)'
+
+  Scenario: unwind vtp edge expression
+    When executing query:
+      """
+      match (v:player)
+      where v.player.name in ["Tim Duncan"]
+      unwind v.player.age as age
+      return age;
+      """
+    Then the result should be, in any order:
+      | age |
+      | 42  |
+    When executing query:
+      """
+      match (v:player)-[e:like]-()
+      where v.player.name in ["Tim Duncan"]
+      unwind e.likeness as age
+      return age, e
+      """
+    Then the result should be, in any order:
+      | age | e                                                           |
+      | 55  | [:like "Marco Belinelli"->"Tim Duncan" @0 {likeness: 55}]   |
+      | 70  | [:like "Danny Green"->"Tim Duncan" @0 {likeness: 70}]       |
+      | 80  | [:like "Tiago Splitter"->"Tim Duncan" @0 {likeness: 80}]    |
+      | 90  | [:like "Manu Ginobili"->"Tim Duncan" @0 {likeness: 90}]     |
+      | 95  | [:like "Tim Duncan"->"Manu Ginobili" @0 {likeness: 95}]     |
+      | 80  | [:like "Boris Diaw"->"Tim Duncan" @0 {likeness: 80}]        |
+      | 75  | [:like "LaMarcus Aldridge"->"Tim Duncan" @0 {likeness: 75}] |
+      | 80  | [:like "Aron Baynes"->"Tim Duncan" @0 {likeness: 80}]       |
+      | 95  | [:like "Tony Parker"->"Tim Duncan" @0 {likeness: 95}]       |
+      | 95  | [:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}]       |
+      | 99  | [:like "Dejounte Murray"->"Tim Duncan" @0 {likeness: 99}]   |
+      | 80  | [:like "Shaquille O'Neal"->"Tim Duncan" @0 {likeness: 80}]  |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #5051 

#### Description:
LabelTagProperty expressions in unwind are treated as AttributeExpressions, causing property-not-found errors.

## How do you solve it?

- Rewrite them to LabelTagProperty expressions and get evaluated as such.
- Hacked AttributeExpression to allow other hard-to-fix expressions like ListComprehensionExpression to work correctly.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] TCK

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
