### PR TITLE
Fix tagnum is not passed into GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -44,7 +44,7 @@ jobs:
           go-version: 'stable'
           cache-dependency-path: nebula-console/go.sum
       - id: tag
-        run: echo tagnum=${{ github.event.inputs.version }}
+        run: echo tagnum=${{ github.event.inputs.version }} >> $GITHUB_OUTPUT
       - name: package
         run: ./package/package.sh -v ${{ steps.tag.outputs.tagnum }}
       - name: output some vars


### PR DESCRIPTION
Fix tagnum is not passed into GITHUB_OUTPUT

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
