### PR TITLE
fix processor_test timeout

### DIFF
--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -48,7 +48,10 @@ bool isLegalTypeConversion(cpp2::ColumnTypeDef from, cpp2::ColumnTypeDef to) {
     if (to.get_type() == nebula::cpp2::PropertyType::STRING) {
       return true;
     } else if (to.get_type() == nebula::cpp2::PropertyType::FIXED_STRING) {
-      return from.get_type_length() <= to.get_type_length();
+      if (!from.type_length_ref().has_value() || !to.type_length_ref().has_value()) {
+        return false;
+      }
+      return *from.type_length_ref() <= *to.type_length_ref();
     } else {
       return false;
     }

--- a/src/meta/processors/schema/AlterEdgeProcessor.cpp
+++ b/src/meta/processors/schema/AlterEdgeProcessor.cpp
@@ -125,7 +125,7 @@ void AlterEdgeProcessor::process(const cpp2::AlterEdgeReq& req) {
     auto& cols = edgeItem.get_schema().get_columns();
     for (auto& col : cols) {
       auto retCode = MetaServiceUtils::alterColumnDefs(
-          columns, prop, col, *edgeItem.op_ref(), std::move(allVersionedColumns), true);
+          columns, prop, col, *edgeItem.op_ref(), allVersionedColumns, true);
       if (retCode != nebula::cpp2::ErrorCode::SUCCEEDED) {
         LOG(INFO) << "Alter edge column error " << apache::thrift::util::enumNameSafe(retCode);
         handleErrorCode(retCode);

--- a/src/meta/processors/schema/AlterTagProcessor.cpp
+++ b/src/meta/processors/schema/AlterTagProcessor.cpp
@@ -122,7 +122,7 @@ void AlterTagProcessor::process(const cpp2::AlterTagReq& req) {
     auto& cols = tagItem.get_schema().get_columns();
     for (auto& col : cols) {
       auto retCode = MetaServiceUtils::alterColumnDefs(
-          columns, prop, col, *tagItem.op_ref(), std::move(allVersionedColumns));
+          columns, prop, col, *tagItem.op_ref(), allVersionedColumns);
       if (retCode != nebula::cpp2::ErrorCode::SUCCEEDED) {
         LOG(INFO) << "Alter tag column error " << apache::thrift::util::enumNameSafe(retCode);
         handleErrorCode(retCode);

--- a/src/meta/test/ProcessorTest.cpp
+++ b/src/meta/test/ProcessorTest.cpp
@@ -1783,11 +1783,28 @@ TEST(ProcessorTest, AlterTagTest) {
     req.space_id_ref() = 1;
     req.tag_name_ref() = "tag_0";
     req.tag_items_ref() = items;
-    auto* processor = AlterTagProcessor::instance(kv.get());
-    auto f = processor->getFuture();
-    processor->process(req);
-    auto resp = std::move(f).get();
-    ASSERT_EQ(nebula::cpp2::ErrorCode::E_UNSUPPORTED, resp.get_code());
+
+    {
+      auto* processor = AlterTagProcessor::instance(kv.get());
+      auto f = processor->getFuture();
+      processor->process(req);
+      auto resp = std::move(f).get();
+      ASSERT_EQ(nebula::cpp2::ErrorCode::E_UNSUPPORTED, resp.get_code());
+    }
+    {
+      req.tag_items_ref()
+          ->back()
+          .schema_ref()
+          ->columns_ref()
+          ->back()
+          .type_ref()
+          ->type_length_ref() = 6;
+      auto* processor = AlterTagProcessor::instance(kv.get());
+      auto f = processor->getFuture();
+      processor->process(req);
+      auto resp = std::move(f).get();
+      ASSERT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+    }
   }
 }
 
@@ -2376,11 +2393,27 @@ TEST(ProcessorTest, AlterEdgeTest) {
     req.space_id_ref() = 1;
     req.edge_name_ref() = "edge_0";
     req.edge_items_ref() = items;
-    auto* processor = AlterEdgeProcessor::instance(kv.get());
-    auto f = processor->getFuture();
-    processor->process(req);
-    auto resp = std::move(f).get();
-    ASSERT_EQ(nebula::cpp2::ErrorCode::E_UNSUPPORTED, resp.get_code());
+    {
+      auto* processor = AlterEdgeProcessor::instance(kv.get());
+      auto f = processor->getFuture();
+      processor->process(req);
+      auto resp = std::move(f).get();
+      ASSERT_EQ(nebula::cpp2::ErrorCode::E_UNSUPPORTED, resp.get_code());
+    }
+    {
+      req.edge_items_ref()
+          ->back()
+          .schema_ref()
+          ->columns_ref()
+          ->back()
+          .type_ref()
+          ->type_length_ref() = 6;
+      auto* processor = AlterEdgeProcessor::instance(kv.get());
+      auto f = processor->getFuture();
+      processor->process(req);
+      auto resp = std::move(f).get();
+      ASSERT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+    }
   }
 }
 

--- a/src/meta/test/ProcessorTest.cpp
+++ b/src/meta/test/ProcessorTest.cpp
@@ -2389,7 +2389,7 @@ TEST(ProcessorTest, AlterTagForMoreThan256TimesTest) {
   auto kv = MockCluster::initMetaKV(rootPath.path());
   TestUtils::assembleSpace(kv.get(), 1, 1);
   TestUtils::mockTag(kv.get(), 1);
-  const int times = 1000;
+  const int times = 300;
   int totalScheVer = 1;
   std::vector<cpp2::ColumnDef> expectedCols;
   for (auto i = 0; i < 2; i++) {
@@ -2516,7 +2516,7 @@ TEST(ProcessorTest, AlterEdgeForMoreThan256TimesTest) {
   auto kv = MockCluster::initMetaKV(rootPath.path());
   TestUtils::assembleSpace(kv.get(), 1, 1);
   TestUtils::mockEdge(kv.get(), 1);
-  const int times = 1000;
+  const int times = 300;
   int totalScheVer = 1;
   std::vector<cpp2::ColumnDef> expectedCols;
   for (auto i = 0; i < 2; i++) {


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
Introduced in #5130, `processor_test` may timeout because history schemas will be scanned. And there is a bug in alter processor...

## How do you solve it?
Need to lower iteration times, it takes about 2 mins in my env with debug version, let's see if ci could survive.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [X] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
