### PR TITLE
fix all path memory tracker

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -236,3 +236,4 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.compiler }}-nebula-test-logs
           path:  ./build/server_*/logs/
+          

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -236,4 +236,4 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.compiler }}-nebula-test-logs
           path:  ./build/server_*/logs/
-          
+

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -90,9 +90,6 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: webiny/action-post-run@3.0.0
-        with:
-          run: sh -c "find . -mindepth 1 -delete"
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
       - uses: actions/checkout@v3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -71,6 +71,7 @@ jobs:
       SCCACHE_S3_KEY_PREFIX: ${{ github.repository }}
       AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET }}
+      SCCACHE_LOG: debug
     container:
       image: vesoft/nebula-dev:${{ matrix.os }}
       options: --cap-add=SYS_PTRACE

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -72,6 +72,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.MINIO_KEY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MINIO_SECRET }}
       SCCACHE_LOG: debug
+      SCCACHE_NO_DAEMON: 1
     container:
       image: vesoft/nebula-dev:${{ matrix.os }}
       options: --cap-add=SYS_PTRACE

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -155,7 +155,7 @@ jobs:
             case ${{ matrix.os }} in
             centos7)
               # build with Release type
-              ninja -j $(nproc)
+              ninja -v -j $(nproc)
               ;;
             ubuntu2004)
               # build with Debug type

--- a/src/graph/executor/algo/AllPathsExecutor.cpp
+++ b/src/graph/executor/algo/AllPathsExecutor.cpp
@@ -211,7 +211,9 @@ folly::Future<Status> AllPathsExecutor::buildResult() {
   return future.via(runner())
       .ensure([this, buildPathTime]() { addState("build_path_time", buildPathTime); })
       .thenValue([this](auto&& resp) {
-        UNUSED(resp);
+        if (!resp.ok()) {
+          return folly::makeFuture<Status>(std::move(resp));
+        }
         if (!withProp_ || emptyPropVids_.empty()) {
           finish(ResultBuilder().value(Value(std::move(result_))).build());
           return folly::makeFuture<Status>(Status::OK());
@@ -259,7 +261,6 @@ folly::Future<std::vector<AllPathsExecutor::NPath*>> AllPathsExecutor::doBuildPa
     size_t end,
     std::shared_ptr<std::vector<NPath*>> pathsPtr,
     bool reverse) {
-  memory::MemoryCheckGuard guard;
   auto maxStep = reverse ? rightSteps_ : leftSteps_;
   if (step > maxStep) {
     return folly::makeFuture<std::vector<NPath*>>(std::vector<NPath*>());
@@ -334,6 +335,7 @@ folly::Future<std::vector<AllPathsExecutor::NPath*>> AllPathsExecutor::doBuildPa
   }
   return folly::collect(futures).via(runner()).thenValue(
       [currentStepResult = newPathsPtr](std::vector<std::vector<NPath*>>&& paths) {
+        memory::MemoryCheckGuard guard;
         std::vector<NPath*> result = std::move(*currentStepResult);
         for (auto& path : paths) {
           if (path.empty()) {
@@ -458,7 +460,6 @@ std::vector<Row> AllPathsExecutor::buildOneWayPathFromHashTable(bool reverse) {
 
 folly::Future<Status> AllPathsExecutor::conjunctPath(std::vector<NPath*>& leftPaths,
                                                      std::vector<NPath*>& rightPaths) {
-  memory::MemoryCheckGuard guard;
   if (leftPaths.empty() || rightPaths.empty()) {
     return folly::makeFuture<Status>(Status::OK());
   }
@@ -486,8 +487,10 @@ folly::Future<Status> AllPathsExecutor::conjunctPath(std::vector<NPath*>& leftPa
           runner(), [this, start, end, reverse]() { return probe(start, end, reverse); }));
     }
   }
-  return folly::collect(futures).via(runner()).thenValue(
-      [this, path = std::move(oneWayPath)](std::vector<std::vector<Row>>&& resps) {
+  return folly::collect(futures)
+      .via(runner())
+      .thenValue([this, path = std::move(oneWayPath)](std::vector<std::vector<Row>>&& resps) {
+        memory::MemoryCheckGuard guard;
         result_.rows = std::move(path);
         for (auto& rows : resps) {
           if (rows.empty()) {
@@ -510,6 +513,14 @@ folly::Future<Status> AllPathsExecutor::conjunctPath(std::vector<NPath*>& leftPa
           result_.rows.resize(limit_);
         }
         return Status::OK();
+      })
+      .thenError(folly::tag_t<std::bad_alloc>{},
+                 [this](const std::bad_alloc&) {
+                   memoryExceeded_ = true;
+                   return folly::makeFuture<Status>(Executor::memoryExceededStatus());
+                 })
+      .thenError(folly::tag_t<std::exception>{}, [](const std::exception& e) {
+        return folly::makeFuture<Status>(std::runtime_error(e.what()));
       });
 }
 
@@ -546,6 +557,9 @@ std::vector<Row> AllPathsExecutor::probe(size_t start, size_t end, bool reverse)
   std::vector<Row> result;
   Row emptyPropVerticesRow;
   for (size_t i = start; i < end; ++i) {
+    if (memoryExceeded_.load(std::memory_order_acquire) == true) {
+      break;
+    }
     auto& probePath = probePaths_[i];
     auto& edgeVal = probePath->edge;
     const auto& intersectVid = edgeVal.getEdge().dst;

--- a/src/graph/executor/algo/AllPathsExecutor.cpp
+++ b/src/graph/executor/algo/AllPathsExecutor.cpp
@@ -259,6 +259,7 @@ folly::Future<std::vector<AllPathsExecutor::NPath*>> AllPathsExecutor::doBuildPa
     size_t end,
     std::shared_ptr<std::vector<NPath*>> pathsPtr,
     bool reverse) {
+  memory::MemoryCheckGuard guard;
   auto maxStep = reverse ? rightSteps_ : leftSteps_;
   if (step > maxStep) {
     return folly::makeFuture<std::vector<NPath*>>(std::vector<NPath*>());
@@ -333,7 +334,6 @@ folly::Future<std::vector<AllPathsExecutor::NPath*>> AllPathsExecutor::doBuildPa
   }
   return folly::collect(futures).via(runner()).thenValue(
       [currentStepResult = newPathsPtr](std::vector<std::vector<NPath*>>&& paths) {
-        memory::MemoryCheckGuard guard;
         std::vector<NPath*> result = std::move(*currentStepResult);
         for (auto& path : paths) {
           if (path.empty()) {
@@ -458,6 +458,7 @@ std::vector<Row> AllPathsExecutor::buildOneWayPathFromHashTable(bool reverse) {
 
 folly::Future<Status> AllPathsExecutor::conjunctPath(std::vector<NPath*>& leftPaths,
                                                      std::vector<NPath*>& rightPaths) {
+  memory::MemoryCheckGuard guard;
   if (leftPaths.empty() || rightPaths.empty()) {
     return folly::makeFuture<Status>(Status::OK());
   }
@@ -487,7 +488,6 @@ folly::Future<Status> AllPathsExecutor::conjunctPath(std::vector<NPath*>& leftPa
   }
   return folly::collect(futures).via(runner()).thenValue(
       [this, path = std::move(oneWayPath)](std::vector<std::vector<Row>>&& resps) {
-        memory::MemoryCheckGuard guard;
         result_.rows = std::move(path);
         for (auto& rows : resps) {
           if (rows.empty()) {
@@ -528,6 +528,7 @@ void AllPathsExecutor::buildHashTable(std::vector<NPath*>& paths, bool reverse) 
 }
 
 std::vector<Row> AllPathsExecutor::probe(size_t start, size_t end, bool reverse) {
+  memory::MemoryCheckGuard guard;
   auto buildPath = [](std::vector<Value>& leftPath,
                       const Value& intersectVertex,
                       std::vector<Value>& rightPath) {

--- a/src/graph/executor/algo/AllPathsExecutor.h
+++ b/src/graph/executor/algo/AllPathsExecutor.h
@@ -110,6 +110,7 @@ class AllPathsExecutor final : public StorageAccessExecutor {
   bool noLoop_{false};
   size_t limit_{std::numeric_limits<size_t>::max()};
   std::atomic<size_t> cnt_{0};
+  std::atomic<bool> memoryExceeded_{false};
   size_t maxStep_{0};
 
   size_t leftSteps_{0};


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula-ent/issues/2906
close https://github.com/vesoft-inc/nebula-ent/issues/2904


#### Description:
before:
![image](https://github.com/vesoft-inc/nebula/assets/6930445/1bf2a99d-252a-49e3-82ab-8822e4c62055)

now:
```
(root@nebula) [nba]> go from 'Tim Duncan' over * yield id($$) as dst| find all path from $-.dst to $-.dst  over * bidirect upto 100 steps yield path as p |yield count(*)
[ERROR (-1005)]: GraphMemoryExceeded: (-2600)

Thu, 06 Jul 2023 10:45:24 CST
```

<img width="1257" alt="image" src="https://github.com/vesoft-inc/nebula/assets/6930445/fb72778f-cbe0-4027-8449-64204d63eeab">


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
