### PR TITLE
Fix picker in PushFilterDownTraverseRule

### DIFF
--- a/src/graph/optimizer/rule/PushFilterDownTraverseRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownTraverseRule.cpp
@@ -75,10 +75,12 @@ StatusOr<OptRule::TransformResult> PushFilterDownTraverseRule::transform(
         return false;
       }
     }
-
     auto varProps = graph::ExpressionUtils::collectAll(
         e, {Expression::Kind::kInputProperty, Expression::Kind::kVarProperty});
     if (varProps.empty()) {
+      return false;
+    }
+    if (!graph::ExpressionUtils::isSingleLenExpandExpr(edgeAlias, e)) {
       return false;
     }
     for (auto* expr : varProps) {

--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -83,7 +83,7 @@ bool ExpressionUtils::findEdgeDstExpr(const Expression *expr) {
   return false;
 }
 
-// Finds all expressions fit the exprected list
+// Finds all expressions fit the expected list
 // Returns an empty vector if no expression found
 std::vector<const Expression *> ExpressionUtils::collectAll(
     const Expression *self, const std::unordered_set<Expression::Kind> &expected) {

--- a/tests/tck/features/match/Base.feature
+++ b/tests/tck/features/match/Base.feature
@@ -970,3 +970,16 @@ Feature: Basic match
       MATCH (v{name: "Tim Duncan"}) return v
       """
     Then a SemanticError should be raised at runtime: `name:"Tim Duncan"': No tag found for property.
+
+  Scenario: match with rank
+    When executing query:
+      """
+      match (v)-[e:like]->()
+      where id(v) == "Tim Duncan"
+      and rank(e) == 0
+      return *
+      """
+    Then the result should be, in any order:
+      | v                                                                                                           | e                                                       |
+      | ("Tim Duncan" :player{age: 42, name: "Tim Duncan"} :bachelor{name: "Tim Duncan", speciality: "psychology"}) | [:like "Tim Duncan"->"Manu Ginobili" @0 {likeness: 95}] |
+      | ("Tim Duncan" :player{age: 42, name: "Tim Duncan"} :bachelor{name: "Tim Duncan", speciality: "psychology"}) | [:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}]   |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula/issues/5123
Close https://github.com/vesoft-inc/nebula/issues/5120
Close https://github.com/vesoft-inc/nebula-ent/issues/1996

#### Description:
`$-.e[0].likeness` can be pushed into AppendVertices and further pushed down into the storage. But `rank($-.e[0])` cannot.

## How do you solve it?
Use the same condition of rewriteEdgePropertyFilter to ban the pushdown of some expressions. Only isSingleLenExpandExpr ones pass through.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] TCK

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
