### PR TITLE
fix possible graph coredump when metadata refresh during certain query invoke ScanEdgeProcessor::checkAndBuildContexts especially in asan binary

### DIFF
--- a/src/storage/query/ScanEdgeProcessor.cpp
+++ b/src/storage/query/ScanEdgeProcessor.cpp
@@ -66,6 +66,10 @@ nebula::cpp2::ErrorCode ScanEdgeProcessor::checkAndBuildContexts(const cpp2::Sca
 
   std::vector<cpp2::EdgeProp> returnProps = *req.return_columns_ref();
   ret = handleEdgeProps(returnProps);
+  if (ret != nebula::cpp2::ErrorCode::SUCCEEDED) {
+    return ret;
+  }
+
   buildEdgeColName(returnProps);
   ret = buildFilter(req, [](const cpp2::ScanEdgeRequest& r, bool onlyTag) -> const std::string* {
     UNUSED(onlyTag);


### PR DESCRIPTION
fix possible graph coredump when metadata refresh during certain query invoke ScanEdgeProcessor::checkAndBuildContexts especially in asan binary
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: https://github.com/vesoft-inc/nebula/issues/5854

#### Description: fix possible graph coredump when metadata refresh during certain query invoke ScanEdgeProcessor::checkAndBuildContexts especially in asan binary


## How do you solve it?
return the ret when it is not succeeded

## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
