### PR TITLE
Fix unstable worker id allocation

### DIFF
--- a/src/meta/processors/id/GetWorkerIdProcessor.cpp
+++ b/src/meta/processors/id/GetWorkerIdProcessor.cpp
@@ -31,7 +31,7 @@ void GetWorkerIdProcessor::process(const cpp2::GetWorkerIdReq& req) {
 
   int64_t workerId = std::stoi(std::move(nebula::value(newResult)));
   // TODO: (jackwener) limit worker, add LOG ERROR
-  auto code = doSyncPut(std::vector<kvstore::KV>{{ipAddr, std::to_string(workerId + 1)}});
+  auto code = doSyncPut(std::vector<kvstore::KV>{{ipAddr, std::to_string(workerId)}});
   if (code != nebula::cpp2::ErrorCode::SUCCEEDED) {
     LOG(ERROR) << "Put worker ipAddr failed during get worker id";
     handleErrorCode(nebula::cpp2::ErrorCode::E_ID_FAILED);

--- a/src/meta/test/IdProcessorTest.cpp
+++ b/src/meta/test/IdProcessorTest.cpp
@@ -29,6 +29,17 @@ TEST(WorkerIdProcessorTest, WorkerIdTest) {
     ASSERT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, resp.get_code());
     ASSERT_EQ(i, resp.get_workerid());
   }
+
+  // Getting the worker id of an existing host should return the id
+  // allocated when the host was first registered.
+  cpp2::GetWorkerIdReq req;
+  req.host_ref() = "0";
+  auto* processor = GetWorkerIdProcessor::instance(kv.get());
+  auto f = processor->getFuture();
+  processor->process(req);
+  auto resp = std::move(f).get();
+  ASSERT_EQ(nebula::cpp2::ErrorCode::SUCCEEDED, resp.get_code());
+  ASSERT_EQ(0, resp.get_workerid());
 }
 
 TEST(SegmentIdProcessorTest, SegmentIdTest) {


### PR DESCRIPTION
## What type of PR is this?

- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?

Issue(s) number: N/A

Description:

`GetWorkerIdProcessor` may return an unstable worker id for the same host.

When a new host requests a worker id, the processor reads the current global `snowflake_worker_id` value and returns it as the allocated worker id. However, the previous implementation persisted `workerId + 1` as the value mapped to that host. As a result, the first request from a host returns `workerId`, while a later request from the same host reads the persisted mapping and returns `workerId + 1`.

This makes the host-to-worker-id mapping inconsistent with the value originally returned to the caller. A worker id should be stable for the same host after it has been allocated.

## How do you solve it?

Store the actual allocated `workerId` in the host-to-worker-id mapping, and update only the global `snowflake_worker_id` counter to `workerId + 1` for future allocations.

This keeps the behavior consistent:

- the current host receives and persists the same `workerId`;
- the global counter still advances for the next new host;
- repeated requests from the same host return the originally allocated worker id.

A regression assertion was also added to `WorkerIdProcessorTest` to verify that requesting the worker id for an existing host returns the same id that was allocated during the first registration.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

To reproduce, request worker ids for hosts and then request the id for an already registered host again.

Before:

```text
request host "0" -> returns worker id 0
request host "1" -> returns worker id 1
request host "0" again -> returns worker id 1
```

The repeated request for host `"0"` returns a different id from the original allocation.

After:

```text
request host "0" -> returns worker id 0
request host "1" -> returns worker id 1
request host "0" again -> returns worker id 0
```

The repeated request for host `"0"` returns the original worker id.

The fix is small and localized to worker id persistence logic. It does not change the allocation order for new hosts; it only corrects the persisted mapping for an existing host.

## Unit Tests:

- Updated `WorkerIdProcessorTest` to cover repeated requests for the same host.

## Checklist:

Tests:

- [x] Unit test (positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:

- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.)
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory

## Release notes:

Fixed the bug where repeated worker id requests for the same host could return a different worker id from the originally allocated one.