### PR TITLE
Fix `addSessionCount()` in multu-thread case

### DIFF
--- a/src/graph/session/GraphSessionManager.cpp
+++ b/src/graph/session/GraphSessionManager.cpp
@@ -367,7 +367,7 @@ void GraphSessionManager::addSessionCount(std::string& key) {
   if (countFindPtr != userIpSessionCount_.end()) {
     countFindPtr->second.get()->fetch_add(1);
   } else {
-    userIpSessionCount_.insert_or_assign(key, std::make_shared<SessionCount>(1));
+    userIpSessionCount_.insert_or_assign(key, std::make_shared<SessionCount>());
   }
 }
 

--- a/src/graph/session/GraphSessionManager.cpp
+++ b/src/graph/session/GraphSessionManager.cpp
@@ -84,10 +84,7 @@ folly::Future<StatusOr<std::shared_ptr<ClientSession>>> GraphSessionManager::fin
           return Status::Error("Insert session to local cache failed.");
         }
         std::string key = session.get_user_name() + session.get_client_ip();
-        bool addResp = addSessionCount(key);
-        if (!addResp) {
-          return Status::Error("Insert userIpSessionCount to local cache failed.");
-        }
+        addSessionCount(key);
 
         // update the space info to sessionPtr
         if (!spaceName.empty()) {
@@ -148,10 +145,7 @@ folly::Future<StatusOr<std::shared_ptr<ClientSession>>> GraphSessionManager::cre
           return Status::Error("Insert session to local cache failed.");
         }
         std::string sessionKey = userName + clientIp;
-        bool addResp = addSessionCount(sessionKey);
-        if (!addResp) {
-          return Status::Error("Insert userIpSessionCount to local cache failed.");
-        }
+        addSessionCount(sessionKey);
         updateSessionInfo(sessionPtr.get());
         return sessionPtr;
       }
@@ -337,10 +331,7 @@ Status GraphSessionManager::init() {
     if (!ret.second) {
       return Status::Error("Insert session to local cache failed.");
     }
-    bool addResp = addSessionCount(key);
-    if (!addResp) {
-      return Status::Error("Insert userIpSessionCount to local cache failed.");
-    }
+    addSessionCount(key);
     updateSessionInfo(sessionPtr.get());
     loadSessionCount++;
   }
@@ -371,29 +362,25 @@ void GraphSessionManager::removeSessionFromLocalCache(const std::vector<SessionI
   }
 }
 
-bool GraphSessionManager::addSessionCount(std::string& key) {
+void GraphSessionManager::addSessionCount(std::string& key) {
   auto countFindPtr = userIpSessionCount_.find(key);
   if (countFindPtr != userIpSessionCount_.end()) {
     countFindPtr->second.get()->fetch_add(1);
   } else {
-    auto ret1 = userIpSessionCount_.emplace(key, std::make_shared<SessionCount>());
-    if (!ret1.second) {
-      return false;
-    }
+    userIpSessionCount_.insert_or_assign(key, std::make_shared<SessionCount>(1));
   }
-  return true;
 }
 
-bool GraphSessionManager::subSessionCount(std::string& key) {
+void GraphSessionManager::subSessionCount(std::string& key) {
   auto countFindPtr = userIpSessionCount_.find(key);
   if (countFindPtr == userIpSessionCount_.end()) {
-    return false;
+    VLOG(1) << "Session count not found for key: " << key;
+    return;
   }
   auto count = countFindPtr->second.get()->fetch_sub(1);
   if (count <= 0) {
     userIpSessionCount_.erase(countFindPtr);
   }
-  return true;
 }
 }  // namespace graph
 }  // namespace nebula

--- a/src/graph/session/GraphSessionManager.h
+++ b/src/graph/session/GraphSessionManager.h
@@ -114,10 +114,10 @@ class GraphSessionManager final : public SessionManager<ClientSession> {
   void updateSessionInfo(ClientSession* session);
 
   // add sessionCount
-  bool addSessionCount(std::string& key);
+  void addSessionCount(std::string& key);
 
   // sub sessionCount
-  bool subSessionCount(std::string& key);
+  void subSessionCount(std::string& key);
 };
 
 }  // namespace graph


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close https://github.com/vesoft-inc/nebula/issues/5392

#### Description:
When multiple threads try to increment session counts at the same time, there is a chance that `emplace()` will return false. To avoid this issue, it's recommended to use insert_or_assign instead of emplace because the check for session counts doesn't need to be too strict.

## How do you solve it?
Use `insert_or_assign` instead of `emplace`.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
