### PR TITLE
support ttl in ms

### DIFF
--- a/src/storage/CommonUtils.cpp
+++ b/src/storage/CommonUtils.cpp
@@ -7,6 +7,10 @@
 
 #include "storage/exec/QueryUtils.h"
 
+DEFINE_bool(ttl_use_ms,
+            false,
+            "whether the ttl is configured as milliseconds instead of default seconds");
+
 namespace nebula {
 namespace storage {
 
@@ -31,7 +35,15 @@ bool CommonUtils::checkDataExpiredForTTL(const meta::NebulaSchemaProvider* schem
       ftype != nebula::cpp2::PropertyType::INT64) {
     return false;
   }
-  auto now = std::time(NULL);
+
+  int64_t now;
+  // The unit of ttl expiration unit is controlled by user, we just use a gflag here.
+  if (!FLAGS_ttl_use_ms) {
+    now = std::time(nullptr);
+  } else {
+    auto t = std::chrono::system_clock::now();
+    now = std::chrono::duration_cast<std::chrono::milliseconds>(t.time_since_epoch()).count();
+  }
 
   // if the value is not INT type (sush as NULL), it will never expire.
   // TODO (sky) : DateTime


### PR DESCRIPTION
## What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Close #5376

#### Description:
Add a flag to control which unit that ttl uses, user **should not modify** it after one ttl column is specified. This behavior has been discussed with @MuYiYong. I think the flag should not be exposed as well. For those scenario who want to use ttl in ms, just set the flag to true once and for all before any ttl column is specified.

For example, if `ttl_use_ms` is false by default, set a ttl column as 500, so data of 500 seconds ago are expired. If user change `ttl_use_ms` from false too true, data of 500ms ago are expired. So again, don't modify it unless no more ttl columns are used.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [X] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
