### PR TITLE
fix leader cache

### DIFF
--- a/src/clients/meta/MetaClient.cpp
+++ b/src/clients/meta/MetaClient.cpp
@@ -369,8 +369,6 @@ bool MetaClient::loadData() {
     return *hostItem.hostAddr_ref();
   });
 
-  loadLeader(hostItems, spaceIndexByName_);
-
   decltype(localCache_) oldCache;
   {
     oldCache = std::move(localCache_);
@@ -385,6 +383,8 @@ bool MetaClient::loadData() {
     spaceAllEdgeMap_ = std::move(spaceAllEdgeMap);
     storageHosts_ = std::move(hosts);
   }
+
+  loadLeader(hostItems, spaceIndexByName_);
 
   localDataLastUpdateTime_.store(metadLastUpdateTime_.load());
   auto newMetaData = new MetaData();


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
when restart graphd, it would update the storage part leader from meta.
but `spaceIndexByName_` has no value yet. 

![image](https://user-images.githubusercontent.com/1726587/236617360-be9ac570-30aa-4dec-93be-0ed486ea0ccb.png)
![image](https://user-images.githubusercontent.com/1726587/236617370-a0fa64d1-ab37-4036-a329-8b963623b8d3.png)


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
