### PR TITLE
fix data type's error

### DIFF
--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -1382,7 +1382,7 @@ void Value::setU(const Set& v) {
 }
 
 void Value::setU(Set&& v) {
-  new (std::addressof(value_.vVal)) std::unique_ptr<Set>(new Set(std::move(v)));
+  new (std::addressof(value_.uVal)) std::unique_ptr<Set>(new Set(std::move(v)));
   type_ = Type::SET;
 }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->



## What type of PR is this?
- [.] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?

#### Description:

```
union Storage {
    
    DateTime dtVal;
    Vertex* vVal;
    Edge* eVal;
    
    std::unique_ptr<Set> uVal;
    std::unique_ptr<DataSet> gVal;
    std::unique_ptr<Geography> ggVal;
    std::unique_ptr<Duration> duVal;

    Storage() {}
    ~Storage() {}
  } value_;


```
Set's value is misused with  Vertex, fix it.
## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
