### PR TITLE
Optimize filter pushdown and fix the bug in TCK tests.

### DIFF
--- a/src/graph/planner/match/MatchSolver.cpp
+++ b/src/graph/planner/match/MatchSolver.cpp
@@ -158,7 +158,10 @@ Expression* MatchSolver::makeIndexFilter(const std::string& label,
   std::vector<Expression*> relationals;
   for (auto item : opnds) {
     if (kinds.count(item->kind()) != 1) {
-      continue;
+      if (optr == LogicalExpression::makeAnd) {
+        continue;
+      }
+      return nullptr;
     }
 
     auto* binary = static_cast<const BinaryExpression*>(item);
@@ -178,10 +181,16 @@ Expression* MatchSolver::makeIndexFilter(const std::string& label,
         la = static_cast<const LabelAttributeExpression*>(right);
         constant = static_cast<const ConstantExpression*>(left);
       } else {
-        continue;
+        if (optr == LogicalExpression::makeAnd) {
+          continue;
+        }
+        return nullptr;
       }
       if (la->left()->name() != alias) {
-        continue;
+        if (optr == LogicalExpression::makeAnd) {
+          continue;
+        }
+        return nullptr;
       }
       propName = la->right()->value().getStr();
     } else {
@@ -204,7 +213,10 @@ Expression* MatchSolver::makeIndexFilter(const std::string& label,
         }
         constant = static_cast<const ConstantExpression*>(left);
       } else {
-        continue;
+        if (optr == LogicalExpression::makeAnd) {
+          continue;
+        }
+        return nullptr;
       }
     }
 

--- a/src/graph/planner/match/MatchSolver.cpp
+++ b/src/graph/planner/match/MatchSolver.cpp
@@ -188,13 +188,19 @@ Expression* MatchSolver::makeIndexFilter(const std::string& label,
       if (left->kind() == Expression::Kind::kLabelTagProperty &&
           right->kind() == Expression::Kind::kConstant) {
         if (!extractTagPropName(left, alias, label, &propName)) {
-          continue;
+          if (optr == LogicalExpression::makeAnd) {
+            continue;
+          }
+          return nullptr;
         }
         constant = static_cast<const ConstantExpression*>(right);
       } else if (right->kind() == Expression::Kind::kLabelTagProperty &&
                  left->kind() == Expression::Kind::kConstant) {
         if (!extractTagPropName(right, alias, label, &propName)) {
-          continue;
+          if (optr == LogicalExpression::makeAnd) {
+            continue;
+          }
+          return nullptr;
         }
         constant = static_cast<const ConstantExpression*>(left);
       } else {

--- a/src/graph/planner/match/MatchSolver.h
+++ b/src/graph/planner/match/MatchSolver.h
@@ -39,7 +39,7 @@ class MatchSolver final {
                                      bool isEdgeProperties = false);
 
   static bool extractTagPropName(const Expression* expr, const string& alias, string* propName);
-  
+
   static bool extractTagPropName(const Expression* expr,
                                  const std::string& alias,
                                  const std::string& label,

--- a/src/graph/planner/match/MatchSolver.h
+++ b/src/graph/planner/match/MatchSolver.h
@@ -38,6 +38,8 @@ class MatchSolver final {
                                      QueryContext* qctx,
                                      bool isEdgeProperties = false);
 
+  static bool extractTagPropName(const Expression* expr, const string& alias, string* propName);
+  
   static bool extractTagPropName(const Expression* expr,
                                  const std::string& alias,
                                  const std::string& label,
@@ -55,6 +57,22 @@ class MatchSolver final {
 
   // Build yield columns for match & shortestPath statement
   static void buildProjectColumns(QueryContext* qctx, const Path& path, SubPlan& plan);
+
+  static bool extractLabelAndConstant(const Expression* left,
+                                      const Expression* right,
+                                      const string& label,
+                                      const string& alias,
+                                      Expression::Kind labelKind,
+                                      const ConstantExpression*& constant,
+                                      string& propName);
+
+  static bool extract(const Expression* left,
+                      const Expression* right,
+                      const string& label,
+                      const string& alias,
+                      Expression::Kind labelKind,
+                      const ConstantExpression*& constant,
+                      string& propName);
 };
 
 }  // namespace graph

--- a/src/graph/util/OptimizerUtils.cpp
+++ b/src/graph/util/OptimizerUtils.cpp
@@ -802,7 +802,7 @@ Status OptimizerUtils::appendColHint(std::vector<IndexColumnHint>& hints,
 
 Status OptimizerUtils::appendIQCtx(const std::shared_ptr<IndexItem>& index,
                                    std::vector<IndexQueryContext>& iqctx,
-                                   const Expression *filter) {
+                                   const Expression* filter) {
   IndexQueryContext ctx;
   ctx.index_id_ref() = index->get_index_id();
   ctx.filter_ref() = (filter) ? Expression::encode(*filter) : "";

--- a/src/graph/util/OptimizerUtils.cpp
+++ b/src/graph/util/OptimizerUtils.cpp
@@ -801,10 +801,11 @@ Status OptimizerUtils::appendColHint(std::vector<IndexColumnHint>& hints,
 }
 
 Status OptimizerUtils::appendIQCtx(const std::shared_ptr<IndexItem>& index,
-                                   std::vector<IndexQueryContext>& iqctx) {
+                                   std::vector<IndexQueryContext>& iqctx,
+                                   const Expression *filter) {
   IndexQueryContext ctx;
   ctx.index_id_ref() = index->get_index_id();
-  ctx.filter_ref() = "";
+  ctx.filter_ref() = (filter) ? Expression::encode(*filter) : "";
   iqctx.emplace_back(std::move(ctx));
   return Status::OK();
 }
@@ -940,7 +941,10 @@ Status OptimizerUtils::createIndexQueryCtx(std::vector<IndexQueryContext>& iqctx
   if (index == nullptr) {
     return Status::IndexNotFound("No valid index found");
   }
-  return appendIQCtx(index, iqctx);
+  auto in = static_cast<const IndexScan*>(node);
+  auto* filter = Expression::decode(qctx->objPool(), in->queryContext().begin()->get_filter());
+  auto* newFilter = ExpressionUtils::rewriteParameter(filter, qctx);
+  return appendIQCtx(index, iqctx, newFilter);
 }
 
 }  // namespace graph

--- a/src/graph/util/OptimizerUtils.h
+++ b/src/graph/util/OptimizerUtils.h
@@ -148,7 +148,7 @@ class OptimizerUtils {
                             const std::vector<FilterItem> &items,
                             IndexQueryContextList &iqctx,
                             const Expression *filter = nullptr);
-  static Status appendIQCtx(const IndexItemPtr &index, IndexQueryContextList &iqctx);
+  static Status appendIQCtx(const IndexItemPtr &index, IndexQueryContextList &iqctx,const Expression *filter = nullptr);
   static Status appendColHint(std::vector<storage::cpp2::IndexColumnHint> &hints,
                               const std::vector<FilterItem> &items,
                               const meta::cpp2::ColumnDef &col);

--- a/src/graph/util/OptimizerUtils.h
+++ b/src/graph/util/OptimizerUtils.h
@@ -148,7 +148,9 @@ class OptimizerUtils {
                             const std::vector<FilterItem> &items,
                             IndexQueryContextList &iqctx,
                             const Expression *filter = nullptr);
-  static Status appendIQCtx(const IndexItemPtr &index, IndexQueryContextList &iqctx,const Expression *filter = nullptr);
+  static Status appendIQCtx(const IndexItemPtr &index,
+                            IndexQueryContextList &iqctx,
+                            const Expression *filter = nullptr);
   static Status appendColHint(std::vector<storage::cpp2::IndexColumnHint> &hints,
                               const std::vector<FilterItem> &items,
                               const meta::cpp2::ColumnDef &col);

--- a/tests/common/plan_differ.py
+++ b/tests/common/plan_differ.py
@@ -183,10 +183,6 @@ class PlanDiffer:
         # The inner map cannot be empty
         if len(extracted_expected_dict) == 0:
             return None
-        # Unnested dict, push the first key into list
-        if extracted_expected_dict == expect:
-            key_list.append(list(expect.keys())[0])
-
         def _try_convert_json(j):
             try:
               res = json.loads(j)
@@ -202,7 +198,7 @@ class PlanDiffer:
                 return j
 
         extracted_resp_dict = {}
-        if len(key_list) == 1:
+        if not key_list:
           for k in resp:
             extracted_resp_dict[k] = _try_convert_json(resp[k])
         else:

--- a/tests/tck/features/match/PushFilterDown.feature
+++ b/tests/tck/features/match/PushFilterDown.feature
@@ -26,18 +26,19 @@ Feature: Push filter down
       """
     And wait all indexes ready
 
+  @ccc
   Scenario: Single vertex
     When profiling query:
       """
       MATCH (v:player) where v.player.name == "Tim Duncan" and v.player.age > 20 RETURN v
       """
     Then the execution plan should be:
-      | id | name           | dependencies | operator info                                                                    |
-      | 5  | Project        | 4            |                                                                                  |
-      | 4  | Filter         | 3            | {"condition": "((v.player.name==\\"Tim Duncan\\") AND (v.player.age>20))"}       |
-      | 3  | AppendVertices | 2            |                                                                                  |
-      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"((player.name==\\"Tim Duncan\\") AND (player.age>20))"}} |
-      | 1  | Start          |              |                                                                                  |
+      | id | name           | dependencies | operator info                                                                  |
+      | 5  | Project        | 4            |                                                                                |
+      | 4  | Filter         | 3            | {"condition": "((v.player.name==\"Tim Duncan\") AND (v.player.age>20))"}       |
+      | 3  | AppendVertices | 2            |                                                                                |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"((player.name==\"Tim Duncan\") AND (player.age>20))"}} |
+      | 1  | Start          |              |                                                                                |
     When profiling query:
       """
       MATCH (v:player) where v.player.age > 20 RETURN v

--- a/tests/tck/features/match/PushFilterDown.feature
+++ b/tests/tck/features/match/PushFilterDown.feature
@@ -26,7 +26,7 @@ Feature: Push filter down
       """
     And wait all indexes ready
 
-  @ccc
+
   Scenario: Single vertex
     When profiling query:
       """

--- a/tests/tck/features/match/PushFilterDown.feature
+++ b/tests/tck/features/match/PushFilterDown.feature
@@ -26,7 +26,6 @@ Feature: Push filter down
       """
     And wait all indexes ready
 
-
   Scenario: Single vertex
     When profiling query:
       """

--- a/tests/tck/features/match/PushFilterDown.feature
+++ b/tests/tck/features/match/PushFilterDown.feature
@@ -66,7 +66,31 @@ Feature: Push filter down
   Scenario: Vertex and edge
     When profiling query:
       """
-      MATCH (v:player)-[e]-() where v.player.age > 20 RETURN v
+      MATCH (v:player)-[]-() where v.player.age > 20 RETURN v
+      """
+    Then the execution plan should be:
+      | id | name           | dependencies | operator info                               |
+      | 6  | Project        | 5            |                                             |
+      | 5  | Filter         | 4            |                                             |
+      | 4  | AppendVertices | 3            |                                             |
+      | 3  | Traverse       | 2            |                                             |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"(player.age>20)"}}  |
+      | 1  | Start          |              |                                             |
+    When profiling query:
+      """
+      MATCH (v:player)-[]-(o:player) where v.player.age > 20 or o.player.name == "Yao Ming"  RETURN v
+      """
+    Then the execution plan should be:
+      | id | name           | dependencies | operator info                               |
+      | 6  | Project        | 5            |                                             |
+      | 5  | Filter         | 4            |                                             |
+      | 4  | AppendVertices | 3            |                                             |
+      | 3  | Traverse       | 2            |                                             |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":""}}                 |
+      | 1  | Start          |              |                                             |
+    When profiling query:
+      """
+      MATCH (v:player)-[]-(o:player) where v.player.age > 20 and o.player.name == "Yao Ming"  RETURN v
       """
     Then the execution plan should be:
       | id | name           | dependencies | operator info                               |

--- a/tests/tck/features/match/PushFilterDown.feature
+++ b/tests/tck/features/match/PushFilterDown.feature
@@ -32,36 +32,34 @@ Feature: Push filter down
       MATCH (v:player) where v.player.name == "Tim Duncan" and v.player.age > 20 RETURN v
       """
     Then the execution plan should be:
-      | id | name           | dependencies | operator info                                                                   |
-      | 5  | Project        | 4            |                                                                                 |
-      | 4  | Filter         | 3            | {"condition": "((v.player.name==\"Tim Duncan\") AND (v.player.age>20))"}        |
-      | 3  | AppendVertices | 2            |                                                                                 |
-      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"((player.name==\"Tim Duncan\") AND (player.age>20))"}}  |
-      | 1  | Start          |              |                                                                                 |
-
+      | id | name           | dependencies | operator info                                                                    |
+      | 5  | Project        | 4            |                                                                                  |
+      | 4  | Filter         | 3            | {"condition": "((v.player.name==\\"Tim Duncan\\") AND (v.player.age>20))"}       |
+      | 3  | AppendVertices | 2            |                                                                                  |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"((player.name==\\"Tim Duncan\\") AND (player.age>20))"}} |
+      | 1  | Start          |              |                                                                                  |
     When profiling query:
       """
       MATCH (v:player) where v.player.age > 20 RETURN v
       """
     Then the execution plan should be:
-      | id | name           | dependencies | operator info                               |
-      | 5  | Project        | 4            |                                             |
-      | 4  | Filter         | 3            | {"condition": "(v.player.age>20)"}          |
-      | 3  | AppendVertices | 2            |                                             |
-      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"(player.age>20)"}}  |
-      | 1  | Start          |              |                                             |
-
+      | id | name           | dependencies | operator info                              |
+      | 5  | Project        | 4            |                                            |
+      | 4  | Filter         | 3            | {"condition": "(v.player.age>20)"}         |
+      | 3  | AppendVertices | 2            |                                            |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"(player.age>20)"}} |
+      | 1  | Start          |              |                                            |
     When profiling query:
       """
       MATCH (v:player) where v.player.age < 3 or v.player.age > 20 RETURN v
       """
     Then the execution plan should be:
-      | id | name           | dependencies | operator info                                                   |
-      | 5  | Project        | 4            |                                                                 |
-      | 4  | Filter         | 3            | {"condition": "((v.player.age<3) OR (v.player.age>20))"}        |
-      | 3  | AppendVertices | 2            |                                                                 |
-      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"((player.age<3) OR (player.age>20))"}}  |
-      | 1  | Start          |              |                                                                 |
+      | id | name           | dependencies | operator info                                                  |
+      | 5  | Project        | 4            |                                                                |
+      | 4  | Filter         | 3            | {"condition": "((v.player.age<3) OR (v.player.age>20))"}       |
+      | 3  | AppendVertices | 2            |                                                                |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"((player.age<3) OR (player.age>20))"}} |
+      | 1  | Start          |              |                                                                |
 
   Scenario: Vertex and edge
     When profiling query:
@@ -69,34 +67,34 @@ Feature: Push filter down
       MATCH (v:player)-[]-() where v.player.age > 20 RETURN v
       """
     Then the execution plan should be:
-      | id | name           | dependencies | operator info                               |
-      | 6  | Project        | 5            |                                             |
-      | 5  | Filter         | 4            |                                             |
-      | 4  | AppendVertices | 3            |                                             |
-      | 3  | Traverse       | 2            |                                             |
-      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"(player.age>20)"}}  |
-      | 1  | Start          |              |                                             |
+      | id | name           | dependencies | operator info                              |
+      | 6  | Project        | 5            |                                            |
+      | 5  | Filter         | 4            |                                            |
+      | 4  | AppendVertices | 3            |                                            |
+      | 3  | Traverse       | 2            |                                            |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"(player.age>20)"}} |
+      | 1  | Start          |              |                                            |
     When profiling query:
       """
       MATCH (v:player)-[]-(o:player) where v.player.age > 20 or o.player.name == "Yao Ming"  RETURN v
       """
     Then the execution plan should be:
-      | id | name           | dependencies | operator info                               |
-      | 6  | Project        | 5            |                                             |
-      | 5  | Filter         | 4            |                                             |
-      | 4  | AppendVertices | 3            |                                             |
-      | 3  | Traverse       | 2            |                                             |
-      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":""}}                 |
-      | 1  | Start          |              |                                             |
+      | id | name           | dependencies | operator info               |
+      | 6  | Project        | 5            |                             |
+      | 5  | Filter         | 4            |                             |
+      | 4  | AppendVertices | 3            |                             |
+      | 3  | Traverse       | 2            |                             |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":""}} |
+      | 1  | Start          |              |                             |
     When profiling query:
       """
       MATCH (v:player)-[]-(o:player) where v.player.age > 20 and o.player.name == "Yao Ming"  RETURN v
       """
     Then the execution plan should be:
-      | id | name           | dependencies | operator info                               |
-      | 6  | Project        | 5            |                                             |
-      | 5  | Filter         | 4            |                                             |
-      | 4  | AppendVertices | 3            |                                             |
-      | 3  | Traverse       | 2            |                                             |
-      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"(player.age>20)"}}  |
-      | 1  | Start          |              |                                             |
+      | id | name           | dependencies | operator info                              |
+      | 6  | Project        | 5            |                                            |
+      | 5  | Filter         | 4            |                                            |
+      | 4  | AppendVertices | 3            |                                            |
+      | 3  | Traverse       | 2            |                                            |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"(player.age>20)"}} |
+      | 1  | Start          |              |                                            |

--- a/tests/tck/features/match/PushFilterDown.feature
+++ b/tests/tck/features/match/PushFilterDown.feature
@@ -1,0 +1,78 @@
+Feature: Push filter down
+
+  Background: Prepare a new space
+    Given an empty graph
+    And create a space with following options:
+      | partition_num  | 1                |
+      | replica_factor | 1                |
+      | vid_type       | FIXED_STRING(30) |
+      | charset        | utf8             |
+      | collate        | utf8_bin         |
+    And having executed:
+      """
+      CREATE tag player(name string, age int, score int, gender bool);
+      CREATE EDGE IF NOT EXISTS follow();
+      """
+    And having executed:
+      """
+      INSERT VERTEX player(name, age, score, gender) VALUES "Tim Duncan":("Tim Duncan", 42, 28, true),"Yao Ming":("Yao Ming", 38, 23, true),"Nneka Ogwumike":("Nneka Ogwumike", 35, 13, false);
+      INSERT EDGE follow () VALUES "Tim Duncan"->"Yao Ming":();
+      """
+    And having executed:
+      """
+      create tag index player_index on player();
+      create tag index player_name_index on player(name(8));
+      rebuild tag index
+      """
+    And wait all indexes ready
+
+  Scenario: Single vertex
+    When profiling query:
+      """
+      MATCH (v:player) where v.player.name == "Tim Duncan" and v.player.age > 20 RETURN v
+      """
+    Then the execution plan should be:
+      | id | name           | dependencies | operator info                                                                   |
+      | 5  | Project        | 4            |                                                                                 |
+      | 4  | Filter         | 3            | {"condition": "((v.player.name==\"Tim Duncan\") AND (v.player.age>20))"}        |
+      | 3  | AppendVertices | 2            |                                                                                 |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"((player.name==\"Tim Duncan\") AND (player.age>20))"}}  |
+      | 1  | Start          |              |                                                                                 |
+
+    When profiling query:
+      """
+      MATCH (v:player) where v.player.age > 20 RETURN v
+      """
+    Then the execution plan should be:
+      | id | name           | dependencies | operator info                               |
+      | 5  | Project        | 4            |                                             |
+      | 4  | Filter         | 3            | {"condition": "(v.player.age>20)"}          |
+      | 3  | AppendVertices | 2            |                                             |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"(player.age>20)"}}  |
+      | 1  | Start          |              |                                             |
+
+    When profiling query:
+      """
+      MATCH (v:player) where v.player.age < 3 or v.player.age > 20 RETURN v
+      """
+    Then the execution plan should be:
+      | id | name           | dependencies | operator info                                                   |
+      | 5  | Project        | 4            |                                                                 |
+      | 4  | Filter         | 3            | {"condition": "((v.player.age<3) OR (v.player.age>20))"}        |
+      | 3  | AppendVertices | 2            |                                                                 |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"((player.age<3) OR (player.age>20))"}}  |
+      | 1  | Start          |              |                                                                 |
+
+  Scenario: Vertex and edge
+    When profiling query:
+      """
+      MATCH (v:player)-[e]-() where v.player.age > 20 RETURN v
+      """
+    Then the execution plan should be:
+      | id | name           | dependencies | operator info                               |
+      | 6  | Project        | 5            |                                             |
+      | 5  | Filter         | 4            |                                             |
+      | 4  | AppendVertices | 3            |                                             |
+      | 3  | Traverse       | 2            |                                             |
+      | 2  | IndexScan      | 1            | {"indexCtx": {"filter":"(player.age>20)"}}  |
+      | 1  | Start          |              |                                             |

--- a/tests/tck/features/yield/parameter.feature
+++ b/tests/tck/features/yield/parameter.feature
@@ -48,6 +48,7 @@ Feature: Parameter
       | v                                 |
       | {a: 3, b: false, c: "Tim Duncan"} |
 
+  @skip #bug to fix: https://github.com/vesoft-inc/nebula/issues/5939
   Scenario: [param-test-004] cypher with parameters
     # where clause
     When executing query:


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
https://discuss.nebula-graph.com.cn/t/topic/15979
进行全量索引扫描时,无法将条件下推至底层IndexScan算子,而利用索引进行前缀搜索时可以。
When performing a full index scan, it is not possible to push down the conditions to the underlying IndexScan operator, whereas it is possible when using the index for prefix searches.

## How do you solve it?
修改OptimizerUtils.h中的函数,使其在未找到最佳索引时,仍然会接受filter并写入`IndexQueryContext`中。
此修改仅能让以and连接的条件下推。
修改MatchSolver.cpp,使其能同样识别OR类型表达式。

在tck测试中,对于未经过转换的字典对象,不再将其key放入keylist,因为该情况后续未使用keylist
直接通过keylist是否为空判断字典是否不存在嵌套
## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
