### PR TITLE
fix stderr  save error log

### DIFF
--- a/conf/nebula-graphd.conf.default
+++ b/conf/nebula-graphd.conf.default
@@ -27,7 +27,7 @@
 --stdout_log_file=graphd-stdout.log
 --stderr_log_file=graphd-stderr.log
 # Copy log messages at or above this level to stderr in addition to logfiles. The numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively.
---stderrthreshold=2
+--stderrthreshold=3
 # wether logging files' name contain time stamp.
 --timestamp_in_logfile_name=true
 ########## query ##########

--- a/conf/nebula-graphd.conf.production
+++ b/conf/nebula-graphd.conf.production
@@ -25,7 +25,7 @@
 --stdout_log_file=graphd-stdout.log
 --stderr_log_file=graphd-stderr.log
 # Copy log messages at or above this level to stderr in addition to logfiles. The numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively.
---stderrthreshold=2
+--stderrthreshold=3
 # wether logging files' name contain timestamp
 --timestamp_in_logfile_name=true
 

--- a/conf/nebula-metad.conf.default
+++ b/conf/nebula-metad.conf.default
@@ -19,7 +19,7 @@
 --stdout_log_file=metad-stdout.log
 --stderr_log_file=metad-stderr.log
 # Copy log messages at or above this level to stderr in addition to logfiles. The numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively.
---stderrthreshold=2
+--stderrthreshold=3
 # wether logging files' name contain time stamp, If Using logrotate to rotate logging files, than should set it to true.
 --timestamp_in_logfile_name=true
 

--- a/conf/nebula-metad.conf.production
+++ b/conf/nebula-metad.conf.production
@@ -19,7 +19,7 @@
 --stdout_log_file=metad-stdout.log
 --stderr_log_file=metad-stderr.log
 # Copy log messages at or above this level to stderr in addition to logfiles. The numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively.
---stderrthreshold=2
+--stderrthreshold=3
 # wether logging files' name contain time stamp.
 --timestamp_in_logfile_name=true
 

--- a/conf/nebula-standalone.conf.default
+++ b/conf/nebula-standalone.conf.default
@@ -27,7 +27,7 @@
 --stdout_log_file=standalone-stdout.log
 --stderr_log_file=standalone-stderr.log
 # Copy log messages at or above this level to stderr in addition to logfiles. The numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively.
---stderrthreshold=2
+--stderrthreshold=3
 
 ########## query ##########
 # Whether to treat partial success as an error.

--- a/conf/nebula-storaged-listener.conf.default
+++ b/conf/nebula-storaged-listener.conf.default
@@ -22,7 +22,7 @@
 --stdout_log_file=storaged-listener-stdout.log
 --stderr_log_file=storaged-listener-stderr.log
 # Copy log messages at or above this level to stderr in addition to logfiles. The numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively.
---stderrthreshold=2
+--stderrthreshold=3
 # Wether logging files' name contain timestamp.
 --timestamp_in_logfile_name=true
 

--- a/conf/nebula-storaged-listener.conf.production
+++ b/conf/nebula-storaged-listener.conf.production
@@ -22,7 +22,7 @@
 --stdout_log_file=storaged-listener-stdout.log
 --stderr_log_file=storaged-listener-stderr.log
 # Copy log messages at or above this level to stderr in addition to logfiles. The numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively.
---stderrthreshold=2
+--stderrthreshold=3
 # Wether logging files' name contain timestamp.
 --timestamp_in_logfile_name=true
 

--- a/conf/nebula-storaged.conf.default
+++ b/conf/nebula-storaged.conf.default
@@ -21,7 +21,7 @@
 --stdout_log_file=storaged-stdout.log
 --stderr_log_file=storaged-stderr.log
 # Copy log messages at or above this level to stderr in addition to logfiles. The numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively.
---stderrthreshold=2
+--stderrthreshold=3
 # Wether logging files' name contain time stamp.
 --timestamp_in_logfile_name=true
 

--- a/conf/nebula-storaged.conf.production
+++ b/conf/nebula-storaged.conf.production
@@ -21,7 +21,7 @@
 --stdout_log_file=storaged-listener-stdout.log
 --stderr_log_file=storaged-listener-stderr.log
 # Copy log messages at or above this level to stderr in addition to logfiles. The numbers of severity levels INFO, WARNING, ERROR, and FATAL are 0, 1, 2, and 3, respectively.
---stderrthreshold=2
+--stderrthreshold=3
 # Wether logging files' name contain timestamp.
 --timestamp_in_logfile_name=true
 


### PR DESCRIPTION
syntax error would be saved in both `nebula-graphd.ERROR` and `graphd-stderr.log`.
to save disk usage, improve the stderrthreshold level.