### PR TITLE
remove EliminateAppendVerticesRule

### DIFF
--- a/src/graph/optimizer/CMakeLists.txt
+++ b/src/graph/optimizer/CMakeLists.txt
@@ -51,7 +51,6 @@ nebula_add_library(
     rule/GetEdgesTransformRule.cpp
     rule/PushLimitDownScanEdgesAppendVerticesRule.cpp
     rule/PushTopNDownIndexScanRule.cpp
-    rule/EliminateAppendVerticesRule.cpp
     rule/PushLimitDownScanEdgesRule.cpp
     rule/RemoveProjectDedupBeforeGetDstBySrcRule.cpp
     rule/PushFilterDownTraverseRule.cpp

--- a/tests/tck/features/optimizer/EliminateAppendVerticesRule.feature
+++ b/tests/tck/features/optimizer/EliminateAppendVerticesRule.feature
@@ -16,11 +16,12 @@ Feature: Eliminate AppendVertices rule
       | "Tim Duncan" |
       | "Tim Duncan" |
     And the execution plan should be:
-      | id | name      | dependencies | operator info |
-      | 5  | Project   | 8            |               |
-      | 8  | Traverse  | 7            |               |
-      | 7  | IndexScan | 0            |               |
-      | 0  | Start     |              |               |
+      | id | name           | dependencies | operator info                                        |
+      | 5  | Project        | 9            |                                                      |
+      | 9  | AppendVertices | 8            |                                                      |
+      | 8  | Traverse       | 7            | {"edge filter": "", "filter": "(like.likeness==95)"} |
+      | 7  | IndexScan      | 0            |                                                      |
+      | 0  | Start          |              |                                                      |
 
   Scenario: eliminate AppendVertices failed with returned path
     When profiling query:

--- a/tests/tck/features/optimizer/PrunePropertiesRule.feature
+++ b/tests/tck/features/optimizer/PrunePropertiesRule.feature
@@ -401,17 +401,18 @@ Feature: Prune Properties rule
       | scount |
       | 270    |
     And the execution plan should be:
-      | id | name          | dependencies | operator info          |
-      | 12 | Aggregate     | 13           |                        |
-      | 13 | HashInnerJoin | 15, 11       |                        |
-      | 15 | Project       | 4            |                        |
-      | 4  | Traverse      | 3            | { "vertexProps": "" }  |
-      | 3  | Traverse      | 14           | {  "vertexProps": "" } |
-      | 14 | IndexScan     | 2            |                        |
-      | 2  | Start         |              |                        |
-      | 11 | Project       | 9            |                        |
-      | 9  | Traverse      | 8            | {  "vertexProps": "" } |
-      | 8  | Argument      |              |                        |
+      | id | name           | dependencies | operator info          |
+      | 12 | Aggregate      | 13           |                        |
+      | 13 | HashInnerJoin  | 15, 11       |                        |
+      | 15 | Project        | 5            |                        |
+      | 5  | AppendVertices | 4            |                        |
+      | 4  | Traverse       | 3            | { "vertexProps": "" }  |
+      | 3  | Traverse       | 14           | {  "vertexProps": "" } |
+      | 14 | IndexScan      | 2            |                        |
+      | 2  | Start          |              |                        |
+      | 11 | Project        | 9            |                        |
+      | 9  | Traverse       | 8            | {  "vertexProps": "" } |
+      | 8  | Argument       |              |                        |
 
   @distonly
   Scenario: return function

--- a/tests/tck/features/optimizer/PushEFilterDownRule.feature
+++ b/tests/tck/features/optimizer/PushEFilterDownRule.feature
@@ -20,11 +20,12 @@ Feature: Push EFilter down rule
       | "Tim Duncan" |
       | "Tim Duncan" |
     And the execution plan should be:
-      | id | name      | dependencies | operator info                                        |
-      | 5  | Project   | 8            |                                                      |
-      | 8  | Traverse  | 7            | {"edge filter": "", "filter": "(like.likeness==95)"} |
-      | 7  | IndexScan | 0            |                                                      |
-      | 0  | Start     |              |                                                      |
+      | id | name           | dependencies | operator info                                        |
+      | 5  | Project        | 9            |                                                      |
+      | 9  | AppendVertices | 8            |                                                      |
+      | 8  | Traverse       | 7            | {"edge filter": "", "filter": "(like.likeness==95)"} |
+      | 7  | IndexScan      | 0            |                                                      |
+      | 0  | Start          |              |                                                      |
     When profiling query:
       """
       MATCH (v:player{name: 'Tim Duncan'})<-[e:like{likeness: 95}]-() return v.player.name AS name
@@ -33,11 +34,12 @@ Feature: Push EFilter down rule
       | name         |
       | "Tim Duncan" |
     And the execution plan should be:
-      | id | name      | dependencies | operator info                                        |
-      | 5  | Project   | 8            |                                                      |
-      | 8  | Traverse  | 7            | {"edge filter": "", "filter": "(like.likeness==95)"} |
-      | 7  | IndexScan | 0            |                                                      |
-      | 0  | Start     |              |                                                      |
+      | id | name           | dependencies | operator info                                        |
+      | 5  | Project        | 9            |                                                      |
+      | 9  | AppendVertices | 8            |                                                      |
+      | 8  | Traverse       | 7            | {"edge filter": "", "filter": "(like.likeness==95)"} |
+      | 7  | IndexScan      | 0            |                                                      |
+      | 0  | Start          |              |                                                      |
     When profiling query:
       """
       MATCH (v:player{name: 'Tim Duncan'})-[e:like|serve{likeness: 95}]-() return v.player.name AS name
@@ -48,11 +50,12 @@ Feature: Push EFilter down rule
       | "Tim Duncan" |
       | "Tim Duncan" |
     And the execution plan should be:
-      | id | name      | dependencies | operator info                                                             |
-      | 5  | Project   | 8            |                                                                           |
-      | 8  | Traverse  | 7            | {"edge filter": "", "filter": "(_any(like.likeness,serve.likeness)==95)"} |
-      | 7  | IndexScan | 0            |                                                                           |
-      | 0  | Start     |              |                                                                           |
+      | id | name           | dependencies | operator info                                                             |
+      | 5  | Project        | 9            |                                                                           |
+      | 9  | AppendVertices | 8            |                                                                           |
+      | 8  | Traverse       | 7            | {"edge filter": "", "filter": "(_any(like.likeness,serve.likeness)==95)"} |
+      | 7  | IndexScan      | 0            |                                                                           |
+      | 0  | Start          |              |                                                                           |
     When profiling query:
       """
       MATCH (v:player{name: 'Tim Duncan'})-[e:like*1..2{likeness: 95}]->() return v.player.name AS name
@@ -64,11 +67,12 @@ Feature: Push EFilter down rule
       | "Tim Duncan" |
       | "Tim Duncan" |
     And the execution plan should be:
-      | id | name      | dependencies | operator info                                        |
-      | 5  | Project   | 8            |                                                      |
-      | 8  | Traverse  | 7            | {"edge filter": "", "filter": "(like.likeness==95)"} |
-      | 7  | IndexScan | 0            |                                                      |
-      | 0  | Start     |              |                                                      |
+      | id | name           | dependencies | operator info                                        |
+      | 5  | Project        | 9            |                                                      |
+      | 9  | AppendVertices | 8            |                                                      |
+      | 8  | Traverse       | 7            | {"edge filter": "", "filter": "(like.likeness==95)"} |
+      | 7  | IndexScan      | 0            |                                                      |
+      | 0  | Start          |              |                                                      |
 
   Scenario Outline: can't push eFilter down when zero step enabled
     When profiling query:
@@ -81,8 +85,9 @@ Feature: Push EFilter down rule
       | "Tim Duncan" |
       | "Tim Duncan" |
     And the execution plan should be:
-      | id | name      | dependencies | operator info                                     |
-      | 5  | Project   | 8            |                                                   |
-      | 8  | Traverse  | 7            | {"edge filter": "(*.likeness==95)", "filter": ""} |
-      | 7  | IndexScan | 0            |                                                   |
-      | 0  | Start     |              |                                                   |
+      | id | name           | dependencies | operator info                                     |
+      | 5  | Project        | 9            |                                                   |
+      | 9  | AppendVertices | 8            |                                                   |
+      | 8  | Traverse       | 7            | {"edge filter": "(*.likeness==95)", "filter": ""} |
+      | 7  | IndexScan      | 0            |                                                   |
+      | 0  | Start          |              |                                                   |

--- a/tests/tck/features/optimizer/PushFilterDownNodeRule.feature
+++ b/tests/tck/features/optimizer/PushFilterDownNodeRule.feature
@@ -49,11 +49,12 @@ Feature: Push Filter down node rule
       | "Tim Duncan" |
       | "Tim Duncan" |
     And the execution plan should be:
-      | id | name      | dependencies | operator info                                                               |
-      | 5  | Project   | 8            |                                                                             |
-      | 8  | Traverse  | 7            | {"vertex filter": "", "first step filter": "(player.name==\"Tim Duncan\")"} |
-      | 7  | IndexScan | 0            |                                                                             |
-      | 0  | Start     |              |                                                                             |
+      | id | name           | dependencies | operator info                                                               |
+      | 5  | Project        | 9            |                                                                             |
+      | 9  | AppendVertices | 8            |                                                                             |
+      | 8  | Traverse       | 7            | {"vertex filter": "", "first step filter": "(player.name==\"Tim Duncan\")"} |
+      | 7  | IndexScan      | 0            |                                                                             |
+      | 0  | Start          |              |                                                                             |
     When profiling query:
       """
       MATCH (v:player{name: 'Tim Duncan'})-[:like]->() WHERE v.player.age == 42 return v.player.name AS name


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

Close https://github.com/vesoft-inc/nebula/issues/5396

#### Description:

The rule  is aimed to optimize https://github.com/vesoft-inc/nebula/issues/4273 at first, 
but this issue could be optimized by the property pruner when the flag optimize_appendvertices is on.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
