### PR TITLE
Fix stale pid handling in nebula.service

### DIFF
--- a/scripts/nebula.service
+++ b/scripts/nebula.service
@@ -135,8 +135,27 @@ function start_daemon {
     pid_file=$(get_pid_file_from_config ${config})
     if [[ -f ${pid_file} ]]; then
         if is_process_running ${pid_file}; then
-            ERROR "${daemon_name} already running: $(cat ${pid_file})"
-            exit 1
+            check_process_executable ${pid_file} ${executable}
+            case $? in
+                0)
+                    ERROR "${daemon_name} already running: $(cat ${pid_file})"
+                    exit 1
+                    ;;
+                1)
+                    WARN "${pid_file} is stale: $(cat ${pid_file}) belongs to another process"
+                    rm -f ${pid_file} ||
+                        ERROR_AND_EXIT "Failed to remove stale pid file ${pid_file}"
+                    ;;
+                *)
+                    ERROR "${daemon_name} already running or ${pid_file} cannot be verified:" \
+                        "$(cat ${pid_file})"
+                    exit 1
+                    ;;
+            esac
+        else
+            WARN "Removing stale pid file ${pid_file}"
+            rm -f ${pid_file} ||
+                ERROR_AND_EXIT "Failed to remove stale pid file ${pid_file}"
         fi
     fi
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -77,6 +77,27 @@ function is_process_running {
 }
 
 
+# Check whether the process in a pid file is the expected executable.
+# Returns 0 when matched, 1 when a different executable is running, and 2 when
+# the process/executable cannot be identified.
+function check_process_executable {
+    local pid_file=${1}
+    local executable=${2}
+    [[ -f ${pid_file} ]] || return 2
+
+    local pid=$(cat ${pid_file})
+    [[ -z ${pid} ]] && return 2
+    ps -p ${pid} &>/dev/null || return 2
+
+    local expected
+    expected=$(readlink -f ${executable} 2>/dev/null) || return 2
+    local actual
+    actual=$(readlink -f /proc/${pid}/exe 2>/dev/null) || return 2
+    [[ ${actual} == ${expected} ]] && return 0
+    return 1
+}
+
+
 # Tell if some process is listening on the target port
 # args: <port number>
 function is_port_listened_on {
@@ -159,4 +180,3 @@ function daemon_version {
     local version=$(${1} --version | head -n 1)
     echo ${version} | sed 's/.*Git: \([[:alnum:]]*\).*/\1/g'
 }
-


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: #5998

#### Description:
`scripts/nebula.service start` refuses to start when a stale pid file points to a live process, even if that pid has been reused by an unrelated executable. Users have to remove the stale pid file manually.

## How do you solve it?
When a pid file exists, verify whether the live pid belongs to the expected Nebula executable. If it is the expected executable, keep the existing "already running" behavior. If it is positively identified as another executable, remove the stale pid file and continue startup. If the process cannot be identified, keep the conservative failure behavior.

## Special notes for your reviewer, ex. impact of this fix, design document, etc:

Validated with `bash -n scripts/nebula.service scripts/utils.sh`, `git diff --check`, and a temporary service-layout repro where the pid file pointed to a live unrelated `sleep` process.

## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [x] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> Fixed `nebula.service start` failing on stale pid files that point to unrelated live processes.
