### PR TITLE
chore: fix build on py36

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -48,8 +48,10 @@ install-deps:
 
 install-nebula-py: install-deps
 	git clone --branch master https://github.com/vesoft-inc/nebula-python $(CURR_DIR)/nebula-python
+	export PIP_EXTRA_INDEX_URL=$(PYPI_MIRROR)
+	export PIP_TRUSTED_HOST=$(PYPI_MIRROR)
 	cd $(CURR_DIR)/nebula-python \
-		&& pip3 install --user . -i $(PYPI_MIRROR) --upgrade
+		&& if [ $(PY_VERSION) -eq 6 ]; then python3 setup.py install; else pip3 install --user . -i $(PYPI_MIRROR) --upgrade; fi
 	rm -rf $(CURR_DIR)/nebula-python
 
 gherkin-fmt: install-deps


### PR DESCRIPTION
To build nebula-python in py36, we have to call `python setup.py install` (only impact those who will to build nebula-python from source in py36)

Note, the wheel built now in Nebula-Python could be installed with `pip install <file>.whl`

dependent on https://github.com/vesoft-inc/nebula-python/pull/307

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement
