### PR TITLE
catch exception in IndexKeyUtils::parseIndexTTL

### DIFF
--- a/src/common/utils/IndexKeyUtils.cpp
+++ b/src/common/utils/IndexKeyUtils.cpp
@@ -165,8 +165,13 @@ std::string IndexKeyUtils::indexVal(const Value& v) {
 // static
 Value IndexKeyUtils::parseIndexTTL(const folly::StringPiece& raw) {
   Value value;
-  auto len = *reinterpret_cast<const size_t*>(raw.data());
-  apache::thrift::CompactSerializer::deserialize(raw.subpiece(sizeof(size_t), len), value);
+  try {
+    auto len = *reinterpret_cast<const size_t*>(raw.data());
+    apache::thrift::CompactSerializer::deserialize(raw.subpiece(sizeof(size_t), len), value);
+  } catch (std::exception& ex) {
+    LOG(WARNING) << folly::stringPrintf(
+        "Decode index value %s got a exception: %s", folly::hexlify(raw).c_str(), ex.what());
+  }
   return value;
 }
 


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

As reported, it will crash when compaction triggered in certain scenario. This is just a bypass, the root cause is still not found. Hope the log would help.


#### Description:


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
