### PR TITLE
fix no newline when returning JSON format(#2676)

### DIFF
--- a/src/webservice/GetFlagsHandler.cpp
+++ b/src/webservice/GetFlagsHandler.cpp
@@ -64,7 +64,7 @@ void GetFlagsHandler::onEOM() noexcept {
     ResponseBuilder(downstream_)
         .status(WebServiceUtils::to(HttpStatusCode::OK),
                 WebServiceUtils::toString(HttpStatusCode::OK))
-        .body(folly::toPrettyJson(res))
+        .body(folly::toPrettyJson(res) + "\n")
         .sendWithEOM();
   } else {
     ResponseBuilder(downstream_)

--- a/src/webservice/GetStatsHandler.cpp
+++ b/src/webservice/GetStatsHandler.cpp
@@ -58,7 +58,7 @@ void GetStatsHandler::onEOM() noexcept {
 
   // read stats
   folly::dynamic vals = getStats();
-  std::string body = returnJson_ ? folly::toPrettyJson(vals) : toStr(vals);
+  std::string body = returnJson_ ? folly::toPrettyJson(vals) + "\n" : toStr(vals);
   ResponseBuilder(downstream_)
       .status(WebServiceUtils::to(HttpStatusCode::OK),
               WebServiceUtils::toString(HttpStatusCode::OK))

--- a/src/webservice/StatusHandler.cpp
+++ b/src/webservice/StatusHandler.cpp
@@ -47,7 +47,7 @@ void StatusHandler::onEOM() noexcept {
   ResponseBuilder(downstream_)
       .status(WebServiceUtils::to(HttpStatusCode::OK),
               WebServiceUtils::toString(HttpStatusCode::OK))
-      .body(folly::toJson(vals))
+      .body(folly::toJson(vals) + "\n")
       .sendWithEOM();
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 2676

#### Description:
There seems to be no newline when returning JSON format with curl request

## How do you solve it?
Add newline after json returns

## Special notes for your reviewer, ex. impact of this fix, design document, etc:
Before:
![image](https://github.com/user-attachments/assets/77e18c82-fb87-4b11-befa-6bdf6bead999)
After:
![image](https://github.com/user-attachments/assets/0bdacff2-9296-4cbc-8d4e-42412e4a1c97)

## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
Fixed the bug no newline when returning JSON format with curl request

