### PR TITLE
Fix scan efilter.

### DIFF
--- a/src/graph/optimizer/rule/GetEdgesTransformAppendVerticesLimitRule.cpp
+++ b/src/graph/optimizer/rule/GetEdgesTransformAppendVerticesLimitRule.cpp
@@ -61,6 +61,14 @@ bool GetEdgesTransformAppendVerticesLimitRule::match(OptContext *ctx,
   if (traverse->stepRange() != nullptr) {
     return false;
   }
+  // Can't apply vertex filter in GetEdges
+  if (traverse->vFilter() != nullptr) {
+    return false;
+  }
+  // If edge filter is not null, means it's can't be pushed down to storage
+  if (traverse->eFilter() != nullptr) {
+    return false;
+  }
   for (auto yieldColumn : project->columns()->columns()) {
     // exclude p=()-[e]->() return p limit 10
     if (yieldColumn->expr()->kind() == nebula::Expression::Kind::kPathBuild) {

--- a/src/graph/optimizer/rule/GetEdgesTransformRule.cpp
+++ b/src/graph/optimizer/rule/GetEdgesTransformRule.cpp
@@ -57,6 +57,14 @@ bool GetEdgesTransformRule::match(OptContext *ctx, const MatchedResult &matched)
   if (traverse->stepRange() != nullptr) {
     return false;
   }
+  // Can't apply vertex filter in GetEdges
+  if (traverse->vFilter() != nullptr) {
+    return false;
+  }
+  // If edge filter is not null, means it's can't be pushed down to storage
+  if (traverse->eFilter() != nullptr) {
+    return false;
+  }
   for (auto yieldColumn : project->columns()->columns()) {
     // exclude p=()-[e]->() return p limit 10
     if (yieldColumn->expr()->kind() == nebula::Expression::Kind::kPathBuild) {

--- a/tests/tck/features/bugfix/LackFilterGetEdges.feature
+++ b/tests/tck/features/bugfix/LackFilterGetEdges.feature
@@ -1,0 +1,25 @@
+# Copyright (c) 2022 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+Feature: Test lack filter of get edges transform
+
+  Background:
+    Given a graph with space named "nba"
+
+  # #5145
+  Scenario: Lack filter of get edges transform
+    When profiling query:
+      """
+      match ()-[e]->()
+      where e.likeness > 78  or uuid() > 100
+      return rank(e) limit 3
+      """
+    Then a ExecutionError should be raised at runtime: Scan vertices or edges need to specify a limit number, or limit number can not push down.
+    And the execution plan should be:
+      | id | name           | dependencies | operator info                                         |
+      | 24 | Project        | 20           |                                                       |
+      | 20 | Limit          | 21           |                                                       |
+      | 21 | AppendVertices | 23           |                                                       |
+      | 23 | Traverse       | 22           | { "edge filter": "((*.likeness>78) OR (uuid()>100))"} |
+      | 22 | ScanVertices   | 3            |                                                       |
+      | 3  | Start          |              |                                                       |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #5145 

#### Description:
This filter can't push down, so the limit can't push down too. Report error is the only way before #5170 

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
