### PR TITLE
fix concurrency bug

### DIFF
--- a/src/graph/executor/Executor.h
+++ b/src/graph/executor/Executor.h
@@ -174,7 +174,7 @@ auto Executor::runMultiJobs(ScatterFunc &&scatter, GatherFunc &&gather, Iterator
   }
 
   // Gather all results and do post works
-  return folly::collect(futures).via(runner()).thenValue(std::move(gather));
+  return folly::collectAll(futures).via(runner()).thenValue(std::move(gather));
 }
 }  // namespace graph
 }  // namespace nebula

--- a/src/graph/executor/query/AppendVerticesExecutor.cpp
+++ b/src/graph/executor/query/AppendVerticesExecutor.cpp
@@ -188,10 +188,19 @@ folly::Future<Status> AppendVerticesExecutor::handleRespMultiJobs(
       return buildVerticesResult(begin, end, tmpIter);
     };
 
-    auto gather = [this](auto &&results) -> Status {
+    auto gather = [this](std::vector<folly::Try<StatusOr<DataSet>>> &&results) -> Status {
       memory::MemoryCheckGuard guard;
-      for (auto &r : results) {
-        auto &&rows = std::move(r).value();
+      for (auto &respVal : results) {
+        if (respVal.hasException()) {
+          auto ex = respVal.exception().get_exception<std::bad_alloc>();
+          if (ex) {
+            throw std::bad_alloc();
+          } else {
+            throw std::runtime_error(respVal.exception().what().c_str());
+          }
+        }
+        auto res = std::move(respVal).value();
+        auto &&rows = std::move(res).value();
         result_.rows.insert(result_.rows.end(),
                             std::make_move_iterator(rows.begin()),
                             std::make_move_iterator(rows.end()));
@@ -207,19 +216,38 @@ folly::Future<Status> AppendVerticesExecutor::handleRespMultiJobs(
     };
 
     auto gather =
-        [this, inputIterNew = std::move(inputIter)](auto &&prepareResult) -> folly::Future<Status> {
+        [this, inputIterNew = std::move(inputIter)](
+            std::vector<folly::Try<folly::Unit>> &&prepareResult) -> folly::Future<Status> {
       memory::MemoryCheckGuard guard1;
-      UNUSED(prepareResult);
+      for (auto &respVal : prepareResult) {
+        if (respVal.hasException()) {
+          auto ex = respVal.exception().get_exception<std::bad_alloc>();
+          if (ex) {
+            throw std::bad_alloc();
+          } else {
+            throw std::runtime_error(respVal.exception().what().c_str());
+          }
+        }
+      }
 
       auto scatterInput =
           [this](size_t begin, size_t end, Iterator *tmpIter) mutable -> StatusOr<DataSet> {
         return handleJob(begin, end, tmpIter);
       };
 
-      auto gatherFinal = [this](auto &&results) -> Status {
+      auto gatherFinal = [this](std::vector<folly::Try<StatusOr<DataSet>>> &&results) -> Status {
         memory::MemoryCheckGuard guard2;
-        for (auto &r : results) {
-          auto &&rows = std::move(r).value();
+        for (auto &respVal : results) {
+          if (respVal.hasException()) {
+            auto ex = respVal.exception().get_exception<std::bad_alloc>();
+            if (ex) {
+              throw std::bad_alloc();
+            } else {
+              throw std::runtime_error(respVal.exception().what().c_str());
+            }
+          }
+          auto res = std::move(respVal).value();
+          auto &&rows = std::move(res).value();
           result_.rows.insert(result_.rows.end(),
                               std::make_move_iterator(rows.begin()),
                               std::make_move_iterator(rows.end()));

--- a/src/graph/executor/query/TraverseExecutor.cpp
+++ b/src/graph/executor/query/TraverseExecutor.cpp
@@ -314,10 +314,19 @@ folly::Future<Status> TraverseExecutor::buildPathMultiJobs(size_t minStep, size_
     return rows;
   };
 
-  auto gather = [this](std::vector<std::vector<Row>> resp) mutable -> Status {
+  auto gather = [this](std::vector<folly::Try<std::vector<Row>>>&& resps) mutable -> Status {
     // MemoryTrackerVerified
     memory::MemoryCheckGuard guard;
-    for (auto& rows : resp) {
+    for (auto& respVal : resps) {
+      if (respVal.hasException()) {
+        auto ex = respVal.exception().get_exception<std::bad_alloc>();
+        if (ex) {
+          throw std::bad_alloc();
+        } else {
+          throw std::runtime_error(respVal.exception().what().c_str());
+        }
+      }
+      auto rows = std::move(respVal).value();
       if (rows.empty()) {
         continue;
       }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula-ent/issues/3006
#### Description:

collectAll holds an iterable collection type whose element type is Future<T>, and any error in the component Future will not cause the process to terminate prematurely

collect() is  similar to collectAll(), the only difference is that if any of the input Futures throws an exception, the Future will be terminated early

so when we set memory tracker, if we use folly::collect , when a thread triggers the limit of the memory threshold，the program may end and there are other threads running.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
