### PR TITLE
Allow the expressions like 'v.tag' in return

### DIFF
--- a/src/graph/visitor/PropertyTrackerVisitor.cpp
+++ b/src/graph/visitor/PropertyTrackerVisitor.cpp
@@ -218,7 +218,7 @@ void PropertyTrackerVisitor::visit(AttributeExpression *expr) {
       auto ret = qctx_->schemaMng()->toTagID(space_, tagName);
       if (!ret.ok()) {
         status_ = std::move(ret).status();
-        return;
+        break;
       }
       auto tagId = ret.value();
       propsUsed_.insertVertexProp(entityAlias, tagId, "*");

--- a/src/graph/visitor/PropertyTrackerVisitor.cpp
+++ b/src/graph/visitor/PropertyTrackerVisitor.cpp
@@ -209,13 +209,12 @@ void PropertyTrackerVisitor::visit(AttributeExpression *expr) {
   switch (lhs->kind()) {
     case Expression::Kind::kInputProperty:
     case Expression::Kind::kVarProperty: {
-      // maybe: $e.prop or $v.tag
+      // maybe: $e.prop
       auto *varPropExpr = static_cast<PropertyExpression *>(lhs);
       auto &entityAlias = varPropExpr->prop();
       propsUsed_.insertEdgeProp(entityAlias, unknownType_, propName);
-      // $v.tag
-      auto &tagName = propName;
-      auto ret = qctx_->schemaMng()->toTagID(space_, tagName);
+      // maybe: $v.tag
+      auto ret = qctx_->schemaMng()->toTagID(space_, propName);
       if (!ret.ok()) {
         status_ = std::move(ret).status();
         break;

--- a/src/graph/visitor/PrunePropertiesVisitor.cpp
+++ b/src/graph/visitor/PrunePropertiesVisitor.cpp
@@ -447,9 +447,7 @@ void PrunePropertiesVisitor::pruneCurrent(AppendVertices *node) {
     newVProp.props_ref() = std::move(newProps);
     prunedVertexProps->emplace_back(std::move(newVProp));
   }
-  if (!prunedVertexProps->empty()) {
-    node->setVertexProps(std::move(prunedVertexProps));
-  }
+  node->setVertexProps(std::move(prunedVertexProps));
 }
 
 void PrunePropertiesVisitor::visit(HashJoin *node) {

--- a/src/graph/visitor/PrunePropertiesVisitor.cpp
+++ b/src/graph/visitor/PrunePropertiesVisitor.cpp
@@ -424,7 +424,11 @@ void PrunePropertiesVisitor::pruneCurrent(AppendVertices *node) {
       usedProps.insert(unknownIter->second.begin(), unknownIter->second.end());
     }
     if (tagIter != usedVertexProps.end()) {
-      usedProps.insert(tagIter->second.begin(), tagIter->second.end());
+      if (tagIter->second.find("*") != tagIter->second.end()) {
+        continue;
+      } else {
+        usedProps.insert(tagIter->second.begin(), tagIter->second.end());
+      }
     }
     if (usedProps.empty()) {
       continue;
@@ -443,7 +447,9 @@ void PrunePropertiesVisitor::pruneCurrent(AppendVertices *node) {
     newVProp.props_ref() = std::move(newProps);
     prunedVertexProps->emplace_back(std::move(newVProp));
   }
-  node->setVertexProps(std::move(prunedVertexProps));
+  if (!prunedVertexProps->empty()) {
+    node->setVertexProps(std::move(prunedVertexProps));
+  }
 }
 
 void PrunePropertiesVisitor::visit(HashJoin *node) {

--- a/src/graph/visitor/PrunePropertiesVisitor.cpp
+++ b/src/graph/visitor/PrunePropertiesVisitor.cpp
@@ -425,7 +425,7 @@ void PrunePropertiesVisitor::pruneCurrent(AppendVertices *node) {
     }
     if (tagIter != usedVertexProps.end()) {
       if (tagIter->second.find("*") != tagIter->second.end()) {
-        continue;
+        usedProps.insert(props.begin(), props.end());
       } else {
         usedProps.insert(tagIter->second.begin(), tagIter->second.end());
       }

--- a/tests/tck/features/match/Base.IntVid.feature
+++ b/tests/tck/features/match/Base.IntVid.feature
@@ -1045,8 +1045,8 @@ Feature: Basic match
       MATCH (v:player{name:"Tim Duncan"}) RETURN v.player AS vtag
       """
     Then the result should be, in any order:
-      | vtag                |
-      | {name:"Tim Duncan"} |
+      | vtag                          |
+      | {age: 42, name: "Tim Duncan"} |
     When executing query:
       """
       MATCH (v:player)-[]->(b) WHERE v.age > 30 RETURN v.player.name AS vname

--- a/tests/tck/features/match/Base.feature
+++ b/tests/tck/features/match/Base.feature
@@ -1449,8 +1449,8 @@ Feature: Basic match
       MATCH (v:player{name:"Tim Duncan"}) RETURN v.player AS vtag
       """
     Then the result should be, in any order:
-      | vtag                |
-      | {name:"Tim Duncan"} |
+      | vtag                          |
+      | {age: 42, name: "Tim Duncan"} |
     When executing query:
       """
       MATCH (v:player)-[]->(b) WHERE v.age > 30 RETURN v.player.name AS vname

--- a/tests/tck/features/match/Base.feature
+++ b/tests/tck/features/match/Base.feature
@@ -1453,6 +1453,15 @@ Feature: Basic match
       | {age: 42, name: "Tim Duncan"} |
     When executing query:
       """
+      match (v)
+      where id(v) == "Tim Duncan"
+      return v.player, v.bachelor.name
+      """
+    Then the result should be, in any order:
+      | v.player                      | v.bachelor.name |
+      | {age: 42, name: "Tim Duncan"} | "Tim Duncan"    |
+    When executing query:
+      """
       MATCH (v:player)-[]->(b) WHERE v.age > 30 RETURN v.player.name AS vname
       """
     Then the result should be, in any order:


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Fix https://github.com/vesoft-inc/nebula/issues/5329

#### Description:
'v.tag' means all properties of that tag are needed. They shall not be pruned by the optimizer.

## How do you solve it?
Add a wildcard `"*"` into the VertexProp map in the tracker when encountered expressions like `v.tag` after the `tag` has been verified to be a real tag.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] TCK

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
