### PR TITLE
Fix the crash caused by a nullptr variable

### DIFF
--- a/src/clients/storage/StorageClientBase-inl.h
+++ b/src/clients/storage/StorageClientBase-inl.h
@@ -198,14 +198,19 @@ folly::Future<StatusOr<Response>> StorageClientBase<ClientType, ClientManagerTyp
 
         using TransportException = apache::thrift::transport::TTransportException;
         auto ex = exWrapper.get_exception<TransportException>();
-        if (ex && ex->getType() == TransportException::TIMED_OUT) {
-          LOG(ERROR) << "Request to " << host << " time out: " << ex->what();
-          return Status::Error("RPC failure in StorageClient, probably timeout: %s", ex->what());
+        if (ex) {
+          if (ex->getType() == TransportException::TIMED_OUT) {
+            LOG(ERROR) << "Request to " << host << " time out: " << ex->what();
+            return Status::Error("RPC failure in StorageClient with timeout: %s", ex->what());
+          } else {
+            LOG(ERROR) << "Request to " << host << " failed: " << ex->what();
+            return Status::Error("RPC failure in StorageClient: %s", ex->what());
+          }
         } else {
           auto partsId = getReqPartsId(request);
           invalidLeader(spaceId, partsId);
           LOG(ERROR) << "Request to " << host << " failed.";
-          return Status::Error("RPC failure in StorageClient, probably timeout.");
+          return Status::Error("RPC failure in StorageClient.");
         }
       });
 }

--- a/src/clients/storage/StorageClientBase-inl.h
+++ b/src/clients/storage/StorageClientBase-inl.h
@@ -200,12 +200,13 @@ folly::Future<StatusOr<Response>> StorageClientBase<ClientType, ClientManagerTyp
         auto ex = exWrapper.get_exception<TransportException>();
         if (ex && ex->getType() == TransportException::TIMED_OUT) {
           LOG(ERROR) << "Request to " << host << " time out: " << ex->what();
+          return Status::Error("RPC failure in StorageClient, probably timeout: %s", ex->what());
         } else {
           auto partsId = getReqPartsId(request);
           invalidLeader(spaceId, partsId);
           LOG(ERROR) << "Request to " << host << " failed.";
+          return Status::Error("RPC failure in StorageClient, probably timeout.");
         }
-        return Status::Error("RPC failure in StorageClient, probably timeout: %s", ex->what());
       });
 }
 

--- a/src/clients/storage/StorageClientBase-inl.h
+++ b/src/clients/storage/StorageClientBase-inl.h
@@ -203,7 +203,7 @@ folly::Future<StatusOr<Response>> StorageClientBase<ClientType, ClientManagerTyp
         } else {
           auto partsId = getReqPartsId(request);
           invalidLeader(spaceId, partsId);
-          LOG(ERROR) << "Request to " << host << " failed: " << ex->what();
+          LOG(ERROR) << "Request to " << host << " failed.";
         }
         return Status::Error("RPC failure in StorageClient, probably timeout: %s", ex->what());
       });


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula-ent/issues/1971
Close https://github.com/vesoft-inc/nebula/issues/5101

#### Description:
ex->what() is called without checking whether ex is nullptr.

## How do you solve it?
For this else body in particular, no need to call ex->what().


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
