### PR TITLE
fix master concurrency bug

### DIFF
--- a/src/graph/executor/Executor.h
+++ b/src/graph/executor/Executor.h
@@ -195,7 +195,7 @@ auto Executor::runMultiJobs(ScatterFunc &&scatter, GatherFunc &&gather, Iterator
   }
 
   // Gather all results and do post works
-  return folly::collect(futures).via(runner()).thenValue(std::move(gather));
+  return folly::collectAll(futures).via(runner()).thenValue(std::move(gather));
 }
 }  // namespace graph
 }  // namespace nebula


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula-ent/issues/3006
#### Description:
collectAll holds an iterable collection type whose element type is Future, and any error in the component Future will not cause the process to terminate prematurely

collect() is similar to collectAll(), the only difference is that if any of the input Futures throws an exception, the Future will be terminated early

so when we set memory tracker, if we use folly::collect , and a thread triggers the limit of the memory threshold，the program may end and there are other threads running.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
