### PR TITLE
change iterRef to iter

### DIFF
--- a/src/graph/executor/query/ExpandAllExecutor.cpp
+++ b/src/graph/executor/query/ExpandAllExecutor.cpp
@@ -20,8 +20,8 @@ namespace graph {
 Status ExpandAllExecutor::buildRequestVids() {
   SCOPED_TIMER(&execTime_);
   const auto& inputVar = expand_->inputVar();
-  auto inputIter = ectx_->getResult(inputVar).iterRef();
-  auto iter = static_cast<SequentialIter*>(inputIter);
+  auto inputIter = ectx_->getResult(inputVar).iter();
+  auto iter = static_cast<SequentialIter*>(inputIter.get());
   size_t iterSize = iter->size();
   nextStepVids_.reserve(iterSize);
   if (joinInput_) {

--- a/src/graph/executor/query/ExpandExecutor.cpp
+++ b/src/graph/executor/query/ExpandExecutor.cpp
@@ -20,8 +20,8 @@ namespace graph {
 Status ExpandExecutor::buildRequestVids() {
   SCOPED_TIMER(&execTime_);
   const auto& inputVar = expand_->inputVar();
-  auto inputIter = ectx_->getResult(inputVar).iterRef();
-  auto iter = static_cast<SequentialIter*>(inputIter);
+  auto inputIter = ectx_->getResult(inputVar).iter();
+  auto iter = static_cast<SequentialIter*>(inputIter.get());
   size_t iterSize = iter->size();
   nextStepVids_.reserve(iterSize);
   QueryExpressionContext ctx(ectx_);

--- a/src/graph/executor/query/TraverseExecutor.cpp
+++ b/src/graph/executor/query/TraverseExecutor.cpp
@@ -36,8 +36,8 @@ folly::Future<Status> TraverseExecutor::execute() {
 Status TraverseExecutor::buildRequestVids() {
   SCOPED_TIMER(&execTime_);
   const auto& inputVar = traverse_->inputVar();
-  auto inputIter = ectx_->getResult(inputVar).iterRef();
-  auto iter = static_cast<SequentialIter*>(inputIter);
+  auto inputIter = ectx_->getResult(inputVar).iter();
+  auto iter = static_cast<SequentialIter*>(inputIter.get());
   size_t iterSize = iter->size();
   vids_.reserve(iterSize);
   auto* src = traverse_->src();

--- a/tests/tck/features/go/GO.feature
+++ b/tests/tck/features/go/GO.feature
@@ -2050,3 +2050,18 @@ Feature: Go Sentence
       | "Grant Hill"         | "Grant Hill"         |
       | "Vince Carter"       | "Vince Carter"       |
       | "Yao Ming"           | "Yao Ming"           |
+
+  Scenario: multiple statements refer to the same variable
+    When executing query:
+      """
+      $m1= LOOKUP ON player WHERE player.name == 'Tim Duncan' YIELD id(vertex) AS vid;
+      $m2 = GO 2 TO 10 STEPS FROM $m1.vid OVER like YIELD distinct id($$) AS dst
+            INTERSECT
+            GO 4 TO 7 STEPS FROM $m1.vid OVER like REVERSELY YIELD distinct id($$) AS dst
+      """
+    Then the result should be, in any order, with relax comparison:
+      | dst                 |
+      | "LaMarcus Aldridge" |
+      | "Tim Duncan"        |
+      | "Manu Ginobili"     |
+      | "Tony Parker"       |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula/issues/5663

#### Description:
iterRef returns the original iterator pointer, when multiple statements refer to the same variable, there will be competition

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
