### PR TITLE
feat:add process_uptime_seconds metrics

### DIFF
--- a/src/webservice/GetStatsHandler.cpp
+++ b/src/webservice/GetStatsHandler.cpp
@@ -12,9 +12,13 @@
 
 #include "common/base/Base.h"
 #include "common/stats/StatsManager.h"
+#include "common/time/WallClock.h"
 #include "webservice/Common.h"
 
 namespace nebula {
+
+// Process start time (auto-recorded via static initialization)
+static const int64_t g_processStartTime = nebula::time::WallClock::fastNowInSec();
 
 using nebula::stats::StatsManager;
 using proxygen::HTTPMessage;
@@ -96,14 +100,24 @@ folly::dynamic GetStatsHandler::getStats() const {
   if (statNames_.empty()) {
     // Read all stats
     StatsManager::readAllValue(stats);
+    // Add process uptime metric to all stats
+    const int64_t uptimeSeconds = nebula::time::WallClock::fastNowInSec() - g_processStartTime;
+    addOneStat(stats, "process_uptime_seconds", uptimeSeconds);
   } else {
     for (auto& sn : statNames_) {
-      auto status = StatsManager::readValue(sn);
-      if (status.ok()) {
-        int64_t statValue = status.value();
-        addOneStat(stats, sn, statValue);
+      // Handle process uptime metrics specially
+      if (sn == "process_uptime_seconds") {
+        const int64_t uptimeSeconds = nebula::time::WallClock::fastNowInSec() - g_processStartTime;
+        addOneStat(stats, sn, uptimeSeconds);
       } else {
-        addOneStat(stats, sn, status.status().toString());
+        // Handle regular metrics
+        auto status = StatsManager::readValue(sn);
+        if (status.ok()) {
+          const int64_t statValue = status.value();
+          addOneStat(stats, sn, statValue);
+        } else {
+          addOneStat(stats, sn, status.status().toString());
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [x] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:
**Currently, if a process restarts right within the stats query interval, an alert may be missed.** 

## How do you solve it?
**A process-level start time has been added to ensure that such cases are not missed.**


## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A
<img width="2496" height="268" alt="image" src="https://github.com/user-attachments/assets/a92a6b81-5572-4d08-b6cd-e17c790aac2c" />
<img width="674" height="488" alt="image" src="https://github.com/user-attachments/assets/0ccf53cf-c658-48e6-8e0c-45eddfd3010e" />


Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
