### PR TITLE
fix limit bug

### DIFF
--- a/src/graph/executor/algo/AllPathsExecutor.cpp
+++ b/src/graph/executor/algo/AllPathsExecutor.cpp
@@ -277,7 +277,11 @@ folly::Future<Status> AllPathsExecutor::buildPathMultiJobs() {
           result_.rows.resize(limit_);
         }
         if (offset_ != 0) {
-          result_.rows.erase(result_.rows.begin(), result_.rows.begin() + offset_);
+          if (result_.rows.size() <= offset_) {
+            result_.rows.clear();
+          } else {
+            result_.rows.erase(result_.rows.begin(), result_.rows.begin() + offset_);
+          }
         }
         addState("conjunct_path_time", conjunctPathTime);
         return Status::OK();

--- a/tests/tck/features/path/AllPath.feature
+++ b/tests/tck/features/path/AllPath.feature
@@ -289,6 +289,16 @@ Feature: All Path
     Then the result should be, in any order, with relax comparison:
       | count(*) |
       | 10       |
+    When executing query:
+      """
+      lookup on player where player.age>20 YIELD id(vertex) as vid
+      | go 1 step from $-.vid over * where "player" in labels($$) yield distinct id($$) as dst,$-.vid as src
+      | find noloop path  from $-.src  to $-.dst  over *   upto 1 step yield path as p | limit 10000,10
+      | yield count(*)
+      """
+    Then the result should be, in any order, with relax comparison:
+      | count(*) |
+      | 0        |
 
   Scenario: [1] ALL PATH REVERSELY
     When executing query:


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
close https://github.com/vesoft-inc/nebula-ent/issues/3390
#### Description:

when invoke the erase interface, if the iterator you pass in exceeds the range of std::vector (that is, greater than the end() of std::vector), then this will be undefined behavior

## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
