### PR TITLE
add some truncated fixed string case

### DIFF
--- a/src/codec/RowWriterV2.cpp
+++ b/src/codec/RowWriterV2.cpp
@@ -7,6 +7,7 @@
 
 #include <cmath>
 
+#include "codec/Common.h"
 #include "common/time/TimeUtils.h"
 #include "common/time/WallClock.h"
 #include "common/utils/DefaultValueContext.h"
@@ -679,7 +680,7 @@ WriteResult RowWriterV2::write(ssize_t index, folly::StringPiece v) noexcept {
     case PropertyType::FIXED_STRING: {
       // In-place string. If the pass-in string is longer than the pre-defined
       // fixed length, the string will be truncated to the fixed length
-      size_t len = v.size() > field->size() ? field->size() : v.size();
+      size_t len = v.size() > field->size() ? utf8CutSize(v, field->size()) : v.size();
       strncpy(&buf_[offset], v.data(), len);
       if (len < field->size()) {
         memset(&buf_[offset + len], 0, field->size() - len);

--- a/tests/tck/features/fetch/FetchEmpty.feature
+++ b/tests/tck/features/fetch/FetchEmpty.feature
@@ -80,3 +80,95 @@ Feature: Fetch prop on empty tag/edge
       | e                               |
       | [:zero_prop_edge "1"->"2" @0{}] |
     And drop the used space
+
+  Scenario: Tag Fixed String Property
+    When executing query:
+      """
+      CREATE TAG tag_with_fixed_string(col1 fixed_string(5));
+      """
+    And wait 5 seconds
+    When executing query:
+      """
+      INSERT VERTEX tag_with_fixed_string(col1)
+      VALUES
+        "1": ("😀😀"),
+        "2": ("😂😂"),
+        "3": ("羊羊羊"),
+        "4": ("🐏🐏🐏");
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      FETCH PROP on tag_with_fixed_string "1" yield tag_with_fixed_string.col1 as col1
+      """
+    Then the result should be, in any order:
+      | col1 |
+      | "😀" |
+    When executing query:
+      """
+      FETCH PROP on tag_with_fixed_string "2" yield tag_with_fixed_string.col1 as col1
+      """
+    Then the result should be, in any order:
+      | col1 |
+      | "😂" |
+    When executing query:
+      """
+      FETCH PROP on tag_with_fixed_string "3" yield tag_with_fixed_string.col1 as col1
+      """
+    Then the result should be, in any order:
+      | col1 |
+      | "羊" |
+    When executing query:
+      """
+      FETCH PROP on tag_with_fixed_string "4" yield tag_with_fixed_string.col1 as col1
+      """
+    Then the result should be, in any order:
+      | col1 |
+      | "🐏" |
+    And drop the used space
+
+  Scenario: Edge Fixed String Property
+    When executing query:
+      """
+      CREATE EDGE edge_with_fixed_string(col1 fixed_string(5));
+      """
+    And wait 5 seconds
+    When executing query:
+      """
+      INSERT EDGE edge_with_fixed_string(col1)
+      VALUES
+        "1" -> "1": ("😀😀"),
+        "2" -> "2": ("😂😂"),
+        "3" -> "3": ("羊羊羊"),
+        "4" -> "4": ("🐏🐏🐏");
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      FETCH PROP on edge_with_fixed_string "1" -> "1" yield edge_with_fixed_string.col1 as col1
+      """
+    Then the result should be, in any order:
+      | col1 |
+      | "😀" |
+    When executing query:
+      """
+      FETCH PROP on edge_with_fixed_string "2" -> "2" yield edge_with_fixed_string.col1 as col1
+      """
+    Then the result should be, in any order:
+      | col1 |
+      | "😂" |
+    When executing query:
+      """
+      FETCH PROP on edge_with_fixed_string "3" -> "3" yield edge_with_fixed_string.col1 as col1
+      """
+    Then the result should be, in any order:
+      | col1 |
+      | "羊" |
+    When executing query:
+      """
+      FETCH PROP on edge_with_fixed_string "4" -> "4" yield edge_with_fixed_string.col1 as col1
+      """
+    Then the result should be, in any order:
+      | col1 |
+      | "🐏" |
+    And drop the used space

--- a/tests/tck/features/index/Index.feature
+++ b/tests/tck/features/index/Index.feature
@@ -1197,3 +1197,307 @@ Feature: IndexTest_Vid_String
       | "1" | "2" |
       | "2" | "1" |
     Then drop the used space
+
+  Scenario: IndexTest TagStringIndexWithTruncate
+    Given an empty graph
+    And create a space with following options:
+      | partition_num  | 1                |
+      | replica_factor | 1                |
+      | vid_type       | FIXED_STRING(30) |
+      | charset        | utf8             |
+      | collate        | utf8_bin         |
+    And having executed:
+      """
+      CREATE TAG t1(col1 string);
+      """
+    When executing query:
+      """
+      CREATE TAG INDEX ti1 ON t1(col1(5));
+      """
+    Then the execution should be successful
+    And wait 5 seconds
+    When executing query:
+      """
+      INSERT VERTEX t1(col1)
+      VALUES
+        "1": ("aaa"),
+        "2": ("aaaaa"),
+        "3": ("aaaaaaa"),
+        "4": ("abc"),
+        "5": ("abcde"),
+        "6": ("abcdefg");
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE t1.col1 == "aaa" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "1" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE t1.col1 == "aaaaa" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "2" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE t1.col1 == "aaaaaaa" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "3" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE t1.col1 == "abc" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "4" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE t1.col1 == "abcde" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "5" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE t1.col1 == "abcdefg" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "6" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE t1.col1 > "aaaaa" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "3" |
+      | "4" |
+      | "5" |
+      | "6" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE t1.col1 >= "aaaaa" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "2" |
+      | "3" |
+      | "4" |
+      | "5" |
+      | "6" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE t1.col1 < "abcde" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "1" |
+      | "2" |
+      | "3" |
+      | "4" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE t1.col1 <= "abcde" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "1" |
+      | "2" |
+      | "3" |
+      | "4" |
+      | "5" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE "aaaaa" < t1.col1 AND t1.col1 < "abcde" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "3" |
+      | "4" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE "aaaaa" <= t1.col1 AND t1.col1 < "abcde" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "2" |
+      | "3" |
+      | "4" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE "aaaaa" < t1.col1 AND t1.col1 <= "abcde" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "3" |
+      | "4" |
+      | "5" |
+    When executing query:
+      """
+      LOOKUP ON t1 WHERE "aaaaa" <= t1.col1 AND t1.col1 <= "abcde" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id  |
+      | "2" |
+      | "3" |
+      | "4" |
+      | "5" |
+    Then drop the used space
+
+  Scenario: IndexTest EdgeStringIndexWithTruncate
+    Given an empty graph
+    And create a space with following options:
+      | partition_num  | 1                |
+      | replica_factor | 1                |
+      | vid_type       | FIXED_STRING(30) |
+      | charset        | utf8             |
+      | collate        | utf8_bin         |
+    And having executed:
+      """
+      CREATE EDGE e1(col1 string);
+      """
+    When executing query:
+      """
+      CREATE EDGE INDEX ei1 ON e1(col1(5));
+      """
+    Then the execution should be successful
+    And wait 5 seconds
+    When executing query:
+      """
+      INSERT EDGE e1(col1)
+      VALUES
+        "1" -> "1": ("aaa"),
+        "2" -> "2": ("aaaaa"),
+        "3" -> "3": ("aaaaaaa"),
+        "4" -> "4": ("abc"),
+        "5" -> "5": ("abcde"),
+        "6" -> "6": ("abcdefg");
+      """
+    Then the execution should be successful
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE e1.col1 == "aaa" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "1" | "1" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE e1.col1 == "aaaaa" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "2" | "2" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE e1.col1 == "aaaaaaa" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "3" | "3" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE e1.col1 == "abc" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "4" | "4" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE e1.col1 == "abcde" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "5" | "5" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE e1.col1 == "abcdefg" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "6" | "6" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE e1.col1 > "aaaaa" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "3" | "3" |
+      | "4" | "4" |
+      | "5" | "5" |
+      | "6" | "6" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE e1.col1 >= "aaaaa" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "2" | "2" |
+      | "3" | "3" |
+      | "4" | "4" |
+      | "5" | "5" |
+      | "6" | "6" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE e1.col1 < "abcde" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "1" | "1" |
+      | "2" | "2" |
+      | "3" | "3" |
+      | "4" | "4" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE e1.col1 <= "abcde" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "1" | "1" |
+      | "2" | "2" |
+      | "3" | "3" |
+      | "4" | "4" |
+      | "5" | "5" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE "aaaaa" < e1.col1 AND e1.col1 < "abcde" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "3" | "3" |
+      | "4" | "4" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE "aaaaa" <= e1.col1 AND e1.col1 < "abcde" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "2" | "2" |
+      | "3" | "3" |
+      | "4" | "4" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE "aaaaa" < e1.col1 AND e1.col1 <= "abcde" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "3" | "3" |
+      | "4" | "4" |
+      | "5" | "5" |
+    When executing query:
+      """
+      LOOKUP ON e1 WHERE "aaaaa" <= e1.col1 AND e1.col1 <= "abcde" YIELD src(edge) as src, dst(edge) as dst
+      """
+    Then the result should be, in any order:
+      | src | dst |
+      | "2" | "2" |
+      | "3" | "3" |
+      | "4" | "4" |
+      | "5" | "5" |
+    Then drop the used space


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
We will truncated FIXED_STRING property at the given offset, which make some utf8 character incomplete, for example we will return some strange characters.

Before:
```
CREATE TAG t1(col1 fixed_string(5));
INSERT VERTEX t1(col1) VALUES "2": ("😂😂")
fetch prop on t1 "2" yield t1.col1 as col
+-------+
| col1  |
+-------+
| "😂�" |
+-------+
```

After:
```
fetch prop on t1 "2" yield t1.col1 as col
+------+
| col  |
+------+
| "😂" |
+------+
```

And I have add some test cases that check index has been handle truncated utf8 chracacters correctly.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
