### PR TITLE
datetime functions fix to return the correct timezone value

### DIFF
--- a/src/common/function/FunctionManager.cpp
+++ b/src/common/function/FunctionManager.cpp
@@ -1552,10 +1552,12 @@ FunctionManager::FunctionManager() {
           return args[0].get().getDate().toString();
         }
         case Value::Type::TIME: {
-          return args[0].get().getTime().toString();
+          Time utcTime = args[0].get().getTime();
+          return time::TimeUtils::utcToTime(utcTime).toString();
         }
         case Value::Type::DATETIME: {
-          return args[0].get().getDateTime().toString();
+          DateTime dt = args[0].get().getDateTime();
+          return time::TimeUtils::utcToDateTime(dt).toString();
         }
         default:
           LOG(ERROR) << "toString has not been implemented for " << args[0].get().type();
@@ -1801,11 +1803,8 @@ FunctionManager::FunctionManager() {
     attr.body_ = [](const auto &args) -> Value {
       switch (args.size()) {
         case 0: {
-          auto result = time::TimeUtils::utcDate();
-          if (!result.ok()) {
-            return Value::kNullBadData;
-          }
-          return Value(std::move(result).value());
+          DateTime dt = time::TimeUtils::utcDateTime();
+          return time::TimeUtils::utcToDateTime(dt).date();
         }
         case 1: {
           if (args[0].get().isStr()) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [X] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: #5894 #5735

#### Description:
The date() and tostring() functions return the value without taking into account the user's time zone offset, while other functions, datetime() and time(), do this. The output has different values.

Fixed return values ​​of functions: _date(), tostring(date()), tostring(datetime()), tostring(time())._ Now the values ​​returned by them correspond to other ones like datetime() or time().


## How do you solve it?
Added the time zone offset performing to the functions.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:
_To reproduce: add “--timezone_name=UTC+11:00“ (or +12, so there is some offset to a time after midnight [next day]) to “/usr/local/nebula/etc/nebula-graphd.conf” and then start the nebula services._

**Before:**
![before-#5894](https://github.com/user-attachments/assets/a3ba7a97-d619-4c08-ac30-3932a72d71b9)
![before-#5735](https://github.com/user-attachments/assets/6bba40af-8dcb-4bbc-97a9-41cf0697d0ef)

---
**After:**
![after-#5894](https://github.com/user-attachments/assets/da2c28e4-ef90-43cd-81f1-3a6f370271c8)
![after-#5735](https://github.com/user-attachments/assets/2400d326-0c1b-4830-93a7-50b06a9a7aec)

Unit Tests:
![after_twice_timezone_conversion_test](https://github.com/user-attachments/assets/ef7c923b-13f8-4257-8ac5-135e59624d03)
![after_function_manager_test](https://github.com/user-attachments/assets/c207c8c7-a381-4948-b267-2ed392299619)


## Checklist:
Tests:
- [X] Unit test (positive and negative cases)
- [X] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:
Fixed the bug of returning the incorrect timezone values.
