### PR TITLE
fix cluster id is not backuped

### DIFF
--- a/src/common/utils/MetaKeyUtils.cpp
+++ b/src/common/utils/MetaKeyUtils.cpp
@@ -32,7 +32,9 @@ static const std::unordered_map<std::string, std::pair<std::string, bool>> syste
 
 // SystemInfo will always be backed up
 static const std::unordered_map<std::string, std::pair<std::string, bool>> systemInfoMaps{
-    {"autoIncrementId", {"__id__", true}}, {"lastUpdateTime", {"__last_update_time__", true}}};
+    {"autoIncrementId", {"__id__", true}},
+    {"lastUpdateTime", {"__last_update_time__", true}},
+    {"clusterId", {"__meta_cluster_id_key__", true}}};
 
 // name => {prefix, parseSpaceid}, nullptr means that the backup should be skipped.
 static const std::unordered_map<


### PR DESCRIPTION
## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula/issues/5574

#### Description:
3.5 has write a random cluster id in meta. If it is not backup/restore, storage will failed to start-up when restoring.


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
