### PR TITLE
Fix LOOKUP STARTS WITH empty string rewrite

### DIFF
--- a/src/graph/util/ExpressionUtils.cpp
+++ b/src/graph/util/ExpressionUtils.cpp
@@ -460,10 +460,14 @@ Expression *ExpressionUtils::rewriteStartsWithExpr(const Expression *expr) {
   QueryExpressionContext ctx(nullptr);
   auto rightBoundary = startsWithExpr->right()->eval(ctx).getStr();
 
+  if (rightBoundary.empty()) {
+    return RelationalExpression::makeGE(pool, startsWithExpr->left(), startsWithExpr->right());
+  }
+
   // Increment the last char of the right boundary to get the range scan boundary
   // Do not increment the last char of the string if it could cause overflow
-  if (*rightBoundary.end() < 127) {
-    rightBoundary[rightBoundary.size() - 1] = ++rightBoundary[rightBoundary.size() - 1];
+  if (rightBoundary.back() < 127) {
+    ++rightBoundary.back();
   } else {  // If the last char is already 127, append a char of minimum value to the string
     rightBoundary += static_cast<char>(0);
   }

--- a/src/graph/util/test/ExpressionUtilsTest.cpp
+++ b/src/graph/util/test/ExpressionUtilsTest.cpp
@@ -6,6 +6,8 @@
 
 #include "common/expression/ArithmeticExpression.h"
 #include "common/expression/ConstantExpression.h"
+#include "common/expression/PropertyExpression.h"
+#include "common/expression/RelationalExpression.h"
 #include "common/expression/TypeCastingExpression.h"
 #include "graph/util/ExpressionUtils.h"
 #include "parser/GQLParser.h"
@@ -538,6 +540,37 @@ TEST_F(ExpressionUtilsTest, rewriteInExpr) {
     auto expected = RelationalExpression::makeEQ(
         pool, ConstantExpression::make(pool, 10), ConstantExpression::make(pool, 100));
     ASSERT_EQ(*expected, *ExpressionUtils::rewriteInExpr(inExpr));
+  }
+}
+
+TEST_F(ExpressionUtilsTest, rewriteStartsWithExpr) {
+  {
+    auto expr = RelationalExpression::makeStartsWith(
+        pool,
+        TagPropertyExpression::make(pool, "team", "name"),
+        ConstantExpression::make(pool, "abc"));
+    auto expected = LogicalExpression::makeAnd(
+        pool,
+        RelationalExpression::makeGE(pool,
+                                     TagPropertyExpression::make(pool, "team", "name"),
+                                     ConstantExpression::make(pool, "abc")),
+        RelationalExpression::makeLT(pool,
+                                     TagPropertyExpression::make(pool, "team", "name"),
+                                     ConstantExpression::make(pool, "abd")));
+
+    ASSERT_EQ(*expected, *ExpressionUtils::rewriteStartsWithExpr(expr));
+  }
+  {
+    auto expr = RelationalExpression::makeStartsWith(
+        pool,
+        TagPropertyExpression::make(pool, "team", "name"),
+        ConstantExpression::make(pool, ""));
+    auto expected = RelationalExpression::makeGE(
+        pool,
+        TagPropertyExpression::make(pool, "team", "name"),
+        ConstantExpression::make(pool, ""));
+
+    ASSERT_EQ(*expected, *ExpressionUtils::rewriteStartsWithExpr(expr));
   }
 }
 

--- a/tests/tck/features/lookup/TagIndexFullScan.feature
+++ b/tests/tck/features/lookup/TagIndexFullScan.feature
@@ -410,6 +410,42 @@ Feature: Lookup tag index full scan
       | id |
     When executing query:
       """
+      LOOKUP ON team WHERE team.name STARTS WITH "" YIELD id(vertex) as id
+      """
+    Then the result should be, in any order:
+      | id              |
+      | "76ers"         |
+      | "Bucks"         |
+      | "Bulls"         |
+      | "Cavaliers"     |
+      | "Celtics"       |
+      | "Clippers"      |
+      | "Grizzlies"     |
+      | "Hawks"         |
+      | "Heat"          |
+      | "Hornets"       |
+      | "Jazz"          |
+      | "Kings"         |
+      | "Knicks"        |
+      | "Lakers"        |
+      | "Magic"         |
+      | "Mavericks"     |
+      | "Nets"          |
+      | "Nuggets"       |
+      | "Pacers"        |
+      | "Pelicans"      |
+      | "Pistons"       |
+      | "Raptors"       |
+      | "Rockets"       |
+      | "Spurs"         |
+      | "Suns"          |
+      | "Thunders"      |
+      | "Timberwolves"  |
+      | "Trail Blazers" |
+      | "Warriors"      |
+      | "Wizards"       |
+    When executing query:
+      """
       LOOKUP ON team WHERE team.name STARTS WITH 123 YIELD id(vertex)
       """
     Then a SemanticError should be raised at runtime: Column type error : name


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: #6115

#### Description:
`LOOKUP ... WHERE <prop> STARTS WITH ""` can crash graphd when the optimizer rewrites `STARTS WITH` for an index range scan. The rewrite reads past the end of the empty string while trying to increment the upper bound.

## How do you solve it?
Handle the empty-prefix case explicitly by rewriting it to a lower-bound range (`prop >= ""`), which matches every non-null indexed string value. Also fix the non-empty boundary increment to use `back()` instead of dereferencing `end()`, and add unit plus TCK coverage.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

Local target build was blocked before reaching this change by an existing GCC 13 `-Werror=interference-size` warning in `MemoryTracker.h`. `git diff --check` passed.

## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> Fixed a graphd crash when optimizing `LOOKUP` queries with `STARTS WITH ""`.
