### PR TITLE
fix #6150: A deadlock risk when space creation happens concurrently with leader balance in NebulaGraph

### DIFF
--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -354,27 +354,36 @@ void NebulaStore::stop() {
 folly::Future<std::pair<GraphSpaceID, std::unique_ptr<KVEngine>>> NebulaStore::newEngineAsync(
     GraphSpaceID spaceId, const std::string& dataPath, const std::string& walPath) {
   return folly::via(folly::getGlobalIOExecutor().get(), [this, spaceId, dataPath, walPath]() {
-    std::unique_ptr<KVEngine> engine;
-    if (FLAGS_engine_type == "rocksdb") {
-      std::shared_ptr<KVCompactionFilterFactory> cfFactory = nullptr;
-      if (options_.cffBuilder_ != nullptr) {
-        cfFactory = options_.cffBuilder_->buildCfFactory(spaceId);
-      }
-      auto vIdLen = getSpaceVidLen(spaceId);
-      engine = std::make_unique<RocksEngine>(
-          spaceId, vIdLen, dataPath, walPath, options_.mergeOp_, cfFactory);
-    } else {
-      LOG(FATAL) << "Unknown engine type " << FLAGS_engine_type;
-    }
-    return std::make_pair(spaceId, std::move(engine));
+    return std::make_pair(spaceId, createEngine(spaceId, dataPath, walPath));
   });
+}
+
+std::unique_ptr<KVEngine> NebulaStore::createEngine(GraphSpaceID spaceId,
+                                                    const std::string& dataPath,
+                                                    const std::string& walPath) {
+  std::unique_ptr<KVEngine> engine;
+  if (FLAGS_engine_type == "rocksdb") {
+    std::shared_ptr<KVCompactionFilterFactory> cfFactory = nullptr;
+    if (options_.cffBuilder_ != nullptr) {
+      cfFactory = options_.cffBuilder_->buildCfFactory(spaceId);
+    }
+    auto vIdLen = getSpaceVidLen(spaceId);
+    engine = std::make_unique<RocksEngine>(spaceId,
+                                           vIdLen,
+                                           dataPath,
+                                           walPath,
+                                           options_.mergeOp_,
+                                           cfFactory);
+  } else {
+    LOG(FATAL) << "Unknown engine type " << FLAGS_engine_type;
+  }
+  return engine;
 }
 
 std::unique_ptr<KVEngine> NebulaStore::newEngine(GraphSpaceID spaceId,
                                                  const std::string& dataPath,
                                                  const std::string& walPath) {
-  auto pair = this->newEngineAsync(spaceId, dataPath, walPath).get();
-  return std::move(pair.second);
+  return createEngine(spaceId, dataPath, walPath);
 }
 
 ErrorOr<nebula::cpp2::ErrorCode, HostAddr> NebulaStore::partLeader(GraphSpaceID spaceId,

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -369,7 +369,7 @@ std::unique_ptr<KVEngine> NebulaStore::createEngine(GraphSpaceID spaceId,
     }
     auto vIdLen = getSpaceVidLen(spaceId);
     engine = std::make_unique<RocksEngine>(
-      spaceId, vIdLen, dataPath, walPath, options_.mergeOp_, cfFactory);
+        spaceId, vIdLen, dataPath, walPath, options_.mergeOp_, cfFactory);
   } else {
     LOG(FATAL) << "Unknown engine type " << FLAGS_engine_type;
   }

--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -368,12 +368,8 @@ std::unique_ptr<KVEngine> NebulaStore::createEngine(GraphSpaceID spaceId,
       cfFactory = options_.cffBuilder_->buildCfFactory(spaceId);
     }
     auto vIdLen = getSpaceVidLen(spaceId);
-    engine = std::make_unique<RocksEngine>(spaceId,
-                                           vIdLen,
-                                           dataPath,
-                                           walPath,
-                                           options_.mergeOp_,
-                                           cfFactory);
+    engine = std::make_unique<RocksEngine>(
+      spaceId, vIdLen, dataPath, walPath, options_.mergeOp_, cfFactory);
   } else {
     LOG(FATAL) << "Unknown engine type " << FLAGS_engine_type;
   }

--- a/src/kvstore/NebulaStore.h
+++ b/src/kvstore/NebulaStore.h
@@ -798,6 +798,18 @@ class NebulaStore : public KVStore, public Handler {
                                       const std::string& walPath);
 
   /**
+   * @brief Build a new kv engine on the current thread
+   *
+   * @param spaceId
+   * @param dataPath
+   * @param walPath
+   * @return std::unique_ptr<KVEngine>
+   */
+  std::unique_ptr<KVEngine> createEngine(GraphSpaceID spaceId,
+                                         const std::string& dataPath,
+                                         const std::string& walPath);
+
+  /**
    * @brief Start a new part
    *
    * @param spaceId


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
Issue(s) number: https://github.com/vesoft-inc/nebula/issues/6150
#### Description:
This PR fixes a deadlock risk when space creation happens concurrently with leader balance in NebulaGraph 3.6.

`NebulaStore::addSpace()` used to hold `NebulaStore::lock_` as a write lock and then wait on `newEngineAsync().get()`. Since `newEngineAsync()` runs on `folly::getGlobalIOExecutor()`, and transfer-leader follow-up checks also run on the same executor and call `partLeader()` (which needs the store lock), this could create a lock/executor dependency cycle under concurrency.

## How do you solve it?
- Extract engine creation logic into a synchronous helper `createEngine()`
- Keep `newEngineAsync()` for the startup path that scans existing engines from disk
- Change `newEngine()` to call `createEngine()` directly instead of waiting on `newEngineAsync().get()`

This removes the dependency on `folly::getGlobalIOExecutor()` from the `addSpace()` path while the store write lock is held.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:
The change only affects the synchronous space-creation path. Startup-time async engine loading remains unchanged.


## Checklist:
Tests:
- [x] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> fix bug: A deadlock risk when space creation happens concurrently with leader balance in NebulaGraph 3.6. 
