### PR TITLE
Fix total rpc time in stats

### DIFF
--- a/src/graph/executor/algo/BatchShortestPath.cpp
+++ b/src/graph/executor/algo/BatchShortestPath.cpp
@@ -9,9 +9,12 @@
 #include "sys/sysinfo.h"
 
 using nebula::storage::StorageClient;
+
 DECLARE_uint32(num_path_thread);
+
 namespace nebula {
 namespace graph {
+
 folly::Future<Status> BatchShortestPath::execute(const HashSet& startVids,
                                                  const HashSet& endVids,
                                                  DataSet* result) {
@@ -550,12 +553,13 @@ size_t BatchShortestPath::splitTask(const HashSet& startVids, const HashSet& end
       ++count;
     }
   }
-  std::stringstream ss;
-  ss << "{\n"
-     << "startVids' size : " << startVidsSize << " endVids's size : " << endVidsSize;
-  ss << " thread num : " << threadNum;
-  ss << " start blocks : " << startSlices << " end blocks : " << endSlices << "\n}";
-  stats_->emplace(folly::sformat("split task "), ss.str());
+  folly::dynamic obj = folly::dynamic::object();
+  obj.insert("startVids' size", startVidsSize);
+  obj.insert("endVids's size", endVidsSize);
+  obj.insert("thread num", threadNum);
+  obj.insert("start blocks", startSlices);
+  obj.insert("end blocks", endSlices);
+  stats_->emplace("split task", folly::toPrettyJson(obj));
   return startSlices * endSlices;
 }
 

--- a/src/graph/executor/algo/BatchShortestPath.h
+++ b/src/graph/executor/algo/BatchShortestPath.h
@@ -9,6 +9,7 @@
 
 namespace nebula {
 namespace graph {
+
 class BatchShortestPath final : public ShortestPathBase {
  public:
   BatchShortestPath(const ShortestPath* node,

--- a/src/graph/executor/algo/ShortestPathBase.h
+++ b/src/graph/executor/algo/ShortestPathBase.h
@@ -13,8 +13,10 @@ using nebula::storage::StorageRpcResponse;
 using nebula::storage::cpp2::GetNeighborsResponse;
 using RpcResponse = StorageRpcResponse<GetNeighborsResponse>;
 using PropRpcResponse = StorageRpcResponse<nebula::storage::cpp2::GetPropResponse>;
+
 namespace nebula {
 namespace graph {
+
 class ShortestPathBase {
  public:
   using HashSet = robin_hood::unordered_flat_set<Value, std::hash<Value>>;

--- a/src/graph/executor/algo/ShortestPathExecutor.cpp
+++ b/src/graph/executor/algo/ShortestPathExecutor.cpp
@@ -13,8 +13,10 @@
 using nebula::storage::StorageClient;
 
 DEFINE_uint32(num_path_thread, 0, "number of concurrent threads when do shortest path");
+
 namespace nebula {
 namespace graph {
+
 folly::Future<Status> ShortestPathExecutor::execute() {
   // MemoryTrackerVerified
   SCOPED_TIMER(&execTime_);

--- a/src/graph/executor/algo/SingleShortestPath.cpp
+++ b/src/graph/executor/algo/SingleShortestPath.cpp
@@ -10,6 +10,7 @@ using nebula::storage::StorageClient;
 
 namespace nebula {
 namespace graph {
+
 folly::Future<Status> SingleShortestPath::execute(const HashSet& startVids,
                                                   const HashSet& endVids,
                                                   DataSet* result) {

--- a/src/graph/executor/algo/SingleShortestPath.h
+++ b/src/graph/executor/algo/SingleShortestPath.h
@@ -9,6 +9,7 @@
 
 namespace nebula {
 namespace graph {
+
 class SingleShortestPath final : public ShortestPathBase {
  public:
   using HashSet = robin_hood::unordered_flat_set<Value, std::hash<Value>>;

--- a/src/graph/executor/query/TraverseExecutor.h
+++ b/src/graph/executor/query/TraverseExecutor.h
@@ -10,6 +10,7 @@
 #include "graph/executor/StorageAccessExecutor.h"
 #include "graph/planner/plan/Query.h"
 #include "interface/gen-cpp2/storage_types.h"
+
 // only used in match scenarios
 // invoke the getNeighbors interface, according to the number of times specified by the user,
 // and assemble the result into paths
@@ -35,6 +36,7 @@
 // `getNeighbors` : invoke the getNeightbors interface
 // `releasePrevPaths` : deleted The path whose length does not meet the user-defined length
 // `hasSameEdge` : check if there are duplicate edges in path
+
 namespace nebula {
 namespace graph {
 
@@ -63,18 +65,16 @@ class TraverseExecutor final : public StorageAccessExecutor {
   folly::Future<Status> buildResult();
 
   std::vector<Row> buildPath(const Value& initVertex, size_t minStep, size_t maxStep);
-
   folly::Future<Status> buildPathMultiJobs(size_t minStep, size_t maxStep);
+  std::vector<Row> joinPrevPath(const Value& initVertex, const std::vector<Row>& newResult) const;
 
   bool isFinalStep() const {
     return currentStep_ == range_.max() || range_.max() == 0;
   }
 
-  bool filterSameEdge(const Row& lhs,
-                      const Row& rhs,
-                      std::unordered_set<Value>* uniqueEdge = nullptr);
-
-  bool hasSameEdge(const std::vector<Value>& edgeList, const Edge& edge);
+  bool hasSameEdge(const std::vector<Value>& edgeList, const Edge& edge) const;
+  bool hasSameEdgeInPath(const Row& lhs, const Row& rhs) const;
+  bool hasSameEdgeInSet(const Row& rhs, const std::unordered_set<Value>& uniqueEdge) const;
 
   std::vector<Row> buildZeroStepPath();
 
@@ -134,6 +134,8 @@ class TraverseExecutor final : public StorageAccessExecutor {
   const Traverse* traverse_{nullptr};
   MatchStepRange range_;
   size_t currentStep_{0};
+
+  size_t expandTime_{0u};
 };
 
 }  // namespace graph

--- a/src/graph/util/Utils.cpp
+++ b/src/graph/util/Utils.cpp
@@ -18,17 +18,13 @@ folly::dynamic getStorageDetail(const std::map<std::string, int32_t>& profileDet
 
 folly::dynamic collectRespProfileData(const storage::cpp2::ResponseCommon& resp,
                                       const std::tuple<HostAddr, int32_t, int32_t>& info,
-                                      size_t numVertices,
-                                      size_t totalRpcTime) {
+                                      size_t numVertices) {
   folly::dynamic stat = folly::dynamic::object();
   stat.insert("host", std::get<0>(info).toRawString());
   stat.insert("exec", folly::sformat("{}(us)", std::get<1>(info)));
   stat.insert("total", folly::sformat("{}(us)", std::get<2>(info)));
   if (numVertices > 0) {
     stat.insert("vertices", numVertices);
-  }
-  if (totalRpcTime > 0) {
-    stat.insert("total_rpc_time", folly::sformat("{}(us)", totalRpcTime));
   }
   if (resp.latency_detail_us_ref().has_value()) {
     stat.insert("storage_detail", getStorageDetail(*resp.get_latency_detail_us()));

--- a/src/graph/util/Utils.h
+++ b/src/graph/util/Utils.h
@@ -35,8 +35,7 @@ folly::dynamic getStorageDetail(const std::map<std::string, int32_t>& profileDet
 
 folly::dynamic collectRespProfileData(const storage::cpp2::ResponseCommon& resp,
                                       const std::tuple<HostAddr, int32_t, int32_t>& info,
-                                      size_t numVertices = 0UL,
-                                      size_t totalRpcTime = 0UL);
+                                      size_t numVertices = 0UL);
 
 }  // namespace nebula::graph::util
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:


## How do you solve it?

1. Move the total rpc time from storage info to other stats
2. cleanup traverseExecutor implementation.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
