### PR TITLE
fix listener may crash when remove

### DIFF
--- a/conf/nebula-storaged-listener.conf.default
+++ b/conf/nebula-storaged-listener.conf.default
@@ -3,13 +3,13 @@
 # Whether to run as a daemon process
 --daemonize=true
 # The file to host the process id
---pid_file=pids_listener/nebula-storaged.pid
+--pid_file=pids/nebula-storaged-listener.pid
 # Whether to use the configuration obtained from the configuration file
 --local_config=true
 
 ########## logging ##########
 # The directory to host logging files
---log_dir=logs_listener
+--log_dir=logs_storaged_listener
 # Log level, 0, 1, 2, 3 for INFO, WARNING, ERROR, FATAL respectively
 --minloglevel=0
 # Verbose log level, 1, 2, 3, 4, the higher of the level, the more verbose of the logging
@@ -19,8 +19,8 @@
 # Whether to redirect stdout and stderr to separate output files
 --redirect_stdout=true
 # Destination filename of stdout and stderr, which will also reside in log_dir.
---stdout_log_file=storaged-stdout.log
---stderr_log_file=storaged-stderr.log
+--stdout_log_file=storaged-listener-stdout.log
+--stderr_log_file=storaged-listener-stderr.log
 # Copy log messages at or above this level to stderr in addition to logfiles. The numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively.
 --stderrthreshold=2
 # Wether logging files' name contain timestamp.

--- a/conf/nebula-storaged-listener.conf.production
+++ b/conf/nebula-storaged-listener.conf.production
@@ -3,13 +3,13 @@
 # Whether to run as a daemon process
 --daemonize=true
 # The file to host the process id
---pid_file=pids_listener/nebula-storaged-listener.pid
+--pid_file=pids/nebula-storaged-listener.pid
 # Whether to use the configuration obtained from the configuration file
 --local_config=true
 
 ########## logging ##########
 # The directory to host logging files
---log_dir=logs_storage_listener
+--log_dir=logs_storaged_listener
 # Log level, 0, 1, 2, 3 for INFO, WARNING, ERROR, FATAL respectively
 --minloglevel=0
 # Verbose log level, 1, 2, 3, 4, the higher of the level, the more verbose of the logging

--- a/src/graph/executor/admin/SpaceExecutor.cpp
+++ b/src/graph/executor/admin/SpaceExecutor.cpp
@@ -258,9 +258,9 @@ folly::Future<Status> ShowCreateSpaceExecutor::execute() {
         row.values.emplace_back(properties.get_space_name());
         auto fmt = properties.comment_ref().has_value()
                        ? "CREATE SPACE `%s` (partition_num = %d, replica_factor = %d, "
-                         "charset = %s, collate = %s, vid_type = %s) ON %s comment = '%s'"
+                         "charset = %s, collate = %s, vid_type = %s) comment = '%s'"
                        : "CREATE SPACE `%s` (partition_num = %d, replica_factor = %d, "
-                         "charset = %s, collate = %s, vid_type = %s) ON %s";
+                         "charset = %s, collate = %s, vid_type = %s)";
         auto zoneNames = folly::join(",", properties.get_zone_names());
         if (properties.comment_ref().has_value()) {
           row.values.emplace_back(
@@ -271,7 +271,6 @@ folly::Future<Status> ShowCreateSpaceExecutor::execute() {
                                   properties.get_charset_name().c_str(),
                                   properties.get_collate_name().c_str(),
                                   SchemaUtil::typeToString(properties.get_vid_type()).c_str(),
-                                  zoneNames.c_str(),
                                   properties.comment_ref()->c_str()));
         } else {
           row.values.emplace_back(
@@ -281,8 +280,7 @@ folly::Future<Status> ShowCreateSpaceExecutor::execute() {
                                   properties.get_replica_factor(),
                                   properties.get_charset_name().c_str(),
                                   properties.get_collate_name().c_str(),
-                                  SchemaUtil::typeToString(properties.get_vid_type()).c_str(),
-                                  zoneNames.c_str()));
+                                  SchemaUtil::typeToString(properties.get_vid_type()).c_str()));
         }
         dataSet.rows.emplace_back(std::move(row));
         return finish(ResultBuilder()

--- a/src/kvstore/listener/Listener.h
+++ b/src/kvstore/listener/Listener.h
@@ -275,6 +275,7 @@ class Listener : public raftex::RaftPart {
   LogID leaderCommitId_ = 0;
   LogID lastApplyLogId_ = 0;
   std::set<HostAddr> peers_;
+  std::unique_ptr<folly::IOThreadPoolExecutor> applyPool_;
 };
 
 }  // namespace kvstore


### PR DESCRIPTION

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula-ent/issues/2010

#### Description:
Listener may crash because the `Listener` has been removed while the background thread is still running. (There life time is different)

## How do you solve it?
We can't use `shared_from_this` like what we did in `RaftPart` because Listener is already an inherited class from `RaftPart`. So for simplicity, we just add one thread `applyPool_` for each `Listener`, and when stopping the Listener, we stop the pool as well, which make their lifetime same.

There are some other minor changes, that is for to keep same configuration as the ent version.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
