### PR TITLE
Implement the key for vector type 

### DIFF
--- a/src/common/thrift/ThriftTypes.h
+++ b/src/common/thrift/ThriftTypes.h
@@ -27,6 +27,7 @@ using Port = int32_t;
 // be appended to the end
 using VertexID = std::string;
 using TagID = int32_t;
+using PropID = int32_t;
 using TagVersion = int64_t;
 using EdgeType = int32_t;
 using EdgeRanking = int64_t;

--- a/src/common/utils/Types.h
+++ b/src/common/utils/Types.h
@@ -21,6 +21,7 @@ enum class NebulaKeyType : uint32_t {
   kVertex = 0x00000007,
   kPrime = 0x00000008,        // used in TOSS, if we write a lock succeed
   kDoublePrime = 0x00000009,  // used in TOSS, if we get RPC back from remote.
+  kVector_ = 0x000000F0,      // used for vector data
 };
 
 enum class NebulaSystemKeyType : uint32_t {
@@ -44,6 +45,10 @@ static typename std::enable_if<std::is_integral<T>::value, T>::type readInt(cons
   return *reinterpret_cast<const T*>(data);
 }
 
+static constexpr int32_t kVectorTagLen = sizeof(PartitionID) + sizeof(TagID) + sizeof(PropID);
+static constexpr int32_t kVectorEdgeLen = sizeof(PartitionID) + sizeof(EdgeType) +
+                                          sizeof(EdgeRanking) + sizeof(EdgeVerPlaceHolder) +
+                                          sizeof(PropID);
 // size of tag key except vertexId
 static constexpr int32_t kTagLen = sizeof(PartitionID) + sizeof(TagID);
 
@@ -59,6 +64,8 @@ static constexpr uint8_t kPartitionOffset = 8;
 // The key type bits Mask
 // See KeyType enum
 static constexpr uint32_t kTypeMask = 0x000000FF;
+static constexpr uint32_t kTypeMaskWithVector = 0x000000F0;
+static constexpr uint32_t kTypeMaskWithoutVector = 0x0000000F;
 
 static constexpr int32_t kTagIndexLen = sizeof(PartitionID) + sizeof(IndexID);
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [x] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

Support DML for vector type
 #6032 （Stage 1）
Implement the key for vector type #6080

#### Description:
Now, nebula has key for other types, like as follows:
```cpp
TagKeyUtils:
type(1) + partId(3) + vertexId(*) + tagId(4)

EdgeKeyUtils:
type(1) + partId(3) + srcId(*) + edgeType(4) + edgeRank(8) + dstId(*) + placeHolder(1)
```
So we need key for vector type to store vector attributes in vector column family of RocksDB.

## How do you solve it?
To support multiple vector attributes, we have added propId in the vector key util to represent the corresponding vector attribute, ensuring the uniqueness of each vector attribute.

```cpp
VectorTagKeyUtils:
type(1) + partId(3) + vertexId(*) + tagId(4) + propId(4)

VectroEdgeKeyUtils:
type(1) + partId(3) + srcId(*) + edgeType(4) + edgeRank(8) + dstId(*) + propId(4) +placeHolder(1)
```

## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

TCK Test:

<img width="3128" height="174" alt="image" src="https://github.com/user-attachments/assets/882672d8-0c73-4cfd-9be9-36b3a2078738" />


Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
