### PR TITLE
Fix too many logs print when listing sessions

### DIFF
--- a/src/meta/processors/session/SessionManagerProcessor.cpp
+++ b/src/meta/processors/session/SessionManagerProcessor.cpp
@@ -133,10 +133,8 @@ void ListSessionsProcessor::process(const cpp2::ListSessionsReq&) {
     sessions.emplace_back(std::move(session));
     iter->next();
   }
+  LOG(INFO) << "resp session size: " << sessions.size();
   resp_.sessions_ref() = std::move(sessions);
-  for (auto& session : resp_.get_sessions()) {
-    LOG(INFO) << "resp list session: " << session.get_session_id();
-  }
   handleErrorCode(nebula::cpp2::ErrorCode::SUCCEEDED);
   onFinished();
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [*] enhancement

## What problem(s) does this PR solve?

#### Description:
In our cluster, there are tens of thousands of sessions established, when executing listing sessions, the metad is blocked as it will print every session to the disk, it's time costed and not very necessary.
Besides, the session id is printed twice, the first time is with VLOG(3) in the above line.

## How do you solve it?
Remove the unnecessary sessions print.

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> Fix too many logs print when listing sessions
