### PR TITLE
remove unnecessary check when print error log

### DIFF
--- a/src/common/memory/MemoryUtils.cpp
+++ b/src/common/memory/MemoryUtils.cpp
@@ -192,9 +192,7 @@ void MemoryUtils::handleMemoryTracker(int64_t total, int64_t available) {
       LOG(INFO) << "MemoryTracker disabled";
     }
   } else {
-    if (kCurrentTotal_ != limitRatio) {
-      LOG(ERROR) << "Invalid memory_tracker_limit_ratio: " << limitRatio;
-    }
+    LOG(ERROR) << "Invalid memory_tracker_limit_ratio: " << limitRatio;
   }
   kCurrentTotal_ = total;
   kCurrentLimitRatio_ = limitRatio;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

minor: check is wrong , and not necessary, just print error log if ratio is set a invalid value 

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
