### PR TITLE
Increment ActiveZones only once

### DIFF
--- a/src/meta/processors/parts/CreateSpaceProcessor.cpp
+++ b/src/meta/processors/parts/CreateSpaceProcessor.cpp
@@ -191,6 +191,7 @@ void CreateSpaceProcessor::process(const cpp2::CreateSpaceReq& req) {
 
     auto now = time::WallClock::fastNowInMilliSec();
     auto hosts = MetaKeyUtils::parseZoneHosts(std::move(nebula::value(zoneValueRet)));
+    bool zoneActive = false;
     for (auto& host : hosts) {
       auto key = MetaKeyUtils::hostKey(host.host, host.port);
       auto ret = doGet(key);
@@ -202,7 +203,7 @@ void CreateSpaceProcessor::process(const cpp2::CreateSpaceReq& req) {
       HostInfo info = HostInfo::decode(nebula::value(ret));
       if (now - info.lastHBTimeInMilliSec_ <
           FLAGS_heartbeat_interval_secs * FLAGS_expired_time_factor * 1000) {
-        activeZoneSize += 1;
+        zoneActive = true;
         auto hostIter = hostLoading_.find(host);
         if (hostIter == hostLoading_.end()) {
           hostLoading_[host] = 0;
@@ -215,6 +216,9 @@ void CreateSpaceProcessor::process(const cpp2::CreateSpaceReq& req) {
       }
     }
 
+    if (zoneActive) {
+      activeZoneSize += 1;
+    }
     CHECK_CODE_AND_BREAK();
     zoneHosts[zone] = std::move(hosts);
   }

--- a/src/meta/processors/parts/CreateSpaceProcessor.cpp
+++ b/src/meta/processors/parts/CreateSpaceProcessor.cpp
@@ -191,7 +191,7 @@ void CreateSpaceProcessor::process(const cpp2::CreateSpaceReq& req) {
 
     auto now = time::WallClock::fastNowInMilliSec();
     auto hosts = MetaKeyUtils::parseZoneHosts(std::move(nebula::value(zoneValueRet)));
-    bool zoneActive = false;
+    bool isZoneActive = false;
     for (auto& host : hosts) {
       auto key = MetaKeyUtils::hostKey(host.host, host.port);
       auto ret = doGet(key);
@@ -203,7 +203,7 @@ void CreateSpaceProcessor::process(const cpp2::CreateSpaceReq& req) {
       HostInfo info = HostInfo::decode(nebula::value(ret));
       if (now - info.lastHBTimeInMilliSec_ <
           FLAGS_heartbeat_interval_secs * FLAGS_expired_time_factor * 1000) {
-        zoneActive = true;
+        isZoneActive = true;
         auto hostIter = hostLoading_.find(host);
         if (hostIter == hostLoading_.end()) {
           hostLoading_[host] = 0;
@@ -216,7 +216,7 @@ void CreateSpaceProcessor::process(const cpp2::CreateSpaceReq& req) {
       }
     }
 
-    if (zoneActive) {
+    if (isZoneActive) {
       activeZoneSize += 1;
     }
     CHECK_CODE_AND_BREAK();


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
In `CreateSpaceProcessor`, we will check that number of replicas not greater than number of zones and number of active zones. By definition, a zone is active as long as there is an active host in the zone. However, the current code would increment `activeZoneSize` whenever there is an active host in the zone, leading to `activeZoneSize` way more than number of zones. This may cause bugs. 

In this PR, we increment `activeZoneSize` only once for each zone as long as there is an active host in the zone.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
