### PR TITLE
Feature/rootless nebula images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,6 @@ RUN cd /home/nebula/BUILD/package \
 
 FROM centos:7 as graphd
 
-RUN groupadd -r nebula && useradd -r -g nebula -d /usr/local/nebula nebula
-
 COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-common.rpm /usr/local/nebula/nebula-common.rpm
 COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-graph.rpm /usr/local/nebula/nebula-graphd.rpm
 
@@ -23,11 +21,10 @@ WORKDIR /usr/local/nebula
 RUN rpm -ivh *.rpm \
   && mkdir -p ./{logs,data,pids} \
   && rm -rf *.rpm \
-  && chown -R nebula:nebula /usr/local/nebula
+  && chgrp -R 0 /usr/local/nebula \
+  && chmod -R g+rwX /usr/local/nebula \
 
 EXPOSE 9669 19669 19670
-
-USER nebula
 
 ENTRYPOINT ["/usr/local/nebula/bin/nebula-graphd", "--flagfile=/usr/local/nebula/etc/nebula-graphd.conf", "--daemonize=false", "--containerized=true"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN rpm -ivh *.rpm \
   && mkdir -p ./{logs,data,pids} \
   && rm -rf *.rpm \
   && chgrp -R 0 /usr/local/nebula \
-  && chmod -R g+rwX /usr/local/nebula \
+  && chmod -R g+rwX /usr/local/nebula
 
 EXPOSE 9669 19669 19670
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,14 +3,14 @@ FROM vesoft/nebula-dev:centos7 as builder
 ENV BUILD_IN_DOCKER TRUE
 ARG VERSION=
 ENV CCACHE_DIR=/root/.ccache
-ENV CCACHE_MAXSIZE=15G
+ENV CCACHE_MAXSIZE=35G
 ARG J=
 
 COPY . /home/nebula/BUILD
 
 RUN cd /home/nebula/BUILD/package \
   && ./package.sh -v "${VERSION}"
-  
+
 FROM centos:7 as graphd
 
 RUN groupadd -r nebula && useradd -r -g nebula -d /usr/local/nebula nebula
@@ -33,8 +33,6 @@ ENTRYPOINT ["/usr/local/nebula/bin/nebula-graphd", "--flagfile=/usr/local/nebula
 
 FROM centos:7 as metad
 
-RUN groupadd -r nebula && useradd -r -g nebula -d /usr/local/nebula nebula
-
 COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-common.rpm /usr/local/nebula/nebula-common.rpm
 COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-meta.rpm /usr/local/nebula/nebula-metad.rpm
 
@@ -43,16 +41,14 @@ WORKDIR /usr/local/nebula
 RUN rpm -ivh *.rpm \
   && mkdir -p ./{logs,data,pids} \
   && rm -rf *.rpm \
-  && chown -R nebula:nebula /usr/local/nebula
+  && chgrp -R 0 /usr/local/nebula \
+  && chmod -R g+rwX /usr/local/nebula
 
 EXPOSE 9559 9560 19559 19560
-
-USER nebula
 
 ENTRYPOINT ["/usr/local/nebula/bin/nebula-metad", "--flagfile=/usr/local/nebula/etc/nebula-metad.conf", "--daemonize=false", "--containerized=true"]
 
 FROM centos:7 as storaged
-
 
 COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-common.rpm /usr/local/nebula/nebula-common.rpm
 COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-storage.rpm /usr/local/nebula/nebula-storaged.rpm
@@ -62,7 +58,7 @@ WORKDIR /usr/local/nebula
 RUN rpm -ivh *.rpm \
   && mkdir -p ./{logs,data,pids,logrotate} \
   && rm -rf *.rpm \
-  && chown -R nebula:nebula /usr/local/nebula \
+  && chgrp -R 0 /usr/local/nebula \
   && chmod -R g+rwX /usr/local/nebula
 
 EXPOSE 9777 9778 9779 9780 19779 19780

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,9 @@ FROM vesoft/nebula-dev:centos7 as builder
 
 ENV BUILD_IN_DOCKER TRUE
 ARG VERSION=
+ENV CCACHE_DIR=/root/.ccache
+ENV CCACHE_MAXSIZE=15G
+ARG J=
 
 COPY . /home/nebula/BUILD
 
@@ -50,7 +53,6 @@ ENTRYPOINT ["/usr/local/nebula/bin/nebula-metad", "--flagfile=/usr/local/nebula/
 
 FROM centos:7 as storaged
 
-RUN groupadd -r nebula && useradd -r -g nebula -d /usr/local/nebula nebula
 
 COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-common.rpm /usr/local/nebula/nebula-common.rpm
 COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-storage.rpm /usr/local/nebula/nebula-storaged.rpm
@@ -58,13 +60,12 @@ COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-storage.r
 WORKDIR /usr/local/nebula
 
 RUN rpm -ivh *.rpm \
-  && mkdir -p ./{logs,data,pids} \
+  && mkdir -p ./{logs,data,pids,logrotate} \
   && rm -rf *.rpm \
-  && chown -R nebula:nebula /usr/local/nebula
+  && chown -R nebula:nebula /usr/local/nebula \
+  && chmod -R g+rwX /usr/local/nebula
 
 EXPOSE 9777 9778 9779 9780 19779 19780
-
-USER nebula
 
 ENTRYPOINT ["/usr/local/nebula/bin/nebula-storaged", "--flagfile=/usr/local/nebula/etc/nebula-storaged.conf", "--daemonize=false", "--containerized=true"]
 

--- a/docker/Dockerfile.metad
+++ b/docker/Dockerfile.metad
@@ -25,5 +25,8 @@ RUN rpm -ivh *.rpm \
 USER nebula
 
 EXPOSE 9559 9560 19559 19560
+RUN ls -lah /bin/
+RUN ls -lah /
+RUN ls -lah /usr/
 
 ENTRYPOINT ["/usr/local/nebula/bin/nebula-metad", "--flagfile=/usr/local/nebula/etc/nebula-metad.conf", "--daemonize=false", "--containerized=true"]

--- a/docker/Dockerfile.storaged
+++ b/docker/Dockerfile.storaged
@@ -3,6 +3,9 @@ FROM vesoft/nebula-dev:centos7 as builder
 
 ENV BUILD_IN_DOCKER=true
 ARG VERSION=
+ENV CCACHE_DIR=/root/.ccache
+ENV CCACHE_MAXSIZE=15G
+ARG J=
 
 COPY . /home/nebula/BUILD
 
@@ -23,9 +26,9 @@ COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-storage.r
 WORKDIR /usr/local/nebula
 
 # Install RPMs and clean up
-RUN rpm -ivh /tmp/*.rpm && \
-    rm -rf /tmp/*.rpm && \
-    chmod -R g+rwX /usr/local/nebula
+RUN rpm -ivh *.rpm  \
+    && rm -rf *.rpm \
+    && chmod -R g+rwX /usr/local/nebula
 
 # Do NOT set USER — OpenShift will inject a random non-root UID
 # `fsGroup` in the Pod spec will ensure proper write access to mounted volumes

--- a/docker/Dockerfile.storaged
+++ b/docker/Dockerfile.storaged
@@ -1,6 +1,7 @@
+# --- Builder Stage ---
 FROM vesoft/nebula-dev:centos7 as builder
 
-ENV BUILD_IN_DOCKER TRUE
+ENV BUILD_IN_DOCKER=true
 ARG VERSION=
 
 COPY . /home/nebula/BUILD
@@ -8,21 +9,26 @@ COPY . /home/nebula/BUILD
 RUN cd /home/nebula/BUILD/package \
   && ./package.sh -v "${VERSION}"
 
+# --- Runtime Stage ---
 FROM centos:7
 
-RUN groupadd -r nebula && useradd -r -g nebula -d /usr/local/nebula nebula
+# Create required directories and ensure group-writable access
+RUN mkdir -p /usr/local/nebula/{logs,data,pids,logrotate} && \
+    chmod -R g+rwX /usr/local/nebula
 
-COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-common.rpm /usr/local/nebula/nebula-common.rpm
-COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-storage.rpm /usr/local/nebula/nebula-storaged.rpm
+# Copy built RPMs
+COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-common.rpm /tmp/
+COPY --from=builder /home/nebula/BUILD/pkg-build/cpack_output/nebula-*-storage.rpm /tmp/
 
 WORKDIR /usr/local/nebula
 
-RUN rpm -ivh *.rpm \
-  && mkdir -p ./{logs,data,pids} \
-  && rm -rf *.rpm \
-  && chown -R nebula:nebula /usr/local/nebula
+# Install RPMs and clean up
+RUN rpm -ivh /tmp/*.rpm && \
+    rm -rf /tmp/*.rpm && \
+    chmod -R g+rwX /usr/local/nebula
 
-USER nebula
+# Do NOT set USER — OpenShift will inject a random non-root UID
+# `fsGroup` in the Pod spec will ensure proper write access to mounted volumes
 
 EXPOSE 9777 9778 9779 9780 19779 19780
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [X] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
https://github.com/vesoft-inc/nebula-operator/pull/561
https://github.com/vesoft-inc/nebula-operator/issues/548
https://github.com/vesoft-inc/nebula-operator/issues/550

#### Description:
Hi
It solves issue with running rootless pods.
It is not needed to set init containers and do changes related to permissions after creating deployment. Together with changes in https://github.com/vesoft-inc/nebula/compare/master...aleksrosz:nebula:feature/rootless it is possible to run Nebula in OpenShift without setting some particular UID. It can be automatically managed by OpenShift according to the best practices of running rootless images.

I did changes from:
MountPath: "/usr/local/nebula/logs",
SubPath: "logs",
to
MountPath: "/etc/logrotate.d/",
SubPath: "logrotate.d",

because it is standard path in Linux systems.


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:
I see that this was merged https://github.com/vesoft-inc/nebula-operator/pull/561
but no one did change in Nebula images that I mentioned in my notes there.



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [X ] Documentation affected (Please add the label if documentation needs to be modified.)
- [X ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
