### PR TITLE
Fix the == operator of Path

### DIFF
--- a/src/common/datatypes/Path.h
+++ b/src/common/datatypes/Path.h
@@ -87,8 +87,8 @@ struct Step {
     if (dst != rhs.dst) {
       return dst < rhs.dst;
     }
-    if (type != rhs.type) {
-      return type < rhs.type;
+    if (type != rhs.type && type != -rhs.type) {
+      return abs(type) < abs(rhs.type);
     }
     if (ranking != rhs.ranking) {
       return ranking < rhs.ranking;

--- a/src/common/datatypes/Path.h
+++ b/src/common/datatypes/Path.h
@@ -79,8 +79,8 @@ struct Step {
   }
 
   bool operator==(const Step& rhs) const {
-    return dst == rhs.dst && type == rhs.type && name == rhs.name && ranking == rhs.ranking &&
-           props == rhs.props;
+    return dst == rhs.dst && (type == rhs.type || type == -rhs.type) && name == rhs.name &&
+           ranking == rhs.ranking && props == rhs.props;
   }
 
   bool operator<(const Step& rhs) const {

--- a/tests/tck/features/match/Path.feature
+++ b/tests/tck/features/match/Path.feature
@@ -42,7 +42,7 @@ Feature: Matching paths
       match p = (v:Label_5)-[e:Rel_0]->(v1:Label_1),
       p2 = (v)<-[e1:Rel_0]-(v1)
       where id(v) == 47
-      and p != p2
+      and (p!=p2 or p<p2 or p>p2)
       and e == e1
       and v == v
       and v1 == v1

--- a/tests/tck/features/match/Path.feature
+++ b/tests/tck/features/match/Path.feature
@@ -37,6 +37,20 @@ Feature: Matching paths
     Then the result should be, in any order:
       | count(p) | count(p2) |
       | 966      | 966       |
+    When executing query:
+      """
+      match p = (v:Label_5)-[e:Rel_0]->(v1:Label_1),
+      p2 = (v)<-[e1:Rel_0]-(v1)
+      where id(v) == 47
+      and p != p2
+      and e == e1
+      and v == v
+      and v1 == v1
+      return count(*)
+      """
+    Then the result should be, in any order:
+      | count(*) |
+      | 0        |
 
   # The correctness of the following test cases needs to be verified, mark it @skip for now
   @skip


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Fix https://github.com/vesoft-inc/nebula/issues/5187

#### Description:
The same self-reflective step with +/- edge types were treated as different steps.

## How do you solve it?
Consider them as equal.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [X] TCK

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
