### PR TITLE
fix:a single node self-loop when executing NOLOOP

### DIFF
--- a/src/graph/executor/algo/AllPathsExecutor.cpp
+++ b/src/graph/executor/algo/AllPathsExecutor.cpp
@@ -331,6 +331,12 @@ folly::Future<std::vector<AllPathsExecutor::NPath*>> AllPathsExecutor::doBuildPa
         continue;
       }
       for (auto& edge : adjEdges) {
+        if (noLoop_) {
+          if (edge.getEdge().dst == edge.getEdge().src) {
+            continue;
+          }
+        }
+        auto path = NPath(src, edge);
         threadLocalPtr_->emplace_back(NPath(src, edge));
         newPathsPtr->emplace_back(&threadLocalPtr_->back());
       }

--- a/src/graph/executor/algo/AllPathsExecutor.cpp
+++ b/src/graph/executor/algo/AllPathsExecutor.cpp
@@ -336,7 +336,6 @@ folly::Future<std::vector<AllPathsExecutor::NPath*>> AllPathsExecutor::doBuildPa
             continue;
           }
         }
-        auto path = NPath(src, edge);
         threadLocalPtr_->emplace_back(NPath(src, edge));
         newPathsPtr->emplace_back(&threadLocalPtr_->back());
       }

--- a/tests/tck/features/path/NoLoop.feature
+++ b/tests/tck/features/path/NoLoop.feature
@@ -266,7 +266,6 @@ Feature: NoLoop Path
       """
     Then the result should be, in any order:
       | p     |
-      | EMPTY |
     When executing query:
       """
       FIND ALL PATH FROM "nodea" TO "nodea" OVER E1 YIELD PATH AS p;

--- a/tests/tck/features/path/NoLoop.feature
+++ b/tests/tck/features/path/NoLoop.feature
@@ -247,6 +247,11 @@ Feature: NoLoop Path
     When executing query:
       """
       CREATE SPACE TestNoLoopSpace(vid_type=fixed_string(20));
+      """
+    And wait 3 seconds
+    Then the execution should be successful
+    When executing query:
+      """
       USE TestNoLoopSpace;
       """
     And wait 3 seconds
@@ -254,8 +259,23 @@ Feature: NoLoop Path
     When executing query:
       """
       CREATE TAG Person(name string);
+      """
+    And wait 1 seconds
+    Then the execution should be successful
+    When executing query:
+      """
       CREATE EDGE Link();
+      """
+    And wait 1 seconds
+    Then the execution should be successful
+    When executing query:
+      """
       INSERT VERTEX Person(name) VALUES "nodea":("Node A");
+      """
+    And wait 1 seconds
+    Then the execution should be successful
+    When executing query:
+      """
       INSERT EDGE Link() VALUES "nodea" -> "nodea":();
       """
     And wait 1 seconds
@@ -268,13 +288,14 @@ Feature: NoLoop Path
       | p |
     When executing query:
       """
-      FIND ALL PATH FROM "nodea" TO "nodea" OVER E1 YIELD PATH AS p;
+      FIND ALL PATH FROM "nodea" TO "nodea" OVER Link YIELD PATH AS p;
       """
     Then the result should be, in any order:
-      | p                                 |
-      | <("nodea")<-[:E1@0 {}]-("nodea")> |
+      | p                                   |
+      | <("nodea")<-[:Link@0 {}]-("nodea")> |
     When executing query:
       """
       DROP SPACE TestNoLoopSpace
       """
+    And wait 1 seconds
     Then the execution should be successful

--- a/tests/tck/features/path/NoLoop.feature
+++ b/tests/tck/features/path/NoLoop.feature
@@ -265,7 +265,7 @@ Feature: NoLoop Path
       FIND NOLOOP PATH FROM "nodea" TO "nodea" OVER Link YIELD PATH AS p;
       """
     Then the result should be, in any order:
-      | p     |
+      | p |
     When executing query:
       """
       FIND ALL PATH FROM "nodea" TO "nodea" OVER E1 YIELD PATH AS p;


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
fix https://github.com/vesoft-inc/nebula/issues/5764
#### Description:
Use of the noloop parameter in the find path statement does not exclude the self-loop case

## How do you solve it?
New logical judgement on self-loops in the AllPathsExecutor::doBuildPath() function


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
