### PR TITLE
forbid string index length <= 0

### DIFF
--- a/src/meta/processors/index/CreateEdgeIndexProcessor.cpp
+++ b/src/meta/processors/index/CreateEdgeIndexProcessor.cpp
@@ -146,9 +146,8 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
       return;
     }
     if (col.type.get_type() == nebula::cpp2::PropertyType::FIXED_STRING) {
-      if (*col.type.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
-        LOG(INFO) << "Unsupported index type lengths greater than " << MAX_INDEX_TYPE_LENGTH
-                  << " : " << field.get_name();
+      if (field.get_type_length() != nullptr) {
+        LOG(INFO) << "Length should not be specified of fixed_string index :" << field.get_name();
         handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
         onFinished();
         return;
@@ -163,6 +162,12 @@ void CreateEdgeIndexProcessor::process(const cpp2::CreateEdgeIndexReq& req) {
       if (*field.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
         LOG(INFO) << "Unsupported index type lengths greater than " << MAX_INDEX_TYPE_LENGTH
                   << " : " << field.get_name();
+        handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
+        onFinished();
+        return;
+      }
+      if (*field.get_type_length() <= 0) {
+        LOG(INFO) << "Unsupported index type length <= 0: " << field.get_name();
         handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
         onFinished();
         return;

--- a/src/meta/processors/index/CreateTagIndexProcessor.cpp
+++ b/src/meta/processors/index/CreateTagIndexProcessor.cpp
@@ -145,9 +145,8 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
       return;
     }
     if (col.type.get_type() == nebula::cpp2::PropertyType::FIXED_STRING) {
-      if (*col.type.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
-        LOG(INFO) << "Unsupported index type lengths greater than " << MAX_INDEX_TYPE_LENGTH
-                  << " : " << field.get_name();
+      if (field.get_type_length() != nullptr) {
+        LOG(INFO) << "Length should not be specified of fixed_string index :" << field.get_name();
         handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
         onFinished();
         return;
@@ -162,6 +161,12 @@ void CreateTagIndexProcessor::process(const cpp2::CreateTagIndexReq& req) {
       if (*field.get_type_length() > MAX_INDEX_TYPE_LENGTH) {
         LOG(INFO) << "Unsupported index type lengths greater than " << MAX_INDEX_TYPE_LENGTH
                   << " : " << field.get_name();
+        handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
+        onFinished();
+        return;
+      }
+      if (*field.get_type_length() <= 0) {
+        LOG(INFO) << "Unsupported index type length <= 0 : " << field.get_name();
         handleErrorCode(nebula::cpp2::ErrorCode::E_UNSUPPORTED);
         onFinished();
         return;

--- a/tests/tck/features/index/Index.feature
+++ b/tests/tck/features/index/Index.feature
@@ -2179,12 +2179,42 @@ Feature: IndexTest_Vid_String
     Then a ExecutionError should be raised at runtime:
     When executing query:
       """
+      CREATE TAG INDEX string_index_with_length_0 ON t1(col4(0));
+      """
+    Then a ExecutionError should be raised at runtime:
+    When executing query:
+      """
+      CREATE EDGE INDEX string_index_with_length_0 ON e1(col4(0));
+      """
+    Then a ExecutionError should be raised at runtime:
+    When executing query:
+      """
       CREATE TAG INDEX string_index_too_long ON t1(col4(257));
       """
     Then a ExecutionError should be raised at runtime:
     When executing query:
       """
       CREATE EDGE INDEX string_index_too_long ON e1(col4(257));
+      """
+    Then a ExecutionError should be raised at runtime:
+    When executing query:
+      """
+      CREATE TAG INDEX fixed_string_index_with_length_0 ON t1(col8(0));
+      """
+    Then a ExecutionError should be raised at runtime:
+    When executing query:
+      """
+      CREATE EDGE INDEX fixed_string_index_with_length_0 ON e1(col8(0));
+      """
+    Then a ExecutionError should be raised at runtime:
+    When executing query:
+      """
+      CREATE TAG INDEX fixed_string_index_with_length_10 ON t1(col8(10));
+      """
+    Then a ExecutionError should be raised at runtime:
+    When executing query:
+      """
+      CREATE EDGE INDEX fixed_string_index_with_length_10 ON e1(col8(10));
       """
     Then a ExecutionError should be raised at runtime:
     When executing query:


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula-ent/issues/1685


#### Description:
Two logic is restricted:
* If create a string property index with length <= 0, return error.
* If length is specified for a fixed_string property index, return error. (Because in tag/edge, the fixed_string property has been specified, index will reuse it)


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
