### PR TITLE
Add the type check when inserting geography value

### DIFF
--- a/src/codec/RowWriterV2.cpp
+++ b/src/codec/RowWriterV2.cpp
@@ -665,6 +665,7 @@ WriteResult RowWriterV2::write(ssize_t index, folly::StringPiece v, bool isWKB) 
       if (!isWKB) {
         return WriteResult::TYPE_MISMATCH;
       }
+      [[fallthrough]];
     }
     case PropertyType::STRING: {
       if (isSet_[index]) {

--- a/src/codec/RowWriterV2.h
+++ b/src/codec/RowWriterV2.h
@@ -254,7 +254,7 @@ class RowWriterV2 {
   WriteResult write(ssize_t index, uint64_t v);
 
   WriteResult write(ssize_t index, const std::string& v);
-  WriteResult write(ssize_t index, folly::StringPiece v);
+  WriteResult write(ssize_t index, folly::StringPiece v, bool isWKB = false);
   WriteResult write(ssize_t index, const char* v);
 
   WriteResult write(ssize_t index, const Date& v);

--- a/tests/tck/features/geo/GeoBase.feature
+++ b/tests/tck/features/geo/GeoBase.feature
@@ -127,6 +127,14 @@ Feature: Geo base
       INSERT VERTEX any_shape(geo) VALUES "103":(ST_GeogFromText("POLYGON((0 1, 1 2, 2 3, 0 1))"));
       """
     Then the execution should be successful
+    # "POINT(3 8)" is a string not a geography literal.
+    # We must use some geography costructor function to construct a geography literal.
+    # e.g.`ST_GeogFromText("POINT(3 8)")`
+    When executing query:
+      """
+      INSERT VERTEX any_shape(geo) VALUES "104":("POINT(3 8)");
+      """
+    Then a ExecutionError should be raised at runtime: Storage Error: The data type does not meet the requirements. Use the correct type of data.
     # Only point is allowed to insert to the column geograph(point)
     When executing query:
       """


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Fix https://github.com/vesoft-inc/nebula/issues/5459
#### Description:

When inserting, the geography value is converted to a WKB string format. However, it is not possible to differentiate whether a string being inserted into a property of geography type is in fact a WKB string or just an ordinary string.

So I add an argument `isWKB` to distinguish it:
```
WriteResult RowWriterV2::write(ssize_t index, folly::StringPiece v, bool isWKB)
```
## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
