### PR TITLE
modify ft index default limit size

### DIFF
--- a/src/common/expression/TextSearchExpression.h
+++ b/src/common/expression/TextSearchExpression.h
@@ -85,7 +85,7 @@ class TextSearchArgument final {
   std::string val_;
   std::string op_;
   int32_t fuzziness_{-2};
-  int32_t limit_{-1};
+  int32_t limit_{10000};
   int32_t timeout_{-1};
 };
 

--- a/src/graph/util/test/FTindexUtilsTest.cpp
+++ b/src/graph/util/test/FTindexUtilsTest.cpp
@@ -70,7 +70,7 @@ TEST_F(FTIndexUtilsTest, rewriteTSFilter) {
   esResult.items = items;
   {
     MockESAdapter mockESAdapter;
-    EXPECT_CALL(mockESAdapter, prefix(indexName, "prefix_pattern", -1, -1))
+    EXPECT_CALL(mockESAdapter, prefix(indexName, "prefix_pattern", 10000, -1))
         .WillOnce(Return(esResult));
     auto argument = TextSearchArgument::make(&pool, tagName, propName, "prefix_pattern");
     auto expr = TextSearchExpression::makePrefix(&pool, argument);
@@ -84,7 +84,7 @@ TEST_F(FTIndexUtilsTest, rewriteTSFilter) {
   {
     plugin::ESQueryResult emptyEsResult;
     MockESAdapter mockESAdapter;
-    EXPECT_CALL(mockESAdapter, prefix(indexName, "prefix_pattern", -1, -1))
+    EXPECT_CALL(mockESAdapter, prefix(indexName, "prefix_pattern", 10000, -1))
         .WillOnce(Return(emptyEsResult));
     auto argument = TextSearchArgument::make(&pool, tagName, propName, "prefix_pattern");
     auto expr = TextSearchExpression::makePrefix(&pool, argument);
@@ -95,7 +95,7 @@ TEST_F(FTIndexUtilsTest, rewriteTSFilter) {
   {
     Status status = Status::Error("mock error");
     MockESAdapter mockESAdapter;
-    EXPECT_CALL(mockESAdapter, prefix(indexName, "prefix_pattern", -1, -1))
+    EXPECT_CALL(mockESAdapter, prefix(indexName, "prefix_pattern", 10000, -1))
         .Times(FLAGS_ft_request_retry_times)
         .WillRepeatedly(Return(status));
     auto argument = TextSearchArgument::make(&pool, tagName, propName, "prefix_pattern");
@@ -106,7 +106,7 @@ TEST_F(FTIndexUtilsTest, rewriteTSFilter) {
   }
   {
     MockESAdapter mockESAdapter;
-    EXPECT_CALL(mockESAdapter, wildcard(indexName, "wildcard_pattern", -1, -1))
+    EXPECT_CALL(mockESAdapter, wildcard(indexName, "wildcard_pattern", 10000, -1))
         .WillOnce(Return(esResult));
     auto argument = TextSearchArgument::make(&pool, edgeName, propName, "wildcard_pattern");
     auto expr = TextSearchExpression::makeWildcard(&pool, argument);
@@ -121,7 +121,7 @@ TEST_F(FTIndexUtilsTest, rewriteTSFilter) {
     plugin::ESQueryResult singleEsResult;
     singleEsResult.items = {Item("a", "b", 1, "edge text")};
     MockESAdapter mockESAdapter;
-    EXPECT_CALL(mockESAdapter, wildcard(indexName, "wildcard_pattern", -1, -1))
+    EXPECT_CALL(mockESAdapter, wildcard(indexName, "wildcard_pattern", 10000, -1))
         .WillOnce(Return(singleEsResult));
     auto argument = TextSearchArgument::make(&pool, edgeName, propName, "wildcard_pattern");
     auto expr = TextSearchExpression::makeWildcard(&pool, argument);
@@ -132,7 +132,7 @@ TEST_F(FTIndexUtilsTest, rewriteTSFilter) {
   }
   {
     MockESAdapter mockESAdapter;
-    EXPECT_CALL(mockESAdapter, regexp(indexName, "regexp_pattern", -1, -1))
+    EXPECT_CALL(mockESAdapter, regexp(indexName, "regexp_pattern", 10000, -1))
         .WillOnce(Return(esResult));
     auto argument = TextSearchArgument::make(&pool, edgeName, propName, "regexp_pattern");
     auto expr = TextSearchExpression::makeRegexp(&pool, argument);
@@ -145,7 +145,7 @@ TEST_F(FTIndexUtilsTest, rewriteTSFilter) {
   }
   {
     MockESAdapter mockESAdapter;
-    EXPECT_CALL(mockESAdapter, fuzzy(indexName, "fuzzy_pattern", "1", -1, -1))
+    EXPECT_CALL(mockESAdapter, fuzzy(indexName, "fuzzy_pattern", "1", 10000, -1))
         .WillOnce(Return(esResult));
     auto argument = TextSearchArgument::make(&pool, tagName, propName, "fuzzy_pattern");
     argument->setFuzziness(1);


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

The default number of doc returned when querying ES is 10. In order to reduce users' confusion when using, for example, he has a lot of data, but in fact only 10 items can be found. When using, we query 10000 items by default, which is the maximum limit of a single ES query.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
