### PR TITLE
Fix rand() constant folding purity

### DIFF
--- a/src/common/function/FunctionManager.cpp
+++ b/src/common/function/FunctionManager.cpp
@@ -1097,7 +1097,7 @@ FunctionManager::FunctionManager() {
     auto &attr = functions_["rand"];
     attr.minArity_ = 0;
     attr.maxArity_ = 0;
-    attr.isAlwaysPure_ = true;
+    setCompleteNonPure(attr);
     attr.body_ = [](const auto &args) -> Value {
       UNUSED(args);
       return folly::Random::randDouble01();

--- a/src/graph/visitor/test/FoldConstantExprVisitorTest.cpp
+++ b/src/graph/visitor/test/FoldConstantExprVisitorTest.cpp
@@ -176,6 +176,15 @@ TEST_F(FoldConstantExprVisitorTest, TestFoldFunction) {
     ASSERT_FALSE(visitor.canBeFolded());
     ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
   }
+  // rand() + 1 => rand() + 1
+  {
+    auto expr = addExpr(fnExpr("rand", {}), constantExpr(1));
+    auto expected = addExpr(fnExpr("rand", {}), constantExpr(1));
+    FoldConstantExprVisitor visitor(pool);
+    expr->accept(&visitor);
+    ASSERT_FALSE(visitor.canBeFolded());
+    ASSERT_EQ(*expr, *expected) << expr->toString() << " vs. " << expected->toString();
+  }
 }
 
 TEST_F(FoldConstantExprVisitorTest, TestFoldFailed) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: #6016

#### Description:
`rand()` is registered as always pure, so constant folding may evaluate it once and replace expressions such as `rand() < 0.1` with a fixed boolean. That makes random sampling predicates return either all rows or no rows.

## How do you solve it?
Mark `rand()` as non-pure, consistent with `rand32()` and `rand64()`, so the optimizer does not fold it into a constant. Add a constant-folding unit test to keep `rand()` calls intact.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

Local target build was blocked before reaching this change by an existing GCC 13 `-Werror=interference-size` warning in `MemoryTracker.h`. `git diff --check` passed.

## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> Fixed `rand()` being incorrectly treated as a pure function during constant folding.
