### PR TITLE
Support mold linker

### DIFF
--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -1,3 +1,8 @@
+# Copyright (c) 2020 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+#
+
 if (ENABLE_CLANG_TIDY)
     if (${CMAKE_VERSION} VERSION_LESS "3.6.0")
         message(FATAL_ERROR "clang-tidy requires CMake version at least 3.6.")

--- a/cmake/FindMoldLinker.cmake
+++ b/cmake/FindMoldLinker.cmake
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+#
+
+find_program (MOLD NAMES "mold")
+if (NOT MOLD)
+  message(FATAL_ERROR "Could not find the mold linker")
+endif()
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12.1.0)
+  get_filename_component(MOLD_PATH ${MOLD} DIRECTORY)
+  nebula_add_exe_linker_flag(-B${MOLD_PATH}/../libexec/mold)
+  nebula_add_shared_linker_flag(-B${MOLD_PATH}/../libexec/mold)
+else()
+  nebula_add_exe_linker_flag(-fuse-ld=mold)
+  nebula_add_shared_linker_flag(-fuse-ld=mold)
+endif()

--- a/cmake/nebula/LinkerConfig.cmake
+++ b/cmake/nebula/LinkerConfig.cmake
@@ -1,7 +1,7 @@
 set(NEBULA_USE_LINKER
   "bfd"
   CACHE STRING "Linker to be used")
-set(USER_LINKER_OPTION_VALUES "lld" "gold" "bfd")
+set(USER_LINKER_OPTION_VALUES "lld" "gold" "bfd" "mold")
 set_property(CACHE NEBULA_USE_LINKER PROPERTY STRINGS ${USER_LINKER_OPTION_VALUES})
 list(
   FIND
@@ -17,8 +17,13 @@ endif()
 
 print_config(NEBULA_USE_LINKER)
 
-nebula_add_exe_linker_flag(-fuse-ld=${NEBULA_USE_LINKER})
-nebula_add_shared_linker_flag(-fuse-ld=${NEBULA_USE_LINKER})
+if (${NEBULA_USE_LINKER} STREQUAL "mold")
+  include(FindMoldLinker)
+else()
+  nebula_add_exe_linker_flag(-fuse-ld=${NEBULA_USE_LINKER})
+  nebula_add_shared_linker_flag(-fuse-ld=${NEBULA_USE_LINKER})
+endif()
+
 nebula_add_exe_linker_flag(-static-libstdc++)
 nebula_add_exe_linker_flag(-static-libgcc)
 nebula_add_exe_linker_flag(-no-pie)


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:

use the [mold](https://github.com/rui314/mold) linker to speed up nebula compilation:

1. download the mold linker from the [release page](https://github.com/rui314/mold/releases) and decompress the tar to your `$PATH` directory, such as `$HOME/.local` by 
    `tar zxf mold-1.10.1-x86_64-linux.tar.gz --strip-components=1 -C $HOME/.local/`
3. enter the nebula repo build directory
4. specify the `NEBULA_USE_LINKER` variable when you configure the cmake:
    ```
    cmake -DNEBULA_USE_LINKER=mold ..
    ```
5. happy to build nebula now

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
