### PR TITLE
ci: optimize nightly multi-arch Docker publishing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,7 @@
 name: nightly
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 18 * * *"
 
@@ -15,8 +16,44 @@ env:
   OSS_DIR: minio/nightly-build/nebula-graph
   
 jobs:
+  check-commits:
+    name: check for new commits
+    runs-on: [self-hosted, nebula, linux, X64]
+    permissions:
+      actions: read
+    outputs:
+      should_build: ${{ steps.check.outputs.should_build }}
+    steps:
+      - name: Check previous successful nightly runs
+        id: check
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // Manual runs can rebuild a commit that already succeeded.
+            if (context.eventName === 'workflow_dispatch') {
+              core.setOutput('should_build', 'true');
+              core.info(`Manual build requested for ${context.sha}`);
+              return;
+            }
+
+            const { data } = await github.rest.actions.listWorkflowRuns({
+              ...context.repo,
+              workflow_id: 'nightly.yml',
+              branch: context.ref.replace(/^refs\/heads\//, ''),
+              head_sha: context.sha,
+              status: 'success',
+              per_page: 1,
+            });
+            const shouldBuild = data.workflow_runs.length === 0;
+            core.setOutput('should_build', String(shouldBuild));
+            core.info(shouldBuild
+              ? `No successful nightly for ${context.sha}; building`
+              : `Commit ${context.sha} already succeeded; skipping build`);
+
   package:
     name: build package
+    needs: check-commits
+    if: ${{ needs.check-commits.outputs.should_build == 'true' }}
     runs-on: [self-hosted, nebula, linux]
     strategy:
       fail-fast: false
@@ -84,45 +121,70 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - uses: docker/setup-buildx-action@v4
       - uses: docker/build-push-action@v7
+        id: graphd
         with:
           context: .
           file: ./docker/Dockerfile
           platforms: linux/${{ matrix.arch }}
-          tags: |
-            vesoft/nebula-graphd:nightly-${{ github.run_id }}-${{ matrix.arch }}
+          outputs: type=image,name=vesoft/nebula-graphd,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+          sbom: false
           target: graphd
           cache-to: type=local,dest=${{ runner.temp }}/buildx-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }},mode=max
-          push: true
       - uses: docker/build-push-action@v7
+        id: storaged
         with:
           context: .
           file: ./docker/Dockerfile
           platforms: linux/${{ matrix.arch }}
-          tags: |
-            vesoft/nebula-storaged:nightly-${{ github.run_id }}-${{ matrix.arch }}
+          outputs: type=image,name=vesoft/nebula-storaged,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+          sbom: false
           target: storaged
           cache-from: type=local,src=${{ runner.temp }}/buildx-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
-          push: true
       - uses: docker/build-push-action@v7
+        id: metad
         with:
           context: .
           file: ./docker/Dockerfile
           platforms: linux/${{ matrix.arch }}
-          tags: |
-            vesoft/nebula-metad:nightly-${{ github.run_id }}-${{ matrix.arch }}
+          outputs: type=image,name=vesoft/nebula-metad,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+          sbom: false
           target: metad
           cache-from: type=local,src=${{ runner.temp }}/buildx-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
-          push: true
       - uses: docker/build-push-action@v7
+        id: tools
         with:
           context: .
           file: ./docker/Dockerfile
           platforms: linux/${{ matrix.arch }}
-          tags: |
-            vesoft/nebula-tools:nightly-${{ github.run_id }}-${{ matrix.arch }}
+          outputs: type=image,name=vesoft/nebula-tools,push-by-digest=true,name-canonical=true,push=true
+          provenance: false
+          sbom: false
           target: tools
           cache-from: type=local,src=${{ runner.temp }}/buildx-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
-          push: true
+      - name: Export image digests
+        env:
+          DIGEST_DIR: ${{ runner.temp }}/docker-digests-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
+          ARCH: ${{ matrix.arch }}
+          GRAPHD_DIGEST: ${{ steps.graphd.outputs.digest }}
+          STORAGED_DIGEST: ${{ steps.storaged.outputs.digest }}
+          METAD_DIGEST: ${{ steps.metad.outputs.digest }}
+          TOOLS_DIGEST: ${{ steps.tools.outputs.digest }}
+        run: |
+          mkdir -p "$DIGEST_DIR"
+          printf '%s\n' "$GRAPHD_DIGEST" > "$DIGEST_DIR/graphd-$ARCH.txt"
+          printf '%s\n' "$STORAGED_DIGEST" > "$DIGEST_DIR/storaged-$ARCH.txt"
+          printf '%s\n' "$METAD_DIGEST" > "$DIGEST_DIR/metad-$ARCH.txt"
+          printf '%s\n' "$TOOLS_DIGEST" > "$DIGEST_DIR/tools-$ARCH.txt"
+      - uses: actions/upload-artifact@v6
+        with:
+          name: docker-digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/docker-digests-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}/*.txt
+          if-no-files-found: error
+          retention-days: 7
+          overwrite: true
       - name: delete the cache
         if: ${{ always() }}
         run: |
@@ -133,6 +195,11 @@ jobs:
     needs: docker
     runs-on: [self-hosted, nebula, linux, X64]
     steps:
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: docker-digests-*
+          path: ${{ runner.temp }}/docker-digests-${{ github.run_id }}-${{ github.run_attempt }}-merged
+          merge-multiple: true
       - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -140,18 +207,32 @@ jobs:
       - uses: docker/setup-buildx-action@v4
       - name: Merge architecture images
         env:
-          BUILD_TAG: nightly-${{ github.run_id }}
+          DIGEST_DIR: ${{ runner.temp }}/docker-digests-${{ github.run_id }}-${{ github.run_attempt }}-merged
         run: |
+          # Validate every digest before updating any nightly tag.
+          for target in graphd storaged metad tools; do
+            for arch in amd64 arm64; do
+              digest=$(cat "$DIGEST_DIR/$target-$arch.txt")
+              if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                echo "Invalid digest for $target/$arch" >&2
+                exit 1
+              fi
+            done
+          done
           for target in graphd storaged metad tools; do
             image="vesoft/nebula-${target}"
+            amd64_digest=$(cat "$DIGEST_DIR/$target-amd64.txt")
+            arm64_digest=$(cat "$DIGEST_DIR/$target-arm64.txt")
             docker buildx imagetools create \
               --tag "${image}:nightly" \
-              "${image}:${BUILD_TAG}-amd64" \
-              "${image}:${BUILD_TAG}-arm64"
+              "${image}@${amd64_digest}" \
+              "${image}@${arm64_digest}"
           done
 
   coverage:
     name: coverage
+    needs: check-commits
+    if: ${{ needs.check-commits.outputs.should_build == 'true' }}
     runs-on: [self-hosted, nebula, linux]
     strategy:
       fail-fast: false
@@ -342,6 +423,8 @@ jobs:
 
   standalone:
     name: standalone-build-tck
+    needs: check-commits
+    if: ${{ needs.check-commits.outputs.should_build == 'true' }}
     runs-on: [self-hosted, nebula]
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,11 +31,11 @@ jobs:
     container:
       image: vesoft/nebula-dev:${{ matrix.os }}
     steps:
-      - uses: webiny/action-post-run@3.1.0
+      - uses: vesoft-inc/action-post-run@4.0.0
         with:
           run: sh -c "find . -mindepth 1 -delete"
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: "^1.16.7"
       - name: package
@@ -48,7 +48,7 @@ jobs:
           find pkg-build/cpack_output -type f \( -iname \*.deb -o -iname \*.rpm -o -iname \*.tar.gz \) -exec bash -c "sha256sum {} > {}.sha256sum.txt" \;
           subdir=$(date -u +%Y.%m.%d)
           echo "subdir=$subdir" >> $GITHUB_OUTPUT
-      # - uses: actions/upload-artifact@v4
+      # - uses: actions/upload-artifact@v6
       #   with:
       #     name: ${{ matrix.os }}-nightly
       #     path: pkg-build/cpack_output
@@ -62,63 +62,93 @@ jobs:
 
 
   docker:
-    name: build docker image
+    name: build docker image (${{ matrix.arch }})
     needs: package
-    runs-on: [self-hosted, nebula, linux]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: [self-hosted, nebula, linux, X64]
+          - arch: arm64
+            runner: [self-hosted, nebula, linux, nebula-arm]
+    runs-on: ${{ matrix.runner }}
     steps:
-      - uses: webiny/action-post-run@3.1.0
+      - uses: vesoft-inc/action-post-run@4.0.0
         with:
           run: sh -c "find . -mindepth 1 -delete"
-      - uses: actions/checkout@v4
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/build-push-action@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch }}
           tags: |
-            vesoft/nebula-graphd:nightly
+            vesoft/nebula-graphd:nightly-${{ github.run_id }}-${{ matrix.arch }}
           target: graphd
-          cache-to: type=local,dest=/tmp/buildx-cache,mode=max
+          cache-to: type=local,dest=${{ runner.temp }}/buildx-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }},mode=max
           push: true
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch }}
           tags: |
-            vesoft/nebula-storaged:nightly
+            vesoft/nebula-storaged:nightly-${{ github.run_id }}-${{ matrix.arch }}
           target: storaged
-          cache-from: type=local,src=/tmp/buildx-cache
+          cache-from: type=local,src=${{ runner.temp }}/buildx-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
           push: true
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch }}
           tags: |
-            vesoft/nebula-metad:nightly
+            vesoft/nebula-metad:nightly-${{ github.run_id }}-${{ matrix.arch }}
           target: metad
-          cache-from: type=local,src=/tmp/buildx-cache
+          cache-from: type=local,src=${{ runner.temp }}/buildx-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
           push: true
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{ matrix.arch }}
           tags: |
-            vesoft/nebula-tools:nightly
+            vesoft/nebula-tools:nightly-${{ github.run_id }}-${{ matrix.arch }}
           target: tools
-          cache-from: type=local,src=/tmp/buildx-cache
+          cache-from: type=local,src=${{ runner.temp }}/buildx-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}
           push: true
       - name: delete the cache
+        if: ${{ always() }}
         run: |
-          rm -rf /tmp/buildx-cache
+          rm -rf "${{ runner.temp }}/buildx-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.arch }}"
+
+  docker-manifest:
+    name: publish multi-arch docker images
+    needs: docker
+    runs-on: [self-hosted, nebula, linux, X64]
+    steps:
+      - uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - uses: docker/setup-buildx-action@v4
+      - name: Merge architecture images
+        env:
+          BUILD_TAG: nightly-${{ github.run_id }}
+        run: |
+          for target in graphd storaged metad tools; do
+            image="vesoft/nebula-${target}"
+            docker buildx imagetools create \
+              --tag "${image}:nightly" \
+              "${image}:${BUILD_TAG}-amd64" \
+              "${image}:${BUILD_TAG}-arm64"
+          done
 
   coverage:
     name: coverage
@@ -139,10 +169,10 @@ jobs:
         - /tmp/ccache/nebula/${{ matrix.os }}-${{ matrix.compiler }}:/tmp/ccache/nebula/${{ matrix.os }}-${{ matrix.compiler }}
       options: --cap-add=SYS_PTRACE
     steps:
-      - uses: webiny/action-post-run@3.1.0
+      - uses: vesoft-inc/action-post-run@4.0.0
         with:
           run: sh -c "find . -mindepth 1 -delete"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Prepare environment
         run: |
           [ -d build/ ] && rm -rf build/* || mkdir -p build
@@ -192,12 +222,12 @@ jobs:
       - name: coverage
         run: |
           ~/.local/bin/fastcov -d build -l -o fastcov.info -p --exclude /usr/include /usr/lib /opt/vesoft build/ tests/ /test /mock .lex .yy
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v6
         with:
           files: fastcov.info
           fail_ci_if_error: false
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: ${{ matrix.os }}-${{ matrix.compiler }}-nebula-test-logs
@@ -235,10 +265,10 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: webiny/action-post-run@3.1.0
+      - uses: vesoft-inc/action-post-run@4.0.0
         with:
           run: sh -c "find . -mindepth 1 -delete"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: output some vars
         id: vars
         env:
@@ -304,7 +334,7 @@ jobs:
         working-directory: tests/
         timeout-minutes: 2
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: ${{ matrix.os }}-${{ matrix.compiler }}-nebula-test-logs
@@ -329,10 +359,10 @@ jobs:
         - /tmp/ccache/nebula/${{ matrix.os }}-${{ matrix.compiler }}:/tmp/ccache/nebula/${{ matrix.os }}-${{ matrix.compiler }}
       options: --cap-add=SYS_PTRACE
     steps:
-      - uses: webiny/action-post-run@3.1.0
+      - uses: vesoft-inc/action-post-run@4.0.0
         with:
           run: sh -c "find . -mindepth 1 -delete"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Prepare environment
         id: prepare
         run: |
@@ -394,7 +424,7 @@ jobs:
         working-directory: tests/
         timeout-minutes: 2
       - name: Upload logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: ${{ failure() }}
         with:
           name: ${{ matrix.os }}-${{ matrix.compiler }}-nebula-test-logs


### PR DESCRIPTION
## Summary
- Upgrade nightly workflow actions to Node.js 24 compatible versions.
- Build AMD64 and ARM64 images on dedicated native runners.
- Publish images by digest and keep only the final `nightly` multi-arch manifest.
- Add manual workflow dispatch and skip scheduled builds for commits that already succeeded.

## Validation
- YAML validation passed.
- Verified digest validation and manifest creation flow.