### PR TITLE
added built-in timestamp transformation in the date function #2747

### DIFF
--- a/src/common/function/FunctionManager.cpp
+++ b/src/common/function/FunctionManager.cpp
@@ -251,7 +251,8 @@ std::unordered_map<std::string, std::vector<TypeSignature>> FunctionManager::typ
     {"date",
      {TypeSignature({}, Value::Type::DATE),
       TypeSignature({Value::Type::STRING}, Value::Type::DATE),
-      TypeSignature({Value::Type::MAP}, Value::Type::DATE)}},
+      TypeSignature({Value::Type::MAP}, Value::Type::DATE),
+      TypeSignature({Value::Type::INT}, Value::Type::DATE)}},
     {"datetime",
      {TypeSignature({}, Value::Type::DATETIME),
       TypeSignature({Value::Type::STRING}, Value::Type::DATETIME),
@@ -1820,6 +1821,8 @@ FunctionManager::FunctionManager() {
               return Value::kNullBadData;
             }
             return result.value();
+          } else if (args[0].get().isInt()) {
+            return time::TimeConversion::unixSecondsToDate(args[0].get().getInt());
           } else {
             return Value::kNullBadType;
           }

--- a/src/common/function/test/FunctionManagerTest.cpp
+++ b/src/common/function/test/FunctionManagerTest.cpp
@@ -583,6 +583,7 @@ TEST_F(FunctionManagerTest, time) {
     TEST_FUNCTION(
         date, {Map({{"year", 2020}, {"month", 12}, {"day", 31}})}, Value(Date(2020, 12, 31)));
   }
+  { TEST_FUNCTION(date, {573206400}, Value(Date(1988, 3, 1))); }
   // leap year February days
   {
     // 2020 is leap
@@ -1432,7 +1433,7 @@ TEST_F(FunctionManagerTest, returnType) {
   }
   // date
   {
-    auto result = FunctionManager::getReturnType("date", {Value::Type::INT});
+    auto result = FunctionManager::getReturnType("date", {Value::Type::FLOAT});
     ASSERT_FALSE(result.ok());
     EXPECT_EQ(result.status().toString(), "Parameter's type error");
   }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
* [x] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number:  #2747

#### Description:
Added the possibility of converting stored timestamps (int) into a convenient readable date string.
Integrated into a stock date() function. This will save the user from the need for additional transformations.

## How do you solve it?
Added the detection of a stored/requested type. If the date(int) function is called, the date string desired to the user is returned. There was a refusal earlier.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:
Before:
![before-1](https://github.com/user-attachments/assets/8d3628d3-bbd5-45e8-908d-ac84cb3ac903)
![before-2](https://github.com/user-attachments/assets/68e686df-8451-4ab4-b028-b05d67a66486)

After:
![after-1](https://github.com/user-attachments/assets/856c523c-4954-4c1f-8b61-cf522ae6fd29)
![after-2](https://github.com/user-attachments/assets/c646dfd2-eb23-4020-a32f-a454cdb51a03)

Unit Test:
![2724-test](https://github.com/user-attachments/assets/2b1b7354-15aa-4075-9ba4-82383768f68b)

## Checklist:
Tests:
* [x] Unit test(positive and negative cases)
* [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
* [x] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:
added built-in timestamp transformation in the date function
