### PR TITLE
Fix meta's cleanup not work as expected

### DIFF
--- a/src/kvstore/Part.h
+++ b/src/kvstore/Part.h
@@ -307,11 +307,18 @@ class Part : public raftex::RaftPart {
                                        TermID committedLogTerm);
 
   /**
-   * @brief clean up data in listener, called in RaftPart::reset
+   * @brief clean up data in storage part, called in RaftPart::reset
    *
    * @return nebula::cpp2::ErrorCode
    */
   nebula::cpp2::ErrorCode cleanup() override;
+
+  /**
+   * @brief clean up data in meta part, called in RaftPart::reset
+   *
+   * @return nebula::cpp2::ErrorCode
+   */
+  nebula::cpp2::ErrorCode metaCleanup();
 
  public:
   struct CallbackOptions {


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula-ent/issues/2399
Close https://github.com/vesoft-inc/nebula/issues/5320

#### Description:
Meta does not clean up all data before receiving snapshot... The bug must have existed for quite a long time...


## How do you solve it?
Delete all data by delete range. The code is quite ugly, but I don't think of any better ways...

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
