### PR TITLE
Implement CREATE TAG statement for vector type

### DIFF
--- a/src/common/datatypes/Value.cpp
+++ b/src/common/datatypes/Value.cpp
@@ -1954,7 +1954,6 @@ Value Value::lessThan(const Value& v) const {
       // e.g. What is the result of `duration('P1M') < duration('P30D')`?
       return kNullBadType;
     }
-
     case Value::Type::VECTOR:
     case Value::Type::NULLVALUE:
     case Value::Type::__EMPTY__: {

--- a/src/common/datatypes/Vector.cpp
+++ b/src/common/datatypes/Vector.cpp
@@ -17,7 +17,7 @@ std::string Vector::toString() const {
     return std::to_string(v);
   });
   std::stringstream os;
-  os << "[" << folly::join(",", value) << "]";
+  os << "vector (" << folly::join(",", value) << ")";
   return os.str();
 }
 

--- a/src/common/datatypes/Vector.h
+++ b/src/common/datatypes/Vector.h
@@ -23,7 +23,8 @@ struct Vector {
   Vector() = default;
   Vector(const Vector& rhs) = default;
   Vector(Vector&& rhs) noexcept = default;
-  explicit Vector(std::vector<float> vals) : values(std::move(vals)) {}
+  explicit Vector(const std::vector<float>& vals) : values(vals) {}
+  explicit Vector(std::vector<float>&& vals) : values(std::move(vals)) {}
 
   Vector& operator=(const Vector& rhs) {
     if (this == &rhs) {

--- a/src/common/datatypes/VectorOps-inl.h
+++ b/src/common/datatypes/VectorOps-inl.h
@@ -45,8 +45,14 @@ uint32_t Cpp2Ops<nebula::Vector>::write(Protocol* proto, nebula::Vector const* o
   xfer += proto->writeStructBegin("Vector");
 
   xfer += proto->writeFieldBegin("values", apache::thrift::protocol::T_LIST, 1);
+  // Convert float vector to double vector for serialization
+  std::vector<double> doubleValues;
+  doubleValues.reserve(obj->values.size());
+  for (const auto& val : obj->values) {
+    doubleValues.emplace_back(static_cast<double>(val));
+  }
   xfer += detail::pm::protocol_methods<type_class::list<type_class::floating_point>,
-                                       std::vector<float>>::write(*proto, obj->values);
+                                       std::vector<double>>::write(*proto, doubleValues);
   xfer += proto->writeFieldEnd();
 
   xfer += proto->writeFieldStop();
@@ -67,9 +73,15 @@ void Cpp2Ops<nebula::Vector>::read(Protocol* proto, nebula::Vector* obj) {
   }
 
 _readField_values : {
-  obj->values = std::vector<float>();
+  // Read as double vector and convert to float vector
+  std::vector<double> doubleValues;
   detail::pm::protocol_methods<type_class::list<type_class::floating_point>,
-                               std::vector<float>>::read(*proto, obj->values);
+                               std::vector<double>>::read(*proto, doubleValues);
+  obj->values.clear();
+  obj->values.reserve(doubleValues.size());
+  for (const auto& val : doubleValues) {
+    obj->values.emplace_back(static_cast<float>(val));
+  }
 }
 
   if (UNLIKELY(!readState.advanceToNextField(proto, 1, 0, protocol::T_STOP))) {
@@ -110,9 +122,15 @@ uint32_t Cpp2Ops<nebula::Vector>::serializedSize(Protocol const* proto, nebula::
   xfer += proto->serializedStructSize("Vector");
 
   xfer += proto->serializedFieldSize("values", apache::thrift::protocol::T_LIST, 2);
-  xfer +=
-      detail::pm::protocol_methods<type_class::list<type_class::floating_point>,
-                                   std::vector<float>>::serializedSize<false>(*proto, obj->values);
+  // Convert float vector to double vector for size calculation
+  std::vector<double> doubleValues;
+  doubleValues.reserve(obj->values.size());
+  for (const auto& val : obj->values) {
+    doubleValues.emplace_back(static_cast<double>(val));
+  }
+  xfer += detail::pm::protocol_methods<type_class::list<type_class::floating_point>,
+                                       std::vector<double>>::serializedSize<false>(*proto,
+                                                                                   doubleValues);
   xfer += proto->serializedSizeStop();
   return xfer;
 }
@@ -124,9 +142,15 @@ uint32_t Cpp2Ops<nebula::Vector>::serializedSizeZC(Protocol const* proto,
   xfer += proto->serializedStructSize("Vector");
 
   xfer += proto->serializedFieldSize("values", apache::thrift::protocol::T_LIST, 2);
-  xfer +=
-      detail::pm::protocol_methods<type_class::list<type_class::floating_point>,
-                                   std::vector<float>>::serializedSize<false>(*proto, obj->values);
+  // Convert float vector to double vector for size calculation
+  std::vector<double> doubleValues;
+  doubleValues.reserve(obj->values.size());
+  for (const auto& val : obj->values) {
+    doubleValues.emplace_back(static_cast<double>(val));
+  }
+  xfer += detail::pm::protocol_methods<type_class::list<type_class::floating_point>,
+                                       std::vector<double>>::serializedSize<false>(*proto,
+                                                                                   doubleValues);
   xfer += proto->serializedSizeStop();
   return xfer;
 }

--- a/src/common/datatypes/test/ValueTest.cpp
+++ b/src/common/datatypes/test/ValueTest.cpp
@@ -1572,7 +1572,30 @@ TEST(Value, typeName) {
 }
 
 using serializer = apache::thrift::CompactSerializer;
-
+TEST(Value, VectorDecodeEncode) {
+  std::vector<Value> values{
+      // Vector
+      Value(Vector({1, 2, 3})),
+  };
+  for (const auto& val : values) {
+    std::string buf;
+    buf.reserve(128);
+    serializer::serialize(val, &buf);
+    Value valCopy;
+    std::size_t s = serializer::deserialize(buf, valCopy);
+    ASSERT_EQ(s, buf.size());
+    if (val.isNull()) {
+      EXPECT_EQ(valCopy.isNull(), true);
+      EXPECT_EQ(val.getNull(), valCopy.getNull());
+      continue;
+    }
+    if (val.empty()) {
+      EXPECT_EQ(valCopy.empty(), true);
+      continue;
+    }
+    EXPECT_EQ(val, valCopy);
+  }
+}
 TEST(Value, DecodeEncode) {
   std::vector<Value> values{
       // empty

--- a/src/common/meta/NebulaSchemaProvider.h
+++ b/src/common/meta/NebulaSchemaProvider.h
@@ -141,9 +141,10 @@ class NebulaSchemaProvider {
   };
 
  public:
-  explicit NebulaSchemaProvider(SchemaVer ver) : ver_(ver), numNullableFields_(0) {}
+  explicit NebulaSchemaProvider(SchemaVer ver)
+      : ver_(ver), numNullableFields_(0), numVectorNullableFields_(0) {}
 
-  NebulaSchemaProvider() : ver_(0), numNullableFields_(0) {}
+  NebulaSchemaProvider() : ver_(0), numNullableFields_(0), numVectorNullableFields_(0) {}
 
   SchemaVer getVersion() const noexcept;
   // Returns the size of fields_
@@ -177,6 +178,26 @@ class NebulaSchemaProvider {
     return Iterator(this, getNumFields());
   }
 
+  size_t getVectorNumFields() const noexcept;
+  size_t getVectorNumNullableFields() const noexcept;
+  size_t vectorSize() const noexcept;
+
+  int64_t getVectorFieldIndex(const std::string& name) const;
+  const char* getVectorFieldName(int64_t index) const;
+
+  nebula::cpp2::PropertyType getVectorFieldType(int64_t index) const;
+  nebula::cpp2::PropertyType getVectorFieldType(const std::string& name) const;
+
+  const SchemaField* vectorField(int64_t index) const;
+  const SchemaField* vectorField(const std::string& name) const;
+
+  void addVectorField(const std::string& name,
+                      nebula::cpp2::PropertyType type,
+                      size_t fixedStrLen,
+                      bool nullable,
+                      std::string defaultValue,
+                      cpp2::GeoShape geoShape);
+
   void setProp(cpp2::SchemaProp schemaProp);
 
   const cpp2::SchemaProp getProp() const;
@@ -184,7 +205,7 @@ class NebulaSchemaProvider {
   StatusOr<std::pair<std::string, int64_t>> getTTLInfo() const;
 
   bool hasNullableCol() const {
-    return numNullableFields_ != 0;
+    return numNullableFields_ != 0 && numVectorNullableFields_ != 0;
   }
 
  private:
@@ -197,6 +218,10 @@ class NebulaSchemaProvider {
   std::unordered_map<std::string, int64_t> fieldNameIndex_;
   std::vector<SchemaField> fields_;
   size_t numNullableFields_;
+  // for vector columns
+  std::unordered_map<std::string, int64_t> vectorFieldNameIndex_;
+  std::vector<SchemaField> vector_fields_;
+  size_t numVectorNullableFields_;
   cpp2::SchemaProp schemaProp_;
 };
 

--- a/src/graph/validator/MaintainValidator.cpp
+++ b/src/graph/validator/MaintainValidator.cpp
@@ -35,7 +35,8 @@ static Status validateColumns(const std::vector<ColumnSpecification *> &columnSp
     auto type = spec->type();
     column.name_ref() = *spec->name();
     column.type.type_ref() = type;
-    if (nebula::cpp2::PropertyType::FIXED_STRING == type) {
+    if (nebula::cpp2::PropertyType::FIXED_STRING == type ||
+        nebula::cpp2::PropertyType::VECTOR == type) {
       column.type.type_length_ref() = spec->typeLen();
     } else if (nebula::cpp2::PropertyType::GEOGRAPHY == type) {
       column.type.geo_shape_ref() = spec->geoShape();
@@ -91,6 +92,10 @@ static StatusOr<std::vector<meta::cpp2::AlterSchemaItem>> validateSchemaOpts(
         meta::cpp2::ColumnDef column;
         column.name = *colName;
         schema.columns_ref().value().emplace_back(std::move(column));
+        // TODO(LZY): we don not know whether the column is a vector column or not
+        // meta::cpp2::ColumnDef vecColumn;
+        // vecColumn.name = *colName;
+        // schema.vector_columns_ref().ensure().emplace_back(std::move(vecColumn));
       }
     } else {
       const auto &specs = schemaOpt->columnSpecs();

--- a/src/interface/meta.thrift
+++ b/src/interface/meta.thrift
@@ -70,7 +70,7 @@ enum GeoShape {
 
 struct ColumnTypeDef {
     1: required common.PropertyType    type,
-    // type_length is valid for fixed_string type
+    // type_length is valid for fixed_string type and vector type for dimension
     2: optional i16                    type_length = 0,
     // geo_shape is valid for geography type
     3: optional GeoShape               geo_shape,
@@ -90,7 +90,7 @@ struct SchemaProp {
     3: optional binary   comment,
 }
 
-struct Schema {
+struct Schema {  
     1: list<ColumnDef> columns,
     2: SchemaProp schema_prop,
 }

--- a/src/kvstore/test/RocksEngineConfigMultiCFTest.cpp
+++ b/src/kvstore/test/RocksEngineConfigMultiCFTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 vesoft inc. All rights reserved.
+/* Copyright (c) 2025 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License.
  */

--- a/src/kvstore/test/RocksEngineMultiCFTest.cpp
+++ b/src/kvstore/test/RocksEngineMultiCFTest.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2018 vesoft inc. All rights reserved.
+/* Copyright (c) 2025 vesoft inc. All rights reserved.
  *
  * This source code is licensed under Apache 2.0 License.
  */

--- a/src/meta/MetaServiceUtils.cpp
+++ b/src/meta/MetaServiceUtils.cpp
@@ -143,7 +143,7 @@ nebula::cpp2::ErrorCode MetaServiceUtils::alterColumnDefs(
           return nebula::cpp2::ErrorCode::SUCCEEDED;
         }
       }
-      LOG(INFO) << "Column not found: " << col.get_name();
+      LOG(ERROR) << "lzy Column not found: " << col.get_name() << ", isEdge: " << isEdge;
       if (isEdge) {
         return nebula::cpp2::ErrorCode::E_EDGE_PROP_NOT_FOUND;
       }

--- a/src/meta/processors/schema/SchemaUtil.cpp
+++ b/src/meta/processors/schema/SchemaUtil.cpp
@@ -278,9 +278,19 @@ bool SchemaUtil::checkType(std::vector<cpp2::ColumnDef>& columns) {
     }
     case PropertyType::VECTOR: {
       // detect column dim and value dim
-      return column.get_type().type_length_ref().has_value() && value.isVector() &&
-             value.getVector().dim() ==
-                 static_cast<size_t>(column.get_type().type_length_ref().value());
+      if (!value.isVector()) {
+        LOG(INFO) << "Invalid default value for ` " << name << "', value type is " << value.type();
+        return false;
+      }
+      if (!column.get_type().type_length_ref().has_value() ||
+          value.getVector().dim() !=
+              static_cast<size_t>(column.get_type().type_length_ref().value())) {
+        LOG(INFO) << "Invalid default value for ` " << name << "', value dim is "
+                  << value.getVector().dim() << ", but column dim is "
+                  << column.get_type().type_length_ref().value();
+        return false;
+      }
+      return true;
     }
     case PropertyType::UNKNOWN:
     case PropertyType::VID:

--- a/src/parser/MaintainSentences.cpp
+++ b/src/parser/MaintainSentences.cpp
@@ -69,6 +69,10 @@ std::string ColumnSpecification::toString() const {
     buf += "FIXED_STRING(";
     buf += std::to_string(typeLen_);
     buf += ")";
+  } else if (nebula::cpp2::PropertyType::VECTOR == type_) {
+    buf += "VECTOR(";
+    buf += std::to_string(typeLen_);
+    buf += ")";
   } else {
     buf += apache::thrift::util::enumNameSafe(type_);
   }

--- a/src/parser/scanner.lex
+++ b/src/parser/scanner.lex
@@ -139,6 +139,7 @@ LABEL_FULL_WIDTH            {CN_EN_FULL_WIDTH}{CN_EN_NUM_FULL_WIDTH}*
 "DATE"                      { return TokenType::KW_DATE; }
 "TIME"                      { return TokenType::KW_TIME; }
 "DATETIME"                  { return TokenType::KW_DATETIME; }
+"VECTOR"                    { return TokenType::KW_VECTOR; }
 "TAG"                       { return TokenType::KW_TAG; }
 "TAGS"                      { return TokenType::KW_TAGS; }
 "UNION"                     { return TokenType::KW_UNION; }

--- a/src/parser/test/ParserTest.cpp
+++ b/src/parser/test/ParserTest.cpp
@@ -117,6 +117,29 @@ TEST_F(ParserTest, TestSchemaCreation) {
   }
 }
 
+TEST_F(ParserTest, TestVectorSchemaCreation) {
+  // All type
+  {
+    std::string query = "CREATE TAG person(id int, vec vector(3))";
+    auto result = parse(query);
+    ASSERT_TRUE(result.ok()) << result.status();
+  }
+
+  {
+    std::string query =
+        "CREATE TAG person(id INT16 DEFAULT 10, vec vector(3) NOT NULL DEFAULT vector "
+        "(0.1,0.2,0.3));";
+    auto result = parse(query);
+    ASSERT_TRUE(result.ok()) << result.status();
+  }
+  {
+    std::string query =
+        "CREATE TAG person(id INT16 DEFAULT 10, vec vector(1) NOT NULL DEFAULT vector (0.1));";
+    auto result = parse(query);
+    ASSERT_TRUE(result.ok()) << result.status();
+  }
+}
+
 TEST_F(ParserTest, Go) {
   {
     std::string query = "GO FROM \"1\" OVER friend";

--- a/tests/common/comparator.py
+++ b/tests/common/comparator.py
@@ -183,6 +183,20 @@ class DataSetComparator:
             if not rhs.getType() == Value.PVAL:
                 return False
             return self.compare_path(lhs.get_pVal(), rhs.get_pVal())
+        if lhs.getType() == Value.VECVAL:
+            print("Comparing vector values")
+            if not rhs.getType() == Value.VECVAL:
+                return False
+            lvec = lhs.get_vecVal()
+            rvec = rhs.get_vecVal()
+            if lvec.values is None or rvec.values is None:
+                return lvec.values is None and rvec.values is None
+            if len(lvec.values) != len(rvec.values):
+                return False
+            for i in range(len(lvec.values)):
+                if not math.isclose(lvec.values[i], rvec.values[i], rel_tol=1e-6):
+                    return False
+            return True
         return False
 
     def compare_path(self, lhs: Path, rhs: Path):

--- a/tests/common/dataset_printer.py
+++ b/tests/common/dataset_printer.py
@@ -86,6 +86,11 @@ class DataSetPrinter:
             return '{' + self.list_to_string(val.get_uVal().values) + '}'
         if val.getType() == Value.GVAL:
             return self.ds_to_string(val.get_gVal())
+        if val.getType() == Value.VECVAL:
+            vec = val.get_vecVal()
+            if vec.values is None or len(vec.values) == 0:
+                return "()"
+            return f"({','.join(str(float(v)) for v in vec.values)})"
         return ""
 
     def list_to_string(self, lst: List[Value], delimiter: str = ",") -> str:

--- a/tests/tck/conftest.py
+++ b/tests/tck/conftest.py
@@ -12,7 +12,7 @@ import re
 import threading
 import json
 
-from nebula3.common.ttypes import NList, NMap, Value, ErrorCode
+from nebula3.common.ttypes import Vector, NList, NMap, Value, ErrorCode
 from nebula3.data.DataObject import ValueWrapper
 from nebula3.Exception import AuthFailedException
 from pytest_bdd import given, parsers, then, when
@@ -153,10 +153,18 @@ def value(any):
         v.set_lVal(list2Nlist(any))
     elif isinstance(any, dict):
         v.set_mVal(map2NMap(any))
+    elif isinstance(any, tuple):
+        v.set_vecVal(tuple2Vector(any))
     else:
         raise TypeError("Do not support convert " + str(type(any)) + " to nebula.Value")
     return v
 
+def tuple2Vector(tuple)->Vector:
+    vector = Vector()
+    vector.values = []
+    for item in tuple:
+        vector.values.append(item)
+    return vector
 
 def list2Nlist(list):
     nlist = NList()

--- a/tests/tck/features/vector/Schema.feature
+++ b/tests/tck/features/vector/Schema.feature
@@ -1,0 +1,168 @@
+# Copyright (c) 2025 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+Feature: Vector tag
+
+  Scenario: describe vector tag
+    Given an empty graph
+    And create a space with following options:
+      | partition_num  | 1                |
+      | replica_factor | 1                |
+      | vid_type       | FIXED_STRING(20) |
+    # empty prop
+    When executing query:
+      """
+      CREATE TAG vectag1(id int, vec vector(3) NOT NULL DEFAULT vector(0.1,0.2,0.3))
+      """
+    Then the execution should be successful
+    # if not exists
+    When executing query:
+      """
+      CREATE TAG IF NOT EXISTS vectag1(id int, vec vector(3))
+      """
+    Then the execution should be successful
+    # check result
+    When executing query:
+      """
+      DESCRIBE TAG vectag1
+      """
+    # desc tag
+    When executing query:
+      """
+      DESCRIBE TAG vectag1
+      """
+    Then the result should be, in any order:
+      | Field | Type        | Null  | Default             | Comment |
+      | "id"  | "int64"     | "YES" | EMPTY               | EMPTY   |
+      | "vec" | "vector(3)" | "NO"  | vector(0.1,0.2,0.3) | EMPTY   |
+    When executing query:
+      """
+      CREATE TAG vectag2(id int, vec vector(3))
+      """
+    Then the execution should be successful
+    # if not exists
+    When executing query:
+      """
+      CREATE TAG IF NOT EXISTS vectag2(id int, vec vector(3) NOT NULL DEFAULT vector(0.1,0.2,0.3))
+      """
+    Then the execution should be successful
+    # check result
+    When executing query:
+      """
+      DESCRIBE TAG vectag2
+      """
+    # desc tag
+    When executing query:
+      """
+      DESCRIBE TAG vectag2
+      """
+    Then the result should be, in any order:
+      | Field | Type        | Null  | Default | Comment |
+      | "id"  | "int64"     | "YES" | EMPTY   | EMPTY   |
+      | "vec" | "vector(3)" | "YES" | EMPTY   | EMPTY   |
+    # create tag succeed
+    When executing query:
+      """
+      CREATE TAG vectag3(id int, vec vector(3) NOT NULL DEFAULT vector(0.2,0.4,0.6) COMMENT 'vector column')
+      """
+    Then the execution should be successful
+    # if not exists
+    When executing query:
+      """
+      CREATE TAG IF NOT EXISTS vectag3(id int, vec vector(3) )
+      """
+    Then the execution should be successful
+    # check result
+    When executing query:
+      """
+      DESCRIBE TAG vectag3
+      """
+    # desc tag
+    When executing query:
+      """
+      DESCRIBE TAG vectag3
+      """
+    Then the result should be, in any order:
+      | Field | Type        | Null  | Default             | Comment         |
+      | "id"  | "int64"     | "YES" | EMPTY               | EMPTY           |
+      | "vec" | "vector(3)" | "NO"  | vector(0.2,0.4,0.6) | "vector column" |
+    # create tag succeed
+    When executing query:
+      """
+      CREATE EDGE vecedge1(id int, vec vector(3))
+      """
+    Then the execution should be successful
+    # if not exists
+    When executing query:
+      """
+      CREATE EDGE IF NOT EXISTS vecedge1(id int, vec vector(3))
+      """
+    Then the execution should be successful
+    # check result
+    When executing query:
+      """
+      DESCRIBE EDGE vecedge1
+      """
+    # desc edge
+    When executing query:
+      """
+      DESCRIBE EDGE vecedge1
+      """
+    Then the result should be, in any order:
+      | Field | Type        | Null  | Default | Comment |
+      | "id"  | "int64"     | "YES" | EMPTY   | EMPTY   |
+      | "vec" | "vector(3)" | "YES" | EMPTY   | EMPTY   |
+    # create edge succeed
+    When executing query:
+      """
+      CREATE EDGE vecedge2(id int, vec vector(3) NOT NULL DEFAULT vector(0.3,0.6,0.9))
+      """
+    Then the execution should be successful
+    # if not exists
+    When executing query:
+      """
+      CREATE EDGE IF NOT EXISTS vecedge2(id int, vec vector(3))
+      """
+    Then the execution should be successful
+    # check result
+    When executing query:
+      """
+      DESCRIBE EDGE vecedge2
+      """
+    # desc edge
+    When executing query:
+      """
+      DESCRIBE EDGE vecedge2
+      """
+    Then the result should be, in any order:
+      | Field | Type        | Null  | Default             | Comment |
+      | "id"  | "int64"     | "YES" | EMPTY               | EMPTY   |
+      | "vec" | "vector(3)" | "NO"  | vector(0.3,0.6,0.9) | EMPTY   |
+    # create edge succeed
+    When executing query:
+      """
+      CREATE EDGE vecedge3(id int, vec vector(3)NOT NULL DEFAULT vector(0.3,0.6,0.9) COMMENT 'vector column')
+      """
+    Then the execution should be successful
+    # if not exists
+    When executing query:
+      """
+      CREATE EDGE IF NOT EXISTS vecedge3(id int, vec vector(3))
+      """
+    Then the execution should be successful
+    # check result
+    When executing query:
+      """
+      DESCRIBE EDGE vecedge3
+      """
+    # desc edge
+    When executing query:
+      """
+      DESCRIBE EDGE vecedge3
+      """
+    Then the result should be, in any order:
+      | Field | Type        | Null  | Default             | Comment         |
+      | "id"  | "int64"     | "YES" | EMPTY               | EMPTY           |
+      | "vec" | "vector(3)" | "NO"  | vector(0.3,0.6,0.9) | "vector column" |
+
+# create edge succeed

--- a/tests/tck/utils/nbv.py
+++ b/tests/tck/utils/nbv.py
@@ -23,6 +23,7 @@ from nebula3.common.ttypes import (
     Edge,
     Path,
     Step,
+    Vector,
 )
 
 Value.__hash__ = lambda self: self.value.__hash__()
@@ -560,11 +561,29 @@ def murmurhash2(v):
     raise ValueError(f"Invalid value type: {type(v)}")
 
 
+def vector(*args):
+    """Create a Vector from numeric values"""
+    vec = Vector()
+    vec.values = []
+    for arg in args:
+        if isinstance(arg, Value):
+            if arg.getType() == Value.FVAL:
+                vec.values.append(arg.get_fVal())
+            else:
+                raise ValueError(f"Vector elements must be numeric, got Value type {arg.getType()}")
+        else:
+            raise ValueError(f"Vector elements must be numeric, got {type(arg)}")
+    val = Value()
+    val.set_vecVal(vec)
+    return val
+
+
 def register_function(name, func):
     functions[name] = func
 
 
 register_function('hash', murmurhash2)
+register_function('vector', vector)
 
 
 parser = yacc.yacc(write_tables=False)
@@ -605,6 +624,10 @@ if __name__ == '__main__':
     expected['''/\\//'''] = re.compile(r'/')
     expected['''hash("hello")'''] = 2762169579135187400
     expected['''hash("World")'''] = -295471233978816215
+    # Test vector function
+    vec1 = Value()
+    vec1.set_vecVal(Vector(values=[0.1, 0.2, 0.3]))
+    expected['vector(0.1,0.2,0.3)'] = vec1
     expected['[]'] = Value(lVal=NList([]))
     expected['[{}]'] = Value(lVal=NList([Value(mVal=NMap({}))]))
     expected['[1,2,3]'] = Value(lVal=NList([


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [x] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

Create tag with vector type properties
 #6040
Implement schema with vector columns for DDL #6075
Implement CREATE TAG statement for vector type #6078

#### Description:
1. Schema Provider Modification 

To simply support original column and vector column, we need to modify the schema provider as follows:

- Original columns (for other types except VECTOR type)
- Vector columns (just for VECTOR type)
- Schema Properties Options (TTL, TTL_COL, etc.)

2. RowWriter and RowReader

Then, we also need to modify RowWriter and RowReader to support vector column. The RowWriter will write the vector data into the RocksDB "vector" column family, and the RowReader will read the vector data from the RocksDB "vector" column family.

## How do you solve it?
### Schema Provider Modification

To simply support original column and vector column, we need to modify the schema as follows:

1.  Original columns (for other types except VECTOR type)
2.  Vector columns (just for VECTOR type)
3.  Schema Properties Options (TTL, TTL_COL, etc.)

<img width="939" height="350" alt="image" src="https://github.com/user-attachments/assets/04bdc26f-8285-402b-8ddb-87aaeec8605b" style="width:50%" />

### Implement CREATE TAG for Vector Type

#### Vector type syntax
We've designed a dedicated syntax for vector types, representing a 3-dimensional vector as (0.1, 0.2, 0.3). Specifically, we've imposed a grammatical restriction that a vector type must have at least two dimensions. 

Internally, vector types are recognized as ConstantExpression for subsequent validation, planning, and execution.

#### Vector Property

- Use `type_lenght` to indicate the dimension of the vector type.

```cpp
struct ColumnTypeDef {
    1: required common.PropertyType    type,
    // type_length is valid for fixed_string type and vector type for dimension
    2: optional i16                    type_length = 0,
    // geo_shape is valid for geography type
    3: optional GeoShape               geo_shape,
}
```

We will validate that the default value matches the dimension of the vector property when we prepare to store the schema in the metadata (or metastore). 

### Modify the processor of graphd and metad
- Check vector property of schema utils
- Implement the description of schema consist of vector columns

### Modify the python test
- Add comparator for vector property
- Use new common generated python code
- Modify new parse of tck for vector property

## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

TCK Tests:
Add new schema for vector property.




<img width="2876" height="178" alt="ddl_tck" src="https://github.com/user-attachments/assets/436b16c5-4cfa-4175-b402-aec0e7fe212c" />


Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
