### PR TITLE
fix: add missing newline when returning JSON format (#2676)

### DIFF
--- a/src/webservice/GetStatsHandler.cpp
+++ b/src/webservice/GetStatsHandler.cpp
@@ -58,7 +58,7 @@ void GetStatsHandler::onEOM() noexcept {
 
   // read stats
   folly::dynamic vals = getStats();
-  std::string body = returnJson_ ? folly::toPrettyJson(vals) : toStr(vals);
+  std::string body = returnJson_ ? folly::toPrettyJson(vals) +"\n" : toStr(vals);
   ResponseBuilder(downstream_)
       .status(WebServiceUtils::to(HttpStatusCode::OK),
               WebServiceUtils::toString(HttpStatusCode::OK))


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number:
Closes #2676 

#### Description:
When returning data in JSON format, the output string is missing a newline (`\n`) character at the very end, causing the terminal cursor/output formatting to look messy.

## How do you solve it?
Updated the ternary operator inside `src/webservice/GetStatsHandler.cpp` to append a `+ "\n"` to the `folly::toPrettyJson(vals)` block when `returnJson_` is true.



## Special notes for your reviewer, ex. impact of this fix, design document, etc:
This is a low-impact, straightforward formatting fix for terminal/web service output consistency.


## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [x] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> Fixed the bug where returning JSON format data lacked a newline character at the end.
