### PR TITLE
Fix probability inaccuracy in reservoir sampling

### DIFF
--- a/src/common/algorithm/ReservoirSampling.h
+++ b/src/common/algorithm/ReservoirSampling.h
@@ -33,7 +33,7 @@ class ReservoirSampling final {
       ++cnt_;
       return true;
     } else {
-      auto index = folly::Random::rand64(cnt_);
+      auto index = folly::Random::rand64(cnt_ + 1);
       if (index < num_) {
         samples_[index] = (std::move(sample));
         ++cnt_;

--- a/src/common/algorithm/test/ReservoirSamplingTest.cpp
+++ b/src/common/algorithm/test/ReservoirSamplingTest.cpp
@@ -39,6 +39,21 @@ TEST(ReservoirSamplingTest, Sample) {
       EXPECT_EQ(2, result[2]);
     }
   }
+  {
+    std::unordered_set<int64_t> hit;
+    for (size_t time = 0; time < 1024; time++) {
+      ReservoirSampling<int64_t> sampler(1);
+      sampler.sampling(1);
+      sampler.sampling(2);
+      auto result = sampler.samples();
+      EXPECT_EQ(1, result.size());
+      EXPECT_TRUE(result[0] == 1 || result[0] == 2);
+      hit.insert(result[0]);
+    }
+    EXPECT_EQ(2, hit.size());
+    EXPECT_TRUE(hit.find(1) != hit.end());
+    EXPECT_TRUE(hit.find(2) != hit.end());
+  }
 }
 }  // namespace algorithm
 }  // namespace nebula


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 6091

#### Description:
The `<go_statement> SAMPLE <sample_list>` statement relay on the reservoir sampling algorithm, but the current implementation exhibits probability inaccuracies.

## How do you solve it?


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
Fix probability inaccuracy in reservoir sampling
