### PR TITLE
fix traverse build path memory tracker

### DIFF
--- a/src/graph/executor/query/TraverseExecutor.cpp
+++ b/src/graph/executor/query/TraverseExecutor.cpp
@@ -478,6 +478,7 @@ folly::Future<Status> TraverseExecutor::buildPathMultiJobs(size_t minStep, size_
 std::vector<Row> TraverseExecutor::buildPath(const Value& initVertex,
                                              size_t minStep,
                                              size_t maxStep) {
+  memory::MemoryCheckGuard guard;
   auto vidIter = adjList_.find(initVertex);
   if (vidIter == adjList_.end()) {
     return std::vector<Row>();


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula/issues/5615

#### Description:
before
<img width="725" alt="image" src="https://github.com/vesoft-inc/nebula/assets/6930445/2bef9c99-a820-4b98-96ea-c930f33df3f7">

now
<img width="647" alt="image" src="https://github.com/vesoft-inc/nebula/assets/6930445/4401e25f-6a49-4479-941b-2a826afb159e">




```
(root@nebula) [nba]> match (a:player)-[*0..9]->(b) return count(b)
[ERROR (-1005)]: GraphMemoryExceeded: (-2600)

Mon, 03 Jul 2023 10:42:45 CST
```
 memory can be monitored now

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
