### PR TITLE
Split optimizer rules

### DIFF
--- a/src/common/expression/Expression.h
+++ b/src/common/expression/Expression.h
@@ -167,6 +167,10 @@ class Expression {
     return false;
   }
 
+  virtual bool isPropertyExpr() const {
+    return false;
+  }
+
   virtual bool isContainerExpr() const {
     return false;
   }

--- a/src/common/expression/PropertyExpression.h
+++ b/src/common/expression/PropertyExpression.h
@@ -32,6 +32,10 @@ class PropertyExpression : public Expression {
  public:
   bool operator==(const Expression& rhs) const override;
 
+  bool isPropertyExpr() const override {
+    return true;
+  }
+
   const Value& eval(ExpressionContext& ctx) override;
 
   const std::string& ref() const {

--- a/src/graph/optimizer/CMakeLists.txt
+++ b/src/graph/optimizer/CMakeLists.txt
@@ -59,6 +59,7 @@ nebula_add_library(
     rule/PushLimitDownScanEdgesRule.cpp
     rule/PushFilterDownTraverseRule.cpp
     rule/RemoveAppendVerticesBelowJoinRule.cpp
+    rule/PushFilterThroughAppendVerticesRule.cpp
 )
 
 nebula_add_subdirectory(test)

--- a/src/graph/optimizer/rule/PushFilterThroughAppendVerticesRule.cpp
+++ b/src/graph/optimizer/rule/PushFilterThroughAppendVerticesRule.cpp
@@ -1,0 +1,123 @@
+/* Copyright (c) 2023 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+#include "graph/optimizer/rule/PushFilterThroughAppendVerticesRule.h"
+
+#include "common/expression/Expression.h"
+#include "graph/optimizer/OptContext.h"
+#include "graph/optimizer/OptGroup.h"
+#include "graph/planner/plan/PlanNode.h"
+#include "graph/planner/plan/Query.h"
+#include "graph/util/ExpressionUtils.h"
+#include "graph/visitor/ExtractFilterExprVisitor.h"
+
+using nebula::Expression;
+using nebula::graph::AppendVertices;
+using nebula::graph::Filter;
+using nebula::graph::PlanNode;
+using nebula::graph::QueryContext;
+
+namespace nebula {
+namespace opt {
+
+std::unique_ptr<OptRule> PushFilterThroughAppendVerticesRule::kInstance =
+    std::unique_ptr<PushFilterThroughAppendVerticesRule>(new PushFilterThroughAppendVerticesRule());
+
+PushFilterThroughAppendVerticesRule::PushFilterThroughAppendVerticesRule() {
+  RuleSet::QueryRules().addRule(this);
+}
+
+const Pattern& PushFilterThroughAppendVerticesRule::pattern() const {
+  static Pattern pattern =
+      Pattern::create(PlanNode::Kind::kFilter, {Pattern::create(PlanNode::Kind::kAppendVertices)});
+  return pattern;
+}
+
+StatusOr<OptRule::TransformResult> PushFilterThroughAppendVerticesRule::transform(
+    OptContext* octx, const MatchedResult& matched) const {
+  auto* oldFilterGroupNode = matched.node;
+  auto* oldFilterGroup = oldFilterGroupNode->group();
+  auto* oldFilterNode = static_cast<graph::Filter*>(oldFilterGroupNode->node());
+  auto* condition = oldFilterNode->condition();
+  auto* oldAvGroupNode = matched.dependencies[0].node;
+  auto* oldAvNode = static_cast<graph::AppendVertices*>(oldAvGroupNode->node());
+  auto& dstNode = oldAvNode->nodeAlias();
+
+  auto inputColNames = oldAvNode->inputVars().front()->colNames;
+  auto qctx = octx->qctx();
+
+  auto picker = [&inputColNames, &dstNode](const Expression* expr) -> bool {
+    auto finder = [&inputColNames, &dstNode](const Expression* e) -> bool {
+      if (e->isPropertyExpr() &&
+          std::find(inputColNames.begin(),
+                    inputColNames.end(),
+                    (static_cast<const PropertyExpression*>(e)->prop())) == inputColNames.end()) {
+        return true;
+      }
+      if (e->kind() == Expression::Kind::kVar &&
+          static_cast<const VariableExpression*>(e)->var() == dstNode) {
+        return true;
+      }
+      return false;
+    };
+    graph::FindVisitor visitor(finder);
+    const_cast<Expression*>(expr)->accept(&visitor);
+    return visitor.results().empty();
+  };
+  Expression* filterPicked = nullptr;
+  Expression* filterUnpicked = nullptr;
+  graph::ExpressionUtils::splitFilter(condition, picker, &filterPicked, &filterUnpicked);
+
+  if (!filterPicked) {
+    return TransformResult::noTransform();
+  }
+
+  // produce new Filter node below
+  auto* newBelowFilterNode =
+      graph::Filter::make(qctx, const_cast<graph::PlanNode*>(oldAvNode->dep()), filterPicked);
+  newBelowFilterNode->setInputVar(oldAvNode->inputVar());
+  newBelowFilterNode->setColNames(oldAvNode->inputVars().front()->colNames);
+  auto newBelowFilterGroup = OptGroup::create(octx);
+  auto newFilterGroupNode = newBelowFilterGroup->makeGroupNode(newBelowFilterNode);
+  newFilterGroupNode->setDeps(oldAvGroupNode->dependencies());
+
+  // produce new AppendVertices node
+  auto* newAvNode = static_cast<graph::AppendVertices*>(oldAvNode->clone());
+  newAvNode->setInputVar(newBelowFilterNode->outputVar());
+
+  TransformResult result;
+  result.eraseAll = true;
+  if (filterUnpicked) {
+    // produce new Filter node above
+    auto* newAboveFilterNode = graph::Filter::make(octx->qctx(), newAvNode, filterUnpicked);
+    newAboveFilterNode->setOutputVar(oldFilterNode->outputVar());
+    auto newAboveFilterGroupNode = OptGroupNode::create(octx, newAboveFilterNode, oldFilterGroup);
+
+    auto newAvGroup = OptGroup::create(octx);
+    auto newAvGroupNode = newAvGroup->makeGroupNode(newAvNode);
+    newAvGroupNode->setDeps({newBelowFilterGroup});
+    newAvNode->setInputVar(newBelowFilterNode->outputVar());
+    newAboveFilterGroupNode->setDeps({newAvGroup});
+    newAboveFilterNode->setInputVar(newAvNode->outputVar());
+    result.newGroupNodes.emplace_back(newAboveFilterGroupNode);
+  } else {
+    newAvNode->setOutputVar(oldFilterNode->outputVar());
+    // newAvNode's col names, on the hand, should inherit those of the oldAvNode
+    // since they are the same project.
+    newAvNode->setColNames(oldAvNode->outputVarPtr()->colNames);
+    auto newAvGroupNode = OptGroupNode::create(octx, newAvNode, oldFilterGroup);
+    newAvGroupNode->setDeps({newBelowFilterGroup});
+    newAvNode->setInputVar(newBelowFilterNode->outputVar());
+    result.newGroupNodes.emplace_back(newAvGroupNode);
+  }
+  return result;
+}
+
+std::string PushFilterThroughAppendVerticesRule::toString() const {
+  return "PushFilterThroughAppendVerticesRule";
+}
+
+}  // namespace opt
+}  // namespace nebula

--- a/src/graph/optimizer/rule/PushFilterThroughAppendVerticesRule.h
+++ b/src/graph/optimizer/rule/PushFilterThroughAppendVerticesRule.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2023 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+#ifndef GRAPH_OPTIMIZER_RULE_PUSHFILTERTHROUGHAPPENDVERTICES_H_
+#define GRAPH_OPTIMIZER_RULE_PUSHFILTERTHROUGHAPPENDVERTICES_H_
+
+#include "graph/optimizer/OptRule.h"
+
+namespace nebula {
+namespace opt {
+
+/*
+ * Before:
+ *    Filter(e.likeness > 78 and v.prop > 40)
+ *        |
+ *   AppendVertices(v)
+ *
+ * After :
+ *   Filter(v.prop > 40)
+ *        |
+ *   AppendVertices(v)
+ *        |
+ *   Filter(e.likeness > 78)
+ *
+ */
+
+class PushFilterThroughAppendVerticesRule final : public OptRule {
+ public:
+  const Pattern &pattern() const override;
+
+  StatusOr<TransformResult> transform(OptContext *ctx, const MatchedResult &matched) const override;
+
+  std::string toString() const override;
+
+ private:
+  PushFilterThroughAppendVerticesRule();
+
+  static std::unique_ptr<OptRule> kInstance;
+};
+
+}  // namespace opt
+}  // namespace nebula
+
+#endif  // GRAPH_OPTIMIZER_RULE_PUSHFILTERTHROUGHAPPENDVERTICES_H_

--- a/tests/tck/features/bugfix/LackFilterGetEdges.feature
+++ b/tests/tck/features/bugfix/LackFilterGetEdges.feature
@@ -10,6 +10,25 @@ Feature: Test lack filter of get edges transform
   Scenario: Lack filter of get edges transform
     When profiling query:
       """
+      match ()-[e*1]->()
+      where e[0].likeness > 78  or uuid() > 100
+      return rank(e[0]) AS re limit 3
+      """
+    Then the result should be, in any order:
+      | re |
+      | 0  |
+      | 0  |
+      | 0  |
+    And the execution plan should be:
+      | id | name           | dependencies | operator info                                         |
+      | 24 | Project        | 20           |                                                       |
+      | 20 | Limit          | 21           |                                                       |
+      | 21 | AppendVertices | 23           |                                                       |
+      | 23 | Traverse       | 22           | { "edge filter": "((*.likeness>78) OR (uuid()>100))"} |
+      | 22 | ScanVertices   | 3            |                                                       |
+      | 3  | Start          |              |                                                       |
+    When profiling query:
+      """
       match ()-[e]->()
       where e.likeness > 78  or uuid() > 100
       return rank(e) limit 3

--- a/tests/tck/features/match/SeekById.feature
+++ b/tests/tck/features/match/SeekById.feature
@@ -860,6 +860,7 @@ Feature: Match seek by id
       | 11 | Project        | 8            |               |
       | 8  | Filter         | 4            |               |
       | 4  | AppendVertices | 10           |               |
+      | 10 | Filter         | 10           |               |
       | 10 | Traverse       | 2            |               |
       | 2  | Dedup          | 4            |               |
       | 1  | PassThrough    | 3            |               |

--- a/tests/tck/features/optimizer/CollapseProjectRule.feature
+++ b/tests/tck/features/optimizer/CollapseProjectRule.feature
@@ -6,6 +6,7 @@ Feature: Collapse Project Rule
   Background:
     Given a graph with space named "nba"
 
+  @czp
   Scenario: Collapse Project
     When profiling query:
       """
@@ -99,6 +100,7 @@ Feature: Collapse Project Rule
       | 14 | Project        | 12           |               |
       | 12 | Filter         | 6            |               |
       | 6  | AppendVertices | 5            |               |
+      | 5  | Filter         | 5            |               |
       | 5  | Traverse       | 4            |               |
       | 4  | Traverse       | 2            |               |
       | 2  | Dedup          | 1            |               |

--- a/tests/tck/features/optimizer/PrunePropertiesRule.feature
+++ b/tests/tck/features/optimizer/PrunePropertiesRule.feature
@@ -579,6 +579,7 @@ Feature: Prune Properties rule
       | 21 | Project        | 20           |                                                                                                                                          |
       | 20 | Filter         | 25           |                                                                                                                                          |
       | 25 | AppendVertices | 24           | {  "props": "[{ \"props\":[\"name\",\"_tag\"]}]" }                                                                                       |
+      | 24 | Filter         | 24           |                                                                                                                                          |
       | 24 | Traverse       | 23           | {"vertexProps": "[{ \"props\":[\"age\"]}]", "edgeProps": "[{  \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                          |
       | 23 | Traverse       | 22           | {"vertexProps": "", "edgeProps": "[{  \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  }                                                  |
       | 22 | Traverse       | 2            | {"vertexProps": "", "edgeProps": "[{  \"props\": [\"_type\", \"_rank\", \"_dst\"]}, {  \"props\": [\"_type\", \"_rank\", \"_dst\"]}]"  } |

--- a/tests/tck/features/optimizer/PushFilterDownBugFixes.feature
+++ b/tests/tck/features/optimizer/PushFilterDownBugFixes.feature
@@ -24,6 +24,7 @@ Feature: Bug fixes on filter push-down
       | 11 | Project        | 10           |               |
       | 10 | Filter         | 6            |               |
       | 6  | AppendVertices | 5            |               |
+      | 5  | Filter         | 5            |               |
       | 5  | Traverse       | 4            |               |
       | 4  | Traverse       | 2            |               |
       | 2  | Dedup          | 1            |               |
@@ -45,6 +46,7 @@ Feature: Bug fixes on filter push-down
       | 11 | Project        | 10           |               |
       | 10 | Filter         | 6            |               |
       | 6  | AppendVertices | 5            |               |
+      | 5  | Filter         | 5            |               |
       | 5  | Traverse       | 4            |               |
       | 4  | Traverse       | 2            |               |
       | 2  | Dedup          | 1            |               |

--- a/tests/tck/features/optimizer/PushFilterDownCrossJoinRule.feature
+++ b/tests/tck/features/optimizer/PushFilterDownCrossJoinRule.feature
@@ -18,15 +18,16 @@ Feature: Push Filter down HashInnerJoin rule
       | count(e) |
       | 8        |
     And the execution plan should be:
-      | id | name           | dependencies | operator info                                                                                                          |
-      | 11 | Aggregate      | 14           |                                                                                                                        |
-      | 14 | CrossJoin      | 1,16         |                                                                                                                        |
-      | 1  | Project        | 2            |                                                                                                                        |
-      | 2  | Start          |              |                                                                                                                        |
-      | 16 | Project        | 15           |                                                                                                                        |
-      | 15 | Filter         | 18           | {"condition": "((id($-.v1) IN [\"Tim Duncan\",\"Tony Parker\"]) AND (id($-.v2) IN [\"Tim Duncan\",\"Tony Parker\"]))"} |
-      | 18 | AppendVertices | 17           |                                                                                                                        |
-      | 17 | Traverse       | 4            |                                                                                                                        |
-      | 4  | Dedup          | 3            |                                                                                                                        |
-      | 3  | PassThrough    | 5            |                                                                                                                        |
-      | 5  | Start          |              |                                                                                                                        |
+      | id | name           | dependencies | operator info                                                    |
+      | 11 | Aggregate      | 14           |                                                                  |
+      | 14 | CrossJoin      | 1,16         |                                                                  |
+      | 1  | Project        | 2            |                                                                  |
+      | 2  | Start          |              |                                                                  |
+      | 16 | Project        | 15           |                                                                  |
+      | 15 | Filter         | 18           | {"condition": "(id($-.v2) IN [\"Tim Duncan\",\"Tony Parker\"])"} |
+      | 18 | AppendVertices | 17           |                                                                  |
+      | 17 | Filter         | 17           | {"condition": "(id($-.v1) IN [\"Tim Duncan\",\"Tony Parker\"])"} |
+      | 17 | Traverse       | 4            |                                                                  |
+      | 4  | Dedup          | 3            |                                                                  |
+      | 3  | PassThrough    | 5            |                                                                  |
+      | 5  | Start          |              |                                                                  |

--- a/tests/tck/features/optimizer/PushFilterDownTraverseRule.feature
+++ b/tests/tck/features/optimizer/PushFilterDownTraverseRule.feature
@@ -137,9 +137,9 @@ Feature: Push Filter down Traverse rule
       | 17 | Aggregate      | 16           |                |                                       |
       | 16 | HashLeftJoin   | 10,15        |                |                                       |
       | 10 | Dedup          | 28           |                |                                       |
-      | 28 | Project        | 22           |                |                                       |
-      | 22 | Filter         | 26           |                |                                       |
+      | 28 | Project        | 26           |                |                                       |
       | 26 | AppendVertices | 25           |                |                                       |
+      | 25 | Filter         | 25           |                |                                       |
       | 25 | Traverse       | 24           |                | {"filter": "(serve.start_year>2010)"} |
       | 24 | Traverse       | 2            |                |                                       |
       | 2  | Dedup          | 1            |                |                                       |

--- a/tests/tck/features/optimizer/PushLimitDownProjectRule.feature
+++ b/tests/tck/features/optimizer/PushLimitDownProjectRule.feature
@@ -27,6 +27,7 @@ Feature: Push Limit down project rule
       | 16 | Limit          | 11           |               |
       | 11 | Filter         | 4            |               |
       | 4  | AppendVertices | 3            |               |
+      | 3  | Filter         | 3            |               |
       | 3  | Traverse       | 2            |               |
       | 2  | Dedup          | 1            |               |
       | 1  | PassThrough    | 0            |               |

--- a/tests/tck/features/optimizer/RemoveAppendVerticesBelowJoinRule.feature
+++ b/tests/tck/features/optimizer/RemoveAppendVerticesBelowJoinRule.feature
@@ -50,9 +50,9 @@ Feature: Remove AppendVertices Below Join
       | 17 | Aggregate      | 16           |                                                                                                                         |
       | 16 | HashLeftJoin   | 10,15        | {"hashKeys": ["_joinkey($-.friendTeam)", "_joinkey($-.friend)"], "probeKeys": ["$-.friendTeam", "_joinkey($-.friend)"]} |
       | 10 | Dedup          | 28           |                                                                                                                         |
-      | 28 | Project        | 22           |                                                                                                                         |
-      | 22 | Filter         | 26           |                                                                                                                         |
+      | 28 | Project        | 26           |                                                                                                                         |
       | 26 | AppendVertices | 25           |                                                                                                                         |
+      | 25 | Filter         | 25           |                                                                                                                         |
       | 25 | Traverse       | 24           |                                                                                                                         |
       | 24 | Traverse       | 2            |                                                                                                                         |
       | 2  | Dedup          | 1            |                                                                                                                         |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
Split the optimizer rule `PushFilterDownTraverseRule` to `PushFilterThroughAppendVerticesRule` and `PushFilterDownTraverseRule`.

This pr is for refactoring purposes but also introduces some optimizations, such as non-endpoint predicates that can be pushed down before AppendVertices.

The purpose of refactoring is that the previous implementation was too ad-hoc for further optimization, and there were some conflicts between rules, so we should try to avoid similar code implementation from a more common perspective, especially for the development of optimizer.

## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory

