### PR TITLE
fix #6138: fold constant unary expressions (e.g. IS NULL) in WHERE clause

### DIFF
--- a/src/graph/visitor/FoldConstantExprVisitor.cpp
+++ b/src/graph/visitor/FoldConstantExprVisitor.cpp
@@ -24,8 +24,12 @@ void FoldConstantExprVisitor::visit(UnaryExpression *expr) {
       if (!ok()) return;
     }
   } else {
-    canBeFolded_ = expr->kind() == Expression::Kind::kUnaryNegate ||
-                   expr->kind() == Expression::Kind::kUnaryPlus;
+    // When the operand is a constant, all pure unary expressions can be
+    // folded into constants, e.g. `1 IS NULL` should be folded into `false`.
+    // kUnaryIncr/kUnaryDecr modify variables, so they must not be folded
+    // even if the operand happens to be a constant expression.
+    canBeFolded_ = expr->kind() != Expression::Kind::kUnaryIncr &&
+                   expr->kind() != Expression::Kind::kUnaryDecr;
   }
 }
 

--- a/src/graph/visitor/test/FoldConstantExprVisitorTest.cpp
+++ b/src/graph/visitor/test/FoldConstantExprVisitorTest.cpp
@@ -45,6 +45,40 @@ TEST_F(FoldConstantExprVisitorTest, TestRelationExpr) {
   ASSERT_EQ(*root, *rootExpected) << root->toString() << " vs. " << rootExpected->toString();
 }
 
+TEST_F(FoldConstantExprVisitorTest, TestIsNullExpr) {
+  // 1 IS NULL => false
+  auto expr = isNullExpr(constantExpr(1));
+  FoldConstantExprVisitor visitor(pool);
+  expr->accept(&visitor);
+  ASSERT(visitor.canBeFolded());
+
+  auto root = visitor.fold(expr);
+  auto rootExpected = constantExpr(false);
+  ASSERT_EQ(*root, *rootExpected) << root->toString() << " vs. " << rootExpected->toString();
+
+  // NULL IS NULL => true
+  auto expr2 = isNullExpr(constantExpr(Value::kNullValue));
+  FoldConstantExprVisitor visitor2(pool);
+  expr2->accept(&visitor2);
+  ASSERT(visitor2.canBeFolded());
+
+  auto root2 = visitor2.fold(expr2);
+  auto rootExpected2 = constantExpr(true);
+  ASSERT_EQ(*root2, *rootExpected2) << root2->toString() << " vs. " << rootExpected2->toString();
+}
+
+TEST_F(FoldConstantExprVisitorTest, TestIsNotNullExpr) {
+  // 1 IS NOT NULL => true
+  auto expr = isNotNullExpr(constantExpr(1));
+  FoldConstantExprVisitor visitor(pool);
+  expr->accept(&visitor);
+  ASSERT(visitor.canBeFolded());
+
+  auto root = visitor.fold(expr);
+  auto rootExpected = constantExpr(true);
+  ASSERT_EQ(*root, *rootExpected) << root->toString() << " vs. " << rootExpected->toString();
+}
+
 TEST_F(FoldConstantExprVisitorTest, TestLogicalExpr) {
   {
     // false AND (false || (3 > (1 + 1))) => false AND true

--- a/src/graph/visitor/test/VisitorTestBase.h
+++ b/src/graph/visitor/test/VisitorTestBase.h
@@ -106,6 +106,14 @@ class VisitorTestBase : public ::testing::Test {
     return UnaryExpression::makeNot(pool, expr);
   }
 
+  UnaryExpression *isNullExpr(Expression *expr) {
+    return UnaryExpression::makeIsNull(pool, expr);
+  }
+
+  UnaryExpression *isNotNullExpr(Expression *expr) {
+    return UnaryExpression::makeIsNotNull(pool, expr);
+  }
+
   LogicalExpression *andExpr(Expression *lhs, Expression *rhs) {
     return LogicalExpression::makeAnd(pool, lhs, rhs);
   }

--- a/tests/tck/features/bugfix/ConstantIsNullInWhere.feature
+++ b/tests/tck/features/bugfix/ConstantIsNullInWhere.feature
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 vesoft inc. All rights reserved.
+#
+# This source code is licensed under Apache 2.0 License.
+Feature: constant is null in where
+
+  Background:
+    Given a graph with space named "nba"
+
+  # Regression for #6138: `WHERE 1 IS NULL` should be folded to a constant
+  # `false` so that it behaves exactly like `WHERE false`, instead of being
+  # executed as a non-folded filter that may crash the graphd service.
+  Scenario: where with constant is null predicate
+    When try to execute query:
+      """
+      UNWIND range(1,100) AS p WITH p WHERE 1 IS NULL RETURN p
+      """
+    Then the execution should be successful
+
+  Scenario: where with constant is not null predicate
+    When try to execute query:
+      """
+      UNWIND range(1,100) AS p WITH p WHERE 1 IS NOT NULL RETURN p
+      """
+    Then the execution should be successful


### PR DESCRIPTION
## Motivation

The graphd service crashes when running a query whose `WHERE` clause contains a constant `IS NULL` predicate, e.g.:

```ngql
UNWIND range(1,10000) AS p WITH p LIMIT 1000
UNWIND range(1,2000000) AS qid WITH p, qid, {age: qid % 50 + 18, score: qid % 100} AS q
WHERE 1 IS NULL RETURN p
```

The control query `WHERE false` succeeds and returns an empty set, while `WHERE 1 IS NULL` is not constant-folded, so the filter cannot be optimized away and the whole 2M-row pipeline is materialized, eventually crashing the service (reported in #6138).

**Root cause:** `FoldConstantExprVisitor::visit(UnaryExpression*)` only treats a unary expression whose operand is already a constant as foldable for `kUnaryNegate` and `kUnaryPlus`. All the other pure unary kinds (`kIsNull`, `kIsNotNull`, `kIsEmpty`, `kIsNotEmpty`, `kUnaryNot`) are incorrectly treated as non-foldable, so `1 IS NULL` is never folded into `false` and the query does not behave like `WHERE false`.

## Changes

- `src/graph/visitor/FoldConstantExprVisitor.cpp`: allow folding any pure unary expression whose operand is a constant, excluding only the variable-modifying `kUnaryIncr`/`kUnaryDecr`. Now `1 IS NULL` folds to `false`, so it behaves exactly like `WHERE false`.
- `src/graph/visitor/test/FoldConstantExprVisitorTest.cpp`: add regression unit tests `TestIsNullExpr` and `TestIsNotNullExpr` verifying that `1 IS NULL => false`, `NULL IS NULL => true` and `1 IS NOT NULL => true` are folded into constants.
- `src/graph/visitor/test/VisitorTestBase.h`: add `isNullExpr`/`isNotNullExpr` test helpers.
- `tests/tck/features/bugfix/ConstantIsNullInWhere.feature`: end-to-end regression test for the crash.

## Testing

A full local build could not be run in the contributing environment (no C++ toolchain). Verification is provided by:

- New unit tests in `src/graph/visitor/test/FoldConstantExprVisitorTest.cpp`, runnable via `ctest -R FoldConstantExprVisitorTest` with `-DENABLE_TESTING=ON`.
- New TCK feature test `tests/tck/features/bugfix/ConstantIsNullInWhere.feature` asserting the query executes successfully.
- CI checks on this PR.

## Checklist

- [x] Code follows the project's coding standards
- [x] Tests have been added/updated
- [ ] Documentation has been updated (if applicable)
- [x] No new dependencies introduced (or justified)
- [x] Changes are backward compatible
