### PR TITLE
fix compare node

### DIFF
--- a/tests/common/comparator.py
+++ b/tests/common/comparator.py
@@ -295,21 +295,20 @@ class DataSetComparator:
         return False
 
     def compare_node(self, lhs: Vertex, rhs: Vertex):
-        rtags = []
+        rtags = [] if rhs.tags is None else rhs.tags
         if self._strict:
             assert rhs.vid is not None
             if not self.compare_vid(lhs.vid, rhs.vid):
                 return False
-            if rhs.tags is None or len(lhs.tags) != len(rhs.tags):
+            if len(lhs.tags) != len(rtags):
                 return False
-            rtags = rhs.tags
         else:
             if rhs.vid is not None:
                 if not self.compare_vid(lhs.vid, rhs.vid):
                     return False
-            if rhs.tags is not None and len(lhs.tags) < len(rhs.tags):
+            if len(lhs.tags) < len(rtags):
                 return False
-            rtags = [] if rhs.tags is None else rhs.tags
+            
         for tag in rtags:
             ltag = [
                 [lt.name, lt.props] for lt in lhs.tags if self.bstr(tag.name) == lt.name

--- a/tests/tck/features/path/NoLoop.feature
+++ b/tests/tck/features/path/NoLoop.feature
@@ -260,25 +260,22 @@ Feature: NoLoop Path
       """
       CREATE TAG Person(name string);
       """
-    And wait 1 seconds
     Then the execution should be successful
     When executing query:
       """
       CREATE EDGE Link();
       """
-    And wait 1 seconds
     Then the execution should be successful
+    And wait 6 seconds
     When executing query:
       """
       INSERT VERTEX Person(name) VALUES "nodea":("Node A");
       """
-    And wait 1 seconds
     Then the execution should be successful
     When executing query:
       """
       INSERT EDGE Link() VALUES "nodea" -> "nodea":();
       """
-    And wait 1 seconds
     Then the execution should be successful
     When executing query:
       """
@@ -297,5 +294,4 @@ Feature: NoLoop Path
       """
       DROP SPACE TestNoLoopSpace
       """
-    And wait 1 seconds
     Then the execution should be successful

--- a/tests/tck/features/path/NoLoop.feature
+++ b/tests/tck/features/path/NoLoop.feature
@@ -243,7 +243,6 @@ Feature: NoLoop Path
       | [[:like "LaMarcus Aldridge"->"Tim Duncan" @0 {}], [:like "Tony Parker"->"LaMarcus Aldridge" @0 {}]] |
       | [[:like "Manu Ginobili"->"Tim Duncan" @0 {}], [:like "Tony Parker"->"Manu Ginobili" @0 {}]]         |
 
-  @skip
   Scenario: Query with NO LOOP on a node without self-loop
     When executing query:
       """


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
In pr https://github.com/vesoft-inc/nebula/pull/5805, results were the same but the test framework reported an error.
![image](https://github.com/vesoft-inc/nebula/assets/48981679/ed4d72fb-32c1-44be-ac3a-fa41b01b3b7b)

## How do you solve it?

In compare_node(lhs, rhs),If lhs.tags == [] and rhs.tags is None, the two tags should be equal.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
