### PR TITLE
fix match stepRange confusion

### DIFF
--- a/src/graph/context/ast/CypherAstContext.h
+++ b/src/graph/context/ast/CypherAstContext.h
@@ -46,7 +46,7 @@ struct NodeInfo {
 
 struct EdgeInfo {
   bool anonymous{false};
-  MatchStepRange* range{nullptr};
+  MatchStepRange range;
   std::vector<EdgeType> edgeTypes;
   MatchEdge::Direction direction{MatchEdge::Direction::OUT_EDGE};
   std::vector<std::string> types;

--- a/src/graph/executor/algo/ShortestPathBase.h
+++ b/src/graph/executor/algo/ShortestPathBase.h
@@ -23,7 +23,7 @@ class ShortestPathBase {
                    std::unordered_map<std::string, std::string>* stats)
       : pathNode_(node), qctx_(qctx), stats_(stats) {
     singleShortest_ = node->singleShortest();
-    maxStep_ = node->stepRange()->max();
+    maxStep_ = node->stepRange().max();
   }
 
   virtual ~ShortestPathBase() {}

--- a/src/graph/executor/query/TraverseExecutor.cpp
+++ b/src/graph/executor/query/TraverseExecutor.cpp
@@ -116,7 +116,7 @@ folly::Future<Status> TraverseExecutor::getNeighbors() {
 
 Expression* TraverseExecutor::selectFilter() {
   Expression* filter = nullptr;
-  if (!(currentStep_ == 1 && traverse_->zeroStep())) {
+  if (!(currentStep_ == 1 && range_.min() == 0)) {
     filter = const_cast<Expression*>(traverse_->filter());
   }
   if (currentStep_ == 1) {
@@ -170,18 +170,14 @@ folly::Future<Status> TraverseExecutor::handleResponse(RpcResponse&& resps) {
         initVertices_.emplace_back(vertex);
       }
     }
-    if (range_ && range_->min() == 0) {
+    if (range_.min() == 0) {
       result_.rows = buildZeroStepPath();
     }
   }
   expand(iter.get());
   if (!isFinalStep()) {
     if (vids_.empty()) {
-      if (range_ != nullptr) {
-        return buildResult();
-      } else {
-        return folly::makeFuture<Status>(Status::OK());
-      }
+      return buildResult();
     } else {
       return getNeighbors();
     }
@@ -271,12 +267,8 @@ std::vector<Row> TraverseExecutor::buildZeroStepPath() {
 }
 
 folly::Future<Status> TraverseExecutor::buildResult() {
-  size_t minStep = 1;
-  size_t maxStep = 1;
-  if (range_ != nullptr) {
-    minStep = range_->min();
-    maxStep = range_->max();
-  }
+  size_t minStep = range_.min();
+  size_t maxStep = range_.max();
 
   result_.colNames = traverse_->colNames();
   if (maxStep == 0) {

--- a/src/graph/executor/query/TraverseExecutor.h
+++ b/src/graph/executor/query/TraverseExecutor.h
@@ -67,8 +67,7 @@ class TraverseExecutor final : public StorageAccessExecutor {
   folly::Future<Status> buildPathMultiJobs(size_t minStep, size_t maxStep);
 
   bool isFinalStep() const {
-    return (range_ == nullptr && currentStep_ == 1) ||
-           (range_ != nullptr && (currentStep_ == range_->max() || range_->max() == 0));
+    return currentStep_ == range_.max() || range_.max() == 0;
   }
 
   bool filterSameEdge(const Row& lhs,
@@ -133,7 +132,7 @@ class TraverseExecutor final : public StorageAccessExecutor {
   std::unordered_map<Value, std::vector<Value>, VertexHash, VertexEqual> adjList_;
   std::unordered_map<Value, std::vector<Row>, VertexHash, VertexEqual> dst2PathsMap_;
   const Traverse* traverse_{nullptr};
-  MatchStepRange* range_{nullptr};
+  MatchStepRange range_;
   size_t currentStep_{0};
 };
 

--- a/src/graph/optimizer/rule/GetEdgesTransformAppendVerticesLimitRule.cpp
+++ b/src/graph/optimizer/rule/GetEdgesTransformAppendVerticesLimitRule.cpp
@@ -58,7 +58,8 @@ bool GetEdgesTransformAppendVerticesLimitRule::match(OptContext *ctx,
   if (colNames[colSize - 2][0] != '_') {  // src
     return false;
   }
-  if (traverse->stepRange() != nullptr) {
+  const auto &stepRange = traverse->stepRange();
+  if (stepRange.min() != 1 || stepRange.max() != 1) {
     return false;
   }
   // Can't apply vertex filter in GetEdges

--- a/src/graph/optimizer/rule/GetEdgesTransformRule.cpp
+++ b/src/graph/optimizer/rule/GetEdgesTransformRule.cpp
@@ -54,7 +54,8 @@ bool GetEdgesTransformRule::match(OptContext *ctx, const MatchedResult &matched)
   if (colNames[colSize - 2][0] != '_') {  // src
     return false;
   }
-  if (traverse->stepRange() != nullptr) {
+  const auto &stepRange = traverse->stepRange();
+  if (stepRange.min() != 1 || stepRange.max() != 1) {
     return false;
   }
   // Can't apply vertex filter in GetEdges

--- a/src/graph/planner/match/LabelIndexSeek.cpp
+++ b/src/graph/planner/match/LabelIndexSeek.cpp
@@ -43,7 +43,7 @@ bool LabelIndexSeek::matchEdge(EdgeContext* edgeCtx) {
     return false;
   }
 
-  if (edge.range != nullptr && edge.range->min() == 0) {
+  if (edge.range.min() == 0) {
     // The 0 step is NodeScan in fact.
     return false;
   }

--- a/src/graph/planner/match/MatchSolver.cpp
+++ b/src/graph/planner/match/MatchSolver.cpp
@@ -234,7 +234,7 @@ static YieldColumn* buildVertexColumn(ObjectPool* pool, const std::string& alias
 static YieldColumn* buildEdgeColumn(QueryContext* qctx, const EdgeInfo& edge) {
   Expression* expr = nullptr;
   auto pool = qctx->objPool();
-  if (edge.range == nullptr) {
+  if (edge.range.min() == 1 && edge.range.max() == 1) {
     expr = SubscriptExpression::make(
         pool, InputPropertyExpression::make(pool, edge.alias), ConstantExpression::make(pool, 0));
   } else {

--- a/src/graph/planner/match/PropIndexSeek.cpp
+++ b/src/graph/planner/match/PropIndexSeek.cpp
@@ -19,7 +19,7 @@ bool PropIndexSeek::matchEdge(EdgeContext* edgeCtx) {
     return false;
   }
 
-  if (edge.range != nullptr && edge.range->min() == 0) {
+  if (edge.range.min() == 0) {
     // The 0 step is NodeScan in fact.
     return false;
   }

--- a/src/graph/planner/plan/Algo.cpp
+++ b/src/graph/planner/plan/Algo.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<PlanNodeDescription> ProduceAllPaths::explain() const {
 std::unique_ptr<PlanNodeDescription> ShortestPath::explain() const {
   auto desc = SingleInputNode::explain();
   addDescription("singleShortest", folly::toJson(util::toJson(singleShortest_)), desc.get());
-  addDescription("steps", range_ != nullptr ? range_->toString() : "", desc.get());
+  addDescription("steps", range_.toString(), desc.get());
   addDescription("edgeDirection", apache::thrift::util::enumNameSafe(edgeDirection_), desc.get());
   addDescription(
       "vertexProps", vertexProps_ ? folly::toJson(util::toJson(*vertexProps_)) : "", desc.get());

--- a/src/graph/planner/plan/Algo.h
+++ b/src/graph/planner/plan/Algo.h
@@ -174,7 +174,7 @@ class ShortestPath final : public SingleInputNode {
 
   std::unique_ptr<PlanNodeDescription> explain() const override;
 
-  MatchStepRange* stepRange() const {
+  const MatchStepRange& stepRange() const {
     return range_;
   }
 
@@ -202,7 +202,7 @@ class ShortestPath final : public SingleInputNode {
     return singleShortest_;
   }
 
-  void setStepRange(MatchStepRange* range) {
+  void setStepRange(const MatchStepRange& range) {
     range_ = range;
   }
 
@@ -234,7 +234,7 @@ class ShortestPath final : public SingleInputNode {
  private:
   GraphSpaceID space_;
   bool singleShortest_{false};
-  MatchStepRange* range_{nullptr};
+  MatchStepRange range_;
   std::unique_ptr<std::vector<EdgeProp>> edgeProps_;
   std::unique_ptr<std::vector<EdgeProp>> reverseEdgeProps_;
   std::unique_ptr<std::vector<VertexProp>> vertexProps_;

--- a/src/graph/planner/plan/Query.cpp
+++ b/src/graph/planner/plan/Query.cpp
@@ -790,7 +790,7 @@ void Traverse::cloneMembers(const Traverse& g) {
 
 std::unique_ptr<PlanNodeDescription> Traverse::explain() const {
   auto desc = GetNeighbors::explain();
-  addDescription("steps", range_ != nullptr ? range_->toString() : "", desc.get());
+  addDescription("steps", range_.toString(), desc.get());
   addDescription("vertex filter", vFilter_ != nullptr ? vFilter_->toString() : "", desc.get());
   addDescription("edge filter", eFilter_ != nullptr ? eFilter_->toString() : "", desc.get());
   addDescription("if_track_previous_path", folly::toJson(util::toJson(trackPrevPath_)), desc.get());

--- a/src/graph/planner/plan/Query.h
+++ b/src/graph/planner/plan/Query.h
@@ -1581,17 +1581,17 @@ class Traverse final : public GetNeighbors {
 
   Traverse* clone() const override;
 
-  MatchStepRange* stepRange() const {
+  MatchStepRange stepRange() const {
     return range_;
   }
 
   bool isOneStep() const {
-    return !range_;
+    return range_.min() == 1 && range_.max() == 1;
   }
 
   // Contains zero step
   bool zeroStep() const {
-    return range_ != nullptr && range_->min() == 0;
+    return range_.min() == 0;
   }
 
   Expression* vFilter() const {
@@ -1617,7 +1617,7 @@ class Traverse final : public GetNeighbors {
     return this->colNames().back();
   }
 
-  void setStepRange(MatchStepRange* range) {
+  void setStepRange(MatchStepRange range) {
     range_ = range;
   }
 
@@ -1659,7 +1659,7 @@ class Traverse final : public GetNeighbors {
  private:
   void cloneMembers(const Traverse& g);
 
-  MatchStepRange* range_{nullptr};
+  MatchStepRange range_;
   Expression* vFilter_{nullptr};
   Expression* eFilter_{nullptr};
   bool trackPrevPath_{true};

--- a/src/graph/validator/MatchValidator.cpp
+++ b/src/graph/validator/MatchValidator.cpp
@@ -161,7 +161,7 @@ Status MatchValidator::buildPathExpr(const MatchPath *path,
       return Status::SemanticError(
           "`shortestPath(...)' only support pattern like (start)-[edge*..hop]-(end)");
     }
-    auto min = edgeInfos.front().range->min();
+    auto min = edgeInfos.front().range.min();
     if (min != 0 && min != 1) {
       return Status::SemanticError(
           "`shortestPath(...)' does not support a minimal length different from 0 or 1");
@@ -296,14 +296,12 @@ Status MatchValidator::buildEdgeInfo(const MatchPath *path,
       }
     }
     AliasType aliasType = AliasType::kEdge;
-    auto *stepRange = edge->range();
-    if (stepRange != nullptr) {
-      NG_RETURN_IF_ERROR(validateStepRange(stepRange));
-      edgeInfos[i].range = stepRange;
-      // Type of [e*1..2], [e*2] should be inference to EdgeList
-      if (stepRange->max() > stepRange->min() || stepRange->min() > 1) {
-        aliasType = AliasType::kEdgeList;
-      }
+    const auto &stepRange = edge->range();
+    NG_RETURN_IF_ERROR(validateStepRange(stepRange));
+    edgeInfos[i].range = stepRange;
+    // Type of [e*1..2], [e*2] should be inference to EdgeList
+    if (stepRange.max() > stepRange.min() || stepRange.min() > 1) {
+      aliasType = AliasType::kEdgeList;
     }
     if (alias.empty()) {
       anonymous = true;
@@ -531,9 +529,9 @@ Status MatchValidator::validateAliases(
 }
 
 // Check validity of step number. e.g. match (v)-[e*2..3]->()
-Status MatchValidator::validateStepRange(const MatchStepRange *range) const {
-  auto min = range->min();
-  auto max = range->max();
+Status MatchValidator::validateStepRange(const MatchStepRange &range) const {
+  auto min = range.min();
+  auto max = range.max();
   if (min > max) {
     return Status::SemanticError(
         "Max hop must be greater equal than min hop: %ld vs. %ld", max, min);

--- a/src/graph/validator/MatchValidator.cpp
+++ b/src/graph/validator/MatchValidator.cpp
@@ -1270,12 +1270,13 @@ Status MatchValidator::validatePathInWhere(
             "PatternExpression are not allowed to introduce new variables: `%s'.",
             edge->alias().c_str());
       }
-      if (!edge->range() && find->second != AliasType::kEdge) {
+      const auto &stepRange = edge->range();
+      if (stepRange.min() == 1 && stepRange.max() == 1 && find->second != AliasType::kEdge) {
         return Status::SemanticError("`%s' is defined with type %s, but referenced with type Edge",
                                      edge->alias().c_str(),
                                      AliasTypeName::get(find->second).c_str());
       }
-      if (edge->range() && find->second != AliasType::kEdgeList) {
+      if ((stepRange.min() != 1 || stepRange.max() != 1) && find->second != AliasType::kEdgeList) {
         return Status::SemanticError(
             "`%s' is defined with type %s, but referenced with type EdgeList",
             edge->alias().c_str(),

--- a/src/graph/validator/MatchValidator.h
+++ b/src/graph/validator/MatchValidator.h
@@ -38,7 +38,7 @@ class MatchValidator final : public Validator {
   Status validateAliases(const std::vector<const Expression *> &exprs,
                          const std::unordered_map<std::string, AliasType> &aliases) const;
 
-  Status validateStepRange(const MatchStepRange *range) const;
+  Status validateStepRange(const MatchStepRange &range) const;
 
   Status validateWith(const WithClause *with,
                       const std::vector<QueryPart> &queryParts,

--- a/src/parser/MatchPath.cpp
+++ b/src/parser/MatchPath.cpp
@@ -27,7 +27,7 @@ std::string MatchEdge::toString() const {
     end = "-";
   }
 
-  if (!alias_.empty() || !types_.empty() || range_ != nullptr || props_ != nullptr) {
+  if (!alias_.empty() || !types_.empty() || props_ != nullptr) {
     buf += '[';
     if (!alias_.empty()) {
       buf += alias_;
@@ -40,22 +40,20 @@ std::string MatchEdge::toString() const {
         buf += *types_[i];
       }
     }
-    if (range_ != nullptr) {
-      buf += "*";
-      if (range_->min() == range_->max()) {
-        buf += folly::to<std::string>(range_->min());
-      } else if (range_->max() == std::numeric_limits<size_t>::max()) {
-        if (range_->min() != 1) {
-          buf += folly::to<std::string>(range_->min());
-          buf += "..";
-        }
-      } else {
-        if (range_->min() != 1) {
-          buf += folly::to<std::string>(range_->min());
-        }
+    buf += "*";
+    if (range_.min() == range_.max()) {
+      buf += folly::to<std::string>(range_.min());
+    } else if (range_.max() == std::numeric_limits<size_t>::max()) {
+      if (range_.min() != 1) {
+        buf += folly::to<std::string>(range_.min());
         buf += "..";
-        buf += folly::to<std::string>(range_->max());
       }
+    } else {
+      if (range_.min() != 1) {
+        buf += folly::to<std::string>(range_.min());
+      }
+      buf += "..";
+      buf += folly::to<std::string>(range_.max());
     }
     if (props_ != nullptr) {
       buf += props_->toString();

--- a/src/parser/MatchPath.h
+++ b/src/parser/MatchPath.h
@@ -56,10 +56,10 @@ class MatchEdgeProp final {
  public:
   MatchEdgeProp(const std::string& alias,
                 MatchEdgeTypeList* types,
-                MatchStepRange* range,
+                const MatchStepRange& range,
                 Expression* props = nullptr) {
     alias_ = alias;
-    range_.reset(range);
+    range_ = range;
     props_ = static_cast<MapExpression*>(props);
     if (types != nullptr) {
       types_ = std::move(*types).items();
@@ -76,7 +76,7 @@ class MatchEdgeProp final {
   std::string alias_;
   std::vector<std::unique_ptr<std::string>> types_;
   MapExpression* props_{nullptr};
-  std::unique_ptr<MatchStepRange> range_;
+  MatchStepRange range_;
 };
 
 class MatchEdge final {
@@ -111,8 +111,8 @@ class MatchEdge final {
     return props_;
   }
 
-  auto* range() const {
-    return range_.get();
+  const MatchStepRange& range() const {
+    return range_;
   }
 
   std::string toString() const;
@@ -121,11 +121,9 @@ class MatchEdge final {
     auto me = MatchEdge();
     me.direction_ = direction_;
     me.alias_ = alias_;
+    me.range_ = range_;
     for (const auto& type : types_) {
       me.types_.emplace_back(std::make_unique<std::string>(*DCHECK_NOTNULL(type)));
-    }
-    if (range_ != nullptr) {
-      me.range_ = std::make_unique<MatchStepRange>(*range_);
     }
     if (props_ != nullptr) {
       me.props_ = static_cast<MapExpression*>(props_->clone());
@@ -137,7 +135,7 @@ class MatchEdge final {
   Direction direction_;
   std::string alias_;
   std::vector<std::unique_ptr<std::string>> types_;
-  std::unique_ptr<MatchStepRange> range_;
+  MatchStepRange range_;
   MapExpression* props_{nullptr};
 };
 

--- a/src/parser/MatchPath.h
+++ b/src/parser/MatchPath.h
@@ -32,10 +32,8 @@ class MatchEdgeTypeList final {
 
 class MatchStepRange final {
  public:
-  explicit MatchStepRange(size_t min = 0, size_t max = std::numeric_limits<size_t>::max()) {
-    min_ = min;
-    max_ = max;
-  }
+  MatchStepRange() = default;
+  MatchStepRange(size_t min, size_t max) : min_(min), max_(max) {}
 
   auto min() const {
     return min_;

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -1877,7 +1877,7 @@ match_step_range
         $$ = new MatchStepRange(1, 1);
     }
     | STAR {
-        $$ = new MatchStepRange(1);
+        $$ = new MatchStepRange(1, std::numeric_limits<size_t>::max());
     }
     | STAR legal_integer {
         if ($2 < 0) {
@@ -1898,7 +1898,7 @@ match_step_range
             throw nebula::GraphParser::syntax_error(@2, "Expected an unsigned integer.");
         }
         auto step = static_cast<size_t>($2);
-        $$ = new MatchStepRange(step);
+        $$ = new MatchStepRange(step, std::numeric_limits<size_t>::max());
     }
     | STAR legal_integer DOT_DOT legal_integer {
         if ($2 < 0) {

--- a/src/parser/parser.yy
+++ b/src/parser/parser.yy
@@ -1852,12 +1852,14 @@ match_edge_prop
         $$ = nullptr;
     }
     | L_BRACKET match_alias opt_match_edge_type_list match_step_range R_BRACKET {
-        $$ = new MatchEdgeProp(*$2, $3, $4, nullptr);
+        $$ = new MatchEdgeProp(*$2, $3, *$4, nullptr);
         delete $2;
+        delete $4;
     }
     | L_BRACKET match_alias opt_match_edge_type_list match_step_range map_expression R_BRACKET {
-        $$ = new MatchEdgeProp(*$2, $3, $4, $5);
+        $$ = new MatchEdgeProp(*$2, $3, *$4, $5);
         delete $2;
+        delete $4;
     }
     ;
 
@@ -1872,7 +1874,7 @@ opt_match_edge_type_list
 
 match_step_range
     : %empty {
-        $$ = nullptr;
+        $$ = new MatchStepRange(1, 1);
     }
     | STAR {
         $$ = new MatchStepRange(1);

--- a/tests/tck/conftest.py
+++ b/tests/tck/conftest.py
@@ -699,7 +699,6 @@ def result_should_be_and_hash(request, result, exec_ctx, hashed_columns):
         hashed_columns=parse_list(hashed_columns),
     )
 
-
 @then(parse("the result should be, in any order, with relax comparison:\n{result}"))
 def result_should_be_relax_cmp(request, result, exec_ctx):
     cmp_dataset(request, exec_ctx, result, order=False, strict=False)

--- a/tests/tck/features/match/PathExpr.feature
+++ b/tests/tck/features/match/PathExpr.feature
@@ -413,3 +413,25 @@ Feature: Basic match
       | [[:like "Tony Parker"->"Manu Ginobili" @0 {likeness: 95}], [:like "Manu Ginobili"->"Tim Duncan" @0 {likeness: 90}]]          |
       | [[:like "Tony Parker"->"Tim Duncan" @0 {likeness: 95}], [:like "Tim Duncan"->"Manu Ginobili" @0 {likeness: 95}]]             |
       | [[:like "Tony Parker"->"Tim Duncan" @0 {likeness: 95}], [:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}]]               |
+    When executing query:
+      """
+      MATCH (v:player{name: 'Tim Duncan'})-[e:like*3]->(n), (t:team {name: "Spurs"})
+      WITH v, e, collect(distinct n) AS ns
+        UNWIND [n in ns | ()-[e*3]->(n:player)] AS p
+        RETURN p
+      """
+    Then the result should be, in any order:
+      | p  |
+      | [] |
+      | [] |
+      | [] |
+      | [] |
+      | [] |
+    When executing query:
+      """
+      MATCH (v:player)-[e:like*3]->(n)
+        WHERE (n)-[e*3]->(:player)
+        RETURN v
+      """
+    Then the result should be, in any order:
+      | v |

--- a/tests/tck/features/match/PathExpr.feature
+++ b/tests/tck/features/match/PathExpr.feature
@@ -387,7 +387,7 @@ Feature: Basic match
     When executing query:
       """
       MATCH (v:player)-[e:like]->(b)
-        WHERE (b)-[e:teammate]->(v)
+        WHERE (b)-[:teammate]->(v)
         RETURN e
       """
     Then the result should be, in any order:
@@ -432,6 +432,18 @@ Feature: Basic match
       MATCH (v:player)-[e:like*3]->(n)
         WHERE (n)-[e*3]->(:player)
         RETURN v
+      """
+    Then the result should be, in any order:
+      | v |
+    When executing query:
+      """
+      MATCH (v:player)-[e:like*1..3]->(n) WHERE (n)-[e*1..4]->(:player) return v
+      """
+    Then the result should be, in any order:
+      | v |
+    When executing query:
+      """
+      MATCH (v:player)-[e:like*3]->(n) WHERE id(v)=="Tim Duncan" and (n)-[e*3]->(:player) return v
       """
     Then the result should be, in any order:
       | v |

--- a/tests/tck/features/match/PathExpr.feature
+++ b/tests/tck/features/match/PathExpr.feature
@@ -362,3 +362,54 @@ Feature: Basic match
       | p                                                                                                                                                                                           |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:serve@0 {end_year: 2016, start_year: 1997}]->("Spurs" :team{name: "Spurs"})> |
       | <("Tim Duncan" :bachelor{name: "Tim Duncan", speciality: "psychology"} :player{age: 42, name: "Tim Duncan"})-[:serve@0 {end_year: 2016, start_year: 1997}]->("Spurs" :team{name: "Spurs"})> |
+
+  Scenario: pattern in where
+    When executing query:
+      """
+      MATCH (v:player)-[e]->(b)
+        WHERE id(v) IN ['Tim Duncan', 'Tony Parker'] AND (b)-[*1..2]->(v)
+        RETURN b
+      """
+    Then the result should be, in any order:
+      | b                                                                                                           |
+      | ("Danny Green" :player{age: 31, name: "Danny Green"})                                                       |
+      | ("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})                                           |
+      | ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})                                                   |
+      | ("Tony Parker" :player{age: 36, name: "Tony Parker"})                                                       |
+      | ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})                                                   |
+      | ("Tony Parker" :player{age: 36, name: "Tony Parker"})                                                       |
+      | ("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})                                           |
+      | ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})                                                   |
+      | ("Tim Duncan" :player{age: 42, name: "Tim Duncan"} :bachelor{name: "Tim Duncan", speciality: "psychology"}) |
+      | ("LaMarcus Aldridge" :player{age: 33, name: "LaMarcus Aldridge"})                                           |
+      | ("Manu Ginobili" :player{age: 41, name: "Manu Ginobili"})                                                   |
+      | ("Tim Duncan" :player{age: 42, name: "Tim Duncan"} :bachelor{name: "Tim Duncan", speciality: "psychology"}) |
+    When executing query:
+      """
+      MATCH (v:player)-[e:like]->(b)
+        WHERE (b)-[e:teammate]->(v)
+        RETURN e
+      """
+    Then the result should be, in any order:
+      | e                                                            |
+      | [:like "Tim Duncan"->"Manu Ginobili" @0 {likeness: 95}]      |
+      | [:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}]        |
+      | [:like "Danny Green"->"Tim Duncan" @0 {likeness: 70}]        |
+      | [:like "Manu Ginobili"->"Tim Duncan" @0 {likeness: 90}]      |
+      | [:like "Tony Parker"->"Manu Ginobili" @0 {likeness: 95}]     |
+      | [:like "Tony Parker"->"Tim Duncan" @0 {likeness: 95}]        |
+      | [:like "LaMarcus Aldridge"->"Tim Duncan" @0 {likeness: 75}]  |
+      | [:like "LaMarcus Aldridge"->"Tony Parker" @0 {likeness: 75}] |
+    When executing query:
+      """
+      MATCH (v:player)-[e:like*2]->(b)
+        WHERE id(v) == 'Tony Parker' AND (b)-[*1..2]->(v)
+        RETURN distinct e
+      """
+    Then the result should be, in any order:
+      | e                                                                                                                            |
+      | [[:like "Tony Parker"->"LaMarcus Aldridge" @0 {likeness: 90}], [:like "LaMarcus Aldridge"->"Tim Duncan" @0 {likeness: 75}]]  |
+      | [[:like "Tony Parker"->"LaMarcus Aldridge" @0 {likeness: 90}], [:like "LaMarcus Aldridge"->"Tony Parker" @0 {likeness: 75}]] |
+      | [[:like "Tony Parker"->"Manu Ginobili" @0 {likeness: 95}], [:like "Manu Ginobili"->"Tim Duncan" @0 {likeness: 90}]]          |
+      | [[:like "Tony Parker"->"Tim Duncan" @0 {likeness: 95}], [:like "Tim Duncan"->"Manu Ginobili" @0 {likeness: 95}]]             |
+      | [[:like "Tony Parker"->"Tim Duncan" @0 {likeness: 95}], [:like "Tim Duncan"->"Tony Parker" @0 {likeness: 95}]]               |

--- a/tests/tck/features/match/PathExprRefLocalVariable.feature
+++ b/tests/tck/features/match/PathExprRefLocalVariable.feature
@@ -123,7 +123,6 @@ Feature: Path expression reference local defined variables
       | "Rajon Rondo"       |
       | "Ray Allen"         |
 
-  @skip
   Scenario: Fix after issue #2045
     When executing query:
       """

--- a/tests/tck/features/match/PathExprRefLocalVariable.feature
+++ b/tests/tck/features/match/PathExprRefLocalVariable.feature
@@ -123,20 +123,6 @@ Feature: Path expression reference local defined variables
       | "Rajon Rondo"       |
       | "Ray Allen"         |
 
-  Scenario: Fix after issue #2045
-    When executing query:
-      """
-      MATCH (v:player)-[e:like*1..3]->(n) WHERE (n)-[e*1..4]->(:player) return v
-      """
-    Then the result should be, in any order:
-      | v |
-    When executing query:
-      """
-      MATCH (v:player)-[e:like*3]->(n) WHERE id(v)=="Tim Duncan" and (n)-[e*3]->(:player) return v
-      """
-    Then the result should be, in any order:
-      | v |
-
   Scenario: In With
     When executing query:
       """

--- a/tests/tck/features/match/VariableLengthPattern.feature
+++ b/tests/tck/features/match/VariableLengthPattern.feature
@@ -251,19 +251,19 @@ Feature: Variable length Pattern match (m to n)
       RETURN e
       """
     Then the result should be, in any order, with relax comparison:
-      | e                                           |
-      | [[:like "Tim Duncan"->"Manu Ginobili"]]     |
-      | [[:like "Tim Duncan"->"Tony Parker"]]       |
-      | [[:like "Tim Duncan"<-"Dejounte Murray"]]   |
-      | [[:like "Tim Duncan"<-"Shaquille O'Neal"]]  |
-      | [[:like "Tim Duncan"<-"Marco Belinelli"]]   |
-      | [[:like "Tim Duncan"<-"Boris Diaw"]]        |
-      | [[:like "Tim Duncan"<-"Manu Ginobili"]]     |
-      | [[:like "Tim Duncan"<-"Danny Green"]]       |
-      | [[:like "Tim Duncan"<-"Tiago Splitter"]]    |
-      | [[:like "Tim Duncan"<-"Aron Baynes"]]       |
-      | [[:like "Tim Duncan"<-"Tony Parker"]]       |
-      | [[:like "Tim Duncan"<-"LaMarcus Aldridge"]] |
+      | e                                         |
+      | [:like "Tim Duncan"->"Manu Ginobili"]     |
+      | [:like "Tim Duncan"->"Tony Parker"]       |
+      | [:like "Tim Duncan"<-"Dejounte Murray"]   |
+      | [:like "Tim Duncan"<-"Shaquille O'Neal"]  |
+      | [:like "Tim Duncan"<-"Marco Belinelli"]   |
+      | [:like "Tim Duncan"<-"Boris Diaw"]        |
+      | [:like "Tim Duncan"<-"Manu Ginobili"]     |
+      | [:like "Tim Duncan"<-"Danny Green"]       |
+      | [:like "Tim Duncan"<-"Tiago Splitter"]    |
+      | [:like "Tim Duncan"<-"Aron Baynes"]       |
+      | [:like "Tim Duncan"<-"Tony Parker"]       |
+      | [:like "Tim Duncan"<-"LaMarcus Aldridge"] |
 
   Scenario: from one step to one step
     When executing query:
@@ -272,19 +272,19 @@ Feature: Variable length Pattern match (m to n)
       RETURN e
       """
     Then the result should be, in any order, with relax comparison:
-      | e                                           |
-      | [[:like "Tim Duncan"->"Manu Ginobili"]]     |
-      | [[:like "Tim Duncan"->"Tony Parker"]]       |
-      | [[:like "Tim Duncan"<-"Dejounte Murray"]]   |
-      | [[:like "Tim Duncan"<-"Shaquille O'Neal"]]  |
-      | [[:like "Tim Duncan"<-"Marco Belinelli"]]   |
-      | [[:like "Tim Duncan"<-"Boris Diaw"]]        |
-      | [[:like "Tim Duncan"<-"Manu Ginobili"]]     |
-      | [[:like "Tim Duncan"<-"Danny Green"]]       |
-      | [[:like "Tim Duncan"<-"Tiago Splitter"]]    |
-      | [[:like "Tim Duncan"<-"Aron Baynes"]]       |
-      | [[:like "Tim Duncan"<-"Tony Parker"]]       |
-      | [[:like "Tim Duncan"<-"LaMarcus Aldridge"]] |
+      | e                                         |
+      | [:like "Tim Duncan"->"Manu Ginobili"]     |
+      | [:like "Tim Duncan"->"Tony Parker"]       |
+      | [:like "Tim Duncan"<-"Dejounte Murray"]   |
+      | [:like "Tim Duncan"<-"Shaquille O'Neal"]  |
+      | [:like "Tim Duncan"<-"Marco Belinelli"]   |
+      | [:like "Tim Duncan"<-"Boris Diaw"]        |
+      | [:like "Tim Duncan"<-"Manu Ginobili"]     |
+      | [:like "Tim Duncan"<-"Danny Green"]       |
+      | [:like "Tim Duncan"<-"Tiago Splitter"]    |
+      | [:like "Tim Duncan"<-"Aron Baynes"]       |
+      | [:like "Tim Duncan"<-"Tony Parker"]       |
+      | [:like "Tim Duncan"<-"LaMarcus Aldridge"] |
 
   Scenario: filter by edges
     When executing query:

--- a/tests/tck/features/match/VariableLengthPattern.intVid.feature
+++ b/tests/tck/features/match/VariableLengthPattern.intVid.feature
@@ -251,19 +251,19 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       RETURN e
       """
     Then the result should be, in any order, with relax comparison:
-      | e                                           |
-      | [[:like "Tim Duncan"->"Manu Ginobili"]]     |
-      | [[:like "Tim Duncan"->"Tony Parker"]]       |
-      | [[:like "Tim Duncan"<-"Dejounte Murray"]]   |
-      | [[:like "Tim Duncan"<-"Shaquille O'Neal"]]  |
-      | [[:like "Tim Duncan"<-"Marco Belinelli"]]   |
-      | [[:like "Tim Duncan"<-"Boris Diaw"]]        |
-      | [[:like "Tim Duncan"<-"Manu Ginobili"]]     |
-      | [[:like "Tim Duncan"<-"Danny Green"]]       |
-      | [[:like "Tim Duncan"<-"Tiago Splitter"]]    |
-      | [[:like "Tim Duncan"<-"Aron Baynes"]]       |
-      | [[:like "Tim Duncan"<-"Tony Parker"]]       |
-      | [[:like "Tim Duncan"<-"LaMarcus Aldridge"]] |
+      | e                                         |
+      | [:like "Tim Duncan"->"Manu Ginobili"]     |
+      | [:like "Tim Duncan"->"Tony Parker"]       |
+      | [:like "Tim Duncan"<-"Dejounte Murray"]   |
+      | [:like "Tim Duncan"<-"Shaquille O'Neal"]  |
+      | [:like "Tim Duncan"<-"Marco Belinelli"]   |
+      | [:like "Tim Duncan"<-"Boris Diaw"]        |
+      | [:like "Tim Duncan"<-"Manu Ginobili"]     |
+      | [:like "Tim Duncan"<-"Danny Green"]       |
+      | [:like "Tim Duncan"<-"Tiago Splitter"]    |
+      | [:like "Tim Duncan"<-"Aron Baynes"]       |
+      | [:like "Tim Duncan"<-"Tony Parker"]       |
+      | [:like "Tim Duncan"<-"LaMarcus Aldridge"] |
 
   Scenario: Integer Vid  from one step to one step
     When executing query:
@@ -272,19 +272,19 @@ Feature: Integer Vid Variable length Pattern match (m to n)
       RETURN e
       """
     Then the result should be, in any order, with relax comparison:
-      | e                                           |
-      | [[:like "Tim Duncan"->"Manu Ginobili"]]     |
-      | [[:like "Tim Duncan"->"Tony Parker"]]       |
-      | [[:like "Tim Duncan"<-"Dejounte Murray"]]   |
-      | [[:like "Tim Duncan"<-"Shaquille O'Neal"]]  |
-      | [[:like "Tim Duncan"<-"Marco Belinelli"]]   |
-      | [[:like "Tim Duncan"<-"Boris Diaw"]]        |
-      | [[:like "Tim Duncan"<-"Manu Ginobili"]]     |
-      | [[:like "Tim Duncan"<-"Danny Green"]]       |
-      | [[:like "Tim Duncan"<-"Tiago Splitter"]]    |
-      | [[:like "Tim Duncan"<-"Aron Baynes"]]       |
-      | [[:like "Tim Duncan"<-"Tony Parker"]]       |
-      | [[:like "Tim Duncan"<-"LaMarcus Aldridge"]] |
+      | e                                         |
+      | [:like "Tim Duncan"->"Manu Ginobili"]     |
+      | [:like "Tim Duncan"->"Tony Parker"]       |
+      | [:like "Tim Duncan"<-"Dejounte Murray"]   |
+      | [:like "Tim Duncan"<-"Shaquille O'Neal"]  |
+      | [:like "Tim Duncan"<-"Marco Belinelli"]   |
+      | [:like "Tim Duncan"<-"Boris Diaw"]        |
+      | [:like "Tim Duncan"<-"Manu Ginobili"]     |
+      | [:like "Tim Duncan"<-"Danny Green"]       |
+      | [:like "Tim Duncan"<-"Tiago Splitter"]    |
+      | [:like "Tim Duncan"<-"Aron Baynes"]       |
+      | [:like "Tim Duncan"<-"Tony Parker"]       |
+      | [:like "Tim Duncan"<-"LaMarcus Aldridge"] |
 
   Scenario: Integer Vid  filter by edges
     When executing query:

--- a/tests/tck/features/match/ZeroStep2.feature
+++ b/tests/tck/features/match/ZeroStep2.feature
@@ -92,13 +92,13 @@ Feature: test zero steps pattern
       RETURN e, v
       """
     Then the result should be, in any order, with relax comparison:
-      | e                                         | v                |
-      | [[:like 'Tracy McGrady'->'Kobe Bryant']]  | ('Kobe Bryant')  |
-      | [[:like 'Tracy McGrady'->'Grant Hill']]   | ('Grant Hill')   |
-      | [[:like 'Tracy McGrady'->'Rudy Gay']]     | ('Rudy Gay')     |
-      | [[:like 'Tracy McGrady'<-'Vince Carter']] | ('Vince Carter') |
-      | [[:like 'Tracy McGrady'<-'Yao Ming']]     | ('Yao Ming')     |
-      | [[:like 'Tracy McGrady'<-'Grant Hill']]   | ('Grant Hill')   |
+      | e                                       | v                |
+      | [:like 'Tracy McGrady'->'Kobe Bryant']  | ('Kobe Bryant')  |
+      | [:like 'Tracy McGrady'->'Grant Hill']   | ('Grant Hill')   |
+      | [:like 'Tracy McGrady'->'Rudy Gay']     | ('Rudy Gay')     |
+      | [:like 'Tracy McGrady'<-'Vince Carter'] | ('Vince Carter') |
+      | [:like 'Tracy McGrady'<-'Yao Ming']     | ('Yao Ming')     |
+      | [:like 'Tracy McGrady'<-'Grant Hill']   | ('Grant Hill')   |
     When executing query:
       """
       MATCH (:player{name:"Tracy McGrady"})-[e:like*0{likeness: 90}]-(v)
@@ -134,10 +134,10 @@ Feature: test zero steps pattern
       RETURN e, v
       """
     Then the result should be, in any order, with relax comparison:
-      | e                                        | v               |
-      | [[:like 'Tracy McGrady'->'Kobe Bryant']] | ('Kobe Bryant') |
-      | [[:like 'Tracy McGrady'->'Grant Hill']]  | ('Grant Hill')  |
-      | [[:like 'Tracy McGrady'->'Rudy Gay']]    | ('Rudy Gay')    |
+      | e                                      | v               |
+      | [:like 'Tracy McGrady'->'Kobe Bryant'] | ('Kobe Bryant') |
+      | [:like 'Tracy McGrady'->'Grant Hill']  | ('Grant Hill')  |
+      | [:like 'Tracy McGrady'->'Rudy Gay']    | ('Rudy Gay')    |
 
   Scenario Outline: Single edge without properties in both directions
     When executing query:


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula-ent/issues/2045

#### Description:

 match (v:player)-[e:like*2]->(b) where id(v) == 'Tony Parker' AND  (b)-[*1..2]->(v) return  distinct e

before 
```
|  8 | Traverse       | 7            |                | outputVar: {                                        |
|    |                |              |                |   "colNames": [                                     |
|    |                |              |                |     "b",                                            |
|    |                |              |                |     "__VAR_1"                                       |
|    |                |              |                |   ],                                                |
|    |                |              |                |   "type": "DATASET",                                |
|    |                |              |                |   "name": "__Traverse_8"                            |
|    |                |              |                | }                                                   |
|    |                |              |                | inputVar: __Argument_7                              |
|    |                |              |                | space: 6                                            |
|    |                |              |                | dedup: true                                         |
|    |                |              |                | limit: -1                                           |
|    |                |              |                | filter:                                             |
|    |                |              |                | orderBy: []                                         |
|    |                |              |                | src: id($-.b)                                       |
|    |                |              |                | edgeTypes: []                                       |
|    |                |              |                | edgeDirection: OUT_EDGE                             |
|    |                |              |                | vertexProps:                                        |
|    |                |              |                | edgeProps: [                                        |
|    |                |              |                |   {                                                 |
|    |                |              |                |     "props": [                                      |
|    |                |              |                |       "_dst",                                       |
|    |                |              |                |       "_type",                                      |
|    |                |              |                |       "_rank"                                       |
|    |                |              |                |     ],                                              |
|    |                |              |                |     "type": 12                                      |
|    |                |              |                |   },                                                |
|    |                |              |                |   {                                                 |
|    |                |              |                |     "type": 10,                                     |
|    |                |              |                |     "props": [                                      |
|    |                |              |                |       "_dst",                                       |
|    |                |              |                |       "_type",                                      |
|    |                |              |                |       "_rank"                                       |
|    |                |              |                |     ]                                               |
|    |                |              |                |   },                                                |
|    |                |              |                |   {                                                 |
|    |                |              |                |     "type": 11,                                     |
|    |                |              |                |     "props": [                                      |
|    |                |              |                |       "_dst",                                       |
|    |                |              |                |       "_type",                                      |
|    |                |              |                |       "_rank"                                       |
|    |                |              |                |     ]                                               |
|    |                |              |                |   }                                                 |
|    |                |              |                | ]                                                   |
|    |                |              |                | statProps:                                          |
|    |                |              |                | exprs:                                              |
|    |                |              |                | random: false                                       |
|    |                |              |                | steps: 0..140233306976544                           |
|    |                |              |                | vertex filter:                                      |
|    |                |              |                | edge filter:                                        |
|    |                |              |                | if_track_previous_path: false                       |
|    |                |              |                | first step filter:                                  |
```

After

```
|  8 | Traverse       | 7            |                | outputVar: {                                        |
|    |                |              |                |   "colNames": [                                     |
|    |                |              |                |     "b",                                            |
|    |                |              |                |     "__VAR_1"                                       |
|    |                |              |                |   ],                                                |
|    |                |              |                |   "type": "DATASET",                                |
|    |                |              |                |   "name": "__Traverse_8"                            |
|    |                |              |                | }                                                   |
|    |                |              |                | inputVar: __Argument_7                              |
|    |                |              |                | space: 11                                           |
|    |                |              |                | dedup: true                                         |
|    |                |              |                | limit: -1                                           |
|    |                |              |                | filter:                                             |
|    |                |              |                | orderBy: []                                         |
|    |                |              |                | src: id($-.b)                                       |
|    |                |              |                | edgeTypes: []                                       |
|    |                |              |                | edgeDirection: OUT_EDGE                             |
|    |                |              |                | vertexProps:                                        |
|    |                |              |                | edgeProps: [                                        |
|    |                |              |                |   {                                                 |
|    |                |              |                |     "type": 17,                                     |
|    |                |              |                |     "props": [                                      |
|    |                |              |                |       "_dst",                                       |
|    |                |              |                |       "_type",                                      |
|    |                |              |                |       "_rank"                                       |
|    |                |              |                |     ]                                               |
|    |                |              |                |   },                                                |
|    |                |              |                |   {                                                 |
|    |                |              |                |     "props": [                                      |
|    |                |              |                |       "_dst",                                       |
|    |                |              |                |       "_type",                                      |
|    |                |              |                |       "_rank"                                       |
|    |                |              |                |     ],                                              |
|    |                |              |                |     "type": 15                                      |
|    |                |              |                |   },                                                |
|    |                |              |                |   {                                                 |
|    |                |              |                |     "props": [                                      |
|    |                |              |                |       "_dst",                                       |
|    |                |              |                |       "_type",                                      |
|    |                |              |                |       "_rank"                                       |
|    |                |              |                |     ],                                              |
|    |                |              |                |     "type": 16                                      |
|    |                |              |                |   }                                                 |
|    |                |              |                | ]                                                   |
|    |                |              |                | statProps:                                          |
|    |                |              |                | exprs:                                              |
|    |                |              |                | random: false                                       |
|    |                |              |                | steps: 1..2                                         |
|    |                |              |                | vertex filter:                                      |
|    |                |              |                | edge filter:                                        |
|    |                |              |                | if_track_previous_path: false                       |
|    |                |              |                | first step filter:                                  |
|    |                |              |                | tag filter:                                         |
```


The steps in traverse used to be in the pointer format, and it was shallow copied when copying, causing the content pointed to by the steps to be released early


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
