### PR TITLE
Fix PushFilterDownHashInnerJoinRule

### DIFF
--- a/src/graph/optimizer/rule/PushFilterDownHashInnerJoinRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterDownHashInnerJoinRule.cpp
@@ -82,7 +82,7 @@ StatusOr<OptRule::TransformResult> PushFilterDownHashInnerJoinRule::transform(
     newGroupNode->dependsOn(const_cast<OptGroup*>(newJoinGroup));
   } else {
     newInnerJoinNode->setOutputVar(oldFilterNode->outputVar());
-    newInnerJoinNode->setColNames(oldFilterNode->colNames());
+    newInnerJoinNode->setColNames(oldInnerJoinNode->colNames());
   }
 
   TransformResult result;

--- a/tests/tck/features/optimizer/PushFilterDownHashInnerJoinRule.feature
+++ b/tests/tck/features/optimizer/PushFilterDownHashInnerJoinRule.feature
@@ -256,3 +256,38 @@ Feature: Push Filter down HashInnerJoin rule
       | 10 | Traverse       | 8            |                                                                    |
       | 8  | Argument       | 9            |                                                                    |
       | 9  | Start          |              |                                                                    |
+
+  Scenario: push filter down hash join bug fix
+    Given a graph with space named "test"
+    When profiling query:
+      """
+      MATCH (v1:Label_6:Label_3)<-[e2:Rel_1]-(:Label_5)-[e3]->(v2)
+      WHERE (id(v1) in [20, 28, 31, 6, 4, 18, 15, 25, 9, 19, 21])
+      MATCH p0 = (v2)<-[e4]-()-[e5]->(v3:Label_6)
+      WITH min(v3.Label_6.Label_6_4_Int) AS pa0,
+      v3.Label_6.Label_6_1_Bool AS pa2
+      WHERE pa2
+      RETURN pa2
+      """
+    Then the result should be, in any order:
+      | pa2  |
+      | true |
+    And the execution plan should be:
+      | id | name           | dependencies | operator info                                 |
+      | 17 | project        | 19           |                                               |
+      | 19 | aggregate      | 24           |                                               |
+      | 24 | HashInnerJoin  | 21,29        |                                               |
+      | 21 | project        | 20           |                                               |
+      | 20 | filter         | 6            |                                               |
+      | 6  | AppendVertices | 26           |                                               |
+      | 26 | Traverse       | 25           |                                               |
+      | 25 | Traverse       | 2            |                                               |
+      | 2  | Dedup          | 1            |                                               |
+      | 1  | PassThrough    | 3            |                                               |
+      | 3  | Start          |              |                                               |
+      | 29 | project        | 28           |                                               |
+      | 28 | Filter         | 27           | {"condition": "$-.v3.Label_6.Label_6_1_Bool"} |
+      | 27 | AppendVertices | 11           |                                               |
+      | 11 | Traverse       | 10           |                                               |
+      | 10 | Traverse       | 9            |                                               |
+      | 9  | Argument       |              |                                               |

--- a/tests/tck/features/optimizer/PushFilterDownHashInnerJoinRule.feature
+++ b/tests/tck/features/optimizer/PushFilterDownHashInnerJoinRule.feature
@@ -258,7 +258,8 @@ Feature: Push Filter down HashInnerJoin rule
       | 9  | Start          |              |                                                                    |
 
   Scenario: push filter down hash join bug fix
-    Given a graph with space named "test"
+    Given an empty graph
+    And load "test" csv data to a new space
     When profiling query:
       """
       MATCH (v1:Label_6:Label_3)<-[e2:Rel_1]-(:Label_5)-[e3]->(v2)


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #5147 

#### Description:
When pushing down a filter over a hash join, the output columns of the join were set to those of the filter, causing the aggregate after the join to lose its dependent columns and produce null values. 

## How do you solve it?
When pushing filters over hash joins, the columns of the join shall stay unchanged, since the filter may at most change the cardinality of the join's inputs and never change its columns.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
