### PR TITLE
Enhance MemoryStats to avoid the false sharing effect on the CPU cache

### DIFF
--- a/src/common/memory/MemoryTracker.h
+++ b/src/common/memory/MemoryTracker.h
@@ -13,9 +13,9 @@ namespace memory {
 
 constexpr size_t
 #if defined(__cpp_lib_hardware_interference_size)
-    L1_CACHE_LINE_SIZE = hardware_destructive_interference_size;
+    CACHE_LINE_SIZE = hardware_destructive_interference_size;
 #else
-    L1_CACHE_LINE_SIZE = 64;
+    CACHE_LINE_SIZE = 64;
 #endif
 
 // Memory stats for each thread.
@@ -121,7 +121,7 @@ class MemoryStats {
 
  private:
   // Global
-  alignas(L1_CACHE_LINE_SIZE) int64_t limit_{std::numeric_limits<int64_t>::max()};
+  alignas(CACHE_LINE_SIZE) int64_t limit_{std::numeric_limits<int64_t>::max()};
   std::atomic<int64_t> used_{0};
   // Thread Local
   static thread_local ThreadMemoryStats threadMemoryStats_;

--- a/src/common/memory/MemoryTracker.h
+++ b/src/common/memory/MemoryTracker.h
@@ -11,6 +11,13 @@
 namespace nebula {
 namespace memory {
 
+constexpr size_t
+#if defined(__cpp_lib_hardware_interference_size)
+    L1_CACHE_LINE_SIZE = hardware_destructive_interference_size;
+#else
+    L1_CACHE_LINE_SIZE = 64;
+#endif
+
 // Memory stats for each thread.
 struct ThreadMemoryStats {
   ThreadMemoryStats();
@@ -114,7 +121,7 @@ class MemoryStats {
 
  private:
   // Global
-  int64_t limit_{std::numeric_limits<int64_t>::max()};
+  alignas(L1_CACHE_LINE_SIZE) int64_t limit_{std::numeric_limits<int64_t>::max()};
   std::atomic<int64_t> used_{0};
   // Thread Local
   static thread_local ThreadMemoryStats threadMemoryStats_;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?

#### Description:
As discussed here: https://github.com/vesoft-inc/nebula/pull/5082/files#r1057092947
![image](https://user-images.githubusercontent.com/26356194/209781565-62a7e131-ccd8-41d4-ae51-6a660f117378.png)

## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory
