### PR TITLE
Add salt when generating cluster id to reduce duplication

### DIFF
--- a/src/meta/KVBasedClusterIdMan.h
+++ b/src/meta/KVBasedClusterIdMan.h
@@ -29,8 +29,17 @@ class ClusterIdMan {
    * @return
    */
   static ClusterID create(const std::string& metaAddrs) {
+    // Generate random salt
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::string randomBytes(16, ' ');
+    std::generate_n(randomBytes.begin(), 16, std::ref(gen));
+
+    // Concatenate salt with input string
+    std::string saltedInput = metaAddrs + randomBytes;
+
     std::hash<std::string> hash_fn;
-    auto clusterId = hash_fn(metaAddrs);
+    auto clusterId = hash_fn(saltedInput);
     uint64_t mask = 0x7FFFFFFFFFFFFFFF;
     clusterId &= mask;
     LOG(INFO) << "Create ClusterId " << clusterId;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
Same as [Add salt when generating cluster id to reduce duplication #2545](https://github.com/vesoft-inc/nebula-ent/pull/2545)

I don't know why but there are 2 methods used to generate cluster ids


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
