### PR TITLE
improve memtracker, add missed check & remove unnecessary thenError&tryCatch check

### DIFF
--- a/cmake/nebula/SanitizerConfig.cmake
+++ b/cmake/nebula/SanitizerConfig.cmake
@@ -15,6 +15,7 @@ if(ENABLE_ASAN)
     add_compile_options(-fsanitize=address)
     add_compile_options(-g)
     add_compile_options(-fno-omit-frame-pointer)
+    add_definitions(-DENABLE_ASAN)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
 endif()
 

--- a/src/codec/test/CMakeLists.txt
+++ b/src/codec/test/CMakeLists.txt
@@ -22,6 +22,8 @@ set(CODEC_TEST_LIBS
     $<TARGET_OBJECTS:file_based_cluster_id_man_obj>
     $<TARGET_OBJECTS:base_obj>
     $<TARGET_OBJECTS:network_obj>
+    $<TARGET_OBJECTS:memory_obj>
+    $<TARGET_OBJECTS:time_obj>
     $<TARGET_OBJECTS:fs_obj>
     $<TARGET_OBJECTS:thread_obj>
     $<TARGET_OBJECTS:stats_obj>

--- a/src/common/base/Status.cpp
+++ b/src/common/base/Status.cpp
@@ -67,10 +67,14 @@ const char *Status::toString(Code code) {
       return "StatementEmpty: ";
     case kSemanticError:
       return "SemanticError: ";
+    case kGraphMemoryExceeded:
+      return "GraphMemoryExceeded: ";
     case kKeyNotFound:
       return "KeyNotFound: ";
     case kPartialSuccess:
       return "PartialSuccess: ";
+    case kStorageMemoryExceeded:
+      return "StorageMemoryExceeded: ";
     case kSpaceNotFound:
       return "SpaceNotFound: ";
     case kHostNotFound:

--- a/src/common/base/Status.h
+++ b/src/common/base/Status.h
@@ -173,7 +173,7 @@ class Status final {
     // 3xx, for storage engine errors
     kKeyNotFound = 301,
     kPartialSuccess = 302,
-    kStorageMemoryExceeded = 304,
+    kStorageMemoryExceeded = 303,
     // 4xx, for meta service errors
     kSpaceNotFound = 404,
     kHostNotFound = 405,

--- a/src/common/base/Status.h
+++ b/src/common/base/Status.h
@@ -119,12 +119,15 @@ class Status final {
   // Graph engine errors
   STATUS_GENERATOR(SyntaxError);
   STATUS_GENERATOR(SemanticError);
+  STATUS_GENERATOR(GraphMemoryExceeded);
+
   // Nothing is executed When command is comment
   STATUS_GENERATOR(StatementEmpty);
 
   // Storage engine errors
   STATUS_GENERATOR(KeyNotFound);
   STATUS_GENERATOR(PartialSuccess);
+  STATUS_GENERATOR(StorageMemoryExceeded);
 
   // Meta engine errors
   // TODO(dangleptr) we could use ErrorOr to replace SpaceNotFound here.
@@ -166,9 +169,11 @@ class Status final {
     kSyntaxError = 201,
     kStatementEmpty = 202,
     kSemanticError = 203,
+    kGraphMemoryExceeded = 204,
     // 3xx, for storage engine errors
     kKeyNotFound = 301,
     kPartialSuccess = 302,
+    kStorageMemoryExceeded = 304,
     // 4xx, for meta service errors
     kSpaceNotFound = 404,
     kHostNotFound = 405,

--- a/src/common/base/test/CMakeLists.txt
+++ b/src/common/base/test/CMakeLists.txt
@@ -110,8 +110,10 @@ nebula_add_executable(
         $<TARGET_OBJECTS:expression_obj>
         $<TARGET_OBJECTS:function_manager_obj>
         $<TARGET_OBJECTS:agg_function_manager_obj>
+        $<TARGET_OBJECTS:memory_obj>
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:time_utils_obj>
+        $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:ast_match_path_obj>
         $<TARGET_OBJECTS:wkt_wkb_io_obj>
         $<TARGET_OBJECTS:datetime_parser_obj>

--- a/src/common/datatypes/DataSetOps-inl.h
+++ b/src/common/datatypes/DataSetOps-inl.h
@@ -13,6 +13,7 @@
 #include "common/base/Base.h"
 #include "common/datatypes/CommonCpp2Ops.h"
 #include "common/datatypes/DataSet.h"
+#include "common/memory/MemoryTracker.h"
 
 namespace apache {
 namespace thrift {
@@ -47,7 +48,10 @@ inline constexpr protocol::TType Cpp2Ops<nebula::DataSet>::thriftType() {
 
 template <class Protocol>
 uint32_t Cpp2Ops<nebula::DataSet>::write(Protocol* proto, nebula::DataSet const* obj) {
+  // we do not turn on memory tracker here, when the DataSet object is creating & inserting, it is
+  // in Processor::process(), where memory tracker is turned on. so we think that is enough.
   uint32_t xfer = 0;
+
   xfer += proto->writeStructBegin("DataSet");
 
   xfer += proto->writeFieldBegin("column_names", protocol::T_LIST, 1);
@@ -62,11 +66,20 @@ uint32_t Cpp2Ops<nebula::DataSet>::write(Protocol* proto, nebula::DataSet const*
 
   xfer += proto->writeFieldStop();
   xfer += proto->writeStructEnd();
+
   return xfer;
 }
 
 template <class Protocol>
 void Cpp2Ops<nebula::DataSet>::read(Protocol* proto, nebula::DataSet* obj) {
+  // memory usage during decode a StorageResponse should be mostly occupied
+  // by DataSet (see interface/storage.thrift), turn on memory check here.
+  //
+  // MemoryTrackerVerified:
+  //    throw std::bad_alloc has verified, can be captured in StorageClientBase::getResponse's
+  //    onError
+  nebula::memory::MemoryCheckGuard guard;
+
   apache::thrift::detail::ProtocolReaderStructReadState<Protocol> readState;
 
   readState.readStructBegin(proto);

--- a/src/common/datatypes/DataSetOps-inl.h
+++ b/src/common/datatypes/DataSetOps-inl.h
@@ -76,8 +76,8 @@ void Cpp2Ops<nebula::DataSet>::read(Protocol* proto, nebula::DataSet* obj) {
   // by DataSet (see interface/storage.thrift), turn on memory check here.
   //
   // MemoryTrackerVerified:
-  //    throw std::bad_alloc has verified, can be captured in StorageClientBase::getResponse's
-  //    onError
+  //    throw std::bad_alloc has verified, can be captured in
+  //    StorageClientBase::getResponse's onError
   nebula::memory::MemoryCheckGuard guard;
 
   apache::thrift::detail::ProtocolReaderStructReadState<Protocol> readState;

--- a/src/common/datatypes/ValueOps-inl.h
+++ b/src/common/datatypes/ValueOps-inl.h
@@ -103,6 +103,7 @@ template <class Protocol>
 uint32_t Cpp2Ops<nebula::Value>::write(Protocol* proto, nebula::Value const* obj) {
   uint32_t xfer = 0;
   xfer += proto->writeStructBegin("Value");
+  // MemoryTrackerVerified: throw bad_alloc verified
 
   switch (obj->type()) {
     case nebula::Value::Type::NULLVALUE: {

--- a/src/common/datatypes/test/CMakeLists.txt
+++ b/src/common/datatypes/test/CMakeLists.txt
@@ -43,6 +43,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:function_manager_obj>
         $<TARGET_OBJECTS:wkt_wkb_io_obj>
         $<TARGET_OBJECTS:agg_function_manager_obj>
+        $<TARGET_OBJECTS:memory_obj>
         $<TARGET_OBJECTS:time_utils_obj>
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:datetime_parser_obj>
@@ -115,6 +116,7 @@ nebula_add_test(
         $<TARGET_OBJECTS:agg_function_manager_obj>
         $<TARGET_OBJECTS:time_utils_obj>
         $<TARGET_OBJECTS:datetime_parser_obj>
+        $<TARGET_OBJECTS:memory_obj>
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:fs_obj>
     LIBRARIES

--- a/src/common/expression/test/CMakeLists.txt
+++ b/src/common/expression/test/CMakeLists.txt
@@ -128,6 +128,7 @@ nebula_add_executable(
         $<TARGET_OBJECTS:expr_ctx_mock_obj>
         $<TARGET_OBJECTS:function_manager_obj>
         $<TARGET_OBJECTS:wkt_wkb_io_obj>
+        $<TARGET_OBJECTS:memory_obj>
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:time_utils_obj>
         $<TARGET_OBJECTS:datetime_parser_obj>
@@ -153,6 +154,7 @@ nebula_add_executable(
         $<TARGET_OBJECTS:function_manager_obj>
         $<TARGET_OBJECTS:wkt_wkb_io_obj>
         $<TARGET_OBJECTS:agg_function_manager_obj>
+        $<TARGET_OBJECTS:memory_obj>
         $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:time_utils_obj>
         $<TARGET_OBJECTS:datetime_parser_obj>

--- a/src/common/geo/test/CMakeLists.txt
+++ b/src/common/geo/test/CMakeLists.txt
@@ -30,6 +30,9 @@ nebula_add_test(
         $<TARGET_OBJECTS:base_obj>
         $<TARGET_OBJECTS:datatypes_obj>
         $<TARGET_OBJECTS:geo_index_obj>
+        $<TARGET_OBJECTS:memory_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:storage_thrift_obj>
         $<TARGET_OBJECTS:meta_thrift_obj>
         $<TARGET_OBJECTS:common_thrift_obj>

--- a/src/common/graph/tests/CMakeLists.txt
+++ b/src/common/graph/tests/CMakeLists.txt
@@ -11,6 +11,9 @@ nebula_add_test(
         $<TARGET_OBJECTS:base_obj>
         $<TARGET_OBJECTS:graph_obj>
         $<TARGET_OBJECTS:graph_thrift_obj>
+        $<TARGET_OBJECTS:memory_obj>
+        $<TARGET_OBJECTS:time_obj>
+        $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:common_thrift_obj>
         $<TARGET_OBJECTS:datatypes_obj>
         $<TARGET_OBJECTS:wkt_wkb_io_obj>

--- a/src/common/id/test/CMakeLists.txt
+++ b/src/common/id/test/CMakeLists.txt
@@ -28,6 +28,7 @@ nebula_add_executable(
       $<TARGET_OBJECTS:agg_function_manager_obj>
       $<TARGET_OBJECTS:time_utils_obj>
       $<TARGET_OBJECTS:datetime_parser_obj>
+      $<TARGET_OBJECTS:memory_obj>
       $<TARGET_OBJECTS:time_obj>
       $<TARGET_OBJECTS:fs_obj>
       $<TARGET_OBJECTS:meta_client_stats_obj>
@@ -67,6 +68,7 @@ nebula_add_test(
     $<TARGET_OBJECTS:agg_function_manager_obj>
     $<TARGET_OBJECTS:time_utils_obj>
     $<TARGET_OBJECTS:datetime_parser_obj>
+    $<TARGET_OBJECTS:memory_obj>
     $<TARGET_OBJECTS:time_obj>
     $<TARGET_OBJECTS:fs_obj>
     $<TARGET_OBJECTS:meta_client_stats_obj>

--- a/src/common/memory/MemoryTracker.cpp
+++ b/src/common/memory/MemoryTracker.cpp
@@ -38,6 +38,10 @@ void MemoryTracker::free(int64_t size) {
   MemoryStats::instance().free(size);
 }
 
+bool MemoryTracker::isOn() {
+  return MemoryStats::instance().throwOnMemoryExceeded();
+}
+
 void MemoryTracker::allocImpl(int64_t size, bool) {
   MemoryStats::instance().alloc(size);
 }

--- a/src/common/memory/MemoryTracker.h
+++ b/src/common/memory/MemoryTracker.h
@@ -138,6 +138,11 @@ class MemoryStats {
     threadMemoryStats_.throwOnMemoryExceeded = false;
   }
 
+  // return true if current thread's throwOnMemoryExceeded'
+  static bool throwOnMemoryExceeded() {
+    return threadMemoryStats_.throwOnMemoryExceeded;
+  }
+
  private:
   inline ALWAYS_INLINE void allocGlobal(int64_t size) {
     int64_t willBe = size + used_.fetch_add(size, std::memory_order_relaxed);
@@ -181,6 +186,9 @@ struct MemoryTracker {
 
   /// This function should be called after memory deallocation.
   static void free(int64_t size);
+
+  /// Test state of memory tracker, return true if memory tracker is turned on, otherwise false.
+  static bool isOn();
 
  private:
   static void allocImpl(int64_t size, bool throw_if_memory_exceeded);

--- a/src/common/memory/MemoryUtils.cpp
+++ b/src/common/memory/MemoryUtils.cpp
@@ -131,7 +131,6 @@ StatusOr<bool> MemoryUtils::hitsHighWatermark() {
                << FLAGS_memory_tracker_untracked_reserved_memory_mb << " Mib";
   }
 
-
   // purge if enabled
   if (FLAGS_memory_purge_enabled) {
     int64_t now = time::WallClock::fastNowInSec();

--- a/src/common/memory/MemoryUtils.cpp
+++ b/src/common/memory/MemoryUtils.cpp
@@ -120,6 +120,7 @@ StatusOr<bool> MemoryUtils::hitsHighWatermark() {
 
   // MemoryStats depends on jemalloc
 #ifdef ENABLE_JEMALLOC
+#ifndef ENABLE_ASAN
   // set MemoryStats limit (MemoryTracker track-able memory)
   int64_t trackable = total - FLAGS_memory_tracker_untracked_reserved_memory_mb * MiB;
   if (trackable > 0) {
@@ -130,7 +131,7 @@ StatusOr<bool> MemoryUtils::hitsHighWatermark() {
                << FLAGS_memory_tracker_untracked_reserved_memory_mb << " Mib";
   }
 
-#ifndef ENABLE_ASAN
+
   // purge if enabled
   if (FLAGS_memory_purge_enabled) {
     int64_t now = time::WallClock::fastNowInSec();
@@ -141,7 +142,6 @@ StatusOr<bool> MemoryUtils::hitsHighWatermark() {
       kLastPurge_ = now;
     }
   }
-#endif
 
   // print system & application level memory stats
   // sys: read from system environment, varies depends on environment:
@@ -168,7 +168,7 @@ StatusOr<bool> MemoryUtils::hitsHighWatermark() {
       kLastPrintMemoryTrackerStats_ = now;
     }
   }
-
+#endif
 #endif
 
   auto hits = (1 - available / total) > FLAGS_system_memory_high_watermark_ratio;

--- a/src/common/memory/NewDelete.cpp
+++ b/src/common/memory/NewDelete.cpp
@@ -11,23 +11,16 @@
 /// Two condition need check before MemoryTracker is on
 ///   1. jemalloc is used
 ///      MemoryTracker need jemalloc API to get accurate size of alloc/free memory.
-#if ENABLE_JEMALLOC
 ///   2. address_sanitizer is off
 ///      sanitizer has already override the new/delete operator,
 ///      only override new/delete operator only when address_sanitizer is off
-#if defined(__clang__)
-#if defined(__has_feature)
-#if not __has_feature(address_sanitizer)
+#ifdef ENABLE_JEMALLOC
+#ifndef ENABLE_ASAN
 #define ENABLE_MEMORY_TRACKER
 #endif
 #endif
 
-#else  // gcc
-#define ENABLE_MEMORY_TRACKER
-#endif
-#endif
-
-#if defined(ENABLE_MEMORY_TRACKER)
+#ifdef ENABLE_MEMORY_TRACKER
 /// new
 void *operator new(std::size_t size) {
   nebula::memory::trackMemory(size);

--- a/src/common/utils/test/CMakeLists.txt
+++ b/src/common/utils/test/CMakeLists.txt
@@ -21,6 +21,9 @@ nebula_add_test(
         $<TARGET_OBJECTS:ast_match_path_obj>
         $<TARGET_OBJECTS:function_manager_obj>
         $<TARGET_OBJECTS:agg_function_manager_obj>
+        $<TARGET_OBJECTS:memory_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:time_utils_obj>
         $<TARGET_OBJECTS:datetime_parser_obj>        
     LIBRARIES
@@ -47,6 +50,9 @@ nebula_add_test(
         $<TARGET_OBJECTS:ast_match_path_obj>
         $<TARGET_OBJECTS:function_manager_obj>
         $<TARGET_OBJECTS:agg_function_manager_obj>
+        $<TARGET_OBJECTS:memory_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:time_utils_obj>
         $<TARGET_OBJECTS:datetime_parser_obj>        
     LIBRARIES
@@ -76,6 +82,9 @@ nebula_add_test(
         $<TARGET_OBJECTS:ast_match_path_obj>
         $<TARGET_OBJECTS:function_manager_obj>
         $<TARGET_OBJECTS:agg_function_manager_obj>
+        $<TARGET_OBJECTS:memory_obj>
+        $<TARGET_OBJECTS:fs_obj>
+        $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:time_utils_obj>
         $<TARGET_OBJECTS:datetime_parser_obj>        
     LIBRARIES
@@ -94,6 +103,8 @@ nebula_add_test(
         $<TARGET_OBJECTS:common_thrift_obj>
         $<TARGET_OBJECTS:thrift_obj>
         $<TARGET_OBJECTS:base_obj>
+        $<TARGET_OBJECTS:memory_obj>
+        $<TARGET_OBJECTS:time_obj>
         $<TARGET_OBJECTS:fs_obj>
         $<TARGET_OBJECTS:network_obj>
         $<TARGET_OBJECTS:thread_obj>

--- a/src/graph/executor/Executor.cpp
+++ b/src/graph/executor/Executor.cpp
@@ -603,6 +603,9 @@ Status Executor::open() {
 }
 
 Status Executor::close() {
+  // MemoryTrackerVerified
+  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
+
   ProfilingStats stats;
   stats.totalDurationInUs = totalDuration_.elapsedInUSec();
   stats.rows = numRows_;
@@ -725,6 +728,8 @@ bool Executor::movable(const Variable *var) {
 }
 
 Status Executor::finish(Result &&result) {
+  // MemoryTrackerVerified
+  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
   if (!FLAGS_enable_lifetime_optimize ||
       node()->outputVarPtr()->userCount.load(std::memory_order_relaxed) != 0) {
     numRows_ = result.size();

--- a/src/graph/executor/Executor.cpp
+++ b/src/graph/executor/Executor.cpp
@@ -604,7 +604,6 @@ Status Executor::open() {
 
 Status Executor::close() {
   // MemoryTrackerVerified
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
 
   ProfilingStats stats;
   stats.totalDurationInUs = totalDuration_.elapsedInUSec();
@@ -729,7 +728,6 @@ bool Executor::movable(const Variable *var) {
 
 Status Executor::finish(Result &&result) {
   // MemoryTrackerVerified
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
   if (!FLAGS_enable_lifetime_optimize ||
       node()->outputVarPtr()->userCount.load(std::memory_order_relaxed) != 0) {
     numRows_ = result.size();

--- a/src/graph/executor/StorageAccessExecutor.h
+++ b/src/graph/executor/StorageAccessExecutor.h
@@ -131,9 +131,11 @@ class StorageAccessExecutor : public Executor {
             "Storage Error: Part {} raft buffer is full. Please retry later.", partId));
       case nebula::cpp2::ErrorCode::E_RAFT_ATOMIC_OP_FAILED:
         return Status::Error("Storage Error: Atomic operation failed.");
+        // E_GRAPH_MEMORY_EXCEEDED may happen during rpc response deserialize.
+      case nebula::cpp2::ErrorCode::E_GRAPH_MEMORY_EXCEEDED:
+        return Status::GraphMemoryExceeded("(%d)", static_cast<int32_t>(code));
       case nebula::cpp2::ErrorCode::E_STORAGE_MEMORY_EXCEEDED:
-        return Status::Error("Storage Error: STORAGE_MEMORY_EXCEEDED(%d)",
-                             static_cast<int32_t>(code));
+        return Status::StorageMemoryExceeded("(%d)", static_cast<int32_t>(code));
       default:
         auto status = Status::Error("Storage Error: part: %d, error: %s(%d).",
                                     partId,

--- a/src/graph/executor/algo/BFSShortestPathExecutor.cpp
+++ b/src/graph/executor/algo/BFSShortestPathExecutor.cpp
@@ -10,6 +10,9 @@ DECLARE_int32(num_operator_threads);
 namespace nebula {
 namespace graph {
 folly::Future<Status> BFSShortestPathExecutor::execute() {
+  // MemoryTrackerVerified
+  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
+
   SCOPED_TIMER(&execTime_);
   pathNode_ = asNode<BFSShortestPath>(node());
   terminateEarlyVar_ = pathNode_->terminateEarlyVar();
@@ -30,10 +33,12 @@ folly::Future<Status> BFSShortestPathExecutor::execute() {
 
   std::vector<folly::Future<Status>> futures;
   auto leftFuture = folly::via(runner(), [this]() {
+    // MemoryTrackerVerified
     memory::MemoryCheckGuard guard;
     return buildPath(false);
   });
   auto rightFuture = folly::via(runner(), [this]() {
+    // MemoryTrackerVerified
     memory::MemoryCheckGuard guard;
     return buildPath(true);
   });
@@ -111,6 +116,7 @@ Status BFSShortestPathExecutor::buildPath(bool reverse) {
       currentEdges.emplace(std::move(dst), std::move(edge));
     }
   }
+
   // set nextVid
   const auto& nextVidVar = reverse ? pathNode_->rightVidVar() : pathNode_->leftVidVar();
   ectx_->setResult(nextVidVar, ResultBuilder().value(std::move(nextStepVids)).build());
@@ -170,12 +176,6 @@ folly::Future<Status> BFSShortestPathExecutor::conjunctPath() {
           currentDs_.append(std::move(resp));
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc&) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/algo/BFSShortestPathExecutor.cpp
+++ b/src/graph/executor/algo/BFSShortestPathExecutor.cpp
@@ -11,7 +11,6 @@ namespace nebula {
 namespace graph {
 folly::Future<Status> BFSShortestPathExecutor::execute() {
   // MemoryTrackerVerified
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
 
   SCOPED_TIMER(&execTime_);
   pathNode_ = asNode<BFSShortestPath>(node());

--- a/src/graph/executor/algo/BatchShortestPath.cpp
+++ b/src/graph/executor/algo/BatchShortestPath.cpp
@@ -16,8 +16,6 @@ folly::Future<Status> BatchShortestPath::execute(const HashSet& startVids,
                                                  const HashSet& endVids,
                                                  DataSet* result) {
   // MemoryTrackerVerified
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
-
   size_t rowSize = init(startVids, endVids);
   std::vector<folly::Future<Status>> futures;
   futures.reserve(rowSize);

--- a/src/graph/executor/algo/ProduceAllPathsExecutor.cpp
+++ b/src/graph/executor/algo/ProduceAllPathsExecutor.cpp
@@ -11,7 +11,6 @@ DECLARE_int32(num_operator_threads);
 namespace nebula {
 namespace graph {
 folly::Future<Status> ProduceAllPathsExecutor::execute() {
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
   SCOPED_TIMER(&execTime_);
   pathNode_ = asNode<ProduceAllPaths>(node());
   noLoop_ = pathNode_->noLoop();

--- a/src/graph/executor/algo/ShortestPathBase.cpp
+++ b/src/graph/executor/algo/ShortestPathBase.cpp
@@ -197,5 +197,12 @@ void ShortestPathBase::addStats(PropRpcResponse& resp, int64_t timeInUSec) const
   statsLock_.unlock();
 }
 
+folly::Executor* ShortestPathBase::runner() const {
+  if (!qctx_ || !qctx_->rctx() || !qctx_->rctx()->runner()) {
+    return &folly::InlineExecutor::instance();
+  }
+  return qctx_->rctx()->runner();
+}
+
 }  // namespace graph
 }  // namespace nebula

--- a/src/graph/executor/algo/ShortestPathBase.h
+++ b/src/graph/executor/algo/ShortestPathBase.h
@@ -51,6 +51,8 @@ class ShortestPathBase {
 
   void addStats(PropRpcResponse& resp, int64_t timeInUSec) const;
 
+  folly::Executor* runner() const;
+
   template <typename Resp>
   StatusOr<Result::State> handleCompleteness(const storage::StorageRpcResponse<Resp>& rpcResp,
                                              bool isPartialSuccessAccepted) const {

--- a/src/graph/executor/algo/ShortestPathExecutor.cpp
+++ b/src/graph/executor/algo/ShortestPathExecutor.cpp
@@ -17,7 +17,6 @@ namespace nebula {
 namespace graph {
 folly::Future<Status> ShortestPathExecutor::execute() {
   // MemoryTrackerVerified
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
   SCOPED_TIMER(&execTime_);
   if (FLAGS_num_path_thread == 0) {
     FLAGS_num_path_thread = get_nprocs_conf();

--- a/src/graph/executor/algo/ShortestPathExecutor.cpp
+++ b/src/graph/executor/algo/ShortestPathExecutor.cpp
@@ -3,6 +3,7 @@
 // This source code is licensed under Apache 2.0 License.
 #include "graph/executor/algo/ShortestPathExecutor.h"
 
+#include "common/memory/MemoryTracker.h"
 #include "graph/executor/algo/BatchShortestPath.h"
 #include "graph/executor/algo/SingleShortestPath.h"
 #include "graph/service/GraphFlags.h"
@@ -15,6 +16,8 @@ DEFINE_uint32(num_path_thread, 0, "number of concurrent threads when do shortest
 namespace nebula {
 namespace graph {
 folly::Future<Status> ShortestPathExecutor::execute() {
+  // MemoryTrackerVerified
+  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
   SCOPED_TIMER(&execTime_);
   if (FLAGS_num_path_thread == 0) {
     FLAGS_num_path_thread = get_nprocs_conf();

--- a/src/graph/executor/algo/SingleShortestPath.cpp
+++ b/src/graph/executor/algo/SingleShortestPath.cpp
@@ -13,6 +13,8 @@ namespace graph {
 folly::Future<Status> SingleShortestPath::execute(const HashSet& startVids,
                                                   const HashSet& endVids,
                                                   DataSet* result) {
+  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
+
   size_t rowSize = startVids.size() * endVids.size();
   init(startVids, endVids, rowSize);
   std::vector<folly::Future<Status>> futures;
@@ -21,26 +23,18 @@ folly::Future<Status> SingleShortestPath::execute(const HashSet& startVids,
     resultDs_[rowNum].colNames = pathNode_->colNames();
     futures.emplace_back(shortestPath(rowNum, 1));
   }
-  return folly::collect(futures)
-      .via(qctx_->rctx()->runner())
-      .thenValue([this, result](auto&& resps) {
-        memory::MemoryCheckGuard guard;
-        for (auto& resp : resps) {
-          NG_RETURN_IF_ERROR(resp);
-        }
-        result->colNames = pathNode_->colNames();
-        for (auto& ds : resultDs_) {
-          result->append(std::move(ds));
-        }
-        return Status::OK();
-      })
-      .thenError(folly::tag_t<std::bad_alloc>{},
-                 [](const std::bad_alloc&) {
-                   return folly::makeFuture<Status>(Executor::memoryExceededStatus());
-                 })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
-      });
+  return folly::collect(futures).via(runner()).thenValue([this, result](auto&& resps) {
+    memory::MemoryCheckGuard guard;
+    throw std::bad_alloc();
+    for (auto& resp : resps) {
+      NG_RETURN_IF_ERROR(resp);
+    }
+    result->colNames = pathNode_->colNames();
+    for (auto& ds : resultDs_) {
+      result->append(std::move(ds));
+    }
+    return Status::OK();
+  });
 }
 
 void SingleShortestPath::init(const HashSet& startVids, const HashSet& endVids, size_t rowSize) {
@@ -75,7 +69,7 @@ folly::Future<Status> SingleShortestPath::shortestPath(size_t rowNum, size_t ste
   futures.emplace_back(getNeighbors(rowNum, stepNum, false));
   futures.emplace_back(getNeighbors(rowNum, stepNum, true));
   return folly::collect(futures)
-      .via(qctx_->rctx()->runner())
+      .via(runner())
       .thenValue([this, rowNum, stepNum](auto&& resps) {
         memory::MemoryCheckGuard guard;
         for (auto& resp : resps) {
@@ -122,18 +116,11 @@ folly::Future<Status> SingleShortestPath::getNeighbors(size_t rowNum,
                      -1,
                      nullptr,
                      nullptr)
-      .via(qctx_->rctx()->runner())
+      .via(runner())
       .thenValue([this, rowNum, stepNum, getNbrTime, reverse](auto&& resp) {
         memory::MemoryCheckGuard guard;
         addStats(resp, stepNum, getNbrTime.elapsedInUSec(), reverse);
         return buildPath(rowNum, std::move(resp), reverse);
-      })
-      .thenError(folly::tag_t<std::bad_alloc>{},
-                 [](const std::bad_alloc&) {
-                   return folly::makeFuture<Status>(Executor::memoryExceededStatus());
-                 })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -198,13 +185,16 @@ Status SingleShortestPath::doBuildPath(size_t rowNum, GetNeighborsIter* iter, bo
 
 folly::Future<Status> SingleShortestPath::handleResponse(size_t rowNum, size_t stepNum) {
   return folly::makeFuture<Status>(Status::OK())
-      .via(qctx_->rctx()->runner())
+      .via(runner())
       .thenValue([this, rowNum, stepNum](auto&& status) {
+        // MemoryTrackerVerified
         memory::MemoryCheckGuard guard;
+
         UNUSED(status);
         return conjunctPath(rowNum, stepNum);
       })
       .thenValue([this, rowNum, stepNum](auto&& result) {
+        memory::MemoryCheckGuard guard;
         if (result || stepNum * 2 >= maxStep_) {
           return folly::makeFuture<Status>(Status::OK());
         }
@@ -214,13 +204,6 @@ folly::Future<Status> SingleShortestPath::handleResponse(size_t rowNum, size_t s
           return folly::makeFuture<Status>(Status::OK());
         }
         return shortestPath(rowNum, stepNum + 1);
-      })
-      .thenError(folly::tag_t<std::bad_alloc>{},
-                 [](const std::bad_alloc&) {
-                   return folly::makeFuture<Status>(Executor::memoryExceededStatus());
-                 })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -281,38 +264,36 @@ void SingleShortestPath::buildOddPath(size_t rowNum, const std::vector<Value>& m
 folly::Future<bool> SingleShortestPath::buildEvenPath(size_t rowNum,
                                                       const std::vector<Value>& meetVids) {
   auto future = getMeetVidsProps(meetVids);
-  return future.via(qctx_->rctx()->runner())
-      .thenValue([this, rowNum](auto&& vertices) {
-        memory::MemoryCheckGuard guard;
-        if (vertices.empty()) {
-          return false;
-        }
-        for (auto& meetVertex : vertices) {
-          if (!meetVertex.isVertex()) {
-            continue;
+  return future.via(runner()).thenValue([this, rowNum](auto&& vertices) {
+    // MemoryTrackerVerified
+    memory::MemoryCheckGuard guard;
+
+    if (vertices.empty()) {
+      return false;
+    }
+    for (auto& meetVertex : vertices) {
+      if (!meetVertex.isVertex()) {
+        continue;
+      }
+      auto meetVid = meetVertex.getVertex().vid;
+      auto leftPaths = createLeftPath(rowNum, meetVid);
+      auto rightPaths = createRightPath(rowNum, meetVid, false);
+      for (auto& leftPath : leftPaths) {
+        for (auto& rightPath : rightPaths) {
+          Row path = leftPath;
+          auto& steps = path.values.back().mutableList().values;
+          steps.emplace_back(meetVertex);
+          steps.insert(steps.end(), rightPath.values.begin(), rightPath.values.end() - 1);
+          path.emplace_back(rightPath.values.back());
+          resultDs_[rowNum].rows.emplace_back(std::move(path));
+          if (singleShortest_) {
+            return true;
           }
-          auto meetVid = meetVertex.getVertex().vid;
-          auto leftPaths = createLeftPath(rowNum, meetVid);
-          auto rightPaths = createRightPath(rowNum, meetVid, false);
-          for (auto& leftPath : leftPaths) {
-            for (auto& rightPath : rightPaths) {
-              Row path = leftPath;
-              auto& steps = path.values.back().mutableList().values;
-              steps.emplace_back(meetVertex);
-              steps.insert(steps.end(), rightPath.values.begin(), rightPath.values.end() - 1);
-              path.emplace_back(rightPath.values.back());
-              resultDs_[rowNum].rows.emplace_back(std::move(path));
-              if (singleShortest_) {
-                return true;
-              }
-            }
-          }
         }
-        return true;
-      })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<bool>(std::runtime_error(e.what()));
-      });
+      }
+    }
+    return true;
+  });
 }
 
 std::vector<Row> SingleShortestPath::createLeftPath(size_t rowNum, const Value& meetVid) {

--- a/src/graph/executor/algo/SingleShortestPath.cpp
+++ b/src/graph/executor/algo/SingleShortestPath.cpp
@@ -25,7 +25,6 @@ folly::Future<Status> SingleShortestPath::execute(const HashSet& startVids,
   }
   return folly::collect(futures).via(runner()).thenValue([this, result](auto&& resps) {
     memory::MemoryCheckGuard guard;
-    throw std::bad_alloc();
     for (auto& resp : resps) {
       NG_RETURN_IF_ERROR(resp);
     }

--- a/src/graph/executor/algo/SingleShortestPath.cpp
+++ b/src/graph/executor/algo/SingleShortestPath.cpp
@@ -13,8 +13,6 @@ namespace graph {
 folly::Future<Status> SingleShortestPath::execute(const HashSet& startVids,
                                                   const HashSet& endVids,
                                                   DataSet* result) {
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
-
   size_t rowSize = startVids.size() * endVids.size();
   init(startVids, endVids, rowSize);
   std::vector<folly::Future<Status>> futures;

--- a/src/graph/executor/algo/SubgraphExecutor.cpp
+++ b/src/graph/executor/algo/SubgraphExecutor.cpp
@@ -53,6 +53,7 @@ folly::Future<Status> SubgraphExecutor::getNeighbors() {
                      currentStep_ == 1 ? nullptr : subgraph_->tagFilter())
       .via(runner())
       .thenValue([this, getNbrTime](RpcResponse&& resp) mutable {
+        // MemoryTrackerVerified
         memory::MemoryCheckGuard guard;
         otherStats_.emplace("total_rpc_time", folly::sformat("{}(us)", getNbrTime.elapsedInUSec()));
         auto& hostLatency = resp.hostLatency();
@@ -67,12 +68,6 @@ folly::Future<Status> SubgraphExecutor::getNeighbors() {
         }
         vids_.clear();
         return handleResponse(std::move(resp));
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc&) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/logic/ArgumentExecutor.cpp
+++ b/src/graph/executor/logic/ArgumentExecutor.cpp
@@ -13,6 +13,9 @@ ArgumentExecutor::ArgumentExecutor(const PlanNode *node, QueryContext *qctx)
     : Executor("ArgumentExecutor", node, qctx) {}
 
 folly::Future<Status> ArgumentExecutor::execute() {
+  // MemoryTrackerVerified
+  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
+
   auto *argNode = asNode<Argument>(node());
   auto &alias = argNode->getAlias();
   auto iter = ectx_->getResult(argNode->inputVar()).iter();

--- a/src/graph/executor/logic/ArgumentExecutor.cpp
+++ b/src/graph/executor/logic/ArgumentExecutor.cpp
@@ -14,8 +14,6 @@ ArgumentExecutor::ArgumentExecutor(const PlanNode *node, QueryContext *qctx)
 
 folly::Future<Status> ArgumentExecutor::execute() {
   // MemoryTrackerVerified
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
-
   auto *argNode = asNode<Argument>(node());
   auto &alias = argNode->getAlias();
   auto iter = ectx_->getResult(argNode->inputVar()).iter();

--- a/src/graph/executor/logic/StartExecutor.cpp
+++ b/src/graph/executor/logic/StartExecutor.cpp
@@ -9,6 +9,7 @@ namespace graph {
 
 folly::Future<Status> StartExecutor::execute() {
   SCOPED_TIMER(&execTime_);
+  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
 
   return start();
 }

--- a/src/graph/executor/logic/StartExecutor.cpp
+++ b/src/graph/executor/logic/StartExecutor.cpp
@@ -9,7 +9,6 @@ namespace graph {
 
 folly::Future<Status> StartExecutor::execute() {
   SCOPED_TIMER(&execTime_);
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
 
   return start();
 }

--- a/src/graph/executor/maintain/EdgeExecutor.cpp
+++ b/src/graph/executor/maintain/EdgeExecutor.cpp
@@ -21,18 +21,13 @@ folly::Future<Status> CreateEdgeExecutor::execute() {
       .via(runner())
       .thenValue([ceNode, spaceId](StatusOr<EdgeType> resp) {
         memory::MemoryCheckGuard guard;
+        // throw in MemoryCheckGuard verified
         if (!resp.ok()) {
           LOG(WARNING) << "SpaceId: " << spaceId << ", Create edge `" << ceNode->getName()
                        << "' failed: " << resp.status();
           return resp.status();
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -47,6 +42,7 @@ folly::Future<Status> DescEdgeExecutor::execute() {
       .via(runner())
       .thenValue([this, deNode, spaceId](StatusOr<meta::cpp2::Schema> resp) {
         memory::MemoryCheckGuard guard;
+        // MemoryTrackerVerified
         if (!resp.ok()) {
           LOG(WARNING) << "SpaceId: " << spaceId << ", Desc edge `" << deNode->getName()
                        << "' failed: " << resp.status();
@@ -62,12 +58,6 @@ folly::Future<Status> DescEdgeExecutor::execute() {
                           .value(Value(std::move(ret).value()))
                           .iter(Iterator::Kind::kDefault)
                           .build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -82,18 +72,13 @@ folly::Future<Status> DropEdgeExecutor::execute() {
       .via(runner())
       .thenValue([deNode, spaceId](StatusOr<bool> resp) {
         memory::MemoryCheckGuard guard;
+        // MemoryTrackerVerified
         if (!resp.ok()) {
           LOG(WARNING) << "SpaceId: " << spaceId << ", Drop edge `" << deNode->getName()
                        << "' failed: " << resp.status();
           return resp.status();
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -128,12 +113,6 @@ folly::Future<Status> ShowEdgesExecutor::execute() {
                           .value(Value(std::move(dataSet)))
                           .iter(Iterator::Kind::kDefault)
                           .build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -161,12 +140,6 @@ folly::Future<Status> ShowCreateEdgeExecutor::execute() {
         }
         return finish(
             ResultBuilder().value(std::move(ret).value()).iter(Iterator::Kind::kDefault).build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -187,12 +160,6 @@ folly::Future<Status> AlterEdgeExecutor::execute() {
           return resp.status();
         }
         return finish(ResultBuilder().value(Value()).iter(Iterator::Kind::kDefault).build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 }  // namespace graph

--- a/src/graph/executor/maintain/EdgeIndexExecutor.cpp
+++ b/src/graph/executor/maintain/EdgeIndexExecutor.cpp
@@ -27,6 +27,7 @@ folly::Future<Status> CreateEdgeIndexExecutor::execute() {
       .via(runner())
       .thenValue([ceiNode, spaceId](StatusOr<IndexID> resp) {
         memory::MemoryCheckGuard guard;
+        // MemoryTrackerVerified
         if (!resp.ok()) {
           LOG(WARNING) << "SpaceId: " << spaceId << ", Create index `" << ceiNode->getIndexName()
                        << "' at edge: `" << ceiNode->getSchemaName()
@@ -34,12 +35,6 @@ folly::Future<Status> CreateEdgeIndexExecutor::execute() {
           return resp.status();
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -60,12 +55,6 @@ folly::Future<Status> DropEdgeIndexExecutor::execute() {
           return resp.status();
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -94,12 +83,6 @@ folly::Future<Status> DescEdgeIndexExecutor::execute() {
         }
         return finish(
             ResultBuilder().value(std::move(ret).value()).iter(Iterator::Kind::kDefault).build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -127,12 +110,6 @@ folly::Future<Status> ShowCreateEdgeIndexExecutor::execute() {
         }
         return finish(
             ResultBuilder().value(std::move(ret).value()).iter(Iterator::Kind::kDefault).build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -190,12 +167,6 @@ folly::Future<Status> ShowEdgeIndexesExecutor::execute() {
                           .value(Value(std::move(dataSet)))
                           .iter(Iterator::Kind::kDefault)
                           .build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -229,12 +200,6 @@ folly::Future<Status> ShowEdgeIndexStatusExecutor::execute() {
                           .value(Value(std::move(dataSet)))
                           .iter(Iterator::Kind::kDefault)
                           .build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/maintain/FTIndexExecutor.cpp
+++ b/src/graph/executor/maintain/FTIndexExecutor.cpp
@@ -26,12 +26,6 @@ folly::Future<Status> CreateFTIndexExecutor::execute() {
           return resp.status();
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -59,67 +53,51 @@ folly::Future<Status> DropFTIndexExecutor::execute() {
           LOG(WARNING) << "Drop fulltext index '" << inode->getName() << "' failed: " << ftRet;
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
 folly::Future<Status> ShowFTIndexesExecutor::execute() {
   SCOPED_TIMER(&execTime_);
   auto spaceId = qctx()->rctx()->session()->space().id;
-  return qctx()
-      ->getMetaClient()
-      ->listFTIndexes()
-      .via(runner())
-      .thenValue(
-          [this, spaceId](StatusOr<std::unordered_map<std::string, meta::cpp2::FTIndex>> resp) {
-            memory::MemoryCheckGuard guard;
-            if (!resp.ok()) {
-              LOG(WARNING) << "SpaceId: " << spaceId << ", Show fulltext indexes failed"
-                           << resp.status();
-              return resp.status();
-            }
+  return qctx()->getMetaClient()->listFTIndexes().via(runner()).thenValue(
+      [this, spaceId](StatusOr<std::unordered_map<std::string, meta::cpp2::FTIndex>> resp) {
+        memory::MemoryCheckGuard guard;
+        if (!resp.ok()) {
+          LOG(WARNING) << "SpaceId: " << spaceId << ", Show fulltext indexes failed"
+                       << resp.status();
+          return resp.status();
+        }
 
-            auto indexes = std::move(resp).value();
-            DataSet dataSet;
-            dataSet.colNames = {"Name", "Schema Type", "Schema Name", "Fields"};
-            for (auto &index : indexes) {
-              if (index.second.get_space_id() != spaceId) {
-                continue;
-              }
-              auto shmId = index.second.get_depend_schema();
-              auto isEdge = shmId.getType() == nebula::cpp2::SchemaID::Type::edge_type;
-              auto shmNameRet =
-                  isEdge ? this->qctx_->schemaMng()->toEdgeName(spaceId, shmId.get_edge_type())
-                         : this->qctx_->schemaMng()->toTagName(spaceId, shmId.get_tag_id());
-              if (!shmNameRet.ok()) {
-                LOG(WARNING) << "SpaceId: " << spaceId
-                             << ", Get schema name failed: " << shmNameRet.status();
-                return shmNameRet.status();
-              }
-              std::string fields;
-              folly::join(", ", index.second.get_fields(), fields);
-              Row row;
-              row.values.emplace_back(index.first);
-              row.values.emplace_back(isEdge ? "Edge" : "Tag");
-              row.values.emplace_back(std::move(shmNameRet).value());
-              row.values.emplace_back(std::move(fields));
-              dataSet.rows.emplace_back(std::move(row));
-            }
-            return finish(ResultBuilder()
-                              .value(Value(std::move(dataSet)))
-                              .iter(Iterator::Kind::kDefault)
-                              .build());
-          })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
+        auto indexes = std::move(resp).value();
+        DataSet dataSet;
+        dataSet.colNames = {"Name", "Schema Type", "Schema Name", "Fields"};
+        for (auto &index : indexes) {
+          if (index.second.get_space_id() != spaceId) {
+            continue;
+          }
+          auto shmId = index.second.get_depend_schema();
+          auto isEdge = shmId.getType() == nebula::cpp2::SchemaID::Type::edge_type;
+          auto shmNameRet =
+              isEdge ? this->qctx_->schemaMng()->toEdgeName(spaceId, shmId.get_edge_type())
+                     : this->qctx_->schemaMng()->toTagName(spaceId, shmId.get_tag_id());
+          if (!shmNameRet.ok()) {
+            LOG(WARNING) << "SpaceId: " << spaceId
+                         << ", Get schema name failed: " << shmNameRet.status();
+            return shmNameRet.status();
+          }
+          std::string fields;
+          folly::join(", ", index.second.get_fields(), fields);
+          Row row;
+          row.values.emplace_back(index.first);
+          row.values.emplace_back(isEdge ? "Edge" : "Tag");
+          row.values.emplace_back(std::move(shmNameRet).value());
+          row.values.emplace_back(std::move(fields));
+          dataSet.rows.emplace_back(std::move(row));
+        }
+        return finish(ResultBuilder()
+                          .value(Value(std::move(dataSet)))
+                          .iter(Iterator::Kind::kDefault)
+                          .build());
       });
 }
 

--- a/src/graph/executor/maintain/TagExecutor.cpp
+++ b/src/graph/executor/maintain/TagExecutor.cpp
@@ -27,12 +27,6 @@ folly::Future<Status> CreateTagExecutor::execute() {
           return resp.status();
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -60,12 +54,6 @@ folly::Future<Status> DescTagExecutor::execute() {
         }
         return finish(
             ResultBuilder().value(std::move(ret).value()).iter(Iterator::Kind::kDefault).build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -86,12 +74,6 @@ folly::Future<Status> DropTagExecutor::execute() {
           return resp.status();
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -99,11 +81,8 @@ folly::Future<Status> ShowTagsExecutor::execute() {
   SCOPED_TIMER(&execTime_);
 
   auto spaceId = qctx()->rctx()->session()->space().id;
-  return qctx()
-      ->getMetaClient()
-      ->listTagSchemas(spaceId)
-      .via(runner())
-      .thenValue([this, spaceId](StatusOr<std::vector<meta::cpp2::TagItem>> resp) {
+  return qctx()->getMetaClient()->listTagSchemas(spaceId).via(runner()).thenValue(
+      [this, spaceId](StatusOr<std::vector<meta::cpp2::TagItem>> resp) {
         memory::MemoryCheckGuard guard;
         if (!resp.ok()) {
           LOG(WARNING) << "SpaceId: " << spaceId << ", Show tags failed: " << resp.status();
@@ -126,12 +105,6 @@ folly::Future<Status> ShowTagsExecutor::execute() {
                           .value(Value(std::move(dataSet)))
                           .iter(Iterator::Kind::kDefault)
                           .build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -159,12 +132,6 @@ folly::Future<Status> ShowCreateTagExecutor::execute() {
         }
         return finish(
             ResultBuilder().value(std::move(ret).value()).iter(Iterator::Kind::kDefault).build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -185,12 +152,6 @@ folly::Future<Status> AlterTagExecutor::execute() {
           return resp.status();
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 }  // namespace graph

--- a/src/graph/executor/maintain/TagIndexExecutor.cpp
+++ b/src/graph/executor/maintain/TagIndexExecutor.cpp
@@ -34,12 +34,6 @@ folly::Future<Status> CreateTagIndexExecutor::execute() {
           return resp.status();
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -60,12 +54,6 @@ folly::Future<Status> DropTagIndexExecutor::execute() {
           return resp.status();
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -94,12 +82,6 @@ folly::Future<Status> DescTagIndexExecutor::execute() {
         }
         return finish(
             ResultBuilder().value(std::move(ret).value()).iter(Iterator::Kind::kDefault).build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -127,12 +109,6 @@ folly::Future<Status> ShowCreateTagIndexExecutor::execute() {
         }
         return finish(
             ResultBuilder().value(std::move(ret).value()).iter(Iterator::Kind::kDefault).build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -141,11 +117,8 @@ folly::Future<Status> ShowTagIndexesExecutor::execute() {
   auto *iNode = asNode<ShowTagIndexes>(node());
   const auto &bySchema = iNode->name();
   auto spaceId = qctx()->rctx()->session()->space().id;
-  return qctx()
-      ->getMetaClient()
-      ->listTagIndexes(spaceId)
-      .via(runner())
-      .thenValue([this, spaceId, bySchema](StatusOr<std::vector<meta::cpp2::IndexItem>> resp) {
+  return qctx()->getMetaClient()->listTagIndexes(spaceId).via(runner()).thenValue(
+      [this, spaceId, bySchema](StatusOr<std::vector<meta::cpp2::IndexItem>> resp) {
         memory::MemoryCheckGuard guard;
         if (!resp.ok()) {
           LOG(WARNING) << "SpaceId: " << spaceId << ", Show tag indexes failed" << resp.status();
@@ -191,12 +164,6 @@ folly::Future<Status> ShowTagIndexesExecutor::execute() {
                           .value(Value(std::move(dataSet)))
                           .iter(Iterator::Kind::kDefault)
                           .build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -204,11 +171,8 @@ folly::Future<Status> ShowTagIndexStatusExecutor::execute() {
   SCOPED_TIMER(&execTime_);
 
   auto spaceId = qctx()->rctx()->session()->space().id;
-  return qctx()
-      ->getMetaClient()
-      ->listTagIndexStatus(spaceId)
-      .via(runner())
-      .thenValue([this, spaceId](StatusOr<std::vector<meta::cpp2::IndexStatus>> resp) {
+  return qctx()->getMetaClient()->listTagIndexStatus(spaceId).via(runner()).thenValue(
+      [this, spaceId](StatusOr<std::vector<meta::cpp2::IndexStatus>> resp) {
         memory::MemoryCheckGuard guard;
         if (!resp.ok()) {
           LOG(WARNING) << "SpaceId: " << spaceId
@@ -230,12 +194,6 @@ folly::Future<Status> ShowTagIndexStatusExecutor::execute() {
                           .value(Value(std::move(dataSet)))
                           .iter(Iterator::Kind::kDefault)
                           .build());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/mutate/DeleteExecutor.cpp
+++ b/src/graph/executor/mutate/DeleteExecutor.cpp
@@ -73,12 +73,6 @@ folly::Future<Status> DeleteVerticesExecutor::deleteVertices() {
         SCOPED_TIMER(&execTime_);
         NG_RETURN_IF_ERROR(handleCompleteness(resp, false));
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc&) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -135,12 +129,6 @@ folly::Future<Status> DeleteTagsExecutor::deleteTags() {
         SCOPED_TIMER(&execTime_);
         NG_RETURN_IF_ERROR(handleCompleteness(resp, false));
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc&) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -228,12 +216,6 @@ folly::Future<Status> DeleteEdgesExecutor::deleteEdges() {
         SCOPED_TIMER(&execTime_);
         NG_RETURN_IF_ERROR(handleCompleteness(resp, false));
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc&) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 }  // namespace graph

--- a/src/graph/executor/mutate/InsertExecutor.cpp
+++ b/src/graph/executor/mutate/InsertExecutor.cpp
@@ -40,12 +40,6 @@ folly::Future<Status> InsertVerticesExecutor::insertVertices() {
         SCOPED_TIMER(&execTime_);
         NG_RETURN_IF_ERROR(handleCompleteness(resp, false));
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -77,12 +71,6 @@ folly::Future<Status> InsertEdgesExecutor::insertEdges() {
         SCOPED_TIMER(&execTime_);
         NG_RETURN_IF_ERROR(handleCompleteness(resp, false));
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 }  // namespace graph

--- a/src/graph/executor/mutate/UpdateExecutor.cpp
+++ b/src/graph/executor/mutate/UpdateExecutor.cpp
@@ -82,12 +82,6 @@ folly::Future<Status> UpdateVertexExecutor::execute() {
                             .build());
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -140,12 +134,6 @@ folly::Future<Status> UpdateEdgeExecutor::execute() {
                             .build());
         }
         return Status::OK();
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 }  // namespace graph

--- a/src/graph/executor/query/AggregateExecutor.cpp
+++ b/src/graph/executor/query/AggregateExecutor.cpp
@@ -11,6 +11,9 @@ namespace graph {
 
 folly::Future<Status> AggregateExecutor::execute() {
   SCOPED_TIMER(&execTime_);
+  // MemoryTrackerVerified
+  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
+
   auto* agg = asNode<Aggregate>(node());
   auto groupKeys = agg->groupKeys();
   auto groupItems = agg->groupItems();

--- a/src/graph/executor/query/AggregateExecutor.cpp
+++ b/src/graph/executor/query/AggregateExecutor.cpp
@@ -12,8 +12,6 @@ namespace graph {
 folly::Future<Status> AggregateExecutor::execute() {
   SCOPED_TIMER(&execTime_);
   // MemoryTrackerVerified
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
-
   auto* agg = asNode<Aggregate>(node());
   auto groupKeys = agg->groupKeys();
   auto groupItems = agg->groupItems();

--- a/src/graph/executor/query/AppendVerticesExecutor.cpp
+++ b/src/graph/executor/query/AppendVerticesExecutor.cpp
@@ -61,6 +61,7 @@ folly::Future<Status> AppendVerticesExecutor::appendVertices() {
         otherStats_.emplace("total_rpc", folly::sformat("{}(us)", getPropsTime.elapsedInUSec()));
       })
       .thenValue([this](StorageRpcResponse<GetPropResponse> &&rpcResp) {
+        // MemoryTrackerVerified
         memory::MemoryCheckGuard guard;
         SCOPED_TIMER(&execTime_);
         addStats(rpcResp, otherStats_);
@@ -69,12 +70,6 @@ folly::Future<Status> AppendVerticesExecutor::appendVertices() {
         } else {
           return handleRespMultiJobs(std::move(rpcResp));
         }
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/query/DedupExecutor.cpp
+++ b/src/graph/executor/query/DedupExecutor.cpp
@@ -11,7 +11,6 @@ namespace nebula {
 namespace graph {
 folly::Future<Status> DedupExecutor::execute() {
   // MemoryTrackerVerified
-  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
   SCOPED_TIMER(&execTime_);
 
   auto* dedup = asNode<Dedup>(node());

--- a/src/graph/executor/query/DedupExecutor.cpp
+++ b/src/graph/executor/query/DedupExecutor.cpp
@@ -10,7 +10,10 @@
 namespace nebula {
 namespace graph {
 folly::Future<Status> DedupExecutor::execute() {
+  // MemoryTrackerVerified
+  DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
   SCOPED_TIMER(&execTime_);
+
   auto* dedup = asNode<Dedup>(node());
   DCHECK(!dedup->inputVar().empty());
   Result result = ectx_->getResult(dedup->inputVar());

--- a/src/graph/executor/query/FilterExecutor.cpp
+++ b/src/graph/executor/query/FilterExecutor.cpp
@@ -29,11 +29,14 @@ folly::Future<Status> FilterExecutor::execute() {
     ds.rows.reserve(iter->size());
     auto scatter = [this](
                        size_t begin, size_t end, Iterator *tmpIter) mutable -> StatusOr<DataSet> {
+      // MemoryTrackerVerified
+      DCHECK(memory::MemoryTracker::isOn()) << "MemoryTracker is off";
       return handleJob(begin, end, tmpIter);
     };
 
     auto gather =
         [this, result = std::move(ds), kind = iter->kind()](auto &&results) mutable -> Status {
+      // MemoryTrackerVerified
       memory::MemoryCheckGuard guard;
       for (auto &r : results) {
         if (!r.ok()) {

--- a/src/graph/executor/query/GetDstBySrcExecutor.cpp
+++ b/src/graph/executor/query/GetDstBySrcExecutor.cpp
@@ -61,12 +61,6 @@ folly::Future<Status> GetDstBySrcExecutor::execute() {
           otherStats_.emplace(folly::sformat("resp[{}]", i), folly::toPrettyJson(info));
         }
         return handleResponse(resp, this->gd_->colNames());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc&) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/query/GetEdgesExecutor.cpp
+++ b/src/graph/executor/query/GetEdgesExecutor.cpp
@@ -105,12 +105,6 @@ folly::Future<Status> GetEdgesExecutor::getEdges() {
         SCOPED_TIMER(&execTime_);
         addStats(rpcResp, otherStats_);
         return handleResp(std::move(rpcResp), ge->colNames());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/query/GetNeighborsExecutor.cpp
+++ b/src/graph/executor/query/GetNeighborsExecutor.cpp
@@ -75,12 +75,6 @@ folly::Future<Status> GetNeighborsExecutor::execute() {
           otherStats_.emplace(folly::sformat("resp[{}]", i), folly::toPrettyJson(info));
         }
         return handleResponse(resp);
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc&) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/query/GetVerticesExecutor.cpp
+++ b/src/graph/executor/query/GetVerticesExecutor.cpp
@@ -55,12 +55,6 @@ folly::Future<Status> GetVerticesExecutor::getVertices() {
         SCOPED_TIMER(&execTime_);
         addStats(rpcResp, otherStats_);
         return handleResp(std::move(rpcResp), gv->colNames());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/query/IndexScanExecutor.cpp
+++ b/src/graph/executor/query/IndexScanExecutor.cpp
@@ -42,15 +42,10 @@ folly::Future<Status> IndexScanExecutor::indexScan() {
                     lookup->limit(qctx_))
       .via(runner())
       .thenValue([this](StorageRpcResponse<LookupIndexResp> &&rpcResp) {
+        // MemoryTrackerVerified
         memory::MemoryCheckGuard guard;
         addStats(rpcResp, otherStats_);
         return handleResp(std::move(rpcResp));
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/query/ProjectExecutor.cpp
+++ b/src/graph/executor/query/ProjectExecutor.cpp
@@ -11,6 +11,7 @@ namespace nebula {
 namespace graph {
 
 folly::Future<Status> ProjectExecutor::execute() {
+  // throw std::bad_alloc in MemoryCheckGuard verified
   SCOPED_TIMER(&execTime_);
   auto *project = asNode<Project>(node());
   auto iter = ectx_->getResult(project->inputVar()).iter();

--- a/src/graph/executor/query/ScanEdgesExecutor.cpp
+++ b/src/graph/executor/query/ScanEdgesExecutor.cpp
@@ -45,12 +45,6 @@ folly::Future<Status> ScanEdgesExecutor::scanEdges() {
         SCOPED_TIMER(&execTime_);
         addStats(rpcResp, otherStats_);
         return handleResp(std::move(rpcResp), {});
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/query/ScanVerticesExecutor.cpp
+++ b/src/graph/executor/query/ScanVerticesExecutor.cpp
@@ -46,12 +46,6 @@ folly::Future<Status> ScanVerticesExecutor::scanVertices() {
         SCOPED_TIMER(&execTime_);
         addStats(rpcResp, otherStats_);
         return handleResp(std::move(rpcResp), sv->colNames());
-      })
-      .thenError(
-          folly::tag_t<std::bad_alloc>{},
-          [](const std::bad_alloc &) { return folly::makeFuture<Status>(memoryExceededStatus()); })
-      .thenError(folly::tag_t<std::exception>{}, [](const std::exception &e) {
-        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 

--- a/src/graph/executor/test/TestMain.cpp
+++ b/src/graph/executor/test/TestMain.cpp
@@ -19,7 +19,6 @@ int main(int argc, char** argv) {
   // This need the analysis in scheduler so disable it when only test executor
   // itself.
   FLAGS_enable_lifetime_optimize = false;
-  nebula::memory::MemoryCheckGuard guard;
 
   return RUN_ALL_TESTS();
 }

--- a/src/graph/executor/test/TestMain.cpp
+++ b/src/graph/executor/test/TestMain.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "common/base/Base.h"
+#include "common/memory/MemoryTracker.h"
 
 DECLARE_bool(enable_lifetime_optimize);
 
@@ -18,6 +19,7 @@ int main(int argc, char** argv) {
   // This need the analysis in scheduler so disable it when only test executor
   // itself.
   FLAGS_enable_lifetime_optimize = false;
+  nebula::memory::MemoryCheckGuard guard;
 
   return RUN_ALL_TESTS();
 }

--- a/src/graph/executor/test/TestMain.cpp
+++ b/src/graph/executor/test/TestMain.cpp
@@ -7,7 +7,6 @@
 #include <gtest/gtest.h>
 
 #include "common/base/Base.h"
-#include "common/memory/MemoryTracker.h"
 
 DECLARE_bool(enable_lifetime_optimize);
 

--- a/src/graph/service/QueryInstance.cpp
+++ b/src/graph/service/QueryInstance.cpp
@@ -67,7 +67,8 @@ void QueryInstance::execute() {
         .thenError(folly::tag_t<std::exception>{},
                    [this](const std::exception &e) { onError(Status::Error("%s", e.what())); });
   } catch (std::bad_alloc &e) {
-    onError(Executor::memoryExceededStatus());
+    onError(Status::GraphMemoryExceeded(
+        "(%d)", static_cast<int32_t>(nebula::cpp2::ErrorCode::E_GRAPH_MEMORY_EXCEEDED)));
   } catch (std::exception &e) {
     onError(Status::Error("%s", e.what()));
   } catch (...) {
@@ -191,6 +192,8 @@ void QueryInstance::onError(Status status) {
     case Status::Code::kUserNotFound:
     case Status::Code::kListenerNotFound:
     case Status::Code::kSessionNotFound:
+    case Status::Code::kGraphMemoryExceeded:
+    case Status::Code::kStorageMemoryExceeded:
       rctx->resp().errorCode = ErrorCode::E_EXECUTION_ERROR;
       break;
   }

--- a/src/kvstore/listener/test/CMakeLists.txt
+++ b/src/kvstore/listener/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LISTENER_TEST_LIBS
     $<TARGET_OBJECTS:datatypes_obj>
     $<TARGET_OBJECTS:conf_obj>
     $<TARGET_OBJECTS:thread_obj>
+    $<TARGET_OBJECTS:memory_obj>
     $<TARGET_OBJECTS:fs_obj>
     $<TARGET_OBJECTS:file_based_cluster_id_man_obj>
     $<TARGET_OBJECTS:network_obj>

--- a/src/kvstore/raftex/test/CMakeLists.txt
+++ b/src/kvstore/raftex/test/CMakeLists.txt
@@ -14,6 +14,7 @@ set(RAFTEX_TEST_LIBS
     $<TARGET_OBJECTS:datatypes_obj>
     $<TARGET_OBJECTS:wkt_wkb_io_obj>
     $<TARGET_OBJECTS:thread_obj>
+    $<TARGET_OBJECTS:memory_obj>
     $<TARGET_OBJECTS:fs_obj>
     $<TARGET_OBJECTS:network_obj>
     $<TARGET_OBJECTS:thrift_obj>

--- a/src/kvstore/test/CMakeLists.txt
+++ b/src/kvstore/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(KVSTORE_TEST_LIBS
     $<TARGET_OBJECTS:datatypes_obj>
     $<TARGET_OBJECTS:conf_obj>
     $<TARGET_OBJECTS:thread_obj>
+    $<TARGET_OBJECTS:memory_obj>
     $<TARGET_OBJECTS:fs_obj>
     $<TARGET_OBJECTS:file_based_cluster_id_man_obj>
     $<TARGET_OBJECTS:network_obj>

--- a/src/kvstore/wal/test/CMakeLists.txt
+++ b/src/kvstore/wal/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(WAL_TEST_LIBS
     $<TARGET_OBJECTS:datatypes_obj>
     $<TARGET_OBJECTS:base_obj>
     $<TARGET_OBJECTS:thread_obj>
+    $<TARGET_OBJECTS:memory_obj>
     $<TARGET_OBJECTS:fs_obj>
     $<TARGET_OBJECTS:time_obj>
     $<TARGET_OBJECTS:thread_obj>

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -109,4 +109,4 @@ nebula_add_library(
 )
 
 nebula_add_subdirectory(stats)
-#nebula_add_subdirectory(test)
+nebula_add_subdirectory(test)

--- a/src/storage/CMakeLists.txt
+++ b/src/storage/CMakeLists.txt
@@ -109,4 +109,4 @@ nebula_add_library(
 )
 
 nebula_add_subdirectory(stats)
-nebula_add_subdirectory(test)
+#nebula_add_subdirectory(test)

--- a/src/storage/kv/GetProcessor.cpp
+++ b/src/storage/kv/GetProcessor.cpp
@@ -13,53 +13,42 @@ namespace storage {
 ProcessorCounters kGetCounters;
 
 void GetProcessor::process(const cpp2::KVGetRequest& req) {
-  try {
-    CHECK_NOTNULL(env_->kvstore_);
-    GraphSpaceID spaceId = req.get_space_id();
-    bool returnPartly = req.get_return_partly();
+  CHECK_NOTNULL(env_->kvstore_);
+  GraphSpaceID spaceId = req.get_space_id();
+  bool returnPartly = req.get_return_partly();
 
-    std::unordered_map<std::string, std::string> pairs;
-    size_t size = 0;
-    for (auto& part : req.get_parts()) {
-      size += part.second.size();
-    }
-    pairs.reserve(size);
-
-    for (auto& part : req.get_parts()) {
-      auto partId = part.first;
-      auto& keys = part.second;
-      std::vector<std::string> kvKeys;
-      kvKeys.reserve(part.second.size());
-      std::transform(
-          keys.begin(), keys.end(), std::back_inserter(kvKeys), [partId](const auto& key) {
-            return NebulaKeyUtils::kvKey(partId, key);
-          });
-      std::vector<std::string> values;
-      auto ret = env_->kvstore_->multiGet(spaceId, partId, kvKeys, &values);
-      if ((ret.first == nebula::cpp2::ErrorCode::SUCCEEDED) ||
-          (ret.first == nebula::cpp2::ErrorCode::E_PARTIAL_RESULT && returnPartly)) {
-        auto& status = ret.second;
-        for (size_t i = 0; i < kvKeys.size(); i++) {
-          if (status[i].ok()) {
-            pairs.emplace(keys[i], values[i]);
-          }
-        }
-      } else {
-        handleErrorCode(ret.first, spaceId, partId);
-      }
-    }
-
-    resp_.key_values_ref() = std::move(pairs);
-    this->onFinished();
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  std::unordered_map<std::string, std::string> pairs;
+  size_t size = 0;
+  for (auto& part : req.get_parts()) {
+    size += part.second.size();
   }
+  pairs.reserve(size);
+
+  for (auto& part : req.get_parts()) {
+    auto partId = part.first;
+    auto& keys = part.second;
+    std::vector<std::string> kvKeys;
+    kvKeys.reserve(part.second.size());
+    std::transform(keys.begin(), keys.end(), std::back_inserter(kvKeys), [partId](const auto& key) {
+      return NebulaKeyUtils::kvKey(partId, key);
+    });
+    std::vector<std::string> values;
+    auto ret = env_->kvstore_->multiGet(spaceId, partId, kvKeys, &values);
+    if ((ret.first == nebula::cpp2::ErrorCode::SUCCEEDED) ||
+        (ret.first == nebula::cpp2::ErrorCode::E_PARTIAL_RESULT && returnPartly)) {
+      auto& status = ret.second;
+      for (size_t i = 0; i < kvKeys.size(); i++) {
+        if (status[i].ok()) {
+          pairs.emplace(keys[i], values[i]);
+        }
+      }
+    } else {
+      handleErrorCode(ret.first, spaceId, partId);
+    }
+  }
+
+  resp_.key_values_ref() = std::move(pairs);
+  this->onFinished();
 }
 
 }  // namespace storage

--- a/src/storage/kv/PutProcessor.cpp
+++ b/src/storage/kv/PutProcessor.cpp
@@ -13,29 +13,19 @@ namespace storage {
 ProcessorCounters kPutCounters;
 
 void PutProcessor::process(const cpp2::KVPutRequest& req) {
-  try {
-    CHECK_NOTNULL(env_->kvstore_);
-    const auto& pairs = req.get_parts();
-    auto space = req.get_space_id();
-    callingNum_ = pairs.size();
+  CHECK_NOTNULL(env_->kvstore_);
+  const auto& pairs = req.get_parts();
+  auto space = req.get_space_id();
+  callingNum_ = pairs.size();
 
-    std::for_each(pairs.begin(), pairs.end(), [&](auto& value) {
-      auto part = value.first;
-      std::vector<kvstore::KV> data;
-      for (auto& pair : value.second) {
-        data.emplace_back(std::move(NebulaKeyUtils::kvKey(part, pair.key)), std::move(pair.value));
-      }
-      doPut(space, part, std::move(data));
-    });
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
-  }
+  std::for_each(pairs.begin(), pairs.end(), [&](auto& value) {
+    auto part = value.first;
+    std::vector<kvstore::KV> data;
+    for (auto& pair : value.second) {
+      data.emplace_back(std::move(NebulaKeyUtils::kvKey(part, pair.key)), std::move(pair.value));
+    }
+    doPut(space, part, std::move(data));
+  });
 }
 
 }  // namespace storage

--- a/src/storage/kv/RemoveProcessor.cpp
+++ b/src/storage/kv/RemoveProcessor.cpp
@@ -13,29 +13,19 @@ namespace storage {
 ProcessorCounters kRemoveCounters;
 
 void RemoveProcessor::process(const cpp2::KVRemoveRequest& req) {
-  try {
-    CHECK_NOTNULL(env_->kvstore_);
-    const auto& pairs = req.get_parts();
-    auto space = req.get_space_id();
-    callingNum_ = pairs.size();
+  CHECK_NOTNULL(env_->kvstore_);
+  const auto& pairs = req.get_parts();
+  auto space = req.get_space_id();
+  callingNum_ = pairs.size();
 
-    std::for_each(pairs.begin(), pairs.end(), [&](auto& value) {
-      auto part = value.first;
-      std::vector<std::string> keys;
-      for (auto& key : value.second) {
-        keys.emplace_back(std::move(NebulaKeyUtils::kvKey(part, key)));
-      }
-      doRemove(space, part, std::move(keys));
-    });
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
-  }
+  std::for_each(pairs.begin(), pairs.end(), [&](auto& value) {
+    auto part = value.first;
+    std::vector<std::string> keys;
+    for (auto& key : value.second) {
+      keys.emplace_back(std::move(NebulaKeyUtils::kvKey(part, key)));
+    }
+    doRemove(space, part, std::move(keys));
+  });
 }
 
 }  // namespace storage

--- a/src/storage/mutate/AddEdgesProcessor.cpp
+++ b/src/storage/mutate/AddEdgesProcessor.cpp
@@ -21,53 +21,43 @@ namespace storage {
 ProcessorCounters kAddEdgesCounters;
 
 void AddEdgesProcessor::process(const cpp2::AddEdgesRequest& req) {
-  try {
-    spaceId_ = req.get_space_id();
-    ifNotExists_ = req.get_if_not_exists();
-    const auto& partEdges = req.get_parts();
+  spaceId_ = req.get_space_id();
+  ifNotExists_ = req.get_if_not_exists();
+  const auto& partEdges = req.get_parts();
 
-    CHECK_NOTNULL(env_->schemaMan_);
-    auto ret = env_->schemaMan_->getSpaceVidLen(spaceId_);
-    if (!ret.ok()) {
-      LOG(ERROR) << ret.status();
-      for (auto& part : partEdges) {
-        pushResultCode(nebula::cpp2::ErrorCode::E_INVALID_SPACEVIDLEN, part.first);
-      }
-      onFinished();
-      return;
+  CHECK_NOTNULL(env_->schemaMan_);
+  auto ret = env_->schemaMan_->getSpaceVidLen(spaceId_);
+  if (!ret.ok()) {
+    LOG(ERROR) << ret.status();
+    for (auto& part : partEdges) {
+      pushResultCode(nebula::cpp2::ErrorCode::E_INVALID_SPACEVIDLEN, part.first);
     }
+    onFinished();
+    return;
+  }
 
-    spaceVidLen_ = ret.value();
-    callingNum_ = partEdges.size();
+  spaceVidLen_ = ret.value();
+  callingNum_ = partEdges.size();
 
-    CHECK_NOTNULL(env_->indexMan_);
-    auto iRet = env_->indexMan_->getEdgeIndexes(spaceId_);
-    if (!iRet.ok()) {
-      LOG(ERROR) << iRet.status();
-      for (auto& part : partEdges) {
-        pushResultCode(nebula::cpp2::ErrorCode::E_SPACE_NOT_FOUND, part.first);
-      }
-      onFinished();
-      return;
+  CHECK_NOTNULL(env_->indexMan_);
+  auto iRet = env_->indexMan_->getEdgeIndexes(spaceId_);
+  if (!iRet.ok()) {
+    LOG(ERROR) << iRet.status();
+    for (auto& part : partEdges) {
+      pushResultCode(nebula::cpp2::ErrorCode::E_SPACE_NOT_FOUND, part.first);
     }
-    indexes_ = std::move(iRet).value();
-    ignoreExistedIndex_ = req.get_ignore_existed_index();
+    onFinished();
+    return;
+  }
+  indexes_ = std::move(iRet).value();
+  ignoreExistedIndex_ = req.get_ignore_existed_index();
 
-    CHECK_NOTNULL(env_->kvstore_);
+  CHECK_NOTNULL(env_->kvstore_);
 
-    if (indexes_.empty()) {
-      doProcess(req);
-    } else {
-      doProcessWithIndex(req);
-    }
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  if (indexes_.empty()) {
+    doProcess(req);
+  } else {
+    doProcessWithIndex(req);
   }
 }
 

--- a/src/storage/mutate/DeleteEdgesProcessor.cpp
+++ b/src/storage/mutate/DeleteEdgesProcessor.cpp
@@ -20,153 +20,140 @@ namespace storage {
 ProcessorCounters kDelEdgesCounters;
 
 void DeleteEdgesProcessor::process(const cpp2::DeleteEdgesRequest& req) {
-  try {
-    spaceId_ = req.get_space_id();
-    const auto& partEdges = req.get_parts();
+  spaceId_ = req.get_space_id();
+  const auto& partEdges = req.get_parts();
 
-    CHECK_NOTNULL(env_->schemaMan_);
-    auto ret = env_->schemaMan_->getSpaceVidLen(spaceId_);
-    if (!ret.ok()) {
-      LOG(ERROR) << ret.status();
-      for (auto& part : partEdges) {
-        pushResultCode(nebula::cpp2::ErrorCode::E_INVALID_SPACEVIDLEN, part.first);
-      }
-      onFinished();
-      return;
+  CHECK_NOTNULL(env_->schemaMan_);
+  auto ret = env_->schemaMan_->getSpaceVidLen(spaceId_);
+  if (!ret.ok()) {
+    LOG(ERROR) << ret.status();
+    for (auto& part : partEdges) {
+      pushResultCode(nebula::cpp2::ErrorCode::E_INVALID_SPACEVIDLEN, part.first);
     }
-    spaceVidLen_ = ret.value();
-    callingNum_ = partEdges.size();
+    onFinished();
+    return;
+  }
+  spaceVidLen_ = ret.value();
+  callingNum_ = partEdges.size();
 
-    CHECK_NOTNULL(env_->indexMan_);
-    auto iRet = env_->indexMan_->getEdgeIndexes(spaceId_);
-    if (!iRet.ok()) {
-      LOG(ERROR) << iRet.status();
-      for (auto& part : partEdges) {
-        pushResultCode(nebula::cpp2::ErrorCode::E_SPACE_NOT_FOUND, part.first);
-      }
-      onFinished();
-      return;
+  CHECK_NOTNULL(env_->indexMan_);
+  auto iRet = env_->indexMan_->getEdgeIndexes(spaceId_);
+  if (!iRet.ok()) {
+    LOG(ERROR) << iRet.status();
+    for (auto& part : partEdges) {
+      pushResultCode(nebula::cpp2::ErrorCode::E_SPACE_NOT_FOUND, part.first);
     }
-    indexes_ = std::move(iRet).value();
+    onFinished();
+    return;
+  }
+  indexes_ = std::move(iRet).value();
 
-    CHECK_NOTNULL(env_->kvstore_);
-    if (indexes_.empty()) {
-      // Operate every part, the graph layer guarantees the unique of the edgeKey
-      for (auto& part : partEdges) {
-        std::vector<std::string> keys;
-        keys.reserve(32);
-        auto partId = part.first;
-        auto code = nebula::cpp2::ErrorCode::SUCCEEDED;
-        for (auto& edgeKey : part.second) {
-          if (!NebulaKeyUtils::isValidVidLen(
-                  spaceVidLen_, edgeKey.src_ref()->getStr(), edgeKey.dst_ref()->getStr())) {
-            LOG(ERROR) << "Space " << spaceId_ << " vertex length invalid, "
-                       << "space vid len: " << spaceVidLen_
-                       << ", edge srcVid: " << *edgeKey.src_ref()
-                       << " dstVid: " << *edgeKey.dst_ref();
-            code = nebula::cpp2::ErrorCode::E_INVALID_VID;
-            break;
-          }
-          // todo(doodle): delete lock in toss
-          auto edge = NebulaKeyUtils::edgeKey(spaceVidLen_,
-                                              partId,
-                                              edgeKey.src_ref()->getStr(),
-                                              *edgeKey.edge_type_ref(),
-                                              *edgeKey.ranking_ref(),
-                                              edgeKey.dst_ref()->getStr());
-          keys.emplace_back(edge.data(), edge.size());
+  CHECK_NOTNULL(env_->kvstore_);
+  if (indexes_.empty()) {
+    // Operate every part, the graph layer guarantees the unique of the edgeKey
+    for (auto& part : partEdges) {
+      std::vector<std::string> keys;
+      keys.reserve(32);
+      auto partId = part.first;
+      auto code = nebula::cpp2::ErrorCode::SUCCEEDED;
+      for (auto& edgeKey : part.second) {
+        if (!NebulaKeyUtils::isValidVidLen(
+                spaceVidLen_, edgeKey.src_ref()->getStr(), edgeKey.dst_ref()->getStr())) {
+          LOG(ERROR) << "Space " << spaceId_ << " vertex length invalid, "
+                     << "space vid len: " << spaceVidLen_ << ", edge srcVid: " << *edgeKey.src_ref()
+                     << " dstVid: " << *edgeKey.dst_ref();
+          code = nebula::cpp2::ErrorCode::E_INVALID_VID;
+          break;
         }
-        if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
-          handleAsync(spaceId_, partId, code);
-          continue;
-        }
-
-        HookFuncPara para;
-        if (tossHookFunc_) {
-          para.keys.emplace(&keys);
-          (*tossHookFunc_)(para);
-        }
-        if (para.result) {
-          env_->kvstore_->asyncAppendBatch(
-              spaceId_,
-              partId,
-              std::move(para.result.value()),
-              [partId, this](nebula::cpp2::ErrorCode rc) { handleAsync(spaceId_, partId, rc); });
-        } else {
-          doRemove(spaceId_, partId, std::move(keys));
-          stats::StatsManager::addValue(kNumEdgesDeleted, keys.size());
-        }
+        // todo(doodle): delete lock in toss
+        auto edge = NebulaKeyUtils::edgeKey(spaceVidLen_,
+                                            partId,
+                                            edgeKey.src_ref()->getStr(),
+                                            *edgeKey.edge_type_ref(),
+                                            *edgeKey.ranking_ref(),
+                                            edgeKey.dst_ref()->getStr());
+        keys.emplace_back(edge.data(), edge.size());
       }
-    } else {
-      for (auto& part : partEdges) {
-        IndexCountWrapper wrapper(env_);
-        auto partId = part.first;
-        std::vector<EMLI> dummyLock;
-        dummyLock.reserve(part.second.size());
+      if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
+        handleAsync(spaceId_, partId, code);
+        continue;
+      }
 
-        nebula::cpp2::ErrorCode err = nebula::cpp2::ErrorCode::SUCCEEDED;
-        for (const auto& edgeKey : part.second) {
-          if (!NebulaKeyUtils::isValidVidLen(
-                  spaceVidLen_, edgeKey.src_ref()->getStr(), edgeKey.dst_ref()->getStr())) {
-            LOG(ERROR) << "Space " << spaceId_ << " vertex length invalid, "
-                       << "space vid len: " << spaceVidLen_
-                       << ", edge srcVid: " << *edgeKey.src_ref()
-                       << " dstVid: " << *edgeKey.dst_ref();
-            err = nebula::cpp2::ErrorCode::E_INVALID_VID;
-            break;
-          }
-          auto l = std::make_tuple(spaceId_,
-                                   partId,
-                                   edgeKey.src_ref()->getStr(),
-                                   *edgeKey.edge_type_ref(),
-                                   *edgeKey.ranking_ref(),
-                                   edgeKey.dst_ref()->getStr());
-          if (std::find(dummyLock.begin(), dummyLock.end(), l) == dummyLock.end()) {
-            if (!env_->edgesML_->try_lock(l)) {
-              LOG(ERROR) << folly::sformat("The edge locked : src {}, type {}, tank {}, dst {}",
-                                           edgeKey.src_ref()->getStr(),
-                                           *edgeKey.edge_type_ref(),
-                                           *edgeKey.ranking_ref(),
-                                           edgeKey.dst_ref()->getStr());
-              err = nebula::cpp2::ErrorCode::E_DATA_CONFLICT_ERROR;
-              break;
-            }
-            dummyLock.emplace_back(std::move(l));
-          }
-        }
-        if (err != nebula::cpp2::ErrorCode::SUCCEEDED) {
-          env_->edgesML_->unlockBatch(dummyLock);
-          handleAsync(spaceId_, partId, err);
-          continue;
-        }
-        auto batch = deleteEdges(partId, std::move(part.second));
-        if (!nebula::ok(batch)) {
-          env_->edgesML_->unlockBatch(dummyLock);
-          handleAsync(spaceId_, partId, nebula::error(batch));
-          continue;
-        }
-        DCHECK(!nebula::value(batch).empty());
-        nebula::MemoryLockGuard<EMLI> lg(env_->edgesML_.get(), std::move(dummyLock), false, false);
+      HookFuncPara para;
+      if (tossHookFunc_) {
+        para.keys.emplace(&keys);
+        (*tossHookFunc_)(para);
+      }
+      if (para.result) {
         env_->kvstore_->asyncAppendBatch(
             spaceId_,
             partId,
-            std::move(nebula::value(batch)),
-            [l = std::move(lg), icw = std::move(wrapper), partId, this](
-                nebula::cpp2::ErrorCode code) {
-              UNUSED(l);
-              UNUSED(icw);
-              handleAsync(spaceId_, partId, code);
-            });
+            std::move(para.result.value()),
+            [partId, this](nebula::cpp2::ErrorCode rc) { handleAsync(spaceId_, partId, rc); });
+      } else {
+        doRemove(spaceId_, partId, std::move(keys));
+        stats::StatsManager::addValue(kNumEdgesDeleted, keys.size());
       }
     }
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  } else {
+    for (auto& part : partEdges) {
+      IndexCountWrapper wrapper(env_);
+      auto partId = part.first;
+      std::vector<EMLI> dummyLock;
+      dummyLock.reserve(part.second.size());
+
+      nebula::cpp2::ErrorCode err = nebula::cpp2::ErrorCode::SUCCEEDED;
+      for (const auto& edgeKey : part.second) {
+        if (!NebulaKeyUtils::isValidVidLen(
+                spaceVidLen_, edgeKey.src_ref()->getStr(), edgeKey.dst_ref()->getStr())) {
+          LOG(ERROR) << "Space " << spaceId_ << " vertex length invalid, "
+                     << "space vid len: " << spaceVidLen_ << ", edge srcVid: " << *edgeKey.src_ref()
+                     << " dstVid: " << *edgeKey.dst_ref();
+          err = nebula::cpp2::ErrorCode::E_INVALID_VID;
+          break;
+        }
+        auto l = std::make_tuple(spaceId_,
+                                 partId,
+                                 edgeKey.src_ref()->getStr(),
+                                 *edgeKey.edge_type_ref(),
+                                 *edgeKey.ranking_ref(),
+                                 edgeKey.dst_ref()->getStr());
+        if (std::find(dummyLock.begin(), dummyLock.end(), l) == dummyLock.end()) {
+          if (!env_->edgesML_->try_lock(l)) {
+            LOG(ERROR) << folly::sformat("The edge locked : src {}, type {}, tank {}, dst {}",
+                                         edgeKey.src_ref()->getStr(),
+                                         *edgeKey.edge_type_ref(),
+                                         *edgeKey.ranking_ref(),
+                                         edgeKey.dst_ref()->getStr());
+            err = nebula::cpp2::ErrorCode::E_DATA_CONFLICT_ERROR;
+            break;
+          }
+          dummyLock.emplace_back(std::move(l));
+        }
+      }
+      if (err != nebula::cpp2::ErrorCode::SUCCEEDED) {
+        env_->edgesML_->unlockBatch(dummyLock);
+        handleAsync(spaceId_, partId, err);
+        continue;
+      }
+      auto batch = deleteEdges(partId, std::move(part.second));
+      if (!nebula::ok(batch)) {
+        env_->edgesML_->unlockBatch(dummyLock);
+        handleAsync(spaceId_, partId, nebula::error(batch));
+        continue;
+      }
+      DCHECK(!nebula::value(batch).empty());
+      nebula::MemoryLockGuard<EMLI> lg(env_->edgesML_.get(), std::move(dummyLock), false, false);
+      env_->kvstore_->asyncAppendBatch(spaceId_,
+                                       partId,
+                                       std::move(nebula::value(batch)),
+                                       [l = std::move(lg), icw = std::move(wrapper), partId, this](
+                                           nebula::cpp2::ErrorCode code) {
+                                         UNUSED(l);
+                                         UNUSED(icw);
+                                         handleAsync(spaceId_, partId, code);
+                                       });
+    }
   }
 }
 

--- a/src/storage/mutate/DeleteTagsProcessor.cpp
+++ b/src/storage/mutate/DeleteTagsProcessor.cpp
@@ -18,87 +18,76 @@ namespace storage {
 ProcessorCounters kDelTagsCounters;
 
 void DeleteTagsProcessor::process(const cpp2::DeleteTagsRequest& req) {
-  try {
-    spaceId_ = req.get_space_id();
-    const auto& parts = req.get_parts();
+  spaceId_ = req.get_space_id();
+  const auto& parts = req.get_parts();
 
-    CHECK_NOTNULL(env_->schemaMan_);
-    auto ret = env_->schemaMan_->getSpaceVidLen(spaceId_);
-    if (!ret.ok()) {
-      LOG(ERROR) << ret.status();
-      for (auto& part : parts) {
-        pushResultCode(nebula::cpp2::ErrorCode::E_INVALID_SPACEVIDLEN, part.first);
-      }
-      onFinished();
-      return;
+  CHECK_NOTNULL(env_->schemaMan_);
+  auto ret = env_->schemaMan_->getSpaceVidLen(spaceId_);
+  if (!ret.ok()) {
+    LOG(ERROR) << ret.status();
+    for (auto& part : parts) {
+      pushResultCode(nebula::cpp2::ErrorCode::E_INVALID_SPACEVIDLEN, part.first);
     }
-    spaceVidLen_ = ret.value();
-    callingNum_ = parts.size();
+    onFinished();
+    return;
+  }
+  spaceVidLen_ = ret.value();
+  callingNum_ = parts.size();
 
-    CHECK_NOTNULL(env_->indexMan_);
-    auto iRet = env_->indexMan_->getTagIndexes(spaceId_);
-    if (!iRet.ok()) {
-      LOG(ERROR) << iRet.status();
-      for (auto& part : parts) {
-        pushResultCode(nebula::cpp2::ErrorCode::E_SPACE_NOT_FOUND, part.first);
-      }
-      onFinished();
-      return;
+  CHECK_NOTNULL(env_->indexMan_);
+  auto iRet = env_->indexMan_->getTagIndexes(spaceId_);
+  if (!iRet.ok()) {
+    LOG(ERROR) << iRet.status();
+    for (auto& part : parts) {
+      pushResultCode(nebula::cpp2::ErrorCode::E_SPACE_NOT_FOUND, part.first);
     }
-    indexes_ = std::move(iRet).value();
+    onFinished();
+    return;
+  }
+  indexes_ = std::move(iRet).value();
 
-    CHECK_NOTNULL(env_->kvstore_);
-    if (indexes_.empty()) {
-      std::vector<std::string> keys;
-      keys.reserve(32);
-      for (const auto& part : parts) {
-        auto partId = part.first;
-        const auto& delTags = part.second;
-        keys.clear();
-        for (const auto& entry : delTags) {
-          const auto& vId = entry.get_id().getStr();
-          for (const auto& tagId : entry.get_tags()) {
-            auto key = NebulaKeyUtils::tagKey(spaceVidLen_, partId, vId, tagId);
-            keys.emplace_back(std::move(key));
-          }
+  CHECK_NOTNULL(env_->kvstore_);
+  if (indexes_.empty()) {
+    std::vector<std::string> keys;
+    keys.reserve(32);
+    for (const auto& part : parts) {
+      auto partId = part.first;
+      const auto& delTags = part.second;
+      keys.clear();
+      for (const auto& entry : delTags) {
+        const auto& vId = entry.get_id().getStr();
+        for (const auto& tagId : entry.get_tags()) {
+          auto key = NebulaKeyUtils::tagKey(spaceVidLen_, partId, vId, tagId);
+          keys.emplace_back(std::move(key));
         }
-        doRemove(spaceId_, partId, std::move(keys));
-        stats::StatsManager::addValue(kNumTagsDeleted, keys.size());
       }
-    } else {
-      for (const auto& part : parts) {
-        IndexCountWrapper wrapper(env_);
-        auto partId = part.first;
-        std::vector<VMLI> lockedKeys;
-        auto batch = deleteTags(partId, part.second, lockedKeys);
-        if (!nebula::ok(batch)) {
-          env_->verticesML_->unlockBatch(lockedKeys);
-          handleAsync(spaceId_, partId, nebula::error(batch));
-          continue;
-        }
-        // keys has been locked in deleteTags
-        nebula::MemoryLockGuard<VMLI> lg(
-            env_->verticesML_.get(), std::move(lockedKeys), false, false);
-        env_->kvstore_->asyncAppendBatch(
-            spaceId_,
-            partId,
-            std::move(nebula::value(batch)),
-            [l = std::move(lg), icw = std::move(wrapper), partId, this](
-                nebula::cpp2::ErrorCode code) {
-              UNUSED(l);
-              UNUSED(icw);
-              handleAsync(spaceId_, partId, code);
-            });
-      }
+      doRemove(spaceId_, partId, std::move(keys));
+      stats::StatsManager::addValue(kNumTagsDeleted, keys.size());
     }
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  } else {
+    for (const auto& part : parts) {
+      IndexCountWrapper wrapper(env_);
+      auto partId = part.first;
+      std::vector<VMLI> lockedKeys;
+      auto batch = deleteTags(partId, part.second, lockedKeys);
+      if (!nebula::ok(batch)) {
+        env_->verticesML_->unlockBatch(lockedKeys);
+        handleAsync(spaceId_, partId, nebula::error(batch));
+        continue;
+      }
+      // keys has been locked in deleteTags
+      nebula::MemoryLockGuard<VMLI> lg(
+          env_->verticesML_.get(), std::move(lockedKeys), false, false);
+      env_->kvstore_->asyncAppendBatch(spaceId_,
+                                       partId,
+                                       std::move(nebula::value(batch)),
+                                       [l = std::move(lg), icw = std::move(wrapper), partId, this](
+                                           nebula::cpp2::ErrorCode code) {
+                                         UNUSED(l);
+                                         UNUSED(icw);
+                                         handleAsync(spaceId_, partId, code);
+                                       });
+    }
   }
 }
 

--- a/src/storage/mutate/DeleteVerticesProcessor.cpp
+++ b/src/storage/mutate/DeleteVerticesProcessor.cpp
@@ -17,107 +17,95 @@ namespace storage {
 ProcessorCounters kDelVerticesCounters;
 
 void DeleteVerticesProcessor::process(const cpp2::DeleteVerticesRequest& req) {
-  try {
-    spaceId_ = req.get_space_id();
-    const auto& partVertices = req.get_parts();
+  spaceId_ = req.get_space_id();
+  const auto& partVertices = req.get_parts();
 
-    CHECK_NOTNULL(env_->schemaMan_);
-    auto ret = env_->schemaMan_->getSpaceVidLen(spaceId_);
-    if (!ret.ok()) {
-      LOG(ERROR) << ret.status();
-      for (auto& part : partVertices) {
-        pushResultCode(nebula::cpp2::ErrorCode::E_INVALID_SPACEVIDLEN, part.first);
-      }
-      onFinished();
-      return;
+  CHECK_NOTNULL(env_->schemaMan_);
+  auto ret = env_->schemaMan_->getSpaceVidLen(spaceId_);
+  if (!ret.ok()) {
+    LOG(ERROR) << ret.status();
+    for (auto& part : partVertices) {
+      pushResultCode(nebula::cpp2::ErrorCode::E_INVALID_SPACEVIDLEN, part.first);
     }
-    spaceVidLen_ = ret.value();
-    callingNum_ = partVertices.size();
+    onFinished();
+    return;
+  }
+  spaceVidLen_ = ret.value();
+  callingNum_ = partVertices.size();
 
-    CHECK_NOTNULL(env_->indexMan_);
-    auto iRet = env_->indexMan_->getTagIndexes(spaceId_);
-    if (!iRet.ok()) {
-      LOG(ERROR) << iRet.status();
-      for (auto& part : partVertices) {
-        pushResultCode(nebula::cpp2::ErrorCode::E_SPACE_NOT_FOUND, part.first);
-      }
-      onFinished();
-      return;
+  CHECK_NOTNULL(env_->indexMan_);
+  auto iRet = env_->indexMan_->getTagIndexes(spaceId_);
+  if (!iRet.ok()) {
+    LOG(ERROR) << iRet.status();
+    for (auto& part : partVertices) {
+      pushResultCode(nebula::cpp2::ErrorCode::E_SPACE_NOT_FOUND, part.first);
     }
-    indexes_ = std::move(iRet).value();
+    onFinished();
+    return;
+  }
+  indexes_ = std::move(iRet).value();
 
-    CHECK_NOTNULL(env_->kvstore_);
-    if (indexes_.empty()) {
-      // Operate every part, the graph layer guarantees the unique of the vid
-      std::vector<std::string> keys;
-      keys.reserve(32);
-      for (auto& part : partVertices) {
-        auto partId = part.first;
-        const auto& vertexIds = part.second;
-        keys.clear();
-        auto code = nebula::cpp2::ErrorCode::SUCCEEDED;
-        for (auto& vid : vertexIds) {
-          if (!NebulaKeyUtils::isValidVidLen(spaceVidLen_, vid.getStr())) {
-            LOG(ERROR) << "Space " << spaceId_ << ", vertex length invalid, "
-                       << " space vid len: " << spaceVidLen_ << ",  vid is " << vid;
-            code = nebula::cpp2::ErrorCode::E_INVALID_VID;
-            break;
-          }
-          keys.emplace_back(NebulaKeyUtils::vertexKey(spaceVidLen_, partId, vid.getStr()));
-          auto prefix = NebulaKeyUtils::tagPrefix(spaceVidLen_, partId, vid.getStr());
-          std::unique_ptr<kvstore::KVIterator> iter;
-          code = env_->kvstore_->prefix(spaceId_, partId, prefix, &iter);
-          if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
-            VLOG(3) << "Error! ret = " << static_cast<int32_t>(code) << ", spaceID " << spaceId_;
-            break;
-          }
-          while (iter->valid()) {
-            auto key = iter->key();
-            keys.emplace_back(key.str());
-            iter->next();
-          }
+  CHECK_NOTNULL(env_->kvstore_);
+  if (indexes_.empty()) {
+    // Operate every part, the graph layer guarantees the unique of the vid
+    std::vector<std::string> keys;
+    keys.reserve(32);
+    for (auto& part : partVertices) {
+      auto partId = part.first;
+      const auto& vertexIds = part.second;
+      keys.clear();
+      auto code = nebula::cpp2::ErrorCode::SUCCEEDED;
+      for (auto& vid : vertexIds) {
+        if (!NebulaKeyUtils::isValidVidLen(spaceVidLen_, vid.getStr())) {
+          LOG(ERROR) << "Space " << spaceId_ << ", vertex length invalid, "
+                     << " space vid len: " << spaceVidLen_ << ",  vid is " << vid;
+          code = nebula::cpp2::ErrorCode::E_INVALID_VID;
+          break;
         }
+        keys.emplace_back(NebulaKeyUtils::vertexKey(spaceVidLen_, partId, vid.getStr()));
+        auto prefix = NebulaKeyUtils::tagPrefix(spaceVidLen_, partId, vid.getStr());
+        std::unique_ptr<kvstore::KVIterator> iter;
+        code = env_->kvstore_->prefix(spaceId_, partId, prefix, &iter);
         if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
-          handleAsync(spaceId_, partId, code);
-          continue;
+          VLOG(3) << "Error! ret = " << static_cast<int32_t>(code) << ", spaceID " << spaceId_;
+          break;
         }
-        doRemove(spaceId_, partId, std::move(keys));
-        stats::StatsManager::addValue(kNumVerticesDeleted, keys.size());
-      }
-    } else {
-      for (auto& pv : partVertices) {
-        IndexCountWrapper wrapper(env_);
-        auto partId = pv.first;
-        std::vector<VMLI> dummyLock;
-        auto batch = deleteVertices(partId, std::move(pv).second, dummyLock);
-        if (!nebula::ok(batch)) {
-          env_->verticesML_->unlockBatch(dummyLock);
-          handleAsync(spaceId_, partId, nebula::error(batch));
-          continue;
+        while (iter->valid()) {
+          auto key = iter->key();
+          keys.emplace_back(key.str());
+          iter->next();
         }
-        DCHECK(!nebula::value(batch).empty());
-        nebula::MemoryLockGuard<VMLI> lg(
-            env_->verticesML_.get(), std::move(dummyLock), false, false);
-        env_->kvstore_->asyncAppendBatch(
-            spaceId_,
-            partId,
-            std::move(nebula::value(batch)),
-            [l = std::move(lg), icw = std::move(wrapper), partId, this](
-                nebula::cpp2::ErrorCode code) {
-              UNUSED(l);
-              UNUSED(icw);
-              handleAsync(spaceId_, partId, code);
-            });
       }
+      if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
+        handleAsync(spaceId_, partId, code);
+        continue;
+      }
+      doRemove(spaceId_, partId, std::move(keys));
+      stats::StatsManager::addValue(kNumVerticesDeleted, keys.size());
     }
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  } else {
+    for (auto& pv : partVertices) {
+      IndexCountWrapper wrapper(env_);
+      auto partId = pv.first;
+      std::vector<VMLI> dummyLock;
+      auto batch = deleteVertices(partId, std::move(pv).second, dummyLock);
+      if (!nebula::ok(batch)) {
+        env_->verticesML_->unlockBatch(dummyLock);
+        handleAsync(spaceId_, partId, nebula::error(batch));
+        continue;
+      }
+      DCHECK(!nebula::value(batch).empty());
+      nebula::MemoryLockGuard<VMLI> lg(env_->verticesML_.get(), std::move(dummyLock), false, false);
+      env_->kvstore_->asyncAppendBatch(spaceId_,
+                                       partId,
+                                       std::move(nebula::value(batch)),
+                                       [l = std::move(lg), icw = std::move(wrapper), partId, this](
+                                           nebula::cpp2::ErrorCode code) {
+                                         UNUSED(l);
+                                         UNUSED(icw);
+                                         handleAsync(spaceId_, partId, code);
+                                       });
+    }
   }
 }
 

--- a/src/storage/mutate/UpdateEdgeProcessor.cpp
+++ b/src/storage/mutate/UpdateEdgeProcessor.cpp
@@ -19,23 +19,11 @@ namespace storage {
 ProcessorCounters kUpdateEdgeCounters;
 
 void UpdateEdgeProcessor::process(const cpp2::UpdateEdgeRequest& req) {
-  try {
-    if (executor_ != nullptr) {
-      executor_->add([req, this]() {
-        memory::MemoryCheckGuard guard;
-        this->doProcess(req);
-      });
-    } else {
-      doProcess(req);
-    }
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  if (executor_ != nullptr) {
+    executor_->add(
+        [this, req]() { MemoryCheckScope wrapper(this, [this, req] { this->doProcess(req); }); });
+  } else {
+    doProcess(req);
   }
 }
 

--- a/src/storage/query/GetDstBySrcProcessor.cpp
+++ b/src/storage/query/GetDstBySrcProcessor.cpp
@@ -21,20 +21,11 @@ namespace storage {
 ProcessorCounters kGetDstBySrcCounters;
 
 void GetDstBySrcProcessor::process(const cpp2::GetDstBySrcRequest& req) {
-  try {
-    if (executor_ != nullptr) {
-      executor_->add([req, this]() { this->doProcess(req); });
-    } else {
-      doProcess(req);
-    }
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  if (executor_ != nullptr) {
+    executor_->add(
+        [this, req]() { MemoryCheckScope wrapper(this, [this, req] { this->doProcess(req); }); });
+  } else {
+    doProcess(req);
   }
 }
 

--- a/src/storage/query/GetNeighborsProcessor.cpp
+++ b/src/storage/query/GetNeighborsProcessor.cpp
@@ -21,20 +21,11 @@ namespace storage {
 ProcessorCounters kGetNeighborsCounters;
 
 void GetNeighborsProcessor::process(const cpp2::GetNeighborsRequest& req) {
-  try {
-    if (executor_ != nullptr) {
-      executor_->add([req, this]() { this->doProcess(req); });
-    } else {
-      doProcess(req);
-    }
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  if (executor_ != nullptr) {
+    executor_->add(
+        [this, req]() { MemoryCheckScope wrapper(this, [this, req] { this->doProcess(req); }); });
+  } else {
+    doProcess(req);
   }
 }
 

--- a/src/storage/query/GetPropProcessor.cpp
+++ b/src/storage/query/GetPropProcessor.cpp
@@ -14,20 +14,11 @@ namespace storage {
 ProcessorCounters kGetPropCounters;
 
 void GetPropProcessor::process(const cpp2::GetPropRequest& req) {
-  try {
-    if (executor_ != nullptr) {
-      executor_->add([req, this]() { this->doProcess(req); });
-    } else {
-      doProcess(req);
-    }
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  if (executor_ != nullptr) {
+    executor_->add(
+        [this, req]() { MemoryCheckScope wrapper(this, [this, req] { this->doProcess(req); }); });
+  } else {
+    doProcess(req);
   }
 }
 

--- a/src/storage/query/ScanEdgeProcessor.cpp
+++ b/src/storage/query/ScanEdgeProcessor.cpp
@@ -16,20 +16,11 @@ namespace storage {
 ProcessorCounters kScanEdgeCounters;
 
 void ScanEdgeProcessor::process(const cpp2::ScanEdgeRequest& req) {
-  try {
-    if (executor_ != nullptr) {
-      executor_->add([req, this]() { this->doProcess(req); });
-    } else {
-      doProcess(req);
-    }
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  if (executor_ != nullptr) {
+    executor_->add(
+        [this, req]() { MemoryCheckScope wrapper(this, [this, req] { this->doProcess(req); }); });
+  } else {
+    doProcess(req);
   }
 }
 

--- a/src/storage/query/ScanVertexProcessor.cpp
+++ b/src/storage/query/ScanVertexProcessor.cpp
@@ -18,20 +18,11 @@ namespace storage {
 ProcessorCounters kScanVertexCounters;
 
 void ScanVertexProcessor::process(const cpp2::ScanVertexRequest& req) {
-  try {
-    if (executor_ != nullptr) {
-      executor_->add([req, this]() { this->doProcess(req); });
-    } else {
-      doProcess(req);
-    }
-  } catch (std::bad_alloc& e) {
-    memoryExceeded_ = true;
-    onError();
-  } catch (std::exception& e) {
-    LOG(ERROR) << e.what();
-    onError();
-  } catch (...) {
-    onError();
+  if (executor_ != nullptr) {
+    executor_->add(
+        [this, req]() { MemoryCheckScope wrapper(this, [this, req] { this->doProcess(req); }); });
+  } else {
+    doProcess(req);
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

https://github.com/vesoft-inc/nebula/issues/5205
https://github.com/vesoft-inc/nebula/issues/5206

#### Description:
- When memory tracker is turned on, we should make sure if some std::bac_alloc throws, the corresponding query should be killed with correct error message. For this purpose, I test with mannually add `throw std::bac_alloc` to check expected bahavior happens.
- Almost every memtracker turned on code block, tested with mannually throw bad_alloc, check query failed with except error, if `// MemoryTrackerVerified` added to that context, these places were manually test;


- graphd: 
    - some thenError is remove, which is not nessacery, future<Status> most of time can chined and returned to up callstack; (what @Shylock-Hg comment  in previouse pr it right,  but have no time to check every place, some place remains need thenError)
    - some code block missed turned on memtracker, added;

- storaged:
    -  remove XXXProcessor::process's try catch, added the root catch in  GraphStorageServiceHandler.cpp;
    -  added a MemoryCheckScope to ease wrap a function in memory tracker turned on context, used by async execution submitted to executor;
 
- rpc
    - added memroy tracker in DataSet::read that decode DataSet  from wire， every rpc response from stroage is defined as a DataSet, so I think this is enough; have tried add a throw in DataSet::read, it works as expected.

- fix a build issue when build using gcc with sanitize


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
