### PR TITLE
fix filter bug

### DIFF
--- a/src/graph/executor/query/AppendVerticesExecutor.cpp
+++ b/src/graph/executor/query/AppendVerticesExecutor.cpp
@@ -197,6 +197,7 @@ folly::Future<Status> AppendVerticesExecutor::handleRespMultiJobs(
           }
         }
         auto res = std::move(respVal).value();
+        NG_RETURN_IF_ERROR(res);
         auto &&rows = std::move(res).value();
         std::move(rows.begin(), rows.end(), std::back_inserter(result_.rows));
       }
@@ -242,6 +243,7 @@ folly::Future<Status> AppendVerticesExecutor::handleRespMultiJobs(
             }
           }
           auto res = std::move(respVal).value();
+          NG_RETURN_IF_ERROR(res);
           auto &&rows = std::move(res).value();
           std::move(rows.begin(), rows.end(), std::back_inserter(result_.rows));
         }

--- a/src/graph/executor/query/FilterExecutor.cpp
+++ b/src/graph/executor/query/FilterExecutor.cpp
@@ -48,6 +48,7 @@ folly::Future<Status> FilterExecutor::execute() {
           }
         }
         auto res = std::move(respVal).value();
+        NG_RETURN_IF_ERROR(res);
         auto &&rows = std::move(res).value();
         result.rows.insert(result.rows.end(),
                            std::make_move_iterator(rows.begin()),

--- a/src/graph/executor/query/InnerJoinExecutor.cpp
+++ b/src/graph/executor/query/InnerJoinExecutor.cpp
@@ -187,6 +187,7 @@ folly::Future<Status> InnerJoinExecutor::probe(const std::vector<Expression*>& p
         }
       }
       auto res = std::move(respVal).value();
+      NG_RETURN_IF_ERROR(res);
       auto&& rows = std::move(res).value();
       result.rows.insert(result.rows.end(),
                          std::make_move_iterator(rows.begin()),
@@ -228,6 +229,7 @@ folly::Future<Status> InnerJoinExecutor::singleKeyProbe(Expression* probeKey, It
         }
       }
       auto res = std::move(respVal).value();
+      NG_RETURN_IF_ERROR(res);
       auto&& rows = std::move(res).value();
       result.rows.insert(result.rows.end(),
                          std::make_move_iterator(rows.begin()),

--- a/src/graph/executor/query/LeftJoinExecutor.cpp
+++ b/src/graph/executor/query/LeftJoinExecutor.cpp
@@ -164,6 +164,7 @@ folly::Future<Status> LeftJoinExecutor::probe(const std::vector<Expression*>& pr
         }
       }
       auto res = std::move(respVal).value();
+      NG_RETURN_IF_ERROR(res);
       auto&& rows = std::move(res).value();
       result.rows.insert(result.rows.end(),
                          std::make_move_iterator(rows.begin()),
@@ -204,6 +205,7 @@ folly::Future<Status> LeftJoinExecutor::singleKeyProbe(Expression* probeKey, Ite
         }
       }
       auto res = std::move(respVal).value();
+      NG_RETURN_IF_ERROR(res);
       auto&& rows = std::move(res).value();
       result.rows.insert(result.rows.end(),
                          std::make_move_iterator(rows.begin()),

--- a/src/graph/executor/query/ProjectExecutor.cpp
+++ b/src/graph/executor/query/ProjectExecutor.cpp
@@ -42,6 +42,7 @@ folly::Future<Status> ProjectExecutor::execute() {
           }
         }
         auto res = std::move(respVal).value();
+        NG_RETURN_IF_ERROR(res);
         auto &&rows = std::move(res).value();
         result.rows.insert(result.rows.end(),
                            std::make_move_iterator(rows.begin()),

--- a/tests/tck/features/expression/StartsWith.feature
+++ b/tests/tck/features/expression/StartsWith.feature
@@ -141,3 +141,10 @@ Feature: Starts With Expression
     Then the result should be, in any order:
       | $^.player.name  | $$.player.name | like.likeness |
       | 'Manu Ginobili' | 'Tim Duncan'   | 90            |
+
+  Scenario: starts with wrong type
+    When executing query:
+      """
+      MATCH (v:player)-[]->() WHERE v.player.name STARTS WITH 1 RETURN v
+      """
+    Then a ExecutionError should be raised at runtime: Failed to evaluate condition: ($-.v.player.name STARTS WITH 1). For boolean conditions, please write in their full forms like <condition> == <true/false> or <condition> IS [NOT] NULL.


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula-ent/issues/3179
#### Description:



When the filter operator is running concurrently, if the condition is abnormal in the scatter function `(WHERE v.player.name STARTS WITH 1)`, an error message will be returned. This exception error message needs to be captured in the gather function.

```
    if (val.isBadNull() || (!val.empty() && !val.isImplicitBool() && !val.isNull())) {
      return Status::Error("Failed to evaluate condition: %s. %s%s",
                           condition->toString().c_str(),
                           "For boolean conditions, please write in their full forms like",
                           " <condition> == <true/false> or <condition> IS [NOT] NULL.");
    }
```

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
