### PR TITLE
fix #6150: A deadlock risk when space creation happens concurrently with leader balance in NebulaGraph 3.6. 

### DIFF
--- a/src/common/expression/PredicateExpression.cpp
+++ b/src/common/expression/PredicateExpression.cpp
@@ -20,11 +20,13 @@ const Value& PredicateExpression::evalExists(ExpressionContext& ctx) {
   DCHECK(collection_->kind() == Expression::Kind::kAttribute ||
          collection_->kind() == Expression::Kind::kSubscript ||
          collection_->kind() == Expression::Kind::kLabelTagProperty ||
-         collection_->kind() == Expression::Kind::kTagProperty)
+         collection_->kind() == Expression::Kind::kTagProperty ||
+         collection_->kind() == Expression::Kind::kConstant)
       << "actual kind: " << collection_->kind() << ", toString: " << toString();
 
   if (collection_->kind() == Expression::Kind::kLabelTagProperty ||
-      collection_->kind() == Expression::Kind::kTagProperty) {
+      collection_->kind() == Expression::Kind::kTagProperty ||
+      collection_->kind() == Expression::Kind::kConstant) {
     auto v = collection_->eval(ctx);
     result_ = (!v.isNull()) && (!v.empty());
     return result_;

--- a/src/graph/executor/CMakeLists.txt
+++ b/src/graph/executor/CMakeLists.txt
@@ -44,6 +44,7 @@ nebula_add_library(
     query/AppendVerticesExecutor.cpp
     query/RollUpApplyExecutor.cpp
     query/PatternApplyExecutor.cpp
+    query/ValueExecutor.cpp
     algo/BFSShortestPathExecutor.cpp
     algo/MultiShortestPathExecutor.cpp
     algo/AllPathsExecutor.cpp

--- a/src/graph/executor/Executor.cpp
+++ b/src/graph/executor/Executor.cpp
@@ -94,6 +94,7 @@
 #include "graph/executor/query/UnionAllVersionVarExecutor.h"
 #include "graph/executor/query/UnionExecutor.h"
 #include "graph/executor/query/UnwindExecutor.h"
+#include "graph/executor/query/ValueExecutor.h"
 #include "graph/planner/plan/Admin.h"
 #include "graph/planner/plan/Logic.h"
 #include "graph/planner/plan/Maintain.h"
@@ -256,6 +257,9 @@ Executor *Executor::makeExecutor(QueryContext *qctx, const PlanNode *node) {
     }
     case PlanNode::Kind::kDedup: {
       return pool->makeAndAdd<DedupExecutor>(node, qctx);
+    }
+    case PlanNode::Kind::kValue: {
+      return pool->makeAndAdd<ValueExecutor>(node, qctx);
     }
     case PlanNode::Kind::kAssign: {
       return pool->makeAndAdd<AssignExecutor>(node, qctx);

--- a/src/graph/executor/algo/AllPathsExecutor.h
+++ b/src/graph/executor/algo/AllPathsExecutor.h
@@ -110,6 +110,7 @@ class AllPathsExecutor final : public StorageAccessExecutor {
   bool noLoop_{false};
   size_t limit_{std::numeric_limits<size_t>::max()};
   std::atomic<size_t> cnt_{0};
+  std::atomic<bool> memoryExceeded_{false};
   size_t maxStep_{0};
 
   size_t leftSteps_{0};

--- a/src/graph/executor/algo/ShortestPathExecutor.cpp
+++ b/src/graph/executor/algo/ShortestPathExecutor.cpp
@@ -44,6 +44,7 @@ size_t ShortestPathExecutor::checkInput(HashSet& startVids, HashSet& endVids) {
   auto iter = ectx_->getResult(pathNode_->inputVar()).iter();
   const auto& metaVidType = *(qctx()->rctx()->session()->space().spaceDesc.vid_type_ref());
   auto vidType = SchemaUtil::propTypeToValueType(metaVidType.get_type());
+  bool isZeroStep = pathNode_->stepRange().min() == 0;
   for (; iter->valid(); iter->next()) {
     auto start = iter->getColumn(0);
     auto end = iter->getColumn(1);
@@ -52,8 +53,10 @@ size_t ShortestPathExecutor::checkInput(HashSet& startVids, HashSet& endVids) {
                  << ", end type: " << end.type() << ", space vid type: " << vidType;
       continue;
     }
-    if (start == end) {
-      // continue or return error
+
+    // When the minimum number of steps is 0, and the starting node and the destination node
+    // are the same. the shortest path between the two nodes is 0
+    if (isZeroStep && start == end) {
       continue;
     }
     startVids.emplace(std::move(start));

--- a/src/graph/executor/query/TraverseExecutor.cpp
+++ b/src/graph/executor/query/TraverseExecutor.cpp
@@ -478,6 +478,7 @@ folly::Future<Status> TraverseExecutor::buildPathMultiJobs(size_t minStep, size_
 std::vector<Row> TraverseExecutor::buildPath(const Value& initVertex,
                                              size_t minStep,
                                              size_t maxStep) {
+  memory::MemoryCheckGuard guard;
   auto vidIter = adjList_.find(initVertex);
   if (vidIter == adjList_.end()) {
     return std::vector<Row>();

--- a/src/graph/executor/query/ValueExecutor.cpp
+++ b/src/graph/executor/query/ValueExecutor.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2023 vesoft inc. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+#include "graph/executor/query/ValueExecutor.h"
+
+#include "graph/context/Result.h"
+#include "graph/planner/plan/Query.h"
+#include "graph/service/GraphFlags.h"
+
+namespace nebula {
+namespace graph {
+
+folly::Future<Status> ValueExecutor::execute() {
+  SCOPED_TIMER(&execTime_);
+  auto value = asNode<ValueNode>(node())->value();
+  return finish(ResultBuilder().value(std::move(value)).build());
+}
+
+}  // namespace graph
+}  // namespace nebula

--- a/src/graph/executor/query/ValueExecutor.h
+++ b/src/graph/executor/query/ValueExecutor.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2023 vesoft inc. All rights reserved.
+//
+// This source code is licensed under Apache 2.0 License.
+
+#pragma once
+
+#include "graph/executor/Executor.h"
+
+// delete the corresponding iterator when the row in the dataset does not meet the conditions
+// and save the filtered iterator to the result
+namespace nebula {
+namespace graph {
+
+class ValueExecutor final : public Executor {
+ public:
+  ValueExecutor(const PlanNode *node, QueryContext *qctx) : Executor("ValueExecutor", node, qctx) {}
+
+  folly::Future<Status> execute() override;
+};
+
+}  // namespace graph
+}  // namespace nebula

--- a/src/graph/optimizer/CMakeLists.txt
+++ b/src/graph/optimizer/CMakeLists.txt
@@ -66,6 +66,7 @@ nebula_add_library(
     rule/RemoveAppendVerticesBelowJoinRule.cpp
     rule/EmbedEdgeAllPredIntoTraverseRule.cpp
     rule/PushFilterThroughAppendVerticesRule.cpp
+    rule/EliminateFilterRule.cpp
 )
 
 nebula_add_subdirectory(test)

--- a/src/graph/optimizer/OptRule.cpp
+++ b/src/graph/optimizer/OptRule.cpp
@@ -213,6 +213,11 @@ RuleSet &RuleSet::DefaultRules() {
   return kDefaultRules;
 }
 
+RuleSet &RuleSet::QueryRules0() {
+  static RuleSet kQueryRules0("QueryRuleSet0");
+  return kQueryRules0;
+}
+
 RuleSet &RuleSet::QueryRules() {
   static RuleSet kQueryRules("QueryRuleSet");
   return kQueryRules;
@@ -229,6 +234,15 @@ RuleSet *RuleSet::addRule(const OptRule *rule) {
     LOG(WARNING) << "Rule set " << name_ << " has contained this rule: " << rule->toString();
   }
   return this;
+}
+
+std::string RuleSet::toString() const {
+  std::stringstream ss;
+  ss << "RuleSet: " << name_ << std::endl;
+  for (auto rule : rules_) {
+    ss << rule->toString() << std::endl;
+  }
+  return ss.str();
 }
 
 void RuleSet::merge(const RuleSet &ruleset) {

--- a/src/graph/optimizer/OptRule.h
+++ b/src/graph/optimizer/OptRule.h
@@ -128,6 +128,7 @@ class OptRule {
 class RuleSet final {
  public:
   static RuleSet &DefaultRules();
+  static RuleSet &QueryRules0();
   static RuleSet &QueryRules();
 
   RuleSet *addRule(const OptRule *rule);
@@ -137,6 +138,8 @@ class RuleSet final {
   const std::vector<const OptRule *> &rules() const {
     return rules_;
   }
+
+  std::string toString() const;
 
  private:
   explicit RuleSet(const std::string &name);

--- a/src/graph/optimizer/rule/EliminateFilterRule.cpp
+++ b/src/graph/optimizer/rule/EliminateFilterRule.cpp
@@ -1,0 +1,77 @@
+/* Copyright (c) 2023 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+#include "graph/optimizer/rule/EliminateFilterRule.h"
+
+#include "common/expression/Expression.h"
+#include "graph/optimizer/OptContext.h"
+#include "graph/optimizer/OptGroup.h"
+#include "graph/planner/plan/Logic.h"
+#include "graph/planner/plan/PlanNode.h"
+#include "graph/planner/plan/Query.h"
+
+using nebula::graph::Filter;
+using nebula::graph::QueryContext;
+using nebula::graph::StartNode;
+using nebula::graph::ValueNode;
+
+namespace nebula {
+namespace opt {
+
+std::unique_ptr<OptRule> EliminateFilterRule::kInstance =
+    std::unique_ptr<EliminateFilterRule>(new EliminateFilterRule());
+
+EliminateFilterRule::EliminateFilterRule() {
+  RuleSet::QueryRules0().addRule(this);
+}
+
+// TODO match Filter->(Any Node with real result)
+const Pattern& EliminateFilterRule::pattern() const {
+  static Pattern pattern = Pattern::create(graph::PlanNode::Kind::kFilter);
+  return pattern;
+}
+
+bool EliminateFilterRule::match(OptContext* octx, const MatchedResult& matched) const {
+  if (!OptRule::match(octx, matched)) {
+    return false;
+  }
+  const auto* filterNode = static_cast<const Filter*>(matched.node->node());
+  const auto* expr = filterNode->condition();
+  if (expr->kind() != Expression::Kind::kConstant) {
+    return false;
+  }
+  const auto* constant = static_cast<const ConstantExpression*>(expr);
+  auto ret = (constant->value().isImplicitBool() && constant->value().getBool() == false) ||
+             constant->value().isNull();
+  return ret;
+}
+
+StatusOr<OptRule::TransformResult> EliminateFilterRule::transform(
+    OptContext* octx, const MatchedResult& matched) const {
+  auto filterGroupNode = matched.node;
+  auto filter = static_cast<const Filter*>(filterGroupNode->node());
+
+  auto newValue = ValueNode::make(octx->qctx(), nullptr, DataSet(filter->colNames()));
+  newValue->setOutputVar(filter->outputVar());
+  auto newValueGroupNode = OptGroupNode::create(octx, newValue, filterGroupNode->group());
+
+  auto newStart = StartNode::make(octx->qctx());
+  auto newStartGroup = OptGroup::create(octx);
+  newStartGroup->makeGroupNode(newStart);
+
+  newValueGroupNode->dependsOn(newStartGroup);
+
+  TransformResult result;
+  result.eraseAll = true;
+  result.newGroupNodes.emplace_back(newValueGroupNode);
+  return result;
+}
+
+std::string EliminateFilterRule::toString() const {
+  return "EliminateFilterRule";
+}
+
+}  // namespace opt
+}  // namespace nebula

--- a/src/graph/optimizer/rule/EliminateFilterRule.h
+++ b/src/graph/optimizer/rule/EliminateFilterRule.h
@@ -1,0 +1,56 @@
+/* Copyright (c) 2023 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+#pragma once
+
+#include "graph/optimizer/OptRule.h"
+
+namespace nebula {
+namespace opt {
+
+//  Eliminate useless [[Filter(false)]] node
+//  Required conditions:
+//   1. Match the pattern
+//   2. Filter condition is false/null
+//  Benefits:
+//   1. Delete unnecessary node
+//
+//  Transformation:
+//  Before:
+//
+//  +------+--------+
+//  | Filter(false) |
+//  +------+--------+
+//         |
+//  +------+------+
+//  |    .....    |
+//  +------+------+
+//
+//  After:
+//
+//  +------+------+
+//  |   Value     |
+//  +------+------+
+//  |    Start    |
+//  +------+------+
+
+class EliminateFilterRule final : public OptRule {
+ public:
+  const Pattern &pattern() const override;
+
+  bool match(OptContext *ctx, const MatchedResult &matched) const override;
+
+  StatusOr<TransformResult> transform(OptContext *ctx, const MatchedResult &matched) const override;
+
+  std::string toString() const override;
+
+ private:
+  EliminateFilterRule();
+
+  static std::unique_ptr<OptRule> kInstance;
+};
+
+}  // namespace opt
+}  // namespace nebula

--- a/src/graph/planner/match/ShortestPathPlanner.cpp
+++ b/src/graph/planner/match/ShortestPathPlanner.cpp
@@ -55,6 +55,10 @@ StatusOr<SubPlan> ShortestPathPlanner::transform(WhereClauseContext* bindWhereCl
   SubPlan subplan;
   bool singleShortest = path_.pathType == Path::PathType::kSingleShortest;
   auto& nodeInfos = path_.nodeInfos;
+  if (nodeInfos.front().alias == nodeInfos.back().alias) {
+    return Status::SemanticError(
+        "The shortest path algorithm does not work when the start and end nodes are the same");
+  }
   auto& edge = path_.edgeInfos.front();
   std::vector<std::string> colNames;
   colNames.emplace_back(nodeInfos.front().alias);

--- a/src/graph/planner/plan/PlanNode.cpp
+++ b/src/graph/planner/plan/PlanNode.cpp
@@ -96,6 +96,8 @@ const char* PlanNode::toString(PlanNode::Kind kind) {
       return "Loop";
     case Kind::kDedup:
       return "Dedup";
+    case Kind::kValue:
+      return "Value";
     case Kind::kPassThrough:
       return "PassThrough";
     case Kind::kAssign:

--- a/src/graph/planner/plan/PlanNode.h
+++ b/src/graph/planner/plan/PlanNode.h
@@ -45,6 +45,8 @@ class PlanNode {
     kScanVertices,
     kScanEdges,
     kFulltextIndexScan,
+    // direct value
+    kValue,
 
     // ------------------
     kFilter,

--- a/src/graph/planner/plan/Query.h
+++ b/src/graph/planner/plan/Query.h
@@ -6,6 +6,8 @@
 #ifndef GRAPH_PLANNER_PLAN_QUERY_H_
 #define GRAPH_PLANNER_PLAN_QUERY_H_
 
+#include <glog/logging.h>
+
 #include "common/expression/AggregateExpression.h"
 #include "graph/context/QueryContext.h"
 #include "graph/planner/plan/PlanNode.h"
@@ -1713,7 +1715,15 @@ class Traverse final : public GetNeighbors {
 
   const std::string& edgeAlias() const {
     DCHECK(!this->colNames().empty());
-    return this->colNames().back();
+    const auto& colNames = this->colNames();
+    auto n = colNames.size();
+
+    if (!genPath_) {
+      return colNames[n - 1];
+    }
+    // When a path needs to be generated, Traverse outputs one more column
+    DCHECK_GT(n, 2);
+    return colNames[n - 2];
   }
 
   void setStepRange(const MatchStepRange& range) {
@@ -2040,6 +2050,28 @@ class PatternApply : public BinaryInputNode {
   // Common columns of subplans on both sides
   std::vector<Expression*> keyCols_;
   bool isAntiPred_{false};
+};
+
+class ValueNode : public SingleInputNode {
+ public:
+  // Value with empty result
+  static ValueNode* make(QueryContext* qctx, PlanNode* dep, DataSet value) {
+    return qctx->objPool()->makeAndAdd<ValueNode>(qctx, dep, std::move(value));
+  }
+
+  Value value() const {
+    return value_;
+  }
+
+ private:
+  friend ObjectPool;
+  ValueNode(QueryContext* qctx, PlanNode* dep, DataSet value)
+      : SingleInputNode(qctx, Kind::kValue, dep), value_(std::move(value)) {
+    setColNames(value_.colNames);
+  }
+
+ private:
+  DataSet value_;
 };
 
 }  // namespace graph

--- a/src/graph/service/QueryEngine.cpp
+++ b/src/graph/service/QueryEngine.cpp
@@ -37,6 +37,7 @@ Status QueryEngine::init(std::shared_ptr<folly::IOThreadPoolExecutor> ioExecutor
   // Set default optimizer rules
   std::vector<const opt::RuleSet*> rulesets{&opt::RuleSet::DefaultRules()};
   if (FLAGS_enable_optimizer) {
+    rulesets.emplace_back(&opt::RuleSet::QueryRules0());
     rulesets.emplace_back(&opt::RuleSet::QueryRules());
   }
   optimizer_ = std::make_unique<opt::Optimizer>(rulesets);

--- a/src/graph/util/ExpressionUtils.h
+++ b/src/graph/util/ExpressionUtils.h
@@ -14,6 +14,7 @@
 #include "common/expression/PropertyExpression.h"
 #include "common/expression/TypeCastingExpression.h"
 #include "common/expression/UnaryExpression.h"
+#include "common/thrift/ThriftTypes.h"
 #include "graph/context/ast/CypherAstContext.h"
 #include "graph/visitor/EvaluableExprVisitor.h"
 #include "graph/visitor/FindVisitor.h"
@@ -265,6 +266,12 @@ class ExpressionUtils {
   static Expression* rewriteVertexPropertyFilter(ObjectPool* pool,
                                                  const std::string& node,
                                                  Expression* expr);
+
+  // label.not_exists_tag.prop => null
+  static Expression* rewriteAlwaysNullLabelTagProperty(ObjectPool* pool,
+                                                       meta::SchemaManager* schemaMan,
+                                                       GraphSpaceID spaceId,
+                                                       Expression* expr);
 };
 
 }  // namespace graph

--- a/src/graph/util/FTIndexUtils.cpp
+++ b/src/graph/util/FTIndexUtils.cpp
@@ -41,6 +41,5 @@ StatusOr<::nebula::plugin::ESAdapter> FTIndexUtils::getESAdapter(meta::MetaClien
   return ::nebula::plugin::ESAdapter(std::move(clients));
 }
 
-
 }  // namespace graph
 }  // namespace nebula

--- a/src/graph/validator/MatchValidator.cpp
+++ b/src/graph/validator/MatchValidator.cpp
@@ -367,6 +367,11 @@ Status MatchValidator::validateFilter(const Expression *filter,
   // rewrite Attribute to LabelTagProperty
   newFilter = ExpressionUtils::rewriteAttr2LabelTagProp(transformRes.value(),
                                                         whereClauseCtx.aliasesAvailable);
+  newFilter = ExpressionUtils::rewriteAlwaysNullLabelTagProperty(
+      qctx_->objPool(), qctx_->schemaMng(), space_.id, newFilter);
+  auto result = ExpressionUtils::foldConstantExpr(newFilter);
+  NG_RETURN_IF_ERROR(result);
+  newFilter = result.value();
   newFilter = ExpressionUtils::rewriteEdgePropFunc2LabelAttribute(newFilter,
                                                                   whereClauseCtx.aliasesAvailable);
 

--- a/src/graph/validator/MutateValidator.cpp
+++ b/src/graph/validator/MutateValidator.cpp
@@ -326,6 +326,10 @@ Status DeleteVerticesValidator::validateImpl() {
   } else {
     auto vIds = sentence->vertices()->vidList();
     for (auto vId : vIds) {
+      if (!ExpressionUtils::isEvaluableExpr(vId, qctx_)) {
+        return Status::SemanticError("`%s' is not an evaluable expression.",
+                                     vId->toString().c_str());
+      }
       auto idStatus = SchemaUtil::toVertexID(vId, vidType_);
       NG_RETURN_IF_ERROR(idStatus);
       vertices_.emplace_back(std::move(idStatus).value());
@@ -464,6 +468,10 @@ Status DeleteTagsValidator::validateImpl() {
   } else {
     auto vIds = sentence->vertices()->vidList();
     for (auto vId : vIds) {
+      if (!ExpressionUtils::isEvaluableExpr(vId, qctx_)) {
+        return Status::SemanticError("`%s' is not an evaluable expression.",
+                                     vId->toString().c_str());
+      }
       auto idStatus = SchemaUtil::toVertexID(vId, vidType_);
       NG_RETURN_IF_ERROR(idStatus);
       vertices_.emplace_back(std::move(idStatus).value());
@@ -551,6 +559,14 @@ Status DeleteEdgesValidator::buildEdgeKeyRef(const std::vector<EdgeKey *> &edgeK
   for (auto &edgeKey : edgeKeys) {
     Row row;
     storage::cpp2::EdgeKey key;
+    if (!ExpressionUtils::isEvaluableExpr(edgeKey->srcid(), qctx_)) {
+      return Status::SemanticError("`%s' is not an evaluable expression.",
+                                   edgeKey->srcid()->toString().c_str());
+    }
+    if (!ExpressionUtils::isEvaluableExpr(edgeKey->dstid(), qctx_)) {
+      return Status::SemanticError("`%s' is not an evaluable expression.",
+                                   edgeKey->dstid()->toString().c_str());
+    }
     auto srcIdStatus = SchemaUtil::toVertexID(edgeKey->srcid(), vidType_);
     NG_RETURN_IF_ERROR(srcIdStatus);
     auto dstIdStatus = SchemaUtil::toVertexID(edgeKey->dstid(), vidType_);

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -354,27 +354,36 @@ void NebulaStore::stop() {
 folly::Future<std::pair<GraphSpaceID, std::unique_ptr<KVEngine>>> NebulaStore::newEngineAsync(
     GraphSpaceID spaceId, const std::string& dataPath, const std::string& walPath) {
   return folly::via(folly::getGlobalIOExecutor().get(), [this, spaceId, dataPath, walPath]() {
-    std::unique_ptr<KVEngine> engine;
-    if (FLAGS_engine_type == "rocksdb") {
-      std::shared_ptr<KVCompactionFilterFactory> cfFactory = nullptr;
-      if (options_.cffBuilder_ != nullptr) {
-        cfFactory = options_.cffBuilder_->buildCfFactory(spaceId);
-      }
-      auto vIdLen = getSpaceVidLen(spaceId);
-      engine = std::make_unique<RocksEngine>(
-          spaceId, vIdLen, dataPath, walPath, options_.mergeOp_, cfFactory);
-    } else {
-      LOG(FATAL) << "Unknown engine type " << FLAGS_engine_type;
-    }
-    return std::make_pair(spaceId, std::move(engine));
+    return std::make_pair(spaceId, createEngine(spaceId, dataPath, walPath));
   });
+}
+
+std::unique_ptr<KVEngine> NebulaStore::createEngine(GraphSpaceID spaceId,
+                                                    const std::string& dataPath,
+                                                    const std::string& walPath) {
+  std::unique_ptr<KVEngine> engine;
+  if (FLAGS_engine_type == "rocksdb") {
+    std::shared_ptr<KVCompactionFilterFactory> cfFactory = nullptr;
+    if (options_.cffBuilder_ != nullptr) {
+      cfFactory = options_.cffBuilder_->buildCfFactory(spaceId);
+    }
+    auto vIdLen = getSpaceVidLen(spaceId);
+    engine = std::make_unique<RocksEngine>(spaceId,
+                                           vIdLen,
+                                           dataPath,
+                                           walPath,
+                                           options_.mergeOp_,
+                                           cfFactory);
+  } else {
+    LOG(FATAL) << "Unknown engine type " << FLAGS_engine_type;
+  }
+  return engine;
 }
 
 std::unique_ptr<KVEngine> NebulaStore::newEngine(GraphSpaceID spaceId,
                                                  const std::string& dataPath,
                                                  const std::string& walPath) {
-  auto pair = this->newEngineAsync(spaceId, dataPath, walPath).get();
-  return std::move(pair.second);
+  return createEngine(spaceId, dataPath, walPath);
 }
 
 ErrorOr<nebula::cpp2::ErrorCode, HostAddr> NebulaStore::partLeader(GraphSpaceID spaceId,

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -786,6 +786,18 @@ class NebulaStore : public KVStore, public Handler {
       GraphSpaceID spaceId, const std::string& dataPath, const std::string& walPath);
 
   /**
+   * @brief Build a new kv engine on the current thread
+   *
+   * @param spaceId
+   * @param dataPath
+   * @param walPath
+   * @return std::unique_ptr<KVEngine>
+   */
+  std::unique_ptr<KVEngine> createEngine(GraphSpaceID spaceId,
+                                         const std::string& dataPath,
+                                         const std::string& walPath);
+
+  /**
    * @brief Start a new kv engine on specified path
    *
    * @param spaceId

--- a/src/kvstore/raftex/Host.h
+++ b/src/kvstore/raftex/Host.h
@@ -169,6 +169,13 @@ class Host final : public std::enable_shared_from_this<Host> {
   nebula::cpp2::ErrorCode canAppendLog() const;
 
   /**
+   * @brief Whether Host can send HB or AskForVote request to the peer
+   *
+   * @return nebula::cpp2::ErrorCode
+   */
+  nebula::cpp2::ErrorCode canSendHBOrVote() const;
+
+  /**
    * @brief Send append log rpc
    *
    * @param eb The eventbase to send rpc
@@ -244,6 +251,12 @@ class Host final : public std::enable_shared_from_this<Host> {
 
   mutable std::mutex lock_;
 
+  // If stopped_ is true, we will not send any request to the peer;
+  // If stopped_ is false:
+  //  1. no mater whether paused_ is true or not, we can send HB request or AskForVote request;
+  //  2. Only if paused_ is false, we can send appendlog request, of course, including HB
+  //     request and AskForRequest request
+  // See canAppendLog() and canSendHBOrVote()
   bool paused_{false};
   bool stopped_{false};
 

--- a/src/kvstore/raftex/RaftPart.cpp
+++ b/src/kvstore/raftex/RaftPart.cpp
@@ -2097,10 +2097,6 @@ void RaftPart::sendHeartbeat() {
           if (!hosts[resp.first]->isLearner() &&
               resp.second.get_error_code() == nebula::cpp2::ErrorCode::SUCCEEDED) {
             ++numSucceeded;
-            // only metad 0 space 0 part need this state now.
-            if (spaceId_ == kDefaultSpaceId) {
-              hosts[resp.first]->setLastHeartbeatTime(time::WallClock::fastNowInMilliSec());
-            }
           }
           highestTerm = std::max(highestTerm, resp.second.get_current_term());
         }

--- a/src/meta/processors/session/SessionManagerProcessor.cpp
+++ b/src/meta/processors/session/SessionManagerProcessor.cpp
@@ -133,10 +133,8 @@ void ListSessionsProcessor::process(const cpp2::ListSessionsReq&) {
     sessions.emplace_back(std::move(session));
     iter->next();
   }
+  LOG(INFO) << "resp session size: " << sessions.size();
   resp_.sessions_ref() = std::move(sessions);
-  for (auto& session : resp_.get_sessions()) {
-    LOG(INFO) << "resp list session: " << session.get_session_id();
-  }
   handleErrorCode(nebula::cpp2::ErrorCode::SUCCEEDED);
   onFinished();
 }

--- a/src/storage/CompactionFilter.h
+++ b/src/storage/CompactionFilter.h
@@ -17,7 +17,7 @@
 #include "storage/StorageFlags.h"
 
 DEFINE_int32(min_level_for_custom_filter,
-             4,
+             0,
              "Minimal level compaction which will go through custom compaction filter");
 
 namespace nebula {

--- a/tests/tck/features/delete/DeleteEdge.IntVid.feature
+++ b/tests/tck/features/delete/DeleteEdge.IntVid.feature
@@ -226,6 +226,12 @@ Feature: Delete int vid of edge
       | "Tim Duncan"  |
     When executing query:
       """
+      GO FROM hash("Boris Diaw") OVER like YIELD edge as e
+      | DELETE EDGE like src($-.e)->dst($-.e)
+      """
+    Then a SemanticError should be raised at runtime: `src($-.e)' is not an evaluable expression.
+    When executing query:
+      """
       GO FROM hash("Boris Diaw") OVER like
       YIELD like._src as src, like._dst as dst, like._rank as rank
       | DELETE EDGE like $-.src->$-.dst @ $-.rank

--- a/tests/tck/features/delete/DeleteEdge.feature
+++ b/tests/tck/features/delete/DeleteEdge.feature
@@ -226,6 +226,12 @@ Feature: Delete string vid of edge
       | "Tim Duncan"  |
     When executing query:
       """
+      GO FROM "Boris Diaw" OVER like YIELD edge as e
+      | DELETE EDGE like src($-.e)->dst($-.e)
+      """
+    Then a SemanticError should be raised at runtime: `src($-.e)' is not an evaluable expression.
+    When executing query:
+      """
       GO FROM "Boris Diaw" OVER like
       YIELD like._src as src, like._dst as dst, like._rank as rank
       | DELETE EDGE like $-.src->$-.dst @ $-.rank

--- a/tests/tck/features/delete/DeleteTag.IntVid.feature
+++ b/tests/tck/features/delete/DeleteTag.IntVid.feature
@@ -249,6 +249,11 @@ Feature: Delete int vid of tag
     # delete one tag
     When executing query:
       """
+      GO FROM hash("Tim Duncan") OVER serve YIELD edge as e | DELETE TAG team FROM src($-.e)
+      """
+    Then a SemanticError should be raised at runtime: `src($-.e)' is not an evaluable expression.
+    When executing query:
+      """
       GO FROM hash("Tim Duncan") OVER serve YIELD serve._dst as id | DELETE TAG team FROM $-.id
       """
     Then the execution should be successful

--- a/tests/tck/features/delete/DeleteTag.feature
+++ b/tests/tck/features/delete/DeleteTag.feature
@@ -249,6 +249,11 @@ Feature: Delete string vid of tag
     # delete one tag
     When executing query:
       """
+      GO FROM "Tim Duncan" OVER serve YIELD edge as e | DELETE TAG team FROM src($-.e)
+      """
+    Then a SemanticError should be raised at runtime: `src($-.e)' is not an evaluable expression.
+    When executing query:
+      """
       GO FROM "Tim Duncan" OVER serve YIELD serve._dst as id | DELETE TAG team FROM $-.id
       """
     Then the execution should be successful

--- a/tests/tck/features/delete/DeleteVertex.IntVid.feature
+++ b/tests/tck/features/delete/DeleteVertex.IntVid.feature
@@ -232,6 +232,11 @@ Feature: Delete int vid of vertex
       | "Manu Ginobili" |
     When executing query:
       """
+      GO FROM hash("Boris Diaw") OVER like YIELD edge as e | DELETE VERTEX src($-.e) WITH EDGE
+      """
+    Then a SemanticError should be raised at runtime: `src($-.e)' is not an evaluable expression.
+    When executing query:
+      """
       GO FROM hash("Boris Diaw") OVER like YIELD like._dst as id | DELETE VERTEX $-.id WITH EDGE
       """
     Then the execution should be successful

--- a/tests/tck/features/delete/DeleteVertex.feature
+++ b/tests/tck/features/delete/DeleteVertex.feature
@@ -233,6 +233,11 @@ Feature: Delete string vid of vertex
       | "Manu Ginobili" |
     When executing query:
       """
+      GO FROM "Boris Diaw" OVER like YIELD edge as e | DELETE VERTEX src($-.e) WITH EDGE
+      """
+    Then a SemanticError should be raised at runtime: `src($-.e)' is not an evaluable expression.
+    When executing query:
+      """
       GO FROM "Boris Diaw" OVER like YIELD like._dst as id | DELETE VERTEX $-.id WITH EDGE
       """
     Then the execution should be successful

--- a/tests/tck/features/delete/DeleteVertexWithoutEdge.feature
+++ b/tests/tck/features/delete/DeleteVertexWithoutEdge.feature
@@ -90,6 +90,11 @@ Feature: delete vertex without edge
       | 3 | 1  |
     When executing query:
       """
+      GO FROM 1 OVER e YIELD edge as e1 | DELETE VERTEX dst($-.e1)
+      """
+    Then a SemanticError should be raised at runtime: `dst($-.e1)' is not an evaluable expression.
+    When executing query:
+      """
       DELETE VERTEX 1;
       """
     Then the execution should be successful

--- a/tests/tck/features/match/AllShortestPaths.feature
+++ b/tests/tck/features/match/AllShortestPaths.feature
@@ -898,3 +898,73 @@ Feature: allShortestPaths
       | 11 | Argument       |              |               |
       | 14 | Project        | 13           |               |
       | 13 | Argument       |              |               |
+
+  Scenario: allShortestPaths for same start and end node
+    When executing query:
+      """
+      MATCH (a:player{name:'Yao Ming'})
+      MATCH p = allShortestPaths((a)-[:like*1..3]-(a))
+      RETURN p
+      """
+    Then a SemanticError should be raised at runtime: The shortest path algorithm does not work when the start and end nodes are the same
+    When executing query:
+      """
+      MATCH p = allShortestPaths((a:player{name:'Yao Ming'})-[:like*1..3]-(a))
+      RETURN p
+      """
+    Then a SemanticError should be raised at runtime: The shortest path algorithm does not work when the start and end nodes are the same
+    When executing query:
+      """
+      MATCH (a:player{name:'Yao Ming'}), (b:player{name:'Yao Ming'})
+      MATCH p = allShortestPaths((a)-[:like*0..3]-(b))
+      RETURN p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p |
+    When executing query:
+      """
+      MATCH p = allShortestPaths((a)-[:like*0..3]-(b))
+        WHERE id(a) == 'Yao Ming' AND id(b) == 'Yao Ming'
+      RETURN p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p |
+    When executing query:
+      """
+      MATCH (a:player{name:'Yao Ming'}), (b:player{name:'Yao Ming'})
+      MATCH p = allShortestPaths((a)-[:like*1..3]-(b))
+      RETURN p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p                                                                                                                                                                                                                     |
+      | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Tracy McGrady" :player{age: 39, name: "Tracy McGrady"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})>       |
+      | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |
+    When executing query:
+      """
+      MATCH (a:player{name:'Yao Ming'})
+      MATCH p = allShortestPaths((a)-[:like*1..3]-(b:player{name:'Yao Ming'}))
+      RETURN p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p                                                                                                                                                                                                                     |
+      | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Tracy McGrady" :player{age: 39, name: "Tracy McGrady"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})>       |
+      | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |
+    When executing query:
+      """
+      MATCH p = allShortestPaths((a:player{name:'Yao Ming'})-[:like*1..3]-(b:player{name:'Yao Ming'}))
+      RETURN p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p                                                                                                                                                                                                                     |
+      | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Tracy McGrady" :player{age: 39, name: "Tracy McGrady"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})>       |
+      | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |
+    When executing query:
+      """
+      MATCH p = allShortestPaths((a)-[:like*1..3]-(b))
+        WHERE id(a) == 'Yao Ming' AND id(b) == 'Yao Ming'
+      RETURN p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p                                                                                                                                                                                                                     |
+      | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Tracy McGrady" :player{age: 39, name: "Tracy McGrady"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})>       |
+      | <("Yao Ming" :player{age: 38, name: "Yao Ming"})-[:like@0 {likeness: 90}]->("Shaquille O'Neal" :player{age: 47, name: "Shaquille O'Neal"})<-[:like@0 {likeness: 90}]-("Yao Ming" :player{age: 38, name: "Yao Ming"})> |

--- a/tests/tck/features/match/SingleShorestPath.feature
+++ b/tests/tck/features/match/SingleShorestPath.feature
@@ -746,3 +746,69 @@ Feature: single shortestPath
       | <("JaVale McGee":player{age:31,name:"JaVale McGee"})-[:serve@0{end_year:2018,start_year:2016}]->("Warriors":team{name:"Warriors"})<-[:serve@0{end_year:2009,start_year:2007}]-("Marco Belinelli":player{age:32,name:"Marco Belinelli"})-[:like@0{likeness:50}]->("Tony Parker":player{age:36,name:"Tony Parker"})>                                                                                                                                                                              |
       | <("LeBron James":player{age:34,name:"LeBron James"})<-[:like@0{likeness:99}]-("Dejounte Murray":player{age:29,name:"Dejounte Murray"})-[:like@0{likeness:99}]->("Tony Parker":player{age:36,name:"Tony Parker"})>                                                                                                                                                                                                                                                                               |
       | <("Kings":team{name:"Kings"})<-[:serve@0{end_year:2016,start_year:2015}]-("Marco Belinelli":player{age:32,name:"Marco Belinelli"})-[:like@0{likeness:50}]->("Tony Parker":player{age:36,name:"Tony Parker"})>                                                                                                                                                                                                                                                                                   |
+
+  Scenario: shortestPath for same start and end node
+    When executing query:
+      """
+      MATCH (a:player{name:'Yao Ming'})
+      MATCH p = shortestPath((a)-[:like*1..3]-(a))
+      RETURN p
+      """
+    Then a SemanticError should be raised at runtime: The shortest path algorithm does not work when the start and end nodes are the same
+    When executing query:
+      """
+      MATCH p = shortestPath((a:player{name:'Yao Ming'})-[:like*1..3]-(a))
+      RETURN p
+      """
+    Then a SemanticError should be raised at runtime: The shortest path algorithm does not work when the start and end nodes are the same
+    When executing query:
+      """
+      MATCH (a:player{name:'Yao Ming'}), (b:player{name:'Yao Ming'})
+      MATCH p = shortestPath((a)-[:like*0..3]-(b))
+      RETURN p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p |
+    When executing query:
+      """
+      MATCH p = shortestPath((a)-[:like*0..3]-(b))
+        WHERE id(a) == 'Yao Ming' AND id(b) == 'Yao Ming'
+      RETURN p
+      """
+    Then the result should be, in any order, with relax comparison:
+      | p |
+    When executing query:
+      """
+      MATCH (a:player{name:'Yao Ming'}), (b:player{name:'Yao Ming'})
+      MATCH p = shortestPath((a)-[:like*1..3]-(b))
+      RETURN a, b
+      """
+    Then the result should be, in any order, with relax comparison:
+      | a                                               | b                                               |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+    When executing query:
+      """
+      MATCH (a:player{name:'Yao Ming'})
+      MATCH p = shortestPath((a)-[:like*1..3]-(b:player{name:'Yao Ming'}))
+      RETURN a,b
+      """
+    Then the result should be, in any order, with relax comparison:
+      | a                                               | b                                               |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+    When executing query:
+      """
+      MATCH p = shortestPath((a:player{name:'Yao Ming'})-[:like*1..3]-(b:player{name:'Yao Ming'}))
+      RETURN a,b
+      """
+    Then the result should be, in any order, with relax comparison:
+      | a                                               | b                                               |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |
+    When executing query:
+      """
+      MATCH p = shortestPath((a)-[:like*1..3]-(b))
+        WHERE id(a) == 'Yao Ming' AND id(b) == 'Yao Ming'
+      RETURN a,b
+      """
+    Then the result should be, in any order, with relax comparison:
+      | a                                               | b                                               |
+      | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) | ("Yao Ming" :player{age: 38, name: "Yao Ming"}) |

--- a/tests/tck/features/optimizer/ElimintateInvalidProp.feature
+++ b/tests/tck/features/optimizer/ElimintateInvalidProp.feature
@@ -1,0 +1,37 @@
+# Copyright (c) 2023 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+Feature: Eliminate invalid property filter
+  Examples:
+     | space_name  |
+     | nba         |
+     | nba_int_vid |
+
+  Background:
+    Given a graph with space named "<space_name>"
+
+  Scenario: Elimintate Not Exists Tag
+    When profiling query:
+      """
+      MATCH (v:player) WHERE v.not_exists_tag.name == 'Tim Duncan' RETURN v.player.age AS age
+      """
+    Then the result should be, in any order:
+      | age |
+    And the execution plan should be:
+      | id | name    | dependencies | operator info |
+      | 0  | Project | 1            |               |
+      | 1  | Value   | 2            |               |
+      | 2  | Start   |              |               |
+
+  Scenario: Elimintate Not Exists Property
+    When profiling query:
+      """
+      MATCH (v:player) WHERE v.player.not_exists_prop == 'Tim Duncan' RETURN v.player.age AS age
+      """
+    Then the result should be, in any order:
+      | age |
+    And the execution plan should be:
+      | id | name    | dependencies | operator info |
+      | 0  | Project | 1            |               |
+      | 1  | Value   | 2            |               |
+      | 2  | Start   |              |               |

--- a/tests/tck/features/optimizer/EmbedEdgeAllPredIntoTraverseRule.feature
+++ b/tests/tck/features/optimizer/EmbedEdgeAllPredIntoTraverseRule.feature
@@ -355,3 +355,355 @@ Feature: Embed edge all predicate into Traverse
       | 39 | Traverse       | 17           |                |                                                                              |
       | 17 | Traverse       | 16           |                |                                                                              |
       | 16 | Argument       |              |                |                                                                              |
+
+  Scenario: Embed edge all predicate into Traverse with path variable
+    When profiling query:
+      """
+      MATCH p= (v:player)-[e:like*1]->(n)
+      WHERE all(i in e where i.likeness>90)
+      RETURN [i in e | i.likeness] AS likeness, n.player.age AS nage
+      """
+    Then the result should be, in any order:
+      | likeness | nage |
+      | [99]     | 33   |
+      | [99]     | 31   |
+      | [99]     | 29   |
+      | [99]     | 30   |
+      | [99]     | 25   |
+      | [99]     | 34   |
+      | [99]     | 41   |
+      | [99]     | 32   |
+      | [99]     | 30   |
+      | [99]     | 42   |
+      | [99]     | 36   |
+      | [95]     | 41   |
+      | [95]     | 42   |
+      | [100]    | 31   |
+      | [95]     | 30   |
+      | [95]     | 41   |
+      | [95]     | 36   |
+      | [100]    | 43   |
+      | [99]     | 34   |
+      | [99]     | 38   |
+    And the execution plan should be:
+      | id | name           | dependencies | profiling data | operator info                    |
+      | 7  | Project        | 11           |                |                                  |
+      | 11 | AppendVertices | 13           |                |                                  |
+      | 13 | Traverse       | 1            |                | {"filter": "(like.likeness>90)"} |
+      | 1  | IndexScan      | 2            |                |                                  |
+      | 2  | Start          |              |                |                                  |
+    When profiling query:
+      """
+      MATCH p= (v:player)-[e:like*1]->(n)
+      WHERE all(i in e where i.likeness>90 or i.likeness<0)
+      RETURN [i in e | i.likeness] AS likeness, n.player.age AS nage
+      """
+    Then the result should be, in any order:
+      | likeness | nage |
+      | [99]     | 33   |
+      | [99]     | 31   |
+      | [99]     | 29   |
+      | [99]     | 30   |
+      | [99]     | 25   |
+      | [99]     | 34   |
+      | [99]     | 41   |
+      | [99]     | 32   |
+      | [99]     | 30   |
+      | [99]     | 42   |
+      | [99]     | 36   |
+      | [95]     | 41   |
+      | [95]     | 42   |
+      | [100]    | 31   |
+      | [95]     | 30   |
+      | [95]     | 41   |
+      | [95]     | 36   |
+      | [100]    | 43   |
+      | [99]     | 34   |
+      | [99]     | 38   |
+      | [-1]     | 43   |
+      | [-1]     | 33   |
+    And the execution plan should be:
+      | id | name           | dependencies | profiling data | operator info                                           |
+      | 7  | Project        | 11           |                |                                                         |
+      | 11 | AppendVertices | 13           |                |                                                         |
+      | 13 | Traverse       | 1            |                | {"filter": "((like.likeness>90) OR (like.likeness<0))"} |
+      | 1  | IndexScan      | 2            |                |                                                         |
+      | 2  | Start          |              |                |                                                         |
+    When profiling query:
+      """
+      MATCH p= (v:player)-[e:like*1]->(n)
+      WHERE all(i in e where i.likeness>90 and v.player.name <> "x")
+      RETURN [i in e | i.likeness] AS likeness, n.player.age AS nage
+      """
+    Then the result should be, in any order:
+      | likeness | nage |
+      | [99]     | 33   |
+      | [99]     | 31   |
+      | [99]     | 29   |
+      | [99]     | 30   |
+      | [99]     | 25   |
+      | [99]     | 34   |
+      | [99]     | 41   |
+      | [99]     | 32   |
+      | [99]     | 30   |
+      | [99]     | 42   |
+      | [99]     | 36   |
+      | [95]     | 41   |
+      | [95]     | 42   |
+      | [100]    | 31   |
+      | [95]     | 30   |
+      | [95]     | 41   |
+      | [95]     | 36   |
+      | [100]    | 43   |
+      | [99]     | 34   |
+      | [99]     | 38   |
+    And the execution plan should be:
+      | id | name           | dependencies | profiling data | operator info                                                                                      |
+      | 7  | Project        | 11           |                |                                                                                                    |
+      | 11 | Filter         | 11           |                | {"condition": "all(__VAR_0 IN $-.e WHERE (($__VAR_0.likeness>90) AND ($-.v.player.name!=\"x\")))"} |
+      | 11 | AppendVertices | 13           |                |                                                                                                    |
+      | 13 | Traverse       | 1            |                |                                                                                                    |
+      | 1  | IndexScan      | 2            |                |                                                                                                    |
+      | 2  | Start          |              |                |                                                                                                    |
+    When profiling query:
+      """
+      MATCH p= (v:player)-[e:like*2]->(n)
+      WHERE all(i in e where i.likeness>90)
+      RETURN [i in e | i.likeness] AS likeness, n.player.age AS nage
+      """
+    Then the result should be, in any order:
+      | likeness  | nage |
+      | [99, 100] | 43   |
+      | [99, 95]  | 41   |
+      | [99, 95]  | 36   |
+      | [99, 95]  | 41   |
+      | [99, 95]  | 42   |
+      | [95, 95]  | 41   |
+      | [95, 95]  | 36   |
+      | [95, 95]  | 41   |
+      | [95, 95]  | 42   |
+      | [99, 99]  | 38   |
+      | [99, 99]  | 34   |
+    And the execution plan should be:
+      | id | name           | dependencies | profiling data | operator info                    |
+      | 7  | Project        | 11           |                |                                  |
+      | 11 | AppendVertices | 13           |                |                                  |
+      | 13 | Traverse       | 1            |                | {"filter": "(like.likeness>90)"} |
+      | 1  | IndexScan      | 2            |                |                                  |
+      | 2  | Start          |              |                |                                  |
+    When profiling query:
+      """
+      MATCH p= (v:player)-[e:like*2..4]->(n)
+      WHERE all(i in e where i.likeness>90)
+      RETURN [i in e | i.likeness] AS likeness, n.player.age AS nage
+      """
+    Then the result should be, in any order:
+      | likeness         | nage |
+      | [99, 100]        | 43   |
+      | [99, 95]         | 41   |
+      | [99, 95]         | 36   |
+      | [99, 95]         | 41   |
+      | [99, 95]         | 42   |
+      | [99, 95, 95]     | 41   |
+      | [99, 95, 95]     | 42   |
+      | [99, 95, 95]     | 41   |
+      | [99, 95, 95]     | 36   |
+      | [99, 95, 95, 95] | 41   |
+      | [99, 95, 95, 95] | 41   |
+      | [95, 95]         | 41   |
+      | [95, 95]         | 36   |
+      | [95, 95, 95]     | 41   |
+      | [95, 95]         | 41   |
+      | [95, 95]         | 42   |
+      | [95, 95, 95]     | 41   |
+      | [99, 99]         | 38   |
+      | [99, 99]         | 34   |
+    And the execution plan should be:
+      | id | name           | dependencies | profiling data | operator info                    |
+      | 7  | Project        | 11           |                |                                  |
+      | 11 | AppendVertices | 13           |                |                                  |
+      | 13 | Traverse       | 1            |                | {"filter": "(like.likeness>90)"} |
+      | 1  | IndexScan      | 2            |                |                                  |
+      | 2  | Start          |              |                |                                  |
+    When profiling query:
+      """
+      MATCH p= (v:player)-[e:like*0..5]->(n)
+      WHERE all(i in e where i.likeness>90) AND size(e)>0 AND (n.player.age>0) == true
+      RETURN [i in e | i.likeness] AS likeness, n.player.age AS nage
+      """
+    Then the result should be, in any order:
+      | likeness         | nage |
+      | [99, 99]         | 34   |
+      | [99]             | 38   |
+      | [99, 99]         | 38   |
+      | [99]             | 34   |
+      | [100]            | 43   |
+      | [95, 95, 95]     | 41   |
+      | [95, 95]         | 42   |
+      | [95, 95]         | 41   |
+      | [95]             | 36   |
+      | [95]             | 41   |
+      | [95]             | 30   |
+      | [100]            | 31   |
+      | [95, 95, 95]     | 41   |
+      | [95, 95]         | 36   |
+      | [95, 95]         | 41   |
+      | [95]             | 42   |
+      | [95]             | 41   |
+      | [99, 95, 95, 95] | 41   |
+      | [99, 95, 95, 95] | 41   |
+      | [99, 95, 95]     | 36   |
+      | [99, 95, 95]     | 41   |
+      | [99, 95, 95]     | 42   |
+      | [99, 95, 95]     | 41   |
+      | [99, 95]         | 42   |
+      | [99, 95]         | 41   |
+      | [99, 95]         | 36   |
+      | [99, 95]         | 41   |
+      | [99, 100]        | 43   |
+      | [99]             | 36   |
+      | [99]             | 42   |
+      | [99]             | 30   |
+      | [99]             | 32   |
+      | [99]             | 41   |
+      | [99]             | 34   |
+      | [99]             | 25   |
+      | [99]             | 30   |
+      | [99]             | 29   |
+      | [99]             | 31   |
+      | [99]             | 33   |
+    And the execution plan should be:
+      | id | name           | dependencies | profiling data | operator info                                |
+      | 7  | Project        | 15           |                |                                              |
+      | 15 | Filter         | 11           |                | {"condition": "(($-.n.player.age>0)==true)"} |
+      | 11 | AppendVertices | 14           |                |                                              |
+      | 14 | Filter         | 13           |                | {"condition": "(size($-.e)>0)"}              |
+      | 13 | Traverse       | 1            |                | {"edge filter": "(*.likeness>90)"}           |
+      | 1  | IndexScan      | 2            |                |                                              |
+      | 2  | Start          |              |                |                                              |
+    When profiling query:
+      """
+      MATCH p= (v:player)-[e:like*1..5]->(n)
+      WHERE all(i in e where i.likeness>90) AND size(e)>0 AND (n.player.age>0) == true
+      RETURN [i in e | i.likeness] AS likeness, n.player.age AS nage
+      """
+    Then the result should be, in any order:
+      | likeness         | nage |
+      | [99, 99]         | 34   |
+      | [99]             | 38   |
+      | [99, 99]         | 38   |
+      | [99]             | 34   |
+      | [100]            | 43   |
+      | [95, 95, 95]     | 41   |
+      | [95, 95]         | 42   |
+      | [95, 95]         | 41   |
+      | [95]             | 36   |
+      | [95]             | 41   |
+      | [95]             | 30   |
+      | [100]            | 31   |
+      | [95, 95, 95]     | 41   |
+      | [95, 95]         | 36   |
+      | [95, 95]         | 41   |
+      | [95]             | 42   |
+      | [95]             | 41   |
+      | [99, 95, 95, 95] | 41   |
+      | [99, 95, 95, 95] | 41   |
+      | [99, 95, 95]     | 36   |
+      | [99, 95, 95]     | 41   |
+      | [99, 95, 95]     | 42   |
+      | [99, 95, 95]     | 41   |
+      | [99, 95]         | 42   |
+      | [99, 95]         | 41   |
+      | [99, 95]         | 36   |
+      | [99, 95]         | 41   |
+      | [99, 100]        | 43   |
+      | [99]             | 36   |
+      | [99]             | 42   |
+      | [99]             | 30   |
+      | [99]             | 32   |
+      | [99]             | 41   |
+      | [99]             | 34   |
+      | [99]             | 25   |
+      | [99]             | 30   |
+      | [99]             | 29   |
+      | [99]             | 31   |
+      | [99]             | 33   |
+    And the execution plan should be:
+      | id | name           | dependencies | profiling data | operator info                                |
+      | 7  | Project        | 15           |                |                                              |
+      | 15 | Filter         | 11           |                | {"condition": "(($-.n.player.age>0)==true)"} |
+      | 11 | AppendVertices | 14           |                |                                              |
+      | 14 | Filter         | 13           |                | {"condition": "(size($-.e)>0)"}              |
+      | 13 | Traverse       | 1            |                | {"filter": "(like.likeness>90)"}             |
+      | 1  | IndexScan      | 2            |                |                                              |
+      | 2  | Start          |              |                |                                              |
+    When profiling query:
+      """
+      MATCH p= (v:player)-[e:like*0..5]->(n)
+      WHERE all(i in e where i.likeness>90) AND not all(i in e where i.likeness > 89)
+      RETURN [i in e | i.likeness] AS likeness, n.player.age AS nage
+      """
+    Then the result should be, in any order:
+      | likeness | nage |
+    And the execution plan should be:
+      | id | name           | dependencies | profiling data | operator info                                                         |
+      | 7  | Project        | 11           |                |                                                                       |
+      | 11 | AppendVertices | 14           |                |                                                                       |
+      | 14 | Filter         | 13           |                | {"condition": "!(all(__VAR_1 IN $-.e WHERE ($__VAR_1.likeness>89)))"} |
+      | 13 | Traverse       | 1            |                | {"edge filter": "(*.likeness>90)"}                                    |
+      | 1  | IndexScan      | 2            |                |                                                                       |
+      | 2  | Start          |              |                |                                                                       |
+    When profiling query:
+      """
+      MATCH p1= (person:player)-[e1:like*1..2]-(friend:player)
+      WHERE id(person) == "Tony Parker" AND id(friend) != "Tony Parker" AND  all(i in e1 where i.likeness > 0)
+      MATCH p2= (friend)-[served:serve]->(friendTeam:team)
+      WHERE served.start_year > 2010 AND all(i in e1 where i.likeness > 1)
+      WITH DISTINCT friend, friendTeam
+      OPTIONAL MATCH p3= (friend)<-[e2:like*2..4]-(friend2:player)<-[:like]-(friendTeam)
+      WITH friendTeam, count(friend2) AS numFriends, e2
+      WHERE e2 IS NULL OR all(i in e2 where i IS NULL)
+      RETURN
+        friendTeam.team.name AS teamName,
+        numFriends,
+        [i in e2 | i.likeness] AS likeness
+        ORDER BY teamName DESC
+        LIMIT 8
+      """
+    Then the result should be, in any order, with relax comparison:
+      | teamName        | numFriends | likeness |
+      | "Warriors"      | 0          | NULL     |
+      | "Trail Blazers" | 0          | NULL     |
+      | "Spurs"         | 0          | NULL     |
+      | "Rockets"       | 0          | NULL     |
+      | "Raptors"       | 0          | NULL     |
+      | "Pistons"       | 0          | NULL     |
+      | "Lakers"        | 0          | NULL     |
+      | "Kings"         | 0          | NULL     |
+    And the execution plan should be:
+      | id | name           | dependencies | profiling data | operator info                                                                |
+      | 28 | TopN           | 24           |                |                                                                              |
+      | 24 | Project        | 30           |                |                                                                              |
+      | 30 | Aggregate      | 29           |                |                                                                              |
+      | 29 | Filter         | 44           |                | {"condition": "($e2 IS NULL OR all(__VAR_2 IN $e2 WHERE $__VAR_2 IS NULL))"} |
+      | 44 | HashLeftJoin   | 15,43        |                |                                                                              |
+      | 15 | Dedup          | 14           |                |                                                                              |
+      | 14 | Project        | 35           |                |                                                                              |
+      | 35 | HashInnerJoin  | 53,50        |                |                                                                              |
+      | 53 | Project        | 53           |                |                                                                              |
+      | 53 | Filter         | 52           |                | {"condition": "(id($-.friend)!=\"Tony Parker\")"}                            |
+      | 52 | AppendVertices | 59           |                |                                                                              |
+      | 59 | Filter         | 60           |                | {"condition": "(id($-.person)==\"Tony Parker\")"}                            |
+      | 60 | Traverse       | 2            |                | {"filter": "((like.likeness>0) AND (like.likeness>1))"}                      |
+      | 2  | Dedup          | 1            |                |                                                                              |
+      | 1  | PassThrough    | 3            |                |                                                                              |
+      | 3  | Start          |              |                |                                                                              |
+      | 50 | Project        | 55           |                |                                                                              |
+      | 55 | AppendVertices | 61           |                |                                                                              |
+      | 61 | Traverse       | 8            |                |                                                                              |
+      | 8  | Argument       |              |                |                                                                              |
+      | 43 | Project        | 39           |                |                                                                              |
+      | 39 | AppendVertices | 39           |                |                                                                              |
+      | 39 | Traverse       | 17           |                |                                                                              |
+      | 17 | Traverse       | 16           |                |                                                                              |
+      | 16 | Argument       |              |                |                                                                              |

--- a/tests/tck/features/optimizer/PushFilterDownHashInnerJoinRule.feature
+++ b/tests/tck/features/optimizer/PushFilterDownHashInnerJoinRule.feature
@@ -263,19 +263,18 @@ Feature: Push Filter down HashInnerJoin rule
       | [:like "Dejounte Murray"->"Tim Duncan" @0 {likeness: 99}] | ("Dejounte Murray" :player{age: 29, name: "Dejounte Murray"}) |
       | [:like "Dejounte Murray"->"Tim Duncan" @0 {likeness: 99}] | ("Dejounte Murray" :player{age: 29, name: "Dejounte Murray"}) |
     And the execution plan should be:
-      | id | name           | dependencies | operator info                                                      |
-      | 20 | TopN           | 15           |                                                                    |
-      | 15 | Project        | 14           |                                                                    |
-      | 14 | Filter         | 13           | { "condition": "(($e.likeness>90) OR (vv.team.start_year>2000))" } |
-      | 13 | HashInnerJoin  | 16,12        |                                                                    |
-      | 16 | Project        | 5            |                                                                    |
-      | 5  | AppendVertices | 17           |                                                                    |
-      | 17 | Traverse       | 2            |                                                                    |
-      | 2  | Dedup          | 1            |                                                                    |
-      | 1  | PassThrough    | 3            |                                                                    |
-      | 3  | Start          |              |                                                                    |
-      | 12 | Project        | 11           |                                                                    |
-      | 11 | AppendVertices | 10           |                                                                    |
-      | 10 | Traverse       | 8            |                                                                    |
-      | 8  | Argument       | 9            |                                                                    |
-      | 9  | Start          |              |                                                                    |
+      | id | name           | dependencies | operator info |
+      | 20 | TopN           | 15           |               |
+      | 15 | Project        | 13           |               |
+      | 13 | HashInnerJoin  | 16,12        |               |
+      | 16 | Project        | 5            |               |
+      | 5  | AppendVertices | 17           |               |
+      | 17 | Traverse       | 2            |               |
+      | 2  | Dedup          | 1            |               |
+      | 1  | PassThrough    | 3            |               |
+      | 3  | Start          |              |               |
+      | 12 | Project        | 11           |               |
+      | 11 | AppendVertices | 10           |               |
+      | 10 | Traverse       | 8            |               |
+      | 8  | Argument       | 9            |               |
+      | 9  | Start          |              |               |


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Issue(s) number: https://github.com/vesoft-inc/nebula/issues/6150
#### Description:
This PR fixes a deadlock risk when space creation happens concurrently with leader balance in NebulaGraph 3.6.

`NebulaStore::addSpace()` used to hold `NebulaStore::lock_` as a write lock and then wait on `newEngineAsync().get()`. Since `newEngineAsync()` runs on `folly::getGlobalIOExecutor()`, and transfer-leader follow-up checks also run on the same executor and call `partLeader()` (which needs the store lock), this could create a lock/executor dependency cycle under concurrency.

## How do you solve it?
- Extract engine creation logic into a synchronous helper `createEngine()`
- Keep `newEngineAsync()` for the startup path that scans existing engines from disk
- Change `newEngine()` to call `createEngine()` directly instead of waiting on `newEngineAsync().get()`

This removes the dependency on `folly::getGlobalIOExecutor()` from the `addSpace()` path while the store write lock is held.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:
The change only affects the synchronous space-creation path. Startup-time async engine loading remains unchanged.


## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> fix bug: A deadlock risk when space creation happens concurrently with leader balance in NebulaGraph 3.6. 
