### PR TITLE
Fix a crash bug. Deduce props in yield.

### DIFF
--- a/src/graph/validator/GroupByValidator.cpp
+++ b/src/graph/validator/GroupByValidator.cpp
@@ -54,6 +54,9 @@ Status GroupByValidator::validateYield(const YieldClause* yieldClause) {
         aggOutputColNames_.emplace_back(agg->toString());
         groupItems_.emplace_back(agg->clone());
         needGenProject_ = true;
+        ExpressionProps yieldProps;
+        NG_RETURN_IF_ERROR(deduceProps(agg, yieldProps));
+        exprProps_.unionProps(std::move(yieldProps));
       }
       if (!aggs.empty()) {
         auto* colRewrited = ExpressionUtils::rewriteAgg2VarProp(colExpr->clone());

--- a/tests/tck/features/yield/parameter.feature
+++ b/tests/tck/features/yield/parameter.feature
@@ -209,3 +209,13 @@ Feature: Parameter
       """
     Then a SyntaxError should be raised at runtime: Direct output of variable is prohibited near `$var'
     Then clear the used parameters
+
+  Scenario: expression with parameters
+    When executing query:
+      """
+      $var=go from "Tim Duncan" over like yield like._dst as id, like.likeness as likeness;
+      yield avg($var.likeness)+1 as v;
+      """
+    Then the result should be, in any order:
+      | v    |
+      | 96.0 |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #5111 

#### Description:
Yield after the pipe operator fails to get its input variable correctly, causing the aggregate executor to use a DefaultIterator from an empty dataset, many unimplemented methods of which contain LOG(FATAL) that crashes the service.

## How do you solve it?
Deduce properties for aggregate expressions, allowing it to get its input variable generated before the pipe operator correctly.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:

## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [x] TCK

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
