### PR TITLE
fix third party version in package.sh

### DIFF
--- a/package/package.sh
+++ b/package/package.sh
@@ -197,8 +197,8 @@ function package {
 function _find_dump_syms_tool {
     if [[ -x ${build_dir}/third-party/install/bin/dump_syms ]]; then
         dump_syms_tool_dir=${build_dir}/third-party/install/bin
-    elif [[ -x /opt/vesoft/third-party/2.0/bin/dump_syms ]]; then
-        dump_syms_tool_dir=/opt/vesoft/third-party/2.0/bin
+    elif [[ -x /opt/vesoft/third-party/3.3/bin/dump_syms ]]; then
+        dump_syms_tool_dir=/opt/vesoft/third-party/3.3/bin
     else
         echo ">>> Failed to find the dump_syms tool <<<"
         exit 1


### PR DESCRIPTION


<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
The dump_syms tool path should be match with third party version.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:
This pr affect all version use nebula third party 3.3.


## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [x] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [x] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
