### PR TITLE
Fix the comparisions involving EMPTY.

### DIFF
--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -1777,7 +1777,7 @@ Value Value::toSet() const {
   }
 }
 Value Value::lessThan(const Value& v) const {
-  if UNLIKELY(empty() || v.empty()) {
+  if (UNLIKELY(empty() || v.empty())) {
     return Value::kNullValue;
   }
   auto vType = v.type();
@@ -1871,8 +1871,8 @@ Value Value::lessThan(const Value& v) const {
 }
 
 Value Value::equal(const Value& v) const {
-  if UNLIKELY(empty() || v.empty()) {
-    return !empty() || !v.empty() ? false: Value::kNullValue;
+  if (UNLIKELY(empty() || v.empty())) {
+    return !empty() || !v.empty() ? false : Value::kNullValue;
   }
   auto vType = v.type();
   auto hasNull = (type_ | vType) & Value::Type::NULLVALUE;

--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -1777,7 +1777,7 @@ Value Value::toSet() const {
   }
 }
 Value Value::lessThan(const Value& v) const {
-  if (empty() || v.empty()) {
+  if UNLIKELY(empty() || v.empty()) {
     return Value::kNullValue;
   }
   auto vType = v.type();

--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -1778,7 +1778,7 @@ Value Value::toSet() const {
 }
 Value Value::lessThan(const Value& v) const {
   if (empty() || v.empty()) {
-    return (v.isNull() || isNull()) ? Value::kNullValue : Value::kEmpty;
+    return Value::kNullValue;
   }
   auto vType = v.type();
   auto hasNull = (type_ | vType) & Value::Type::NULLVALUE;
@@ -1871,8 +1871,12 @@ Value Value::lessThan(const Value& v) const {
 }
 
 Value Value::equal(const Value& v) const {
-  if (empty()) {
-    return v.isNull() ? Value::kNullValue : v.empty();
+  if (empty() || v.empty()) {
+    if (!empty() || !v.empty()) {
+      return false;
+    } else {
+      return Value::kNullValue;
+    }
   }
   auto vType = v.type();
   auto hasNull = (type_ | vType) & Value::Type::NULLVALUE;

--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -1871,12 +1871,8 @@ Value Value::lessThan(const Value& v) const {
 }
 
 Value Value::equal(const Value& v) const {
-  if (empty() || v.empty()) {
-    if (!empty() || !v.empty()) {
-      return false;
-    } else {
-      return Value::kNullValue;
-    }
+  if UNLIKELY(empty() || v.empty()) {
+    return !empty() || !v.empty() ? false: Value::kNullValue;
   }
   auto vType = v.type();
   auto hasNull = (type_ | vType) & Value::Type::NULLVALUE;

--- a/src/common/expression/test/RelationalExpressionTest.cpp
+++ b/src/common/expression/test/RelationalExpressionTest.cpp
@@ -100,8 +100,8 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
     auto *operand2 = ConstantExpression::make(&pool, Value());
     auto *expr = RelationalExpression::makeEQ(&pool, operand1, operand2);
     auto eval = Expression::eval(expr, gExpCtxt);
-    EXPECT_EQ(eval.type(), Value(true).type()) << "type check failed: " << expr->toString();
-    EXPECT_EQ(eval, Value(true)) << "check failed: " << expr->toString();
+    EXPECT_EQ(eval.type(), Value::kNullValue.type()) << "type check failed: " << expr->toString();
+    EXPECT_EQ(eval, Value::kNullValue) << "check failed: " << expr->toString();
   }
   {
     // empty == null
@@ -109,8 +109,8 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
     auto *operand2 = ConstantExpression::make(&pool, Value(NullType::__NULL__));
     auto *expr = RelationalExpression::makeEQ(&pool, operand1, operand2);
     auto eval = Expression::eval(expr, gExpCtxt);
-    EXPECT_EQ(eval.type(), Value::kNullValue.type()) << "type check failed: " << expr->toString();
-    EXPECT_EQ(eval, Value::kNullValue) << "check failed: " << expr->toString();
+    EXPECT_EQ(eval.type(), Value(false).type()) << "type check failed: " << expr->toString();
+    EXPECT_EQ(eval, Value(false)) << "check failed: " << expr->toString();
   }
   {
     // empty != null
@@ -118,8 +118,8 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
     auto *operand2 = ConstantExpression::make(&pool, Value(NullType::__NULL__));
     auto *expr = RelationalExpression::makeNE(&pool, operand1, operand2);
     auto eval = Expression::eval(expr, gExpCtxt);
-    EXPECT_EQ(eval.type(), Value::kNullValue.type()) << "type check failed: " << expr->toString();
-    EXPECT_EQ(eval, Value::kNullValue) << "check failed: " << expr->toString();
+    EXPECT_EQ(eval.type(), Value(true).type()) << "type check failed: " << expr->toString();
+    EXPECT_EQ(eval, Value(true)) << "check failed: " << expr->toString();
   }
   {
     // empty != 1
@@ -145,8 +145,8 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
     auto *operand2 = ConstantExpression::make(&pool, Value("1"));
     auto *expr = RelationalExpression::makeGT(&pool, operand1, operand2);
     auto eval = Expression::eval(expr, gExpCtxt);
-    EXPECT_EQ(eval.type(), Value::kEmpty.type()) << "type check failed: " << expr->toString();
-    EXPECT_EQ(eval, Value::kEmpty) << "check failed: " << expr->toString();
+    EXPECT_EQ(eval.type(), Value::kNullValue.type()) << "type check failed: " << expr->toString();
+    EXPECT_EQ(eval, Value::kNullValue) << "check failed: " << expr->toString();
   }
   {
     // empty < 1
@@ -154,8 +154,8 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
     auto *operand2 = ConstantExpression::make(&pool, Value(1));
     auto *expr = RelationalExpression::makeLT(&pool, operand1, operand2);
     auto eval = Expression::eval(expr, gExpCtxt);
-    EXPECT_EQ(eval.type(), Value::kEmpty.type()) << "type check failed: " << expr->toString();
-    EXPECT_EQ(eval, Value::kEmpty) << "check failed: " << expr->toString();
+    EXPECT_EQ(eval.type(), Value::kNullValue.type()) << "type check failed: " << expr->toString();
+    EXPECT_EQ(eval, Value::kNullValue) << "check failed: " << expr->toString();
   }
   {
     // empty >= 1.11
@@ -163,8 +163,8 @@ TEST_F(ExpressionTest, LiteralConstantsRelational) {
     auto *operand2 = ConstantExpression::make(&pool, Value(1.11));
     auto *expr = RelationalExpression::makeGE(&pool, operand1, operand2);
     auto eval = Expression::eval(expr, gExpCtxt);
-    EXPECT_EQ(eval.type(), Value::kEmpty.type()) << "type check failed: " << expr->toString();
-    EXPECT_EQ(eval, Value::kEmpty) << "check failed: " << expr->toString();
+    EXPECT_EQ(eval.type(), Value::kNullValue.type()) << "type check failed: " << expr->toString();
+    EXPECT_EQ(eval, Value::kNullValue) << "check failed: " << expr->toString();
   }
   {
     TEST_EXPR(null != 1, Value::kNullValue);

--- a/src/graph/executor/logic/LoopExecutor.cpp
+++ b/src/graph/executor/logic/LoopExecutor.cpp
@@ -20,6 +20,9 @@ folly::Future<Status> LoopExecutor::execute() {
   QueryExpressionContext ctx(ectx_);
 
   auto value = expr->eval(ctx);
+  if (value.isNull()) {
+    value = Value(true);
+  }
   finally_ = !(value.isBool() && value.getBool());
   return finish(ResultBuilder().value(std::move(value)).iter(Iterator::Kind::kDefault).build());
 }

--- a/src/graph/executor/logic/LoopExecutor.cpp
+++ b/src/graph/executor/logic/LoopExecutor.cpp
@@ -20,6 +20,9 @@ folly::Future<Status> LoopExecutor::execute() {
   QueryExpressionContext ctx(ectx_);
 
   auto value = expr->eval(ctx);
+  if (value.isNull()) {
+    value = Value(true);
+  }
   DCHECK(value.isBool());
   finally_ = !(value.isBool() && value.getBool());
   return finish(ResultBuilder().value(std::move(value)).iter(Iterator::Kind::kDefault).build());

--- a/src/graph/executor/logic/LoopExecutor.cpp
+++ b/src/graph/executor/logic/LoopExecutor.cpp
@@ -20,10 +20,6 @@ folly::Future<Status> LoopExecutor::execute() {
   QueryExpressionContext ctx(ectx_);
 
   auto value = expr->eval(ctx);
-  if (value.isNull()) {
-    value = Value(true);
-  }
-  DCHECK(value.isBool());
   finally_ = !(value.isBool() && value.getBool());
   return finish(ResultBuilder().value(std::move(value)).iter(Iterator::Kind::kDefault).build());
 }

--- a/tests/tck/features/expression/BugFixWithngdata.feature
+++ b/tests/tck/features/expression/BugFixWithngdata.feature
@@ -1,0 +1,18 @@
+# Copyright (c) 2023 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+Feature: Bug fixes with ngdata
+
+  Background:
+    Given a graph with space named "ngdata"
+
+  Scenario: Comparing EMPTY values
+    When executing query:
+      """
+      MATCH (v0:Label_0)-[e0]->()-[e1*1..1]->(v1)
+      WHERE (id(v0) == 11) AND (v1.Label_6.Label_6_400_Int == v1.Label_6.Label_6_500_Int)
+      RETURN count(*)
+      """
+    Then the result should be, in any order:
+      | count(*) |
+      | 0        |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Fix https://github.com/vesoft-inc/nebula/issues/5432

#### Description:
`EMPTY == EMPTY` shall not return true.

## How do you solve it?


```
EMPTY == (x), return value: 
==      EMPTY		NULL		Others
EMPTY	NULL		FALSE		FALSE

EMPTY < (x), return value:
<	EMPTY		NULL		Others
EMPTY	NULL		NULL		NULL
```

Tried to return null in all cases if an EMPTY value is involved in comparisions. But some cases have relied on it to return FALSE. Thus, I applied the above truth table for `==` and `<`.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:
I think we currently haven't explained any truth table involving EMTPY or EMTPY-like values in our documents. Right? Not sure. 

Simlar to NULL (https://docs.nebula-graph.com.cn/3.4.0/3.ngql-guide/3.data-types/5.null/), we may need to explain the behaviours involving EMTPY or EMTPY-like values.

For example, queries like 
```
MATCH (v:player)-[]-(v2) WHERE v.player.nnnnnnnnnnnnnn == v2.player.nnnnnnnnnnnnnn RETURN *
```
would return nothing, as the property `nnnnnnnnnnnnnn` does not exist (EMPTY) and `EMTPY == EMPTY` = NULL.


## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] TCK

Affects:
- [X] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
