### PR TITLE
Newline added to JSON return format (For issue 2676)

### DIFF
--- a/src/webservice/GetStatsHandler.cpp
+++ b/src/webservice/GetStatsHandler.cpp
@@ -58,7 +58,7 @@ void GetStatsHandler::onEOM() noexcept {
 
   // read stats
   folly::dynamic vals = getStats();
-  std::string body = returnJson_ ? folly::toPrettyJson(vals) : toStr(vals);
+  std::string body = returnJson_ ? std:strcat(folly::toPrettyJson(vals), "\n") : toStr(vals);
   ResponseBuilder(downstream_)
       .status(WebServiceUtils::to(HttpStatusCode::OK),
               WebServiceUtils::toString(HttpStatusCode::OK))


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [*] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 2676

#### Description:
Code was not adding a newline to the end of the generated JSON from folly

## How do you solve it?
Changed line 61 in GetStatsHandler.cpp from 
std::string body = returnJson_ ? folly::toPrettyJson(vals) : toStr(vals);
to
std::string body = returnJson_ ? std::strcat(folly::toPrettyJson(vals), "\n") : toStr(vals);



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> Added an enhancement
