### PR TITLE
each group applies a rule only once

### DIFF
--- a/src/graph/optimizer/OptContext.h
+++ b/src/graph/optimizer/OptContext.h
@@ -9,6 +9,7 @@
 #include <boost/core/noncopyable.hpp>
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "common/cpp/helpers.h"
 
@@ -18,11 +19,14 @@ class ObjectPool;
 
 namespace graph {
 class QueryContext;
+class PlanNode;
 }  // namespace graph
 
 namespace opt {
 
 class OptGroupNode;
+class OptGroup;
+class Optimizer;
 
 class OptContext final : private boost::noncopyable, private cpp::NonMovable {
  public:
@@ -48,12 +52,16 @@ class OptContext final : private boost::noncopyable, private cpp::NonMovable {
   const OptGroupNode *findOptGroupNodeByPlanNodeId(int64_t planNodeId) const;
 
  private:
+  friend OptGroup;
+  friend Optimizer;
   // A global flag to record whether this iteration caused a change to the plan
   bool changed_{true};
   graph::QueryContext *qctx_{nullptr};
   // Memo memory management in the Optimizer phase
   std::unique_ptr<ObjectPool> objPool_;
   std::unordered_map<int64_t, const OptGroupNode *> planNodeToOptGroupNodeMap_;
+  std::unordered_set<const OptGroup *> visited_;
+  std::unordered_map<const OptGroup *, const graph::PlanNode *> group2PlanNodeMap_;
 };
 
 }  // namespace opt

--- a/src/graph/optimizer/Optimizer.h
+++ b/src/graph/optimizer/Optimizer.h
@@ -47,9 +47,12 @@ class Optimizer final {
                           OptGroupNode *gnode,
                           std::unordered_map<int64_t, OptGroup *> *visited);
 
-  static Status rewriteArgumentInputVar(graph::PlanNode *root);
-  static Status rewriteArgumentInputVarInternal(graph::PlanNode *root,
-                                                std::vector<const graph::PlanNode *> &path);
+  static Status rewriteArgumentInputVar(
+      graph::PlanNode *root, std::unordered_set<const graph::PlanNode *> &visitedPlanNode);
+  static Status rewriteArgumentInputVarInternal(
+      graph::PlanNode *root,
+      std::vector<const graph::PlanNode *> &path,
+      std::unordered_set<const graph::PlanNode *> &visitedPlanNode);
 
   Status checkPlanDepth(const graph::PlanNode *root) const;
 

--- a/src/graph/scheduler/Scheduler.cpp
+++ b/src/graph/scheduler/Scheduler.cpp
@@ -23,6 +23,7 @@ namespace graph {
 
 /*static*/ void Scheduler::analyzeLifetime(const PlanNode* root, std::size_t loopLayers) {
   std::stack<std::tuple<const PlanNode*, std::size_t>> stack;
+  std::unordered_set<const PlanNode*> visited;
   stack.push(std::make_tuple(root, loopLayers));
   while (!stack.empty()) {
     const auto& current = stack.top();
@@ -36,6 +37,9 @@ namespace graph {
     auto* currentMutNode = const_cast<PlanNode*>(currentNode);
     currentMutNode->setLoopLayers(currentLoopLayers);
     stack.pop();
+    if (!visited.emplace(currentNode).second) {
+      continue;
+    }
 
     for (auto dep : currentNode->dependencies()) {
       stack.push(std::make_tuple(dep, currentLoopLayers));

--- a/src/graph/visitor/PrunePropertiesVisitor.cpp
+++ b/src/graph/visitor/PrunePropertiesVisitor.cpp
@@ -16,10 +16,16 @@ PrunePropertiesVisitor::PrunePropertiesVisitor(PropertyTracker &propsUsed,
 }
 
 void PrunePropertiesVisitor::visit(PlanNode *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   status_ = depsPruneProperties(node->dependencies());
 }
 
 void PrunePropertiesVisitor::visit(Filter *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   visitCurrent(node);  // Filter will use properties in filter expression
   status_ = depsPruneProperties(node->dependencies());
 }
@@ -34,6 +40,9 @@ void PrunePropertiesVisitor::visitCurrent(Filter *node) {
 }
 
 void PrunePropertiesVisitor::visit(Project *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   visitCurrent(node);  // Project won't use properties in column expression
   status_ = depsPruneProperties(node->dependencies());
 }
@@ -107,6 +116,9 @@ void PrunePropertiesVisitor::visitCurrent(Project *node) {
 }
 
 void PrunePropertiesVisitor::visit(Aggregate *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   visitCurrent(node);
   status_ = depsPruneProperties(node->dependencies());
 }
@@ -153,6 +165,9 @@ void PrunePropertiesVisitor::visitCurrent(Aggregate *node) {
 }
 
 void PrunePropertiesVisitor::visit(ScanEdges *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   rootNode_ = false;
   pruneCurrent(node);
   status_ = depsPruneProperties(node->dependencies());
@@ -208,6 +223,9 @@ void PrunePropertiesVisitor::pruneCurrent(ScanEdges *node) {
 }
 
 void PrunePropertiesVisitor::visit(Traverse *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   rootNode_ = false;
   visitCurrent(node);
   status_ = depsPruneProperties(node->dependencies());
@@ -358,6 +376,9 @@ void PrunePropertiesVisitor::pruneCurrent(Traverse *node) {
 
 // AppendVertices should be deleted when no properties it pulls are used by the parent node.
 void PrunePropertiesVisitor::visit(AppendVertices *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   visitCurrent(node);
   status_ = depsPruneProperties(node->dependencies());
 }
@@ -478,18 +499,30 @@ void PrunePropertiesVisitor::pruneCurrent(AppendVertices *node) {
 }
 
 void PrunePropertiesVisitor::visit(HashJoin *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   status_ = depsPruneProperties(node->dependencies());
 }
 
 void PrunePropertiesVisitor::visit(CrossJoin *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   status_ = pruneBinaryBranch(node->dependencies());
 }
 
 void PrunePropertiesVisitor::visit(Union *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   status_ = pruneBinaryBranch(node->dependencies());
 }
 
 void PrunePropertiesVisitor::visit(Unwind *node) {
+  if (!visitedPlanNode_.emplace(node).second) {
+    return;
+  }
   visitCurrent(node);
   status_ = depsPruneProperties(node->dependencies());
 }

--- a/src/graph/visitor/PrunePropertiesVisitor.h
+++ b/src/graph/visitor/PrunePropertiesVisitor.h
@@ -85,6 +85,7 @@ class PrunePropertiesVisitor final : public PlanNodeVisitor {
   Status status_;
   bool rootNode_{true};
   const int unknownType_ = 0;
+  std::unordered_set<PlanNode *> visitedPlanNode_;
 };
 
 }  // namespace graph


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula-ent/issues/3052
#### Description:

The execution plan tree is a DAG
In the optimizer phase, checkPlanDepth, explore, getPlan, pruneProperties and analyzeLifetime in the scheduling phase will recursively traverse the execution plan tree, and nodes that have been visited will be visited again.

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
