### PR TITLE
fix gflags's description of session_reclaim_interval_secs

### DIFF
--- a/src/graph/service/GraphFlags.cpp
+++ b/src/graph/service/GraphFlags.cpp
@@ -12,7 +12,10 @@ DEFINE_int32(client_idle_timeout_secs,
              28800,
              "The number of seconds NebulaGraph service waits before closing the idle connections");
 DEFINE_int32(session_idle_timeout_secs, 28800, "The number of seconds before idle sessions expire");
-DEFINE_int32(session_reclaim_interval_secs, 60, "Period we try to reclaim expired sessions");
+DEFINE_int32(
+    session_reclaim_interval_secs,
+    60,
+    "Period we try to reclaim expired sessions and update session information to the meta server");
 DEFINE_int32(num_netio_threads,
              0,
              "The number of networking threads, 0 for number of physical CPU cores");


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Description:
session_reclaim_interval_secs is not for reclaim session, but also for update session


## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [x] Function test
- [x] Performance test
- [x] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory

