### PR TITLE
Fix the crash caused by failed downcast of iter

### DIFF
--- a/src/graph/executor/query/DataCollectExecutor.cpp
+++ b/src/graph/executor/query/DataCollectExecutor.cpp
@@ -65,6 +65,9 @@ Status DataCollectExecutor::collectSubgraph(const std::vector<std::string>& vars
   ds.colNames = std::move(colNames_);
   const auto& hist = ectx_->getHistory(vars[0]);
   for (const auto& result : hist) {
+    if (!result.iterRef()->isGetNeighborsIter()) {
+      continue;
+    }
     auto iter = result.iter();
     auto* gnIter = static_cast<GetNeighborsIter*>(iter.get());
     List vertices;

--- a/tests/tck/features/bugfix/FixIterCrash.feature
+++ b/tests/tck/features/bugfix/FixIterCrash.feature
@@ -1,0 +1,23 @@
+# Copyright (c) 2022 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+Feature: FixIterCrash
+
+  Scenario: Fix GetNeighborsIter Crash
+    Given an empty graph
+    And having executed:
+      """
+      CREATE SPACE nba_FixIterCrash as nba
+      """
+    And wait 6 seconds
+    And having executed:
+      """
+      USE nba_FixIterCrash
+      """
+    When executing query:
+      """
+      GO from 'Tim Duncan' OVER serve YIELD serve._src AS id |
+      GET SUBGRAPH WITH PROP FROM $-.id
+      YIELD vertices as nodes, edges as relationships
+      """
+    Then the execution should be successful


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula-ent/issues/2336
Close https://github.com/vesoft-inc/nebula/issues/5292

#### Description:
The cast of iter to GetNeighborsIter using static_cast may fail and leave a non-accessible GetNeighborsIter*, which would later crash the graphd on seg fault.

## How do you solve it?
Tried using dynamic_cast. On the advice by @yixinglu, changed to protect the static_cast by checking the kind of iter.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
