### PR TITLE
Update response message when adding schema historically existed

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -828,6 +828,8 @@ Status MetaClient::handleResponse(const RESP& resp) {
       return Status::Error("No hosts!");
     case nebula::cpp2::ErrorCode::E_EXISTED:
       return Status::Error("Existed!");
+    case nebula::cpp2::ErrorCode::E_HISTORY_CONFLICT:
+      return Status::Error("Schema exisited before!");
     case nebula::cpp2::ErrorCode::E_SPACE_NOT_FOUND:
       return Status::SpaceNotFound("Space not existed!");
     case nebula::cpp2::ErrorCode::E_TAG_NOT_FOUND:

--- a/src/common/graph/Response.h
+++ b/src/common/graph/Response.h
@@ -77,6 +77,7 @@
   X(E_WRONGCLUSTER, -2010)                                                    \
   X(E_ZONE_NOT_ENOUGH, -2011)                                                 \
   X(E_ZONE_IS_EMPTY, -2012)                                                   \
+  X(E_HISTORY_CONFLICT, -2018)                                                \
                                                                               \
   X(E_STORE_FAILURE, -2021)                                                   \
   X(E_STORE_SEGMENT_ILLEGAL, -2022)                                           \

--- a/src/interface/common.thrift
+++ b/src/interface/common.thrift
@@ -376,6 +376,7 @@ enum ErrorCode {
     E_RELATED_INDEX_EXISTS            = -2015,  // There are still indexes related to tag or edge, cannot drop it
     E_RELATED_SPACE_EXISTS            = -2016,  // There are still some space on the host, cannot drop it
     E_RELATED_FULLTEXT_INDEX_EXISTS   = -2017,  // There are still fulltext index on tag/edge
+    E_HISTORY_CONFLICT                = -2018,  // Existed before (e.g., schema)
 
     E_STORE_FAILURE                   = -2021,  // Failed to store data
     E_STORE_SEGMENT_ILLEGAL           = -2022,  // Illegal storage segment

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -87,11 +87,20 @@ nebula::cpp2::ErrorCode MetaServiceUtils::alterColumnDefs(
     bool isEdge) {
   switch (op) {
     case cpp2::AlterSchemaOp::ADD:
+      // Check the current schema first. Then check all schemas.
+      for (auto it = cols.begin(); it != cols.end(); ++it) {
+        if (it->get_name() == col.get_name()) {
+          LOG(INFO) << "Column existing: " << col.get_name();
+          return nebula::cpp2::ErrorCode::E_EXISTED;
+        }
+      }
+      // There won't any two columns having the same name across all schemas. If there is a column
+      // in all schemas having the same name, it must be from history schemas.
       for (auto& versionedCols : allVersionedCols) {
         for (auto it = versionedCols.begin(); it != versionedCols.end(); ++it) {
           if (it->get_name() == col.get_name()) {
             LOG(ERROR) << "Column currently or previously existing: " << col.get_name();
-            return nebula::cpp2::ErrorCode::E_EXISTED;
+            return nebula::cpp2::ErrorCode::E_HISTORY_CONFLICT;
           }
         }
       }

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -95,7 +95,7 @@ nebula::cpp2::ErrorCode MetaServiceUtils::alterColumnDefs(
         }
       }
       // There won't any two columns having the same name across all schemas. If there is a column
-      // in all schemas having the same name, it must be from history schemas.
+      // having the same name with the intended change, it must be from history schemas.
       for (auto& versionedCols : allVersionedCols) {
         for (auto it = versionedCols.begin(); it != versionedCols.end(); ++it) {
           if (it->get_name() == col.get_name()) {

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -90,7 +90,7 @@ nebula::cpp2::ErrorCode MetaServiceUtils::alterColumnDefs(
       // Check the current schema first. Then check all schemas.
       for (auto it = cols.begin(); it != cols.end(); ++it) {
         if (it->get_name() == col.get_name()) {
-          LOG(INFO) << "Column existing: " << col.get_name();
+          LOG(ERROR) << "Column existing: " << col.get_name();
           return nebula::cpp2::ErrorCode::E_EXISTED;
         }
       }
@@ -99,7 +99,7 @@ nebula::cpp2::ErrorCode MetaServiceUtils::alterColumnDefs(
       for (auto& versionedCols : allVersionedCols) {
         for (auto it = versionedCols.begin(); it != versionedCols.end(); ++it) {
           if (it->get_name() == col.get_name()) {
-            LOG(ERROR) << "Column currently or previously existing: " << col.get_name();
+            LOG(ERROR) << "Column previously existing: " << col.get_name();
             return nebula::cpp2::ErrorCode::E_HISTORY_CONFLICT;
           }
         }

--- a/tests/tck/features/ddl/Ddl.feature
+++ b/tests/tck/features/ddl/Ddl.feature
@@ -83,7 +83,7 @@ Feature: DDL test
       ALTER TAG B ADD (name string)
       """
     # IMHO, this is really confusing. https://github.com/vesoft-inc/nebula/issues/2671
-    Then a ExecutionError should be raised at runtime: Existed!
+    Then a ExecutionError should be raised at runtime: Schema exisited before!
     When executing query:
       """
       ALTER TAG B ADD (namex string)
@@ -225,7 +225,7 @@ Feature: DDL test
       """
       ALTER EDGE E2 ADD (name string)
       """
-    Then a ExecutionError should be raised at runtime: Existed!
+    Then a ExecutionError should be raised at runtime: Schema exisited before!
     When executing query:
       """
       ALTER EDGE E2 ADD (namex string)

--- a/tests/tck/features/schema/Schema.feature
+++ b/tests/tck/features/schema/Schema.feature
@@ -956,7 +956,7 @@ Feature: Insert string vid of vertex and edge
       CREATE TAG person(name string, age int);
       """
     Then the execution should be successful
-    And wait 3 seconds
+    And wait 10 seconds
     When executing query:
       """
       INSERT VERTEX person values "1":("Tom", 23);
@@ -974,7 +974,7 @@ Feature: Insert string vid of vertex and edge
       ALTER TAG person DROP (age);
       """
     Then the execution should be successful
-    And wait 3 seconds
+    And wait 10 seconds
     When executing query:
       """
       FETCH PROP ON person "1" yield properties(vertex) AS props;

--- a/tests/tck/features/schema/Schema.feature
+++ b/tests/tck/features/schema/Schema.feature
@@ -986,4 +986,4 @@ Feature: Insert string vid of vertex and edge
       """
       ALTER TAG person ADD (age int);
       """
-    Then a ExecutionError should be raised at runtime: Existed
+    Then a ExecutionError should be raised at runtime: Schema exisited before!


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Followup of Case 1 in https://github.com/vesoft-inc/nebula/issues/2671
Previous PR: #5130 
In this PR, we distinguish behaviors of adding column that is currently existed from historically existed. So users will get better hints.

<img width="451" alt="image" src="https://user-images.githubusercontent.com/19355821/211429397-36bd22d9-3545-41b8-a6c2-29b8ddc8b130.png">


## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
